### PR TITLE
CSS-only breakdown tabs on the Overview usage chart (#4)

### DIFF
--- a/src/agent_chronicle/api.py
+++ b/src/agent_chronicle/api.py
@@ -3803,6 +3803,18 @@ _DASHBOARD_STYLE = """    :root {
     .ov-utabs { background: var(--color-surface-muted); border: 1px solid var(--color-border); border-radius: 8px; display: inline-flex; gap: 2px; letter-spacing: 0; padding: 2px; text-transform: none; }
     .ov-utab { border-radius: 6px; color: var(--color-text-muted); font-size: 0.72rem; font-weight: 650; min-height: 28px; padding: 0.2rem 0.55rem; text-decoration: none; display: inline-flex; align-items: center; }
     .ov-utab.is-on { background: var(--color-surface); box-shadow: var(--shadow-sm); color: var(--color-text); }
+    /* CSS-only breakdown tabs: visually-hidden radios drive which panel + label
+       is active via :checked ~ sibling rules. Zero JS, zero page navigation. */
+    .ov-usage-bars .ov-utab-radio { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; border: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+    .ov-utab { cursor: pointer; }
+    .ov-usage-bars .ov-utab-panel { display: none; }
+    .ov-usage-bars #ov-bd-agent:checked ~ .ov-utab-panel-agent,
+    .ov-usage-bars #ov-bd-model:checked ~ .ov-utab-panel-model,
+    .ov-usage-bars #ov-bd-agent-model:checked ~ .ov-utab-panel-agent-model { display: block; }
+    .ov-usage-bars #ov-bd-agent:checked ~ .ov-chart-subhead label[for="ov-bd-agent"],
+    .ov-usage-bars #ov-bd-model:checked ~ .ov-chart-subhead label[for="ov-bd-model"],
+    .ov-usage-bars #ov-bd-agent-model:checked ~ .ov-chart-subhead label[for="ov-bd-agent-model"] { background: var(--color-surface); box-shadow: var(--shadow-sm); color: var(--color-text); }
+    .ov-usage-bars .ov-utab-radio:focus-visible ~ .ov-chart-subhead .ov-utabs { outline: 2px solid var(--color-text); outline-offset: 2px; }
     .ov-linechart svg, .ov-barchart svg { max-height: 220px; }
     .ov-line-path { fill: none; stroke: var(--color-accent); stroke-width: 2; }
     .ov-line-dot { fill: var(--color-surface); stroke: var(--color-accent); stroke-width: 2; }
@@ -8535,21 +8547,35 @@ def _overview_metric_tiles_html(
 def _overview_usage_charts_html(
     *,
     line_html: str,
-    bar_html: str,
-    breakdown: str,
+    bar_charts: dict[str, str],
+    active_breakdown: str,
     range_label: str,
     measured_days: int,
     esc: Any,
 ) -> str:
     """Usage section: the cumulative line chart plus the daily stacked-bar chart
-    with a no-JS breakdown selector (query-param links that re-render the page).
+    with a CSS-only (no-JS) breakdown selector.
+
+    All three breakdown charts (agent / model / agent-model) are rendered up
+    front; visually-hidden radio inputs plus `:checked ~` sibling rules show one
+    at a time, so switching costs no JS and no page navigation. The radios and
+    panels are siblings under `.ov-usage-bars` on purpose — the general-sibling
+    combinator only reaches following siblings. The `?usage_breakdown=` deep link
+    still works: it sets which radio starts `checked`, so an existing link opens
+    on the right tab and the user can switch from there without a reload.
     """
 
+    labels = (("agent", "By agent"), ("model", "By model"), ("agent-model", "By agent-model"))
+    radios: list[str] = []
     tabs: list[str] = []
-    for key, label in (("agent", "By agent"), ("model", "By model"), ("agent-model", "By agent-model")):
-        active = " is-on" if key == breakdown else ""
-        current = ' aria-current="true"' if key == breakdown else ""
-        tabs.append(f'<a class="ov-utab{active}" href="/?usage_breakdown={esc(key)}"{current}>{esc(label)}</a>')
+    panels: list[str] = []
+    for key, label in labels:
+        rid = f"ov-bd-{key}"
+        checked = " checked" if key == active_breakdown else ""
+        current = ' aria-current="true"' if key == active_breakdown else ""
+        radios.append(f'<input type="radio" name="ov-usage-breakdown" id="{rid}" class="ov-utab-radio"{checked}>')
+        tabs.append(f'<label class="ov-utab" for="{rid}"{current}>{esc(label)}</label>')
+        panels.append(f'<div class="ov-utab-panel ov-utab-panel-{key}">{bar_charts[key]}</div>')
     measured_note = (
         f"{_fmt_int(measured_days)} measured {'day' if measured_days == 1 else 'days'} in this window"
         if measured_days
@@ -8562,9 +8588,10 @@ def _overview_usage_charts_html(
         <div class="ov-chart-subhead"><span>Total usage</span><span class="note">cumulative · {esc(range_label)}</span></div>
         {line_html}
       </div>
-      <div class="ov-chart-block">
+      <div class="ov-chart-block ov-usage-bars">
+        {"".join(radios)}
         <div class="ov-chart-subhead"><span>Daily usage</span><span class="ov-utabs" role="tablist" aria-label="Daily usage breakdown">{"".join(tabs)}</span></div>
-        {bar_html}
+        {"".join(panels)}
       </div>
     </section>
     """
@@ -10141,12 +10168,30 @@ def _overview_body(
     )
     usage_totals_30d = usage_cube_30d["totals"]
     held_30d = int(usage_totals_30d.get("excluded_non_additive_rows") or 0)
-    line_days, bar_days, breakdown_series = _overview_breakdown_series(
-        usage_cube_30d, scoped_records, breakdown=safe_breakdown, today=today
-    )
-    measured_days = sum(1 for _period, rows, _total in line_days if rows > 0)
     range_label = "last 30 days"
-    breakdown_word = {"agent": "by agent", "model": "by model", "agent-model": "by agent-model"}[safe_breakdown]
+    breakdown_words = {"agent": "by agent", "model": "by model", "agent-model": "by agent-model"}
+    # Render all three breakdowns up front so the tab selector can be CSS-only.
+    # The cumulative line + measured-day count are breakdown-independent, so take
+    # them from the first computed breakdown.
+    line_days: list[tuple[str, int, int]] | None = None
+    bar_charts: dict[str, str] = {}
+    for key in ("agent", "model", "agent-model"):
+        b_line_days, bar_days, breakdown_series = _overview_breakdown_series(
+            usage_cube_30d, scoped_records, breakdown=key, today=today
+        )
+        if line_days is None:
+            line_days = b_line_days
+        bar_charts[key] = _overview_daily_stack_html(
+            bar_days,
+            breakdown_series,
+            esc=esc,
+            chart_id=f"ov-usage-bars-{key}",
+            held_rows=held_30d,
+            range_label=range_label,
+            breakdown_label=breakdown_words[key],
+        )
+    assert line_days is not None
+    measured_days = sum(1 for _period, rows, _total in line_days if rows > 0)
     usage_charts_html = _overview_usage_charts_html(
         line_html=_overview_usage_line_html(
             line_days,
@@ -10156,16 +10201,8 @@ def _overview_body(
             range_label=range_label,
             measured_days=measured_days,
         ),
-        bar_html=_overview_daily_stack_html(
-            bar_days,
-            breakdown_series,
-            esc=esc,
-            chart_id="ov-usage-bars",
-            held_rows=held_30d,
-            range_label=range_label,
-            breakdown_label=breakdown_word,
-        ),
-        breakdown=safe_breakdown,
+        bar_charts=bar_charts,
+        active_breakdown=safe_breakdown,
         range_label=range_label,
         measured_days=measured_days,
         esc=esc,

--- a/tests/test_overview_v2_dashboard.py
+++ b/tests/test_overview_v2_dashboard.py
@@ -73,41 +73,59 @@ def test_overview_v2_metric_tiles_and_charts_render(tmp_path):
     assert '<path class="ov-line-path"' in html
     assert "No saved usage rows in this window yet" not in html
 
-    # Daily stacked bars: real chart-bar rects and the daily-usage subhead.
-    assert 'id="ov-usage-bars"' in html
+    # Daily stacked bars: real chart-bar rects and the daily-usage subhead. The
+    # default (agent) breakdown chart carries the ov-usage-bars-agent id; all
+    # three breakdown charts render up front for the CSS-only tab selector.
+    assert 'id="ov-usage-bars-agent"' in html
     assert '<rect class="chart-bar"' in html
     assert "Token usage over time" in html
 
 
-def test_overview_v2_breakdown_tabs_switch_series(tmp_path):
+def test_overview_v2_breakdown_tabs_are_css_only_and_render_all_series(tmp_path):
+    store_root = tmp_path / "state"
+    _seed_multiday(store_root)
+    html = _client(store_root).get("/", headers=HTML_ACCEPT).text
+
+    # Selector is CSS-only: visually-hidden radios + labels, NOT query-param links.
+    assert 'href="/?usage_breakdown=' not in html
+    assert '<input type="radio" name="ov-usage-breakdown" id="ov-bd-agent" class="ov-utab-radio" checked>' in html
+    assert '<input type="radio" name="ov-usage-breakdown" id="ov-bd-model" class="ov-utab-radio">' in html
+    assert '<input type="radio" name="ov-usage-breakdown" id="ov-bd-agent-model" class="ov-utab-radio">' in html
+    assert '<label class="ov-utab" for="ov-bd-agent"' in html
+    assert '<label class="ov-utab" for="ov-bd-model">By model</label>' in html
+    # The :checked ~ sibling rules do the switching — no JS anywhere.
+    assert "<script" not in html.lower()
+    assert ".ov-usage-bars #ov-bd-model:checked ~ .ov-utab-panel-model" in html
+
+    # ALL THREE breakdown series render up front (CSS reveals one at a time):
+    # agent legend, model legend, and agent-model composite labels all present.
+    for label in ("Claude Code", "Codex", "Hermes"):
+        assert f'</span>{label}</span>' in html
+    assert "fill:var(--lane-claude-code)" in html
+    assert "claude-opus-4" in html
+    assert "claude-sonnet-4" in html
+    assert "opacity:" in html
+    assert "Claude Code · claude-opus-4" in html
+    # One panel per breakdown, each with its own chart id.
+    assert 'id="ov-usage-bars-agent"' in html
+    assert 'id="ov-usage-bars-model"' in html
+    assert 'id="ov-usage-bars-agent-model"' in html
+
+
+def test_overview_v2_breakdown_deep_link_sets_the_default_checked_radio(tmp_path):
+    """The old ?usage_breakdown= link coexists: it only chooses which radio starts
+    checked, so an existing deep link opens on the right tab (then CSS switches)."""
     store_root = tmp_path / "state"
     _seed_multiday(store_root)
     client = _client(store_root)
 
-    # Default = by agent: three lane legends, the agent tab active.
-    agent_html = client.get("/", headers=HTML_ACCEPT).text
-    assert '<a class="ov-utab is-on" href="/?usage_breakdown=agent"' in agent_html
-    for label in ("Claude Code", "Codex", "Hermes"):
-        assert f'</span>{label}</span>' in agent_html
-    # Agent lanes use the shared platform lane color via an inline fill var.
-    assert "fill:var(--lane-claude-code)" in agent_html
-
-    # By model: the model tab active and model-named legend chips.
     model_html = client.get("/?usage_breakdown=model", headers=HTML_ACCEPT).text
-    assert '<a class="ov-utab is-on" href="/?usage_breakdown=model"' in model_html
-    assert "claude-opus-4" in model_html
-    assert "claude-sonnet-4" in model_html
-    # Sub-models within one agent step opacity so two Claude models differ.
-    assert "opacity:" in model_html
+    assert '<input type="radio" name="ov-usage-breakdown" id="ov-bd-model" class="ov-utab-radio" checked>' in model_html
+    assert '<input type="radio" name="ov-usage-breakdown" id="ov-bd-agent" class="ov-utab-radio">' in model_html
 
-    # By agent-model: composite labels.
-    am_html = client.get("/?usage_breakdown=agent-model", headers=HTML_ACCEPT).text
-    assert '<a class="ov-utab is-on" href="/?usage_breakdown=agent-model"' in am_html
-    assert "Claude Code · claude-opus-4" in am_html
-
-    # An unknown breakdown falls back to the agent view (page-wide _safe_choice).
+    # An unknown breakdown falls back to the agent radio (page-wide _safe_choice).
     bogus_html = client.get("/?usage_breakdown=bogus", headers=HTML_ACCEPT).text
-    assert '<a class="ov-utab is-on" href="/?usage_breakdown=agent"' in bogus_html
+    assert '<input type="radio" name="ov-usage-breakdown" id="ov-bd-agent" class="ov-utab-radio" checked>' in bogus_html
 
 
 def test_overview_v2_roster_shows_per_agent_tokens_and_cost(tmp_path):
@@ -281,8 +299,9 @@ def test_overview_v2_charts_have_instant_css_hover_tooltips_no_js(tmp_path):
     assert 'class="ovh-hit"' in html
     assert 'class="ovh-tip"' in html
     assert ".ovh:hover .ovh-cross, .ovh:hover .ovh-dot, .ovh:hover .ovh-tip" in html
-    # Bar-chart tooltip lists each series that day plus a Total row.
-    bars = html[html.index('id="ov-usage-bars"') : html.index("</figure>", html.index('id="ov-usage-bars"'))]
+    # Bar-chart tooltip lists each series that day plus a Total row (inspect the
+    # default agent-breakdown chart; all three render for the CSS-only tabs).
+    bars = html[html.index('id="ov-usage-bars-agent"') : html.index("</figure>", html.index('id="ov-usage-bars-agent"'))]
     assert ">Total<" in bars
     assert ">Claude Code<" in bars
     # Line-chart tooltip carries the daily + cumulative figures and a hover dot.
@@ -304,7 +323,8 @@ def test_overview_v2_bar_tooltip_folds_long_series_and_keeps_total(tmp_path):
                        input_tokens=1000 * (i + 1), output_tokens=100, cached_input_tokens=50,
                        cost=0.01 * (i + 1), started_at=now - 3600 - i * 30)
     html = _client(store_root).get("/?usage_breakdown=model", headers=HTML_ACCEPT).text
-    bars = html[html.index('id="ov-usage-bars"') : html.index("</figure>", html.index('id="ov-usage-bars"'))]
+    # The many models live in the by-model chart; inspect that panel directly.
+    bars = html[html.index('id="ov-usage-bars-model"') : html.index("</figure>", html.index('id="ov-usage-bars-model"'))]
     assert re.search(r">\+\d+ more<", bars)
     assert ">Total<" in bars
 
@@ -355,7 +375,7 @@ def test_overview_v2_bar_chart_axis_labels_are_compact(tmp_path):
         started_at=time.time() - 3600,
     )
     html = _client(store_root).get("/", headers=HTML_ACCEPT).text
-    bars_start = html.index('id="ov-usage-bars"')
+    bars_start = html.index('id="ov-usage-bars-agent"')
     bars = html[bars_start : html.index("</figure>", bars_start)]
     assert 'class="chart-axis-label"' in bars
     assert ">10B</text>" in bars


### PR DESCRIPTION
Backlog #4.

The Overview daily-usage **breakdown selector** (By agent / By model / By agent-model) was a set of query-param links (`/?usage_breakdown=…`) that **reloaded the whole page** on every switch. This makes it a **CSS-only** selector instead.

## How

- All three breakdown charts are rendered up front, each panel with its own chart id (`ov-usage-bars-{agent,model,agent-model}`).
- Three visually-hidden radio inputs (`.ov-utab-radio`) + `<label>` tabs drive which panel + label is active via `#…:checked ~ .ov-utab-panel-…` sibling rules. The radios and panels are siblings under `.ov-usage-bars` on purpose — the general-sibling combinator only reaches following siblings.
- **Zero JS** (the dashboard CSP forbids scripts anyway) and **zero page navigation** — switching tabs never hits the server.

## Deep-link coexists

The old `?usage_breakdown=` link still works: it only sets which radio starts `checked`, so an existing deep link opens on the right tab and the user switches from there without a reload.

## Trade-off (accepted, per the backlog)

All three charts render server-side instead of one. In exchange, tab switches are instant and stateless.

## Tests

`pytest -q` → **2844 passed, 1 skipped**. The breakdown-tab test is rewritten for the CSS-only structure, plus a deep-link test; the chart-detail tests target the per-breakdown panel ids. Verified visually with a headless screenshot: only the checked panel shows, and the tabs render with **By agent** active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
