### PR TITLE
fix(mcp): degraded-but-connected serve when store is unresolvable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,6 +150,7 @@ agentacct serve
 Replace `hermes` with `opencode` or `openclaw` for those clients.
 
 - These clients keep MCP config in profile/global or client-specific locations, so `setup mcp` PREVIEWS the exact registration command instead of writing it.
+- First remove any stale pre-rename server, e.g. `opencode mcp remove agent-sentinel` (also `agent-chronicle`): only `agentacct` ships now, so a leftover old-name entry launches a command that no longer exists (ENOENT), which the client reports as a crashed MCP server.
 - Show the previewed command to the user and ask before modifying global agent configuration, then paste it into that client's own MCP setup flow.
 - For an unlisted MCP-capable client, use `--agent generic` to get a portable stdio server definition.
 

--- a/src/agent_chronicle/cli.py
+++ b/src/agent_chronicle/cli.py
@@ -112,7 +112,7 @@ from .hooks import (
 from .log_evidence import build_log_evidence_index, summarize_log_evidence_donor_rows
 from . import install_guide
 from .install_guide import full_prompt as install_guide_full_prompt, one_line_prompt as install_guide_one_line_prompt
-from .mcp import TOOLS, SentinelMCPServer, run_mcp_event_workflow_smoke, serve_stdio
+from .mcp import DEGRADED_NO_STORE_MESSAGE, TOOLS, SentinelMCPServer, run_mcp_event_workflow_smoke, serve_stdio
 from .mcp_client_smoke import MCPClientSmokeError, assert_deepseek_mcp_client_smoke_passed, run_deepseek_mcp_client_smoke
 from .outcome import (
     apply_judge_result,
@@ -949,11 +949,34 @@ def _print_codex_mcp_setup(config_store_dir: Path | str, *, command: str = "agen
     print(_codex_mcp_toml_block(config_store_dir, command=command).rstrip())
 
 
+def _print_stale_registration_remediation(agent: str) -> None:
+    """Tell the user to remove any leftover pre-rename server before adding agentacct.
+
+    A registration left over from the ``agent-sentinel`` / ``agent-chronicle``
+    era points at a command name that no longer ships (only ``agentacct`` does),
+    so the host tries to launch a missing binary — an ENOENT that reads to the
+    client as a crashed MCP server. Removing the dead entry first is the fix.
+    """
+    console.print(
+        "First remove any stale pre-rename server — a leftover agent-sentinel/agent-chronicle "
+        "entry launches a command that no longer exists (ENOENT), which the client reports as a crash:"
+    )
+    if agent == "generic":
+        console.print(
+            "In the agent's MCP config, delete any server named 'agent-sentinel' or 'agent-chronicle' "
+            "(only 'agentacct' ships now), then add the definition below."
+        )
+        return
+    print(f"{agent} mcp remove agent-sentinel")
+    print(f"{agent} mcp remove agent-chronicle")
+
+
 def _print_agent_mcp_preview(agent: str, config_store_dir: Path | str, *, command: str = "agentacct") -> None:
     quoted_store_dir = shlex.quote(str(config_store_dir))
     quoted_command = shlex.quote(command)
     if agent == "generic":
         console.print("Generic MCP-capable agent")
+        _print_stale_registration_remediation(agent)
         console.print("Use this stdio MCP server definition in the agent's project-local MCP config:")
         print(_claude_mcp_json(config_store_dir, command=command).rstrip())
         console.print("Command form:")
@@ -962,16 +985,19 @@ def _print_agent_mcp_preview(agent: str, config_store_dir: Path | str, *, comman
     if agent == "hermes":
         console.print("Hermes")
         console.print("Hermes manages MCP servers in the active Hermes profile, not in this repo.")
+        _print_stale_registration_remediation(agent)
         console.print("Copy/paste command:")
         print(f"hermes mcp add agentacct --command {quoted_command} --args mcp serve --store-dir {quoted_store_dir}")
         return
     if agent == "opencode":
         console.print("OpenCode")
+        _print_stale_registration_remediation(agent)
         console.print("Copy/paste command:")
         print(f"opencode mcp add agentacct -- {quoted_command} mcp serve --store-dir {quoted_store_dir}")
         return
     if agent == "openclaw":
         console.print("OpenClaw")
+        _print_stale_registration_remediation(agent)
         console.print("Copy/paste command:")
         print(
             "openclaw mcp add agentacct "
@@ -3235,15 +3261,31 @@ def mcp_serve(
     """Serve agentacct MCP tools over stdio.
 
     This exposes safe report/outcome/value primitives and does not call paid judge APIs.
-    Store resolution is strict: the MCP client controls this process's cwd, so a
-    visibly failed server beats a silently wrong ledger.
+    Store resolution stays strict — the MCP client controls this process's cwd,
+    so a silently wrong ledger is never acceptable — but a server that EXITS reads
+    to the host as a crash. So an unresolvable store starts a degraded-but-connected
+    session instead: initialize and tools/list still answer, recording tools return
+    a legible "no store configured" error, and no store is ever silently created.
     """
+    # As an MCP server this process's exit is the ONLY liveness signal the host
+    # has: an exit at startup reads as a crash. So an unresolvable store must
+    # NOT exit — it starts a degraded-but-connected session (initialize +
+    # tools/list still answer; recording tools return a legible error). We still
+    # never silently create or pick a store (honesty rule): degraded_reason is
+    # set and no store path is resolved.
+    resolved: Path | None = None
+    degraded_reason: str | None = None
     if store_dir is None:
         try:
             resolved = resolve_store_dir(None).path
         except StoreResolutionError as exc:
-            print(str(exc), file=sys.stderr)
-            raise typer.Exit(2) from exc
+            print(
+                f"agentacct mcp serve: {exc}\n"
+                "Starting a degraded MCP session (connected, but not recording): restart the server with "
+                f"--store-dir <absolute path> or set {ENV_STORE_DIR}=<absolute path>.",
+                file=sys.stderr,
+            )
+            degraded_reason = DEGRADED_NO_STORE_MESSAGE
     else:
         expanded = store_dir.expanduser()
         if expanded.is_absolute():
@@ -3258,7 +3300,7 @@ def mcp_serve(
             # named the store, which beats a dead server.
             try:
                 resolution = resolve_store_dir(None, env={})
-            except StoreResolutionError as exc:
+            except StoreResolutionError:
                 try:
                     env_value = store_env_dir_value(os.environ) or ""
                 except StoreResolutionError:
@@ -3284,13 +3326,19 @@ def mcp_serve(
                         )
                     print(
                         "Fix: re-run `agentacct setup mcp --agent <claude-code|codex> --write` in the project root to "
-                        f"write an absolute store path into the MCP config, or set {ENV_STORE_DIR}=<absolute path>.",
+                        f"write an absolute store path into the MCP config, or set {ENV_STORE_DIR}=<absolute path>. "
+                        "Starting a degraded MCP session (connected, but not recording) until then.",
                         file=sys.stderr,
                     )
-                    raise typer.Exit(2) from exc
+                    degraded_reason = DEGRADED_NO_STORE_MESSAGE
             else:
                 anchor = resolution.project_root if resolution.project_root is not None else resolution.path.parent.parent
                 resolved = anchor / expanded
+    if degraded_reason is not None:
+        # No resolvable store: stay connected but refuse to record. serve_stdio
+        # gets store_dir=None so it never constructs (or creates) a store.
+        serve_stdio(store_dir=None, degraded_reason=degraded_reason)
+        return
     print(f"agentacct mcp serve: store={resolved}", file=sys.stderr)
     serve_stdio(store_dir=resolved)
 

--- a/src/agent_chronicle/install_guide.py
+++ b/src/agent_chronicle/install_guide.py
@@ -149,6 +149,7 @@ def mcp_preview_block(agent: str) -> str:
 
 MCP_PREVIEW_NOTES = (
     "These clients keep MCP config in profile/global or client-specific locations, so `setup mcp` PREVIEWS the exact registration command instead of writing it.",
+    "First remove any stale pre-rename server, e.g. `opencode mcp remove agent-sentinel` (also `agent-chronicle`): only `agentacct` ships now, so a leftover old-name entry launches a command that no longer exists (ENOENT), which the client reports as a crashed MCP server.",
     "Show the previewed command to the user and ask before modifying global agent configuration, then paste it into that client's own MCP setup flow.",
     "For an unlisted MCP-capable client, use `--agent generic` to get a portable stdio server definition.",
 )

--- a/src/agent_chronicle/mcp.py
+++ b/src/agent_chronicle/mcp.py
@@ -763,26 +763,7 @@ class SentinelMCPServer:
         msg_id = message.get("id")
         try:
             if method == "initialize":
-                params = message.get("params", {})
-                requested_protocol = params.get("protocolVersion") if isinstance(params, dict) else None
-                protocol_version = requested_protocol if isinstance(requested_protocol, str) and requested_protocol else "2024-11-05"
-                return self._response(
-                    msg_id,
-                    {
-                        "protocolVersion": protocol_version,
-                        # Pre-rename registrations still launch this server under the old
-                        # config key; pairing accepts both (log_evidence), so the
-                        # serverInfo name can advertise the new brand unconditionally.
-                        "serverInfo": {"name": "agent-chronicle", "version": "0.1.0"},
-                        "capabilities": {"tools": {}},
-                        # Directive, tool-aware guidance delivered at the tool
-                        # layer, where Claude Code's tool-deferral barrier lives:
-                        # tells the agent to record its work (and to load these
-                        # tools first if they are deferred) even when a
-                        # background CLAUDE.md instruction would not reach it.
-                        "instructions": MCP_SERVER_INSTRUCTIONS,
-                    },
-                )
+                return self._response(msg_id, build_initialize_result(message.get("params", {})))
             if method == "notifications/initialized":
                 return None
             if method == "tools/list":
@@ -1575,10 +1556,107 @@ def run_mcp_event_workflow_smoke(*, store_dir: Path | str | None = None, run_id:
     }
 
 
-def serve_stdio(*, store_dir: Path | str, stdin: BinaryIO | None = None, stdout: BinaryIO | None = None) -> None:
-    server = SentinelMCPServer(store_dir=store_dir)
+def build_initialize_result(params: Any) -> dict[str, Any]:
+    """The static MCP ``initialize`` result, shared by the live and degraded servers.
+
+    A degraded (store-less) server must answer ``initialize`` and ``tools/list``
+    byte-identically to the live server so the host stays fully connected;
+    factoring the payload here keeps the two from drifting.
+    """
+    requested_protocol = params.get("protocolVersion") if isinstance(params, dict) else None
+    protocol_version = requested_protocol if isinstance(requested_protocol, str) and requested_protocol else "2024-11-05"
+    return {
+        "protocolVersion": protocol_version,
+        # Pre-rename registrations still launch this server under the old
+        # config key; pairing accepts both (log_evidence), so the
+        # serverInfo name can advertise the new brand unconditionally.
+        "serverInfo": {"name": "agent-chronicle", "version": "0.1.0"},
+        "capabilities": {"tools": {}},
+        # Directive, tool-aware guidance delivered at the tool
+        # layer, where Claude Code's tool-deferral barrier lives:
+        # tells the agent to record its work (and to load these
+        # tools first if they are deferred) even when a
+        # background CLAUDE.md instruction would not reach it.
+        "instructions": MCP_SERVER_INSTRUCTIONS,
+    }
+
+
+# The tool-call error a degraded server returns when no store could be
+# resolved. It must be legible in a host's error surface and tell the user
+# exactly how to recover — WITHOUT the server ever creating or picking a store
+# on its own (agentacct's honesty rule).
+DEGRADED_NO_STORE_MESSAGE = (
+    "agentacct: no store configured — restart the MCP server with "
+    "--store-dir <abs path> (or set an absolute AGENT_CHRONICLE_STORE_DIR). "
+    "The server is connected but cannot record work until a store is set; "
+    "it will not create or pick a store on its own."
+)
+
+
+def degraded_store_unwritable_message(store_dir: Path | str | None, error: object) -> str:
+    """Tool-call error when a configured --store-dir cannot be used (mkdir failed)."""
+    return (
+        f"agentacct: configured store directory {store_dir} is not usable ({error}). "
+        "Restart the MCP server with a writable --store-dir <abs path> "
+        "(or an absolute AGENT_CHRONICLE_STORE_DIR). The server is connected but "
+        "cannot record work until a usable store is set."
+    )
+
+
+class _DegradedMCPServer:
+    """Store-less stand-in that keeps an MCP stdio session alive and honest.
+
+    When the store cannot be resolved — or the configured ``--store-dir`` is
+    not usable — constructing the real server would raise before the read loop,
+    and a server that exits at startup looks CRASHED to the host (the most
+    likely cause of the reported "it crashed my opencode"). Instead we run this:
+    it answers ``initialize`` and ``tools/list`` exactly like the live server so
+    the host stays connected, but every tool call returns a legible JSON-RPC
+    error explaining how to configure a store. It NEVER creates or selects a
+    store — staying connected while refusing to record is the entire point.
+    """
+
+    def __init__(self, reason: str) -> None:
+        self._reason = reason
+
+    def handle_message(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        method = message.get("method")
+        msg_id = message.get("id")
+        if method == "initialize":
+            return SentinelMCPServer._response(msg_id, build_initialize_result(message.get("params", {})))
+        if method == "notifications/initialized":
+            return None
+        if method == "tools/list":
+            return SentinelMCPServer._response(msg_id, {"tools": TOOLS})
+        if method == "tools/call":
+            # Same serialized-error shape the live server uses for unexpected
+            # failures: a clear message, never a crash, never a silent store.
+            return SentinelMCPServer._error(msg_id, -32000, self._reason)
+        return SentinelMCPServer._error(msg_id, -32601, f"Unknown method: {method}")
+
+
+def serve_stdio(
+    *,
+    store_dir: Path | str | None,
+    stdin: BinaryIO | None = None,
+    stdout: BinaryIO | None = None,
+    degraded_reason: str | None = None,
+) -> None:
     stdin_stream: BinaryIO = stdin or sys.stdin.buffer
     stdout_stream: BinaryIO = stdout or sys.stdout.buffer
+    server: SentinelMCPServer | _DegradedMCPServer
+    if degraded_reason is not None:
+        # The store was unresolvable upstream (cli.mcp_serve): run degraded
+        # WITHOUT touching the filesystem. Never construct a store here.
+        server = _DegradedMCPServer(degraded_reason)
+    else:
+        try:
+            server = SentinelMCPServer(store_dir=store_dir)
+        except Exception as exc:  # noqa: BLE001 - a store we cannot build must degrade, not crash the server.
+            # An unwritable/invalid --store-dir (RunStore.mkdir failed) must
+            # surface as a JSON-RPC error at the first tool call, NOT an
+            # uncaught startup exception that the host reads as a dead server.
+            server = _DegradedMCPServer(degraded_store_unwritable_message(store_dir, exc))
     while True:
         framed = read_mcp_message_with_framing(stdin_stream)
         if framed is None:

--- a/tests/test_mcp_onboarding.py
+++ b/tests/test_mcp_onboarding.py
@@ -555,9 +555,24 @@ def test_setup_mcp_opencode_preview_uses_verified_separator_syntax(tmp_path: Pat
 
     assert result.exit_code == 0, result.output
     assert "OpenCode" in result.output
-    assert "opencode mcp add agentacct -- agentacct mcp serve" in result.output
+    # The registration command must carry the absolute --store-dir (store-pinned
+    # form), not the bare `mcp serve` that would resolve against the client cwd.
+    expected_store = str((tmp_path / ".agent-sentinel" / "state").resolve())
+    assert f"opencode mcp add agentacct -- agentacct mcp serve --store-dir {expected_store}" in result.output
     assert "Preview only" in result.output
     assert not (tmp_path / ".config" / "opencode" / "opencode.jsonc").exists()
+
+
+def test_setup_mcp_opencode_preview_advises_removing_stale_old_name_server(tmp_path: Path) -> None:
+    """The reported opencode crash was a leftover pre-rename registration whose
+    old binary no longer exists (ENOENT). The preview must tell the user to
+    remove any stale agent-sentinel/agent-chronicle server before adding
+    agentacct."""
+    result = runner.invoke(app, ["setup", "mcp", "--agent", "opencode", "--project-dir", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "opencode mcp remove agent-sentinel" in result.output
+    assert "opencode mcp remove agent-chronicle" in result.output
 
 
 def test_setup_mcp_openclaw_preview_uses_repeatable_arg_syntax(tmp_path: Path) -> None:

--- a/tests/test_mcp_serve_degraded.py
+++ b/tests/test_mcp_serve_degraded.py
@@ -1,0 +1,200 @@
+"""Degraded-but-connected `agentacct mcp serve` (fix/opencode-connection, Phase 1).
+
+An MCP server's process exit is the only liveness signal the host has: exiting
+at startup because the store could not be resolved reads to the client as a
+CRASH (the most likely cause of the reported "it crashed my opencode"). These
+tests lock the new contract:
+
+- a store-less server stays connected — it answers `initialize` and
+  `tools/list` and returns a legible JSON-RPC error on any recording tool call,
+  never exits non-zero, and never creates or picks a store;
+- an unwritable/invalid `--store-dir` surfaces as that same JSON-RPC error, not
+  an uncaught startup exception;
+- stdout carries only JSON-RPC frames (no banner/log) before the first response.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from agent_chronicle.mcp import (
+    DEGRADED_NO_STORE_MESSAGE,
+    read_mcp_message_with_framing,
+    serve_stdio,
+)
+
+_REQUESTS = (
+    {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}}},
+    {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "sentinel_record_section",
+            "arguments": {"source": "opencode", "section_id": "x", "section_status": "started"},
+        },
+    },
+)
+
+
+def _request_bytes() -> bytes:
+    # Raw newline-delimited JSON — the framing Claude Code / Codex / opencode use
+    # for local stdio MCP servers.
+    return b"".join(json.dumps(message).encode("utf-8") + b"\n" for message in _REQUESTS)
+
+
+def _drive_serve_stdio(**serve_kwargs) -> tuple[list[dict], bytes]:
+    out = io.BytesIO()
+    serve_stdio(stdin=io.BytesIO(_request_bytes()), stdout=out, **serve_kwargs)
+    raw = out.getvalue()
+    reader = io.BytesIO(raw)
+    responses: list[dict] = []
+    while True:
+        framed = read_mcp_message_with_framing(reader)
+        if framed is None:
+            break
+        responses.append(framed[0])
+    return responses, raw
+
+
+def _parse_responses(raw_stdout: bytes) -> list[dict]:
+    reader = io.BytesIO(raw_stdout)
+    responses: list[dict] = []
+    while True:
+        framed = read_mcp_message_with_framing(reader)
+        if framed is None:
+            break
+        responses.append(framed[0])
+    return responses
+
+
+# --- In-process serve_stdio (fast, deterministic) ----------------------------
+
+
+def test_serve_stdio_degraded_answers_handshake_and_errors_on_tool_call() -> None:
+    responses, raw = _drive_serve_stdio(store_dir=None, degraded_reason=DEGRADED_NO_STORE_MESSAGE)
+
+    assert len(responses) == 3
+    init, tools, call = responses
+
+    # initialize + tools/list answer exactly like the live server.
+    assert init["result"]["serverInfo"]["name"] == "agent-chronicle"
+    assert init["result"]["protocolVersion"] == "2024-11-05"
+    assert "instructions" in init["result"]
+    assert isinstance(tools["result"]["tools"], list) and tools["result"]["tools"]
+
+    # The recording tool call returns a legible JSON-RPC error, not a crash.
+    assert "result" not in call
+    assert call["error"]["code"] == -32000
+    assert "no store configured" in call["error"]["message"]
+
+    # Stdout cleanliness: the very first byte is the JSON-RPC frame — no banner
+    # or log precedes the first response.
+    assert raw[:1] == b"{"
+
+
+def test_serve_stdio_unwritable_store_dir_degrades_instead_of_raising(tmp_path: Path) -> None:
+    blocker = tmp_path / "afile"
+    blocker.write_text("not a directory", encoding="utf-8")
+    bad_store = blocker / "state"  # mkdir(parents=True) must fail: parent is a file
+
+    # Must NOT raise before the read loop.
+    responses, _raw = _drive_serve_stdio(store_dir=bad_store)
+
+    assert len(responses) == 3
+    init, _tools, call = responses
+    assert init["result"]["serverInfo"]["name"] == "agent-chronicle"
+    assert call["error"]["code"] == -32000
+    assert "not usable" in call["error"]["message"]
+    assert str(bad_store) in call["error"]["message"]
+
+    # Honesty rule: no stray store was created.
+    assert not bad_store.exists()
+    assert blocker.is_file()
+
+
+# --- End-to-end subprocess (the EXACT registered command form) ----------------
+
+
+def _serve_env(home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    # Store-less scenario: strip the suite-wide store env (conftest sets it) and
+    # both accepted names, and point HOME at a fresh dir with no global store.
+    env.pop("AGENT_CHRONICLE_STORE_DIR", None)
+    env.pop("AGENT_SENTINEL_STORE_DIR", None)
+    env["HOME"] = str(home)
+    return env
+
+
+def _run_serve(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", "from agent_chronicle.cli import app; app()", *args],
+        input=_request_bytes(),
+        cwd=str(cwd),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+    )
+
+
+def test_storeless_mcp_serve_stays_connected_end_to_end(tmp_path: Path) -> None:
+    """Launch the EXACT store-less registered form (`agentacct mcp serve`) from a
+    store-less cwd and assert the process does NOT exit non-zero: it answers the
+    handshake and returns a clear JSON-RPC error on a record tool call."""
+    home = tmp_path / "home"
+    home.mkdir()
+    cwd = tmp_path / "storeless"
+    cwd.mkdir()
+
+    proc = _run_serve(["mcp", "serve"], cwd=cwd, env=_serve_env(home))
+
+    # Never looks dead to the host.
+    assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+
+    responses = _parse_responses(proc.stdout)
+    assert len(responses) == 3
+    init, tools, call = responses
+    assert init["result"]["serverInfo"]["name"] == "agent-chronicle"
+    assert isinstance(tools["result"]["tools"], list) and tools["result"]["tools"]
+    assert call["error"]["code"] == -32000
+    assert "no store configured" in call["error"]["message"]
+
+    # Stdout carries only JSON-RPC frames — no banner/log before the first one.
+    assert proc.stdout[:1] == b"{"
+
+    # The human-facing diagnostic goes to stderr, not stdout.
+    stderr = proc.stderr.decode("utf-8", "replace")
+    assert "No agentacct store found" in stderr
+    assert "degraded" in stderr.lower()
+
+    # Honesty rule: the store-less server created nothing.
+    assert not (cwd / ".agent-sentinel").exists()
+    assert not (home / ".agent-sentinel").exists()
+
+
+def test_unwritable_store_dir_mcp_serve_does_not_crash_end_to_end(tmp_path: Path) -> None:
+    """An unwritable absolute --store-dir must surface as a JSON-RPC error, not
+    an uncaught startup exception (which would exit non-zero with a traceback)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    blocker = tmp_path / "afile"
+    blocker.write_text("not a directory", encoding="utf-8")
+    bad_store = blocker / "state"
+
+    proc = _run_serve(["mcp", "serve", "--store-dir", str(bad_store)], cwd=tmp_path, env=_serve_env(home))
+
+    assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+    responses = _parse_responses(proc.stdout)
+    assert len(responses) == 3
+    init, _tools, call = responses
+    assert init["result"]["serverInfo"]["name"] == "agent-chronicle"
+    assert call["error"]["code"] == -32000
+    assert "not usable" in call["error"]["message"]
+    assert not bad_store.exists()

--- a/tests/test_rename_compat.py
+++ b/tests/test_rename_compat.py
@@ -589,6 +589,12 @@ _ALLOWED_OLD_NAME_TOKENS = (
     # the pre-rename smoke commands its 2026-06-27 run actually used, and the
     # doc-gate test quotes them (dated evidence keeps the observed name).
     "agent-sentinel smoke",
+    # Stale-registration remediation (fix/opencode-connection): the MCP preview
+    # and install notes deliberately name the old server so the user can REMOVE
+    # a leftover pre-rename registration (its old binary no longer exists — the
+    # ENOENT that reads as a crash). These two forms carry that guidance.
+    "mcp remove agent-sentinel",  # `opencode mcp remove agent-sentinel` remediation command
+    "agent-sentinel/agent-chronicle",  # prose pairing in the "remove any stale ..." guidance
 )
 
 

--- a/tests/test_store_defaults_cli.py
+++ b/tests/test_store_defaults_cli.py
@@ -215,30 +215,46 @@ def test_mcp_serve_relative_store_dir_resolves_against_project_root(tmp_path, mo
     assert not (subdir / ".agent-sentinel").exists()
 
 
-def test_mcp_serve_relative_store_dir_without_project_fails_loudly(tmp_path, monkeypatch) -> None:
+def test_mcp_serve_relative_store_dir_without_project_starts_degraded(tmp_path, monkeypatch) -> None:
+    """A legacy relative --store-dir with no project anchor must NOT exit — a
+    non-zero exit reads to the MCP host as a crashed server. It starts a
+    degraded-but-connected session and still never creates a stray store."""
     cwd, fake_home = _isolate(monkeypatch, tmp_path)
-    served: list[Path] = []
-    monkeypatch.setattr(cli_module, "serve_stdio", lambda *, store_dir: served.append(Path(store_dir)))
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        cli_module,
+        "serve_stdio",
+        lambda *, store_dir=None, degraded_reason=None: calls.append({"store_dir": store_dir, "degraded_reason": degraded_reason}),
+    )
 
     result = runner.invoke(app, ["mcp", "serve", "--store-dir", ".agent-sentinel/state"])
 
-    assert result.exit_code == 2, result.output
+    assert result.exit_code == 0, result.output
     assert "legacy config form" in result.output
     assert "setup mcp --agent" in result.output
-    assert served == []
+    assert "degraded" in result.output.lower()
+    assert len(calls) == 1
+    assert calls[0]["store_dir"] is None
+    assert calls[0]["degraded_reason"] is not None
     assert not (cwd / ".agent-sentinel").exists()
     assert not (fake_home / ".agent-sentinel").exists()
 
 
-def test_mcp_serve_without_store_dir_uses_resolver_and_fails_outside_project(tmp_path, monkeypatch) -> None:
+def test_mcp_serve_without_store_dir_starts_degraded_outside_project(tmp_path, monkeypatch) -> None:
     _isolate(monkeypatch, tmp_path)
-    served: list[Path] = []
-    monkeypatch.setattr(cli_module, "serve_stdio", lambda *, store_dir: served.append(Path(store_dir)))
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        cli_module,
+        "serve_stdio",
+        lambda *, store_dir=None, degraded_reason=None: calls.append({"store_dir": store_dir, "degraded_reason": degraded_reason}),
+    )
 
     outside = runner.invoke(app, ["mcp", "serve"])
-    assert outside.exit_code == 2, outside.output
+    assert outside.exit_code == 0, outside.output
     assert "No agentacct store found" in outside.output
-    assert served == []
+    assert len(calls) == 1
+    assert calls[0]["store_dir"] is None
+    assert calls[0]["degraded_reason"] is not None
 
     project = tmp_path / "project"
     project.mkdir()
@@ -246,7 +262,8 @@ def test_mcp_serve_without_store_dir_uses_resolver_and_fails_outside_project(tmp
     monkeypatch.chdir(project)
     inside = runner.invoke(app, ["mcp", "serve"])
     assert inside.exit_code == 0, inside.output
-    assert served == [(project / ".agent-sentinel" / "state").resolve()]
+    assert calls[-1]["store_dir"] == (project / ".agent-sentinel" / "state").resolve()
+    assert calls[-1]["degraded_reason"] is None
 
 
 def test_mcp_serve_honors_env_store_dir(tmp_path, monkeypatch) -> None:
@@ -331,29 +348,39 @@ def test_mcp_serve_relative_store_dir_without_project_honors_env_store(tmp_path,
 
 def test_mcp_serve_relative_store_dir_refusal_mentions_env_option(tmp_path, monkeypatch) -> None:
     _isolate(monkeypatch, tmp_path)
-    served: list[Path] = []
-    monkeypatch.setattr(cli_module, "serve_stdio", lambda *, store_dir: served.append(Path(store_dir)))
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        cli_module,
+        "serve_stdio",
+        lambda *, store_dir=None, degraded_reason=None: calls.append({"store_dir": store_dir, "degraded_reason": degraded_reason}),
+    )
 
     result = runner.invoke(app, ["mcp", "serve", "--store-dir", ".agent-sentinel/state"])
 
-    assert result.exit_code == 2, result.output
+    assert result.exit_code == 0, result.output
     assert "legacy config form" in result.output
     assert "setup mcp --agent" in result.output
     assert f"set {ENV_STORE_DIR}=<absolute path>" in result.output
-    assert served == []
+    assert calls[0]["degraded_reason"] is not None
+    assert calls[0]["store_dir"] is None
 
 
 def test_mcp_serve_relative_store_dir_refusal_flags_relative_env_value(tmp_path, monkeypatch) -> None:
     _isolate(monkeypatch, tmp_path)
     monkeypatch.setenv(ENV_STORE_DIR, "relative/env-store")
-    served: list[Path] = []
-    monkeypatch.setattr(cli_module, "serve_stdio", lambda *, store_dir: served.append(Path(store_dir)))
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        cli_module,
+        "serve_stdio",
+        lambda *, store_dir=None, degraded_reason=None: calls.append({"store_dir": store_dir, "degraded_reason": degraded_reason}),
+    )
 
     result = runner.invoke(app, ["mcp", "serve", "--store-dir", ".agent-sentinel/state"])
 
-    assert result.exit_code == 2, result.output
+    assert result.exit_code == 0, result.output
     assert "not an absolute path" in result.output
-    assert served == []
+    assert calls[0]["degraded_reason"] is not None
+    assert calls[0]["store_dir"] is None
 
 
 def test_version_flag_prints_installed_version_and_exits() -> None:


### PR DESCRIPTION
An MCP server whose process exits at startup reads to the host (opencode / Claude Code / Codex) as a crash. `agentacct mcp serve` previously did `raise typer.Exit(2)` when it could not resolve a store — the most likely cause of the reported "it crashed my opencode."

`mcp serve` now starts a **degraded-but-connected** stdio session instead of exiting: it answers `initialize` + `tools/list` normally so the host stays connected, and returns a clear JSON-RPC error on any recording tool call ("no store configured — restart with --store-dir <abs path>"). It never exits non-zero and never silently creates or picks a store. `serve_stdio` also wraps store construction so an unwritable/invalid `--store-dir` surfaces as that same JSON-RPC error rather than an uncaught startup exception.

MCP setup previews for opencode/hermes/openclaw/generic now tell the user to remove any stale pre-rename server (`agent-sentinel` / `agent-chronicle`) first — a leftover old-name registration launches a binary that no longer exists (ENOENT), the other crash vector.

Tests: new `tests/test_mcp_serve_degraded.py` drives the exact registered command form from a store-less cwd (subprocess asserts returncode 0, handshake answered, tool call errors, clean stdout) and the unwritable-store case; existing exit-2 serve tests updated to the degraded contract. Full suite green.