### PR TITLE
docs: fix article 'a' → 'an' before 'agentacct-owned' in public-alpha-checklist.md

### DIFF
--- a/docs/public-alpha-checklist.md
+++ b/docs/public-alpha-checklist.md
@@ -32,7 +32,7 @@ agentacct demo
 
 Expected properties:
 
-- creates a agentacct-owned run
+- creates an agentacct-owned run
 - captures stdout/stderr
 - records objective machine-check evidence
 - writes a report


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/public-alpha-checklist.md` (line 35).

## Problem

Incorrect article 'a' before 'agentacct-owned', which starts with a vowel sound. Should be 'an agentacct-owned'.

The problematic text:

```markdown
creates a agentacct-owned run
```

## Fix

Replaced with:

```markdown
creates an agentacct-owned run
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text