### PR TITLE
Install-recipe fixes from real-machine global validation (F1/F2/F5)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -211,6 +211,7 @@ mkdir -p "$HOME/.agent-sentinel-global/state"
 AGENTACCT_BIN="$(command -v agentacct)"
 [ -n "$AGENTACCT_BIN" ] || AGENTACCT_BIN="$HOME/.agentacct-cli/.venv/bin/agentacct"  # non-PATH install: substitute YOUR absolute path from Step 1 — an empty command would register a dead server
 # the two `mcp add` lines below rewrite USER-LEVEL client config (~/.claude.json, ~/.codex/config.toml): show them to the user and ask first (ground rule)
+# NO `claude`/`codex` CLI on PATH? (common: the Claude Code desktop app and ChatGPT.app's Codex ship none) — skip the two `mcp add` lines and hand-write the same registration per the "no CLI" note below.
 claude mcp add --scope user agentacct -- "$AGENTACCT_BIN" mcp serve --store-dir "$HOME/.agent-sentinel-global/state"
 codex mcp add agentacct -- "$AGENTACCT_BIN" mcp serve --store-dir "$HOME/.agent-sentinel-global/state"
 agentacct hooks claude-code install --project-dir "$HOME/.agent-sentinel-global" --store-dir "$HOME/.agent-sentinel-global/state" --user-settings-example
@@ -221,6 +222,7 @@ agentacct setup instructions --agent codex --user --store-dir "$HOME/.agent-sent
 agentacct serve --store-dir "$HOME/.agent-sentinel-global/state"
 ```
 
+- No CLI? The `claude mcp add` / `codex mcp add` lines need the `claude` and `codex` CLIs on PATH — but the Claude Code desktop app and ChatGPT.app's Codex read their config files directly and often ship NO such CLI, so those two lines fail with `command not found`. Register by hand instead, using the absolute path from `command -v agentacct` (call it BIN): (1) Codex — add to `~/.codex/config.toml` a table `[mcp_servers.agentacct]` with `command = "BIN"` and `args = ["mcp", "serve", "--store-dir", "$HOME/.agent-sentinel-global/state"]`; (2) Claude Code — add to `~/.claude.json`, under the top-level `mcpServers` object, `"agentacct": {"type": "stdio", "command": "BIN", "args": ["mcp", "serve", "--store-dir", "<the same absolute store path>"]}` (edit this JSON while no Claude Code session is running, or a live session may overwrite your change). Then start NEW client sessions.
 - The store is `$HOME/.agent-sentinel-global/state` — deliberately NOT the legacy `~/.agent-sentinel` directory, which older versions used as a silent fallback store; reusing it would mix that stray data into global mode. The directory keeps its pre-rename `agent-sentinel` name for compatibility with existing global stores.
 - Every registration embeds an explicit absolute `--store-dir` on purpose: GUI-launched clients (Claude Code desktop, Codex.app) do not inherit shell environment variables, so `AGENT_CHRONICLE_STORE_DIR` (or its pre-rename alias `AGENT_SENTINEL_STORE_DIR`) is shell convenience only — never the mechanism.
 - The printed settings example includes `"env": {"ENABLE_TOOL_SEARCH": "auto"}` alongside the hooks — merge that block too (never overwriting env keys the user already has): without it the agentacct MCP tools stay deferred in Claude Code and un-primed sessions record nothing, however well the hooks are wired.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ pipx install agentacct
 agentacct onboard   # from your repo root
 ```
 
+No `pipx` yet? Install it first with `brew install pipx` (macOS) or `python3 -m pip install --user pipx` — or skip pipx entirely and use `uv tool install agentacct`. See [INSTALL.md](INSTALL.md) for a plain-`venv` fallback.
+
 `onboard` detects your local coding-agent logs, sets up the project-local store, runs a first usage sync, and starts the dashboard at `http://127.0.0.1:8765`. Then open a **new** agent session in the project — MCP servers and hooks bind at session start, so the session that ran onboarding cannot become the first recorded Task.
 
 Prefer to let the agent do it? Paste this into the coding agent working in your target repo:

--- a/src/agent_chronicle/cli.py
+++ b/src/agent_chronicle/cli.py
@@ -167,6 +167,38 @@ app = typer.Typer(
     help="Local-first Agent Work Intelligence for coding agents: usage truth, recorded work, and honest joins.",
     pretty_exceptions_show_locals=False,
 )
+
+
+def _version_callback(value: bool) -> None:
+    """Print the installed agentacct version and exit (eager --version option)."""
+    if not value:
+        return
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _dist_version
+
+    try:
+        resolved = _dist_version("agentacct")
+    except PackageNotFoundError:  # source checkout without installed dist metadata
+        resolved = "0.0.0+source"
+    print(f"agentacct {resolved}")
+    raise typer.Exit()
+
+
+@app.callback()
+def _app_main(
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--version",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show the installed agentacct version and exit.",
+        ),
+    ] = None,
+) -> None:
+    # No docstring: Typer falls back to the app-level help= above, so adding this
+    # callback for --version does not change `agentacct --help` output.
+    return
 cost_app = typer.Typer(help="Cost proxy and usage ledger commands.")
 hooks_app = typer.Typer(help="Hook pack commands for agent runtimes.")
 policy_app = typer.Typer(help="Project policy commands.")

--- a/src/agent_chronicle/install_guide.py
+++ b/src/agent_chronicle/install_guide.py
@@ -209,6 +209,7 @@ GLOBAL_INSTALL_BLOCK = """mkdir -p "$HOME/.agent-sentinel-global/state"
 AGENTACCT_BIN="$(command -v agentacct)"
 [ -n "$AGENTACCT_BIN" ] || AGENTACCT_BIN="$HOME/.agentacct-cli/.venv/bin/agentacct"  # non-PATH install: substitute YOUR absolute path from Step 1 — an empty command would register a dead server
 # the two `mcp add` lines below rewrite USER-LEVEL client config (~/.claude.json, ~/.codex/config.toml): show them to the user and ask first (ground rule)
+# NO `claude`/`codex` CLI on PATH? (common: the Claude Code desktop app and ChatGPT.app's Codex ship none) — skip the two `mcp add` lines and hand-write the same registration per the "no CLI" note below.
 claude mcp add --scope user agentacct -- "$AGENTACCT_BIN" mcp serve --store-dir "$HOME/.agent-sentinel-global/state"
 codex mcp add agentacct -- "$AGENTACCT_BIN" mcp serve --store-dir "$HOME/.agent-sentinel-global/state"
 agentacct hooks claude-code install --project-dir "$HOME/.agent-sentinel-global" --store-dir "$HOME/.agent-sentinel-global/state" --user-settings-example
@@ -219,6 +220,7 @@ agentacct setup instructions --agent codex --user --store-dir "$HOME/.agent-sent
 agentacct serve --store-dir "$HOME/.agent-sentinel-global/state\""""
 
 GLOBAL_INSTALL_NOTES = (
+    "No CLI? The `claude mcp add` / `codex mcp add` lines need the `claude` and `codex` CLIs on PATH — but the Claude Code desktop app and ChatGPT.app's Codex read their config files directly and often ship NO such CLI, so those two lines fail with `command not found`. Register by hand instead, using the absolute path from `command -v agentacct` (call it BIN): (1) Codex — add to `~/.codex/config.toml` a table `[mcp_servers.agentacct]` with `command = \"BIN\"` and `args = [\"mcp\", \"serve\", \"--store-dir\", \"$HOME/.agent-sentinel-global/state\"]`; (2) Claude Code — add to `~/.claude.json`, under the top-level `mcpServers` object, `\"agentacct\": {\"type\": \"stdio\", \"command\": \"BIN\", \"args\": [\"mcp\", \"serve\", \"--store-dir\", \"<the same absolute store path>\"]}` (edit this JSON while no Claude Code session is running, or a live session may overwrite your change). Then start NEW client sessions.",
     "The store is `$HOME/.agent-sentinel-global/state` — deliberately NOT the legacy `~/.agent-sentinel` directory, which older versions used as a silent fallback store; reusing it would mix that stray data into global mode. The directory keeps its pre-rename `agent-sentinel` name for compatibility with existing global stores.",
     "Every registration embeds an explicit absolute `--store-dir` on purpose: GUI-launched clients (Claude Code desktop, Codex.app) do not inherit shell environment variables, so `AGENT_CHRONICLE_STORE_DIR` (or its pre-rename alias `AGENT_SENTINEL_STORE_DIR`) is shell convenience only — never the mechanism.",
     "The printed settings example includes `\"env\": {\"ENABLE_TOOL_SEARCH\": \"auto\"}` alongside the hooks — merge that block too (never overwriting env keys the user already has): without it the agentacct MCP tools stay deferred in Claude Code and un-primed sessions record nothing, however well the hooks are wired.",

--- a/tests/test_store_defaults_cli.py
+++ b/tests/test_store_defaults_cli.py
@@ -354,3 +354,25 @@ def test_mcp_serve_relative_store_dir_refusal_flags_relative_env_value(tmp_path,
     assert result.exit_code == 2, result.output
     assert "not an absolute path" in result.output
     assert served == []
+
+
+def test_version_flag_prints_installed_version_and_exits() -> None:
+    """F5 (clean-machine finding): `agentacct --version` prints the installed
+    version and exits 0 without needing a subcommand — a new user's instinct to
+    check the version must not fall through to the help text."""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("agentacct "), result.output
+    token = result.output.split("agentacct ", 1)[1].strip()
+    assert token, "version token is empty"
+
+
+def test_version_flag_does_not_change_help_or_break_subcommands() -> None:
+    """The added --version callback must not change the app-level help text or
+    stop `agentacct <subcommand>` from resolving."""
+    help_result = runner.invoke(app, ["--help"])
+    assert help_result.exit_code == 0, help_result.output
+    assert "Local-first Agent Work Intelligence" in help_result.output
+    # A known subcommand still resolves (its own help renders, exit 0).
+    sub = runner.invoke(app, ["serve", "--help"])
+    assert sub.exit_code == 0, sub.output


### PR DESCRIPTION
Fixes surfaced by a from-zero **global** reinstall on a real desktop-app Mac (Claude Code desktop app + ChatGPT.app Codex).

## What & why

- **F2 (headline):** the *Global install* recipe registered MCP with `claude mcp add` / `codex mcp add`, but the Claude Code desktop app and ChatGPT.app's Codex read their config files directly and ship **no such CLI on PATH** — so those two lines fail with `command not found`. This blocks the whole global setup for the most common desktop-app users. Adds a **CLI-less hand-registration path** (the exact `~/.codex/config.toml` TOML block and `~/.claude.json` `mcpServers` JSON) to the global recipe in `install_guide.py` and, mirrored verbatim, `INSTALL.md`. The `mcp add` lines stay for users who do have the CLIs.
- **F1:** the README led with `pipx install agentacct`, but a fresh machine has no `pipx`, so step 1 dead-ends. Adds a bootstrap note (`brew install pipx` / `pip install --user pipx` / `uv tool install`).
- **F5:** `agentacct --version` fell through to the help text. Adds a `--version` flag (reads the installed dist version) with two regression tests; verified `--help` and subcommand resolution are unchanged.

## Not in this PR

- **F3** (the installed Claude Code hook script lives *inside* the store dir and fails **closed** on a `"*"` matcher — moving/renaming the store bricks every tool call in a running session) is a real robustness bug, but a behavior change touching hook generation, the failure mode, and existing-install migration. It deserves its own focused PR with tests, filed as a fast-follow.

## Tests

`pytest -q` → **2838 passed, 1 skipped**. The `install_guide` ↔ `INSTALL.md` verbatim-consistency, brand-scan, and README-pin tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
