### PR TITLE
feat(dashboard): time-first activity feed on the overview

### DIFF
--- a/src/agent_chronicle/api.py
+++ b/src/agent_chronicle/api.py
@@ -169,6 +169,12 @@ from .work_ledger import (
 from .work_events import WORK_EVENT_KINDS, WORK_EVENT_STATUSES, WorkEvent
 
 DASHBOARD_USAGE_LIMIT_SESSIONS = 500
+# Recent-activity feed on the overview shows a newest-first slice; the full
+# history lives on /sessions.
+DASHBOARD_RECENT_ACTIVITY_LIMIT = 25
+# The pinned Needs-attention strip shows the newest open findings/blockers; the
+# rest stay one click away so the strip can never bury the recent-activity feed.
+DASHBOARD_ATTENTION_LIMIT = 6
 MECHANICAL_PROJECTION_LIMIT = 10_000
 ADVANCED_EVIDENCE_PRODUCT_LIMIT = 2_000
 # Conflict repair is a safety path for timestamp-only retry variants. Keep its
@@ -9909,6 +9915,21 @@ def _overview_body(
         for task in (projection.get("tasks") if isinstance(projection.get("tasks"), list) else [])
         if isinstance(task, dict) and task_in_scope(task)
     ]
+    # Root session groups (all in-scope sessions, incl. ones with no recorded
+    # work) are needed both for the activity feed below and, later, for the
+    # usage charts / roster. Compute once here.
+    scoped_sessions = [
+        entry
+        for entry in data.rollup_sessions
+        if isinstance(entry, dict)
+        and _overview_project_in_scope(
+            data,
+            entry.get("project"),
+            entry.get("project_identity"),
+            entry.get("project_identity_state"),
+        )
+    ]
+    session_groups = _overview_root_session_groups(scoped_sessions)
     task_entries: list[dict[str, Any]] = []
     states: list[dict[str, Any]] = []
     for task in tasks:
@@ -10051,29 +10072,30 @@ def _overview_body(
     </section>
         """
 
-    task_entries.sort(
-        key=lambda entry: (
-            0
-            if isinstance(entry.get("state"), Mapping) and entry["state"].get("action_required")
-            else 1
-            if isinstance(entry.get("state"), Mapping) and entry["state"].get("key") == "in_progress"
-            else 2,
-            0
-            if isinstance(entry.get("state"), Mapping) and entry["state"].get("finding_open")
-            else 1,
-            -float(entry.get("updated_at") or 0.0),
+    # Time-first: newest activity on top. The task projection already emits one
+    # entry per root session — work-bearing OR usage-only — so a recent hands-on
+    # session (with no recorded work yet) is a first-class entry here, not hidden.
+    # Attribution / severity are surfaced as card badges and the pinned
+    # Needs-attention strip below, never as the sort key.
+    task_entries.sort(key=lambda entry: -float(entry.get("updated_at") or 0.0))
+
+    def _entry_is_attention(entry: Mapping[str, Any]) -> bool:
+        # Open findings and blockers are pinned so they are never capped out of
+        # the recent slice, matching the pre-time-first force-keep behaviour.
+        state = entry.get("state")
+        return isinstance(state, Mapping) and bool(
+            state.get("action_required") or state.get("finding_open")
         )
-    )
-    visible_entries = _visible_attention_entries(task_entries)
-    feed_html = "".join(
-        _task_feed_item_html(
-            entry["task"],
-            candidate_tasks=[candidate for candidate in tasks if candidate is not entry["task"]],
-            csrf_token=data.task_csrf_token,
-            esc=esc,
-        )
-        if entry["kind"] == "task"
-        else _work_group_feed_item_html(
+
+    def _render_feed_entry(entry: Mapping[str, Any]) -> str:
+        if entry["kind"] == "task":
+            return _task_feed_item_html(
+                entry["task"],
+                candidate_tasks=[candidate for candidate in tasks if candidate is not entry["task"]],
+                csrf_token=data.task_csrf_token,
+                esc=esc,
+            )
+        return _work_group_feed_item_html(
             entry["items"],
             state=entry["state"],
             state_item=entry["state_item"],
@@ -10083,9 +10105,17 @@ def _overview_body(
             csrf_token=data.task_csrf_token,
             esc=esc,
         )
-        for entry in visible_entries
-    )
-    if not feed_html:
+
+    # Actionable entries (open findings, blockers) are pinned in a Needs-attention
+    # strip above the chronological feed; the recent feed below is a pure
+    # newest-first slice of everything else.
+    attention_entries = [entry for entry in task_entries if _entry_is_attention(entry)]
+    recent_entries = [entry for entry in task_entries if not _entry_is_attention(entry)]
+    visible_attention = attention_entries[:DASHBOARD_ATTENTION_LIMIT]
+    visible_recent = recent_entries[:DASHBOARD_RECENT_ACTIVITY_LIMIT]
+    attention_feed_html = "".join(_render_feed_entry(entry) for entry in visible_attention)
+    feed_html = "".join(_render_feed_entry(entry) for entry in visible_recent)
+    if not feed_html and not attention_feed_html:
         feed_html = (
             '<div class="empty-state">No work or local activity has been recorded for this workspace yet. '
             "Refresh local activity or start an agent with agentacct recording enabled.</div>"
@@ -10130,26 +10160,13 @@ def _overview_body(
         summary = "Agents found issues in the work being reviewed. agentacct recorded them without assigning the next action to you."
     else:
         headline = "You're caught up"
-        summary = "Nothing recorded needs your input or has an open finding. Recent Tasks and observed chats are below."
+        summary = "Nothing recorded needs your input or has an open finding. Recent activity is below, newest first."
     verified_share = round(verified_count / len(states) * 100) if states else 0
     cap_note = (
-        f"Showing {len(visible_entries)} of {len(task_entries)} recent Tasks."
-        if len(visible_entries) < len(task_entries)
-        else f"{len(task_entries)} recent {'Task' if len(task_entries) == 1 else 'Tasks'} in this workspace."
+        f"Showing the {len(visible_recent)} most recent of {len(recent_entries)} activity entries."
+        if len(visible_recent) < len(recent_entries)
+        else f"{len(recent_entries)} recent {'entry' if len(recent_entries) == 1 else 'entries'} in this workspace."
     )
-
-    scoped_sessions = [
-        entry
-        for entry in data.rollup_sessions
-        if isinstance(entry, dict)
-        and _overview_project_in_scope(
-            data,
-            entry.get("project"),
-            entry.get("project_identity"),
-            entry.get("project_identity_state"),
-        )
-    ]
-    session_groups = _overview_root_session_groups(scoped_sessions)
 
     # Dashboard v2 usage surface. One scoped 30-day daily cube drives the metric
     # tiles, the cumulative line, and the daily stacked bars so they can never
@@ -10234,6 +10251,23 @@ def _overview_body(
         top_sessions_html=_overview_top_sessions_html(session_groups, esc),
     )
 
+    needs_attention_section = ""
+    if attention_feed_html:
+        attention_cap_note = ""
+        if len(visible_attention) < len(attention_entries):
+            attention_cap_note = (
+                '<div class="work-feed-footer"><p>'
+                f"{esc(f'Showing the {len(visible_attention)} newest of {len(attention_entries)} open items.')}"
+                '</p><div><a class="see-all" href="/advanced">Review all findings →</a></div></div>'
+            )
+        needs_attention_section = f"""
+    <section class="section run-section needs-attention" id="needs-attention" aria-label="Needs attention">
+      <div class="section-header"><div><div class="eyebrow">Needs attention</div><h2>Open findings &amp; blockers</h2><p>The newest open findings and blockers are pinned here so they never scroll away with the recent-activity timeline below.</p></div></div>
+      <div class="work-feed">{attention_feed_html}</div>
+      {attention_cap_note}
+    </section>
+        """
+
     return f"""
     {_activation_panel_html(activation, esc)}
     <section class="work-overview" aria-labelledby="work-overview-title">
@@ -10256,10 +10290,12 @@ def _overview_body(
 
     {roster_html}
 
+    {needs_attention_section}
+
     {unassigned_findings_section}
 
-    <section class="section run-section" id="work-feed" aria-label="Task feed">
-      <div class="section-header"><div><div class="eyebrow">Task timeline</div><h2>Recent Tasks</h2><p>Each card starts with a real root chat. Continuations, subagents, reported runs, work steps, and checks stay nested inside it.</p></div><a class="see-all" href="/sessions">View all activity →</a></div>
+    <section class="section run-section" id="work-feed" aria-label="Recent activity">
+      <div class="section-header"><div><div class="eyebrow">Activity timeline</div><h2>Recent activity</h2><p>Every recent session, newest first — chats you ran, with reported runs, work steps, and checks nested inside the ones that recorded work.</p></div><a class="see-all" href="/sessions">View all activity →</a></div>
       <div class="work-feed">{feed_html}</div>
       <div class="work-feed-footer"><p>{esc(cap_note)}</p><div><a class="see-all" href="/tokens">View usage →</a> · <a class="see-all" href="/advanced">Data &amp; evidence →</a></div></div>
     </section>
@@ -11411,8 +11447,8 @@ def _overview_subtitle(data: _DashboardPageData) -> str:
     the same page stay identically worded."""
 
     if data.store_label == "All projects":
-        return "All projects · What agents are doing across all local projects. Blockers and verified outcomes come first."
-    return f"What agents are doing in {data.store_label}. Blockers and verified outcomes come first."
+        return "All projects · What agents are doing across all local projects. Newest activity first; open findings and blockers stay pinned."
+    return f"What agents are doing in {data.store_label}. Newest activity first; open findings and blockers stay pinned."
 
 
 def _render_overview_page(

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -496,8 +496,8 @@ def test_work_home_is_one_product_feed_and_hides_diagnostic_surfaces(tmp_path):
     )
     html = _client(store_root).get("/").text
 
-    assert "Recent Tasks" in html
-    assert 'id="work-feed" aria-label="Task feed"' in html
+    assert "Recent activity" in html
+    assert 'id="work-feed" aria-label="Recent activity"' in html
     assert "Productize the work dashboard" in html
     assert html.count('id="work-feed"') == 1
     assert 'id="attention"' not in html
@@ -963,21 +963,23 @@ def test_overview_caps_the_single_feed_and_keeps_full_sessions_explorer(tmp_path
     # Session ids whose 8-char display labels are unique (full ids never
     # render, so the probes below must target the short labels). codex labels
     # keep the LAST 8 chars (UUIDv7 tail rule), so the ids are tail-unique.
-    for index in range(12):
+    for index in range(30):
         _trusted_usage(store_root, session=f"session-rec{index:02d}", started_at=base + index * 3600)
     client = _client(store_root)
 
     overview = client.get("/").text
-    assert overview.count('<article class="work-feed-item">') == 10
+    # The recent-activity feed shows a newest-first slice (DASHBOARD_RECENT_ACTIVITY_LIMIT);
+    # the full history stays on /sessions.
+    assert overview.count('<article class="work-feed-item">') == 25
     assert '<details class="session-row">' not in overview
-    assert "Showing 10 of 12 recent Tasks." in overview
+    assert "Showing the 25 most recent of 30 activity entries." in overview
     assert '<a class="see-all" href="/sessions">View all activity →</a>' in overview
 
     # The explorer defaults to a 30-day last-activity window (locked PRD
     # decision); these synthetic sessions are older, so the full list needs
     # days=all.
     sessions_page = client.get("/sessions?days=all", headers=HTML_ACCEPT).text
-    assert sessions_page.count('<details class="session-row">') == 12
+    assert sessions_page.count('<details class="session-row">') == 30
 
 
 def test_recent_completed_task_is_not_hidden_behind_old_verified_tasks(tmp_path, monkeypatch):
@@ -1036,8 +1038,10 @@ def test_recent_completed_task_is_not_hidden_behind_old_verified_tasks(tmp_path,
     overview = _client(store_root).get("/").text
 
     assert "Newest completed Task" in overview
-    assert "Old verified 0" not in overview
-    assert "Showing 10 of 11 recent Tasks." in overview
+    # Time-first: the newest completed Task sorts to the top of the recent feed
+    # instead of being hidden behind older verified Tasks.
+    assert overview.index("Newest completed Task") < overview.index("Old verified 0")
+    assert "11 recent entries in this workspace." in overview
 
 
 def test_work_home_keeps_cost_compact_and_tokens_page_owns_full_disclosure(tmp_path):
@@ -1084,7 +1088,9 @@ def test_work_home_only_promotes_blocked_work_not_join_hygiene(tmp_path):
     assert "Choose the default homepage scope." in overview
     assert "3 usage row(s) have no work context" not in overview
     assert "Enable MCP context attach at session start" not in overview
-    assert "Needs attention" not in overview
+    # The blocked task is promoted into the pinned Needs-attention strip.
+    assert 'id="needs-attention"' in overview
+    assert "Ship the dashboard" in overview
 
 
 def test_work_home_shows_explicit_blocker_resolution_without_faking_verified_completion(tmp_path):

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -609,8 +609,8 @@ def test_local_dashboard_renders_work_first_and_keeps_live_usage_in_advanced(tmp
     # source diagnostics remain in Sessions/Advanced instead of posing as
     # user-facing tasks.
     assert "<h1>Work</h1>" in html
-    assert "Recent Tasks" in html
-    assert 'id="work-feed" aria-label="Task feed"' in html
+    assert "Recent activity" in html
+    assert 'id="work-feed" aria-label="Recent activity"' in html
     assert "Source coverage" not in html
     assert "Usage snapshot" not in html
     assert "unknown is not zero" not in html

--- a/tests/test_overview_v2_dashboard.py
+++ b/tests/test_overview_v2_dashboard.py
@@ -180,7 +180,7 @@ def test_overview_v2_section_order_matches_approved_layout(tmp_path):
         '<section class="usage-pulse"',
         '<section class="section ov-usage"',
         '<section class="agent-board"',
-        'id="work-feed" aria-label="Task feed"',
+        'id="work-feed" aria-label="Recent activity"',
     ]
     positions = [html.index(marker) for marker in order]
     assert positions == sorted(positions), positions


### PR DESCRIPTION
## What & why

The overview's main feed was ordered **attribution-first** (attributed → has-work → recency), so a recently-run session with **no recorded work** sank below every attributed session and out of the visible slice. On a store with lots of imported usage history, a hands-on session you just ran could vanish from the homepage even though it was one of the newest chats.

This makes the overview feed **time-first (newest on top)**, which is what the feed should do.

## Changes (all in `_overview_body`)

- Sort feed entries by real last-activity (`-updated_at`) instead of the attribution/severity triage tiers.
- Split into a pinned **"Needs attention"** strip (newest open findings + blockers, capped at `DASHBOARD_ATTENTION_LIMIT = 6`, with a *Review all findings →* link) above a newest-first **"Recent activity"** feed (`DASHBOARD_RECENT_ACTIVITY_LIMIT = 25`).
- Relabel the section "Recent Tasks" → "Recent activity"; update the overview subtitle to match.
- No new card type: the task projection already emits one entry per root session (usage-only sessions included), so a work-less recent session now renders as a named card at the top.

## Scope / safety

- `/sessions` explorer and `_session_display_sort_key` are **unchanged** — only the overview feed order changed.
- Page section order (usage charts / roster above the feed) is unchanged; this PR fixes feed content and order only.

## Tests

- `./.venv/bin/pytest -q` → **2844 passed, 1 skipped** (baseline).
- Updated 6 dashboard tests to the new copy/order (Recent activity label, time-first order, Needs-attention strip, recent-slice cap).
