### PR TITLE
Move Claude Code hook wrapper out of the store dir + fail open (F3)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -214,7 +214,7 @@ AGENTACCT_BIN="$(command -v agentacct)"
 # NO `claude`/`codex` CLI on PATH? (common: the Claude Code desktop app and ChatGPT.app's Codex ship none) — skip the two `mcp add` lines and hand-write the same registration per the "no CLI" note below.
 claude mcp add --scope user agentacct -- "$AGENTACCT_BIN" mcp serve --store-dir "$HOME/.agent-sentinel-global/state"
 codex mcp add agentacct -- "$AGENTACCT_BIN" mcp serve --store-dir "$HOME/.agent-sentinel-global/state"
-agentacct hooks claude-code install --project-dir "$HOME/.agent-sentinel-global" --store-dir "$HOME/.agent-sentinel-global/state" --user-settings-example
+agentacct hooks claude-code install --project-dir "$HOME" --store-dir "$HOME/.agent-sentinel-global/state" --user-settings-example  # wrapper homes in ~/.claude/hooks/ (NOT the store dir): a store move must never vanish the hook and brick sessions
 # merge the printed "hooks" AND "env" blocks into ~/.claude/settings.json (user-level; ask the user first; merge, never overwrite existing keys)
 # standing "record your work" instructions — this is what fills the dashboard with work context (writes ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md; ask the user first, --dry-run to preview)
 agentacct setup instructions --agent claude-code --user --store-dir "$HOME/.agent-sentinel-global/state"

