### PR TITLE
docs: fix missing possessive apostrophe in canonical-authoritative-writes-design.md

### DIFF
--- a/docs/canonical-authoritative-writes-design.md
+++ b/docs/canonical-authoritative-writes-design.md
@@ -18,7 +18,7 @@ ledger first (under a cross-process lock), then a per-event canonical "shadow"
 write runs off-lock and may fail without ever failing the v1 write. v1 is the
 record; canonical is disposable evidence.
 
-"Authoritative" means the inverse for the lanes canonical models: the canonical
+"Authoritative" means the inverse for the lanes' canonical models: the canonical
 store becomes the primary write target and source of read truth, v1 becomes a
 compatibility mirror, and a canonical write failure surfaces instead of being
 swallowed. That inversion touches durability, concurrency, completeness, trust,


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/canonical-authoritative-writes-design.md` (line 21).

## Problem

Missing possessive apostrophe. "the lanes canonical models" should be "the lanes' canonical models" (the canonical models belonging to the lanes).

The problematic text:

```markdown
the inverse for the lanes canonical models
```

## Fix

Replaced with:

```markdown
the inverse for the lanes' canonical models
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text