### PR TITLE
feat(dashboard): inline finding resolve/review actions

### DIFF
--- a/src/agent_chronicle/api.py
+++ b/src/agent_chronicle/api.py
@@ -7128,17 +7128,16 @@ def _work_group_feed_item_html(
         session=sessions[0] if sessions else None,
         models=models,
         session_line=session_line,
-        action_html=_work_action_html(state_item, state, esc),
+        # Finding review + resolve/reopen render inline in the visible card body
+        # (action slot), not behind the details expander, so the disposition
+        # action is one click away instead of buried.
+        action_html=(
+            _work_action_html(state_item, state, esc)
+            + _finding_episode_controls_html(finding_episodes, csrf_token=csrf_token, esc=esc)
+        ),
         details_label=details_label,
-        details_extra_html=(
-            _work_group_details_html(
-                items, models, sessions, esc, show_session_totals=show_session_totals
-            )
-            + _finding_episode_controls_html(
-                finding_episodes,
-                csrf_token=csrf_token,
-                esc=esc,
-            )
+        details_extra_html=_work_group_details_html(
+            items, models, sessions, esc, show_session_totals=show_session_totals
         ),
         has_work=True,
     )
@@ -7766,13 +7765,8 @@ def _task_details_html(
             '<div class="run-detail-block"><strong>Session structure</strong>'
             f'<p class="note">{esc(root_copy)}.{esc(usage_copy)}</p></div>'
         )
-    blocks.append(
-        _finding_episode_controls_html(
-            task.get("finding_episodes"),
-            csrf_token=csrf_token,
-            esc=esc,
-        )
-    )
+    # Finding review/resolve controls now render inline in the card body (see
+    # _task_feed_item_html action slot); only task-link controls stay here.
     blocks.append(
         _task_controls_html(
             task,
@@ -7922,6 +7916,11 @@ def _task_feed_item_html(
         or state.get("key") == "resolved"
     ):
         action_html += _work_action_html(state_item, state, esc)
+    # Inline finding review + resolve/reopen in the visible card body, not the
+    # details expander, so the disposition action is one click away.
+    action_html += _finding_episode_controls_html(
+        task.get("finding_episodes"), csrf_token=csrf_token, esc=esc
+    )
     return _run_card_html(
         title=_task_title(task),
         client=display_client,
@@ -8004,16 +8003,20 @@ def _unassigned_finding_feed_item_html(
         metrics=[],
         esc=esc,
         session_line="Task association unavailable",
-        action_html=_work_action_html(item, state, esc),
-        details_label="Finding details",
-        details_extra_html=(
-            '<div class="run-detail-block"><strong>Assignment</strong>'
-            f'<p class="note">{esc(assignment_reason)}</p></div>'
+        # Resolve/review the unassigned finding inline in the visible card body,
+        # so it can be dispositioned in one click instead of via the expander.
+        action_html=(
+            _work_action_html(item, state, esc)
             + _finding_episode_controls_html(
                 [finding.get("episode")] if isinstance(finding.get("episode"), Mapping) else [],
                 csrf_token=csrf_token,
                 esc=esc,
             )
+        ),
+        details_label="Finding details",
+        details_extra_html=(
+            '<div class="run-detail-block"><strong>Assignment</strong>'
+            f'<p class="note">{esc(assignment_reason)}</p></div>'
         ),
         has_work=False,
     )

--- a/tests/test_tokens_explorer.py
+++ b/tests/test_tokens_explorer.py
@@ -1153,7 +1153,11 @@ def test_by_model_row_without_stored_cost_keeps_honest_no_estimate(tmp_path):
 
 def test_partial_cost_sum_is_labeled_with_row_coverage_everywhere(tmp_path):
     store_root = tmp_path / "state"
-    now = time.time()
+    # Anchor both rows to local midday so they always fall in one day bucket. A
+    # bare time.time() offset straddles midnight when the suite runs just after
+    # 00:00, and the per-period breakdown would then show two single-row days
+    # (each fully priced/unpriced) instead of one partially-priced day.
+    now = datetime.combine(date.today(), dtime(12, 0)).timestamp()
     _trusted_usage(
         store_root,
         session="priced-row",


### PR DESCRIPTION
> Stacked on #6 (time-first activity feed). GitHub will retarget this to `main` once #6 merges. Review after / together with #6.

## What & why

The resolve / mark-reviewed / reopen controls for an open finding lived inside each card's collapsed **"details"** expander, so acting on a finding meant expanding a card and hunting for the button. This surfaces the **finding-review controls inline in the visible card body** (esp. in the new "Needs attention" strip), so a finding is one click from resolved.

## Changes

Move the `_finding_episode_controls_html(...)` block from `details_extra_html` → the visible `action_html` slot in three renderers:
- `_work_group_feed_item_html` (unlinked work groups)
- `_task_feed_item_html` (task cards) — and drop it from `_task_details_html`; only task-link controls stay in the expander
- `_unassigned_finding_feed_item_html` (workspace findings) — this also gives the stale "GBrain doctor" workspace finding a one-click **Mark reviewed / resolved**, addressing feedback point 4

**No backend change** — same forms, same `/findings/disposition` route, same CSRF and gating (only `mcp_agent_reported` / `client_hook` findings with a valid chain render controls).

## Blocked items

Blocked work is left informational (its card links to the task page for the dependency). A true "dismiss blocked" state would need a new action in `finding_disposition.py` — out of scope here.

## Tests

- `./.venv/bin/pytest -q` → **2844 passed, 1 skipped**.
- Second commit fixes a **pre-existing** midnight-boundary flake in `test_tokens_explorer.py` (unrelated to this change; two seeded rows straddled a day when the suite ran after 00:00).