--- a/src/agent_chronicle/cli.py
+++ b/src/agent_chronicle/cli.py
@@ -2383,13 +2383,16 @@ def claude_code_pre_tool_use(
     Also persists hook-provided session_id/transcript_path as the project's
     current client context so MCP sections can inherit real join ids.
     """
-    raw = sys.stdin.read()
-    decision = evaluate_stdin_json(raw)
     try:
-        capture_claude_code_client_context(raw, store_dir=store_dir)
-    except Exception:  # noqa: BLE001 - context capture must never affect the hook decision.
-        pass
-    print(json.dumps(decision, ensure_ascii=False))
+        raw = sys.stdin.read()
+        decision = evaluate_stdin_json(raw)
+        try:
+            capture_claude_code_client_context(raw, store_dir=store_dir)
+        except Exception:  # noqa: BLE001 - context capture must never affect the hook decision.
+            pass
+        print(json.dumps(decision, ensure_ascii=False))
+    except Exception as exc:  # noqa: BLE001 - FAIL OPEN: a PreToolUse hook must NEVER block a tool call, even on an internal agentacct error. An observe-only recorder that can brick every tool call is worse than one that records nothing.
+        print(json.dumps({"agent_sentinel": {"decision": "allow", "risk": "low", "reason": f"agentacct hook error ({type(exc).__name__}); failing open"}}, ensure_ascii=False))
 
 
 @claude_code_hooks_app.command("session-start")
@@ -2407,17 +2410,20 @@ def claude_code_session_start(
     the agent to record its work as sections. Subagent sessions: no capture,
     empty response — the root session owns the semantic goal.
     """
-    raw = sys.stdin.read()
-    response = claude_session_start_response(raw)
-    if response:
-        # Subagent/malformed events return {} above AND skip capture: a burst
-        # of subagent captures could evict the root session's context file
-        # from the capped per-session dir.
-        try:
-            capture_claude_code_client_context(raw, store_dir=store_dir)
-        except Exception:  # noqa: BLE001 - context capture must never affect the hook response.
-            pass
-    print(json.dumps(response, ensure_ascii=False))
+    try:
+        raw = sys.stdin.read()
+        response = claude_session_start_response(raw)
+        if response:
+            # Subagent/malformed events return {} above AND skip capture: a burst
+            # of subagent captures could evict the root session's context file
+            # from the capped per-session dir.
+            try:
+                capture_claude_code_client_context(raw, store_dir=store_dir)
+            except Exception:  # noqa: BLE001 - context capture must never affect the hook response.
+                pass
+        print(json.dumps(response, ensure_ascii=False))
+    except Exception:  # noqa: BLE001 - FAIL OPEN: a SessionStart error must never break session startup; emit the empty no-op response and exit 0.
+        print("{}")
 
 
 @claude_code_hooks_app.command("install")

--- a/src/agent_chronicle/hooks.py
+++ b/src/agent_chronicle/hooks.py
@@ -740,11 +740,25 @@ def claude_code_hook_context_status(
     return {"status": "invalid", "age_seconds": None, "client_session_id": None, "client_transcript_id": None, "fresh_count": 0}
 
 
-# frozen: both filenames predate the agentacct rename and are carried by
-# historical stores/logs/files forever — installed Claude Code settings point
-# at the wrapper path, and shipped docs/tests reference the example filename.
-# The wrapper lives inside the (equally frozen) ".agent-sentinel/" project dir.
-CLAUDE_HOOK_RELATIVE_PATH = Path(".agent-sentinel/hooks/claude_pre_tool_use.py")
+# The wrapper FILENAME is frozen (`claude_pre_tool_use.py`): doctor and the
+# settings-command matcher recognize an installed hook by this basename, so
+# pre-rename and pre-relocation installs keep being recognized forever.
+#
+# The wrapper DIRECTORY moved OUT of the store dir (was `.agent-sentinel/hooks/`,
+# now `.claude/hooks/`). Rationale (F3): the store directory is a movable thing —
+# renaming/moving it is a normal admin action — and a wrapper that lives INSIDE
+# the store vanishes when the store moves. Claude Code then runs `python <gone>`,
+# which fails before the wrapper's own fail-open can run, and a `"*"` PreToolUse
+# hook that fails closed blocks EVERY tool call in every running session. Homing
+# the wrapper under `.claude/` (a sibling of the settings that reference it, never
+# the store) keeps a store move from bricking sessions. Existing installs keep
+# their old `.agent-sentinel/hooks/` path until re-run; doctor recognizes both.
+CLAUDE_HOOK_RELATIVE_PATH = Path(".claude/hooks/claude_pre_tool_use.py")
+# Pre-relocation installs (F3) kept the wrapper under the store dir. Doctor still
+# finds and inspects it there so an un-migrated install stays diagnosable, and
+# `install --force` migrates it to the new home. Same frozen basename, so the
+# settings-command matcher recognizes both without a second name.
+LEGACY_CLAUDE_HOOK_RELATIVE_PATH = Path(".agent-sentinel/hooks/claude_pre_tool_use.py")
 CLAUDE_SETTINGS_RELATIVE_PATH = Path(".claude/settings.agent-sentinel.example.json")
 # Active settings files doctor also inspects for agentacct hook commands. The
 # example file is safe to rewrite; these are user-owned and only ever read.
@@ -1218,6 +1232,13 @@ def claude_code_hook_doctor_checks(project_dir: Path | str) -> list[dict[str, st
     """Doctor rows for the project-local hook install: (status, name, details)."""
     root = Path(project_dir)
     hook_path, settings_path = claude_code_hook_paths(root)
+    # Un-migrated install: the wrapper still lives at the pre-relocation store
+    # path. Inspect it there so doctor keeps diagnosing it (the settings-command
+    # matcher already recognizes both by the frozen basename).
+    if not hook_path.exists():
+        legacy_hook_path = root / LEGACY_CLAUDE_HOOK_RELATIVE_PATH
+        if legacy_hook_path.exists():
+            hook_path = legacy_hook_path
     checks: list[dict[str, str]] = [
         {"status": "ok" if hook_path.exists() else "warn", "name": "hook wrapper", "details": str(hook_path)},
         {"status": "ok" if settings_path.exists() else "warn", "name": "example settings", "details": str(settings_path)},

--- a/src/agent_chronicle/install_guide.py
+++ b/src/agent_chronicle/install_guide.py
@@ -212,7 +212,7 @@ AGENTACCT_BIN="$(command -v agentacct)"
 # NO `claude`/`codex` CLI on PATH? (common: the Claude Code desktop app and ChatGPT.app's Codex ship none) — skip the two `mcp add` lines and hand-write the same registration per the "no CLI" note below.
 claude mcp add --scope user agentacct -- "$AGENTACCT_BIN" mcp serve --store-dir "$HOME/.agent-sentinel-global/state"
 codex mcp add agentacct -- "$AGENTACCT_BIN" mcp serve --store-dir "$HOME/.agent-sentinel-global/state"
-agentacct hooks claude-code install --project-dir "$HOME/.agent-sentinel-global" --store-dir "$HOME/.agent-sentinel-global/state" --user-settings-example
+agentacct hooks claude-code install --project-dir "$HOME" --store-dir "$HOME/.agent-sentinel-global/state" --user-settings-example  # wrapper homes in ~/.claude/hooks/ (NOT the store dir): a store move must never vanish the hook and brick sessions
 # merge the printed "hooks" AND "env" blocks into ~/.claude/settings.json (user-level; ask the user first; merge, never overwrite existing keys)
 # standing "record your work" instructions — this is what fills the dashboard with work context (writes ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md; ask the user first, --dry-run to preview)
 agentacct setup instructions --agent claude-code --user --store-dir "$HOME/.agent-sentinel-global/state"

--- a/tests/test_activation_cli.py
+++ b/tests/test_activation_cli.py
@@ -414,8 +414,10 @@ def test_existing_but_invalid_claude_hook_never_claims_ready(
         lambda **_kwargs: {"imported_events": 0, "refreshed_events": 0},
     )
     hook, example = claude_code_hook_paths(tmp_path)
-    hook.parent.mkdir(parents=True)
-    example.parent.mkdir(parents=True)
+    # hook (.claude/hooks/) and example (.claude/) now share the .claude/ parent,
+    # so both mkdirs must tolerate it already existing.
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    example.parent.mkdir(parents=True, exist_ok=True)
     hook.write_text("", encoding="utf-8")
     example.write_text(
         json.dumps({"env": {"ENABLE_TOOL_SEARCH": "auto"}, "hooks": {}}),

--- a/tests/test_hooks_claude_code.py
+++ b/tests/test_hooks_claude_code.py
@@ -78,7 +78,7 @@ def test_claude_code_hook_install_dry_run_does_not_write_files(tmp_path):
     assert result.exit_code == 0
     assert "Dry run" in result.output
     assert "claude_pre_tool_use.py" in result.output
-    assert not (tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py").exists()
+    assert not (tmp_path / ".claude" / "hooks" / "claude_pre_tool_use.py").exists()
 
 
 def test_claude_code_hook_install_writes_project_local_files(tmp_path):
@@ -87,7 +87,7 @@ def test_claude_code_hook_install_writes_project_local_files(tmp_path):
     result = runner.invoke(app, ["hooks", "claude-code", "install", "--project-dir", str(tmp_path)])
 
     assert result.exit_code == 0
-    hook_path = tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py"
+    hook_path = tmp_path / ".claude" / "hooks" / "claude_pre_tool_use.py"
     settings_path = tmp_path / ".claude" / "settings.agent-sentinel.example.json"
     assert hook_path.exists()
     assert settings_path.exists()
@@ -107,7 +107,7 @@ def test_claude_code_hook_install_writes_project_local_files(tmp_path):
 
 def test_claude_code_hook_install_refuses_to_overwrite_without_force(tmp_path):
     runner = CliRunner()
-    hook_path = tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py"
+    hook_path = tmp_path / ".claude" / "hooks" / "claude_pre_tool_use.py"
     hook_path.parent.mkdir(parents=True)
     hook_path.write_text("custom hook")
 
@@ -784,7 +784,7 @@ def test_install_embeds_resolved_executable_and_python_paths(tmp_path, monkeypat
 
     assert result.exit_code == 0
     assert str(stub) in result.output
-    wrapper_text = (tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py").read_text()
+    wrapper_text = (tmp_path / ".claude" / "hooks" / "claude_pre_tool_use.py").read_text()
     assert str(stub) in wrapper_text
     assert "'agent-chronicle'" in wrapper_text  # PATH fallback for relocated projects
     settings = json.loads((tmp_path / ".claude" / "settings.agent-sentinel.example.json").read_text())
@@ -792,7 +792,7 @@ def test_install_embeds_resolved_executable_and_python_paths(tmp_path, monkeypat
     # shlex round-trip, not naive whitespace split: the executable token must
     # survive shell parsing even if the interpreter path needed quoting.
     assert shlex.split(command)[0] == sys.executable
-    assert '"$CLAUDE_PROJECT_DIR/.agent-sentinel/hooks/claude_pre_tool_use.py"' in command
+    assert '"$CLAUDE_PROJECT_DIR/.claude/hooks/claude_pre_tool_use.py"' in command
 
 
 def test_install_warns_when_no_absolute_executable_resolvable(tmp_path, monkeypatch):
@@ -804,7 +804,7 @@ def test_install_warns_when_no_absolute_executable_resolvable(tmp_path, monkeypa
 
     assert result.exit_code == 0
     assert "Warning: no absolute agentacct executable could be resolved" in result.output
-    wrapper_text = (tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py").read_text()
+    wrapper_text = (tmp_path / ".claude" / "hooks" / "claude_pre_tool_use.py").read_text()
     assert "AGENT_CHRONICLE_CANDIDATES = ['agentacct', 'agent-chronicle', 'agent-sentinel']" in wrapper_text
 
 
@@ -890,7 +890,7 @@ def test_installed_wrapper_end_to_end_without_shell_path(tmp_path):
         pytest.skip("no agent-chronicle executable available in this environment")
     install = CliRunner().invoke(app, ["hooks", "claude-code", "install", "--project-dir", str(tmp_path)])
     assert install.exit_code == 0
-    wrapper = tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py"
+    wrapper = tmp_path / ".claude" / "hooks" / "claude_pre_tool_use.py"
     empty_bin = tmp_path / "emptybin"
     empty_bin.mkdir()
 
@@ -1129,9 +1129,10 @@ def test_install_force_migrates_legacy_install_to_embedded_paths(tmp_path, monke
     """The remediation every warn message prescribes must actually work."""
     from agent_chronicle import hooks as hooks_module
 
-    hook_path = tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py"
-    hook_path.parent.mkdir(parents=True)
-    hook_path.write_text(_LEGACY_WRAPPER)
+    # A pre-relocation (F3) install: the wrapper lives under the store dir.
+    legacy_hook_path = tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py"
+    legacy_hook_path.parent.mkdir(parents=True)
+    legacy_hook_path.write_text(_LEGACY_WRAPPER)
     settings_path = tmp_path / ".claude" / "settings.agent-sentinel.example.json"
     settings_path.parent.mkdir(parents=True)
     settings_path.write_text(json.dumps({"hooks": {"PreToolUse": []}}))
@@ -1141,9 +1142,15 @@ def test_install_force_migrates_legacy_install_to_embedded_paths(tmp_path, monke
     result = CliRunner().invoke(app, ["hooks", "claude-code", "install", "--project-dir", str(tmp_path), "--force"])
 
     assert result.exit_code == 0
-    assert str(stub) in hook_path.read_text()
+    # --force migrates the wrapper to its new home OUTSIDE the store dir; the
+    # example settings command now points there. The legacy wrapper is left in
+    # place so an active settings file that still references it keeps working
+    # until the user re-merges the refreshed example.
+    new_hook_path = tmp_path / ".claude" / "hooks" / "claude_pre_tool_use.py"
+    assert str(stub) in new_hook_path.read_text()
     command = json.loads(settings_path.read_text())["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
     assert shlex.split(command)[0] == sys.executable
+    assert ".claude/hooks/claude_pre_tool_use.py" in command
     rows = hooks_module.claude_code_hook_doctor_checks(tmp_path)
     assert all(row["status"] == "ok" for row in rows), rows
 
@@ -1158,7 +1165,7 @@ def test_install_writes_utf8_wrapper_for_non_ascii_paths(tmp_path, monkeypatch):
     result = CliRunner().invoke(app, ["hooks", "claude-code", "install", "--project-dir", str(tmp_path)])
 
     assert result.exit_code == 0
-    raw = (tmp_path / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py").read_bytes()
+    raw = (tmp_path / ".claude" / "hooks" / "claude_pre_tool_use.py").read_bytes()
     text = raw.decode("utf-8")  # must be UTF-8 regardless of host locale
     assert "/opt/josé-venv/bin/agent-sentinel" in text
     ast.parse(text)  # and valid Python source
@@ -1575,3 +1582,52 @@ def test_hook_doctor_emits_no_env_row_without_active_settings_files(tmp_path):
     rows = [row for row in claude_code_hook_doctor_checks(tmp_path) if row["name"] == "env.ENABLE_TOOL_SEARCH"]
 
     assert rows == []
+
+
+def test_hook_wrapper_survives_a_store_dir_move(tmp_path):
+    """F3 regression: the installed wrapper lives OUTSIDE the store dir, so moving
+    or renaming the store (a normal admin action) can't vanish it. A vanished
+    wrapper makes `python <gone>` fail closed, and a "*" PreToolUse hook that fails
+    closed then blocks EVERY tool call in every running session (observed live)."""
+    from agent_chronicle.hooks import CLAUDE_HOOK_RELATIVE_PATH
+
+    assert ".agent-sentinel" not in CLAUDE_HOOK_RELATIVE_PATH.parts, CLAUDE_HOOK_RELATIVE_PATH
+    (tmp_path / ".agent-sentinel" / "state").mkdir(parents=True)
+    install = CliRunner().invoke(app, ["hooks", "claude-code", "install", "--project-dir", str(tmp_path)])
+    assert install.exit_code == 0
+    wrapper = tmp_path / CLAUDE_HOOK_RELATIVE_PATH
+    assert wrapper.exists()
+    # Move the whole store aside: the wrapper is not under it, so it stays put.
+    (tmp_path / ".agent-sentinel").rename(tmp_path / ".agent-sentinel.KEEP")
+    assert wrapper.exists(), "wrapper vanished when the store dir moved — F3 regression"
+
+
+def test_pre_tool_use_subcommand_fails_open_on_internal_error(monkeypatch):
+    """F3: the PreToolUse subcommand must NEVER exit non-zero — a crash would make
+    Claude Code block the tool call. On any internal error it emits an allow
+    decision and exits 0 (fail open)."""
+    from agent_chronicle import cli as cli_module
+
+    def _boom(_raw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli_module, "evaluate_stdin_json", _boom)
+    result = CliRunner().invoke(app, ["hooks", "claude-code", "pre-tool-use"], input='{"tool_name": "Bash"}')
+    assert result.exit_code == 0, result.output
+    decision = json.loads(result.output)
+    assert decision["agent_sentinel"]["decision"] == "allow"
+    assert "failing open" in decision["agent_sentinel"]["reason"]
+
+
+def test_session_start_subcommand_fails_open_on_internal_error(monkeypatch):
+    """F3: a SessionStart subcommand crash must not break session startup; it
+    emits the empty no-op response and exits 0."""
+    from agent_chronicle import cli as cli_module
+
+    def _boom(_raw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli_module, "claude_session_start_response", _boom)
+    result = CliRunner().invoke(app, ["hooks", "claude-code", "session-start"], input='{"hook_event_name": "SessionStart"}')
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "{}"

--- a/tests/test_rename_compat.py
+++ b/tests/test_rename_compat.py
@@ -450,9 +450,19 @@ def test_frozen_metadata_keys_wire_vocab_and_store_dirs() -> None:
     assert DEFAULT_POLICY_FILE == Path(".agent-sentinel/policy.yaml")
     assert '".agent-sentinel" / "state"' in _src("store_resolution.py")
     assert '"$HOME/.agent-sentinel-global/state"' in install_guide.GLOBAL_INSTALL_BLOCK
-    from agent_chronicle.hooks import CLAUDE_HOOK_RELATIVE_PATH, CLAUDE_SETTINGS_RELATIVE_PATH
+    from agent_chronicle.hooks import (
+        CLAUDE_HOOK_RELATIVE_PATH,
+        CLAUDE_SETTINGS_RELATIVE_PATH,
+        LEGACY_CLAUDE_HOOK_RELATIVE_PATH,
+    )
 
-    assert CLAUDE_HOOK_RELATIVE_PATH == Path(".agent-sentinel/hooks/claude_pre_tool_use.py")
+    # F3: the wrapper BASENAME is frozen (doctor + the settings-command matcher
+    # recognize an install by this filename), but the directory moved out of the
+    # store dir so a store move can't vanish it. The pre-relocation path stays
+    # recognized forever via LEGACY_CLAUDE_HOOK_RELATIVE_PATH.
+    assert CLAUDE_HOOK_RELATIVE_PATH == Path(".claude/hooks/claude_pre_tool_use.py")
+    assert LEGACY_CLAUDE_HOOK_RELATIVE_PATH == Path(".agent-sentinel/hooks/claude_pre_tool_use.py")
+    assert CLAUDE_HOOK_RELATIVE_PATH.name == LEGACY_CLAUDE_HOOK_RELATIVE_PATH.name == "claude_pre_tool_use.py"
     assert CLAUDE_SETTINGS_RELATIVE_PATH == Path(".claude/settings.agent-sentinel.example.json")
     # Legacy managed markers stay recognized verbatim.
     assert install_guide.LEGACY_INSTRUCTIONS_BEGIN_MARKER == (


### PR DESCRIPTION
The fast-follow to #1, fixing the F3 robustness bug found during the real-machine global migration.

## The bug (observed live)

agentacct installs a Claude Code PreToolUse/SessionStart wrapper and points `settings.json` at it. The wrapper lived **inside the store dir** (`.agent-sentinel/hooks/claude_pre_tool_use.py`). Moving or renaming the store — a normal admin action — makes that path vanish. Claude Code then runs `python <gone>`, which fails at the "can't open file" level *before* the wrapper's own fail-open logic can run. A `"*"` PreToolUse hook that exits non-zero **fails closed**, so Claude Code blocks **every tool call in every running session** — the whole session bricks. This happened live while renaming the global store during the #1 migration.

The wrapper itself is well-built (multi-candidate binary resolution, internal fail-open). The bug is purely its **location**.

## The fix

- **Relocate** the wrapper to `.claude/hooks/claude_pre_tool_use.py` — a sibling of the settings that reference it, never the store dir. A store move can no longer vanish it. The basename is unchanged, so the doctor/settings-command matcher still recognizes installs by filename.
- **Backward compat:** `LEGACY_CLAUDE_HOOK_RELATIVE_PATH` keeps the old `.agent-sentinel/hooks/` path recognized. Doctor inspects an un-migrated wrapper there; `hooks claude-code install --force` migrates it to the new home and *leaves* the old file so an active settings file that still references it keeps working until the user re-merges the refreshed example.
- **Global recipe:** `--project-dir` is now `$HOME`, so the global wrapper homes in `~/.claude/hooks/` (outside the movable `~/.agent-sentinel-global` store) — `install_guide.py` + `INSTALL.md`.
- **Defense in depth:** the `hooks claude-code pre-tool-use` / `session-start` subcommands now *never* exit non-zero — on any internal error they emit an allow/empty response and exit 0. An observe-only recorder must never be able to block a tool call, even on its own bug.

## Tests

`pytest -q` → **2841 passed, 1 skipped**. +3 F3 regression tests: the wrapper survives a store-dir move, and both subcommands fail open on an internal error. ~10 path-assertion tests updated for the new home; legacy-recognition tests pass unchanged via the doctor fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
