### PR TITLE
OSS front matter: badges, CHANGELOG, CI Python matrix (#5)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,15 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # All three gate on the Linux CI runner. Local caveat: on macOS + 3.13
+        # the psutil-based process-ownership tests (control / runner / supervisor)
+        # currently fail — a platform quirk in how process identity reads back on
+        # that combo (create_time / cmdline / cwd). It does not affect Linux CI
+        # and is tracked as a separate follow-up.
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,7 +27,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - name: Install package
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to agentacct are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
+follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `agentacct --version` prints the installed version.
+- CSS-only breakdown tabs on the Overview usage chart — the By agent / By model /
+  By agent-model selector switches without JavaScript or a page reload; the
+  `?usage_breakdown=` deep link still sets the initially-selected tab.
+- OSS front matter: CI/PyPI/Python/license badges, this changelog, and a CI test
+  matrix across Python 3.11, 3.12, and 3.13 (all green on the Linux CI runner).
+
+### Changed
+- Install docs: the README notes how to get `pipx` (or use `uv`) before the first
+  install step, and the Global install recipe adds a CLI-less MCP registration
+  path for desktop-app clients that ship no `claude` / `codex` CLI.
+- `/health` now reports `service: agentacct-local-api`; the readiness check and the
+  read canary still accept the pre-rename `agent-sentinel-local-api` value, so
+  cross-version upgrades keep recognizing the dashboard.
+
+### Fixed
+- The Claude Code hook wrapper is installed under `.claude/hooks/` instead of inside
+  the store directory, and its subcommands fail open. Moving or renaming the store
+  can no longer make a `"*"` PreToolUse hook fail closed and block every tool call
+  in a running session. Doctor still recognizes pre-relocation installs; re-running
+  `hooks claude-code install --force` migrates them.
+
+## [0.1.0] - 2026-07-25
+
+### Added
+- Initial public release. Local-first Agent Work Intelligence for coding agents:
+  imports client-reported token usage from local session files, records MCP work
+  context (sections, machine checks), joins the two with honest confidence labels,
+  and shows it on a local dashboard (`agentacct serve`). Ships the `agentacct`,
+  `agentacct-claude`, and `agentacct-codex` console scripts. Local-first,
+  observe-only, no telemetry, no provider API keys. Python ≥ 3.11 on macOS / Linux.
+
+[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/mikehasa/agentacct/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # agentacct
 
+[![tests](https://github.com/mikehasa/agentacct/actions/workflows/tests.yml/badge.svg)](https://github.com/mikehasa/agentacct/actions/workflows/tests.yml)
+[![PyPI](https://img.shields.io/pypi/v/agentacct.svg)](https://pypi.org/project/agentacct/)
+[![Python](https://img.shields.io/pypi/pyversions/agentacct.svg)](https://pypi.org/project/agentacct/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
+
 **See what your coding agents actually did — and what it cost — on a dashboard that never leaves your machine.**
 
 agentacct is local-first Agent Work Intelligence for coding agents. It reads the session logs that Claude Code and Codex already write on your machine, joins them with the work each session records as it goes, and shows the result — tokens, estimated cost, tasks, and evidence — on a local dashboard.


### PR DESCRIPTION
Backlog #5 — OSS front matter.

Much of the front matter already existed (CONTRIBUTING, SECURITY, PR template, and the bug / feature / integration issue templates), so this fills the gaps.

## Added

- **README badges** — CI (tests workflow), PyPI version, supported Python versions, and MIT license.
- **`CHANGELOG.md`** — [Keep a Changelog](https://keepachangelog.com/) format, with the `0.1.0` release and an `Unreleased` section covering the recent fixes.
- **CI Python matrix** — the `tests` workflow now runs **3.11, 3.12, and 3.13**, all green on the Linux CI runner.

## macOS + 3.13 caveat (local only)

While validating the matrix locally, the psutil-based process-ownership tests (`control` / `runner` / `supervisor`) failed on **macOS + 3.13** with `PermissionError: process identity no longer matches` — a platform quirk in how `create_time` / `cmdline` / `cwd` read back on that combo. It does **not** affect the Linux CI runner (where 3.13 is fully green), so 3.13 gates normally; the macOS quirk is noted in the workflow and tracked as a separate follow-up.

## Tests

`pytest -q` → **2844 passed, 1 skipped** (branch rebased on #3 + #4). README-pin and brand-scan tests still pass with the badges added. CI: 3.11 / 3.12 / 3.13 all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
