### PR TITLE
docs: fix article 'a' → 'an' before 'agentacct' in reference.md

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -235,7 +235,7 @@ Task status is deliberately split into three independent axes:
 - **Outcome:** whether the result is unknown, agent-reported, verified, blocked, or has an open finding.
 - **Control:** whether agentacct is ready, awaiting approval, holding on policy, or encountered a control failure.
 
-This keeps a failed target-product check from being mislabeled as a agentacct failure or automatically turned into a user action. See [Task Intelligence and the local control plane](task-control-plane.md) for the contract.
+This keeps a failed target-product check from being mislabeled as an agentacct failure or automatically turned into a user action. See [Task Intelligence and the local control plane](task-control-plane.md) for the contract.
 
 ## Local Control
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/reference.md` (line 238).

## Problem

Incorrect article 'a' before 'agentacct', which starts with a vowel sound. Should be 'an agentacct'.

The problematic text:

```markdown
This keeps a failed target-product check from being mislabeled as a agentacct failure or automatically turned into a user action.
```

## Fix

Replaced with:

```markdown
This keeps a failed target-product check from being mislabeled as an agentacct failure or automatically turned into a user action.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text