### PR TITLE
fix(serve): auto-advance dashboard port when the default 8765 is busy

### DIFF
--- a/src/agent_chronicle/cli.py
+++ b/src/agent_chronicle/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import math
@@ -7,6 +8,7 @@ import os
 import shlex
 import shutil
 import signal
+import socket
 import stat
 import sys
 import tempfile
@@ -8006,8 +8008,55 @@ def usage_truth_table_command(
         console.print(f"- {row['integration']}: {row['setup_path']}")
 
 
+_SERVE_PORT_FALLBACK_SPAN = 20
+"""How many ports past the default the dashboard probes before giving up."""
+
+
+def _probe_port_free(host: str, port: int) -> bool:
+    """Return True if ``(host, port)`` can be bound right now.
+
+    Mirrors uvicorn's own socket setup (``SO_REUSEADDR``) so the probe reflects
+    what the server will attempt a moment later. There is an unavoidable TOCTOU
+    window between this check and uvicorn's bind, but for a localhost dashboard
+    the practical risk is negligible.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def _select_serve_port(
+    host: str,
+    port: int,
+    *,
+    allow_fallback: bool,
+    max_offset: int = _SERVE_PORT_FALLBACK_SPAN,
+) -> int:
+    """Pick a bindable port for the local dashboard.
+
+    When ``allow_fallback`` is False (the user passed an explicit ``--port``) the
+    requested port must be free or an ``OSError`` is raised so the caller can
+    fail with an actionable message. When True (the default-port path) a busy
+    port advances through ``port+1 .. port+max_offset`` and the first free port is
+    returned; ``OSError`` is raised only if the whole range is occupied.
+    """
+    if _probe_port_free(host, port):
+        return port
+    if not allow_fallback:
+        raise OSError(errno.EADDRINUSE, f"port {port} is already in use")
+    for candidate in range(port + 1, port + max_offset + 1):
+        if _probe_port_free(host, candidate):
+            return candidate
+    raise OSError(errno.EADDRINUSE, f"no free port in range {port}-{port + max_offset}")
+
+
 @app.command("serve")
 def serve(
+    ctx: typer.Context,
     host: Annotated[str, typer.Option(help="Bind host. Default is 127.0.0.1 for local dashboard safety.")] = "127.0.0.1",
     port: Annotated[int, typer.Option(help="Bind port for the local dashboard and event API.")] = 8765,
     store_dir: Annotated[
@@ -8016,7 +8065,13 @@ def serve(
     ] = None,
     allow_host: Annotated[Optional[list[str]], typer.Option("--allow-host", help=_ALLOW_HOST_HELP)] = None,
 ) -> None:
-    """Serve the local dashboard on localhost with local usage discovery enabled."""
+    """Serve the local dashboard on localhost with local usage discovery enabled.
+
+    The default port (8765) auto-advances to the next free port when it is busy,
+    so the dashboard never fails to start just because a port is taken. An
+    explicit ``--port`` is honored strictly: if that exact port is occupied the
+    command fails rather than silently moving.
+    """
     import uvicorn
 
     if host not in {"127.0.0.1", "localhost"}:
@@ -8026,7 +8081,29 @@ def serve(
     # not a server crash mid-startup.
     resolution = _resolve_dashboard_cli_store_dir(store_dir)
     effective_store_dir = resolution.path
-    console.print(f"Starting agentacct dashboard: http://{host}:{port}")
+    # Only auto-advance when the port came from the default; an explicit --port
+    # is a specific request and must fail loudly instead of moving. Compare the
+    # click ParameterSource by name -- typer's runtime enum is not identical to
+    # click.core's, so identity/value comparisons are unreliable across versions.
+    port_source = ctx.get_parameter_source("port")
+    port_explicitly_set = getattr(port_source, "name", "DEFAULT") != "DEFAULT"
+    try:
+        bound_port = _select_serve_port(host, port, allow_fallback=not port_explicitly_set)
+    except OSError:
+        if port_explicitly_set:
+            console.print(
+                f"Port {port} is already in use. Pass a free --port, or omit --port to let "
+                "agentacct pick the next free port automatically."
+            )
+        else:
+            console.print(
+                f"Ports {port}-{port + _SERVE_PORT_FALLBACK_SPAN} are all in use. "
+                "Free one up or pass an explicit --port."
+            )
+        raise typer.Exit(1)
+    if bound_port != port:
+        console.print(f"Port {port} was busy; dashboard on http://{host}:{bound_port}")
+    console.print(f"Starting agentacct dashboard: http://{host}:{bound_port}")
     if resolution.source == "global":
         console.print("Dashboard scope: All projects (machine-wide store).")
         _warn_dashboard_mcp_store_shadow(effective_store_dir)
@@ -8045,7 +8122,7 @@ def serve(
             extra_allowed_hosts=tuple(allow_host or ()),
         ),
         host=host,
-        port=port,
+        port=bound_port,
         log_level="info",
     )
 

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -1,7 +1,9 @@
 import json
 import os
+import socket
 import sqlite3
 
+import pytest
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 
@@ -2032,6 +2034,9 @@ def test_top_level_serve_prints_local_usage_scan_notice(tmp_path, monkeypatch):
         calls.append({"api_app": api_app, "host": host, "port": port, "log_level": log_level})
 
     monkeypatch.setattr("uvicorn.run", fake_run)
+    # Keep the default-port path deterministic regardless of what is bound on the
+    # machine running the suite (the live dashboard may hold 8765).
+    monkeypatch.setattr("agent_chronicle.cli._probe_port_free", lambda host, port: True)
 
     result = CliRunner().invoke(app, ["serve", "--store-dir", str(tmp_path / "state")])
 
@@ -2048,6 +2053,81 @@ def test_top_level_serve_help_describes_local_dashboard():
     assert result.exit_code == 0
     assert "dashboard" in result.output.lower()
     assert "127.0.0.1" in result.output
+
+
+def test_top_level_serve_falls_back_when_default_port_busy(tmp_path, monkeypatch):
+    """A busy DEFAULT port advances to the next free one and reports it."""
+    calls = []
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: calls.append(kwargs))
+    # Simulate the default 8765 being occupied and 8766 free.
+    monkeypatch.setattr("agent_chronicle.cli._probe_port_free", lambda host, port: port != 8765)
+
+    result = CliRunner().invoke(app, ["serve", "--store-dir", str(tmp_path / "state")])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0]["port"] == 8766
+    assert "Port 8765 was busy" in result.output
+    assert "http://127.0.0.1:8766" in result.output
+
+
+def test_top_level_serve_explicit_busy_port_errors(tmp_path, monkeypatch):
+    """An explicit --port that is occupied fails loudly instead of moving."""
+    calls = []
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: calls.append(kwargs))
+    # Every port is busy; with an explicit --port there must be no silent move.
+    monkeypatch.setattr("agent_chronicle.cli._probe_port_free", lambda host, port: False)
+
+    result = CliRunner().invoke(app, ["serve", "--port", "9000", "--store-dir", str(tmp_path / "state")])
+
+    assert result.exit_code == 1, result.output
+    assert "Port 9000 is already in use" in result.output
+    assert calls == []  # uvicorn.run was never reached
+
+
+def test_top_level_serve_explicit_free_port_binds_exactly(tmp_path, monkeypatch):
+    """An explicit --port that is free binds that exact port (no probing drift)."""
+    calls = []
+    monkeypatch.setattr("uvicorn.run", lambda *args, **kwargs: calls.append(kwargs))
+    monkeypatch.setattr("agent_chronicle.cli._probe_port_free", lambda host, port: True)
+
+    result = CliRunner().invoke(app, ["serve", "--port", "9123", "--store-dir", str(tmp_path / "state")])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0]["port"] == 9123
+    assert "was busy" not in result.output
+
+
+def test_select_serve_port_advances_past_real_busy_socket():
+    """End-to-end probe: a real listening socket forces a real fallback."""
+    from agent_chronicle.cli import _select_serve_port
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    busy_port = sock.getsockname()[1]
+    try:
+        chosen = _select_serve_port("127.0.0.1", busy_port, allow_fallback=True)
+        assert chosen != busy_port
+        assert busy_port < chosen <= busy_port + 20
+    finally:
+        sock.close()
+
+
+def test_select_serve_port_explicit_busy_raises_on_real_socket():
+    """With fallback disabled, a real busy port raises instead of moving."""
+    from agent_chronicle.cli import _select_serve_port
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    busy_port = sock.getsockname()[1]
+    try:
+        with pytest.raises(OSError):
+            _select_serve_port("127.0.0.1", busy_port, allow_fallback=False)
+    finally:
+        sock.close()
 
 
 def _make_home_claude_mixed_model_source(home):


### PR DESCRIPTION
The dashboard failed to start when port 8765 was already in use. Now the default port auto-advances to the next free port (probing up to +20) and prints the port it actually bound, so `agentacct serve` always comes up. An explicit `--port` is still honored strictly: if that exact port is occupied the command fails with a clear message rather than silently moving.

Tests: `tests/test_local_api.py` — 5 new cases covering default-port fallback, explicit-port strict failure, and real-socket bind behavior.