### PR TITLE
feat(onboard): install once globally by default (zero repo files)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # agentacct — install runbook for coding agents
 
-This file is written for the CODING AGENT performing the install (Claude Code, Codex, Hermes, OpenCode, OpenClaw, or any MCP-capable agent). agentacct is public: install it with `pipx install agentacct` (or straight from the public repository with `pipx install git+https://github.com/mikehasa/agentacct`). Work from the target repository's root and follow the section for the client you are running inside.
+This file is written for the CODING AGENT performing the install (Claude Code, Codex, Hermes, OpenCode, OpenClaw, or any MCP-capable agent). agentacct is public: install it with `pipx install agentacct` (or straight from the public repository with `pipx install git+https://github.com/mikehasa/agentacct`). The fast path is `agentacct onboard`, which installs agentacct once per machine (global by default, zero repo files) — see Step 2. The per-client sections (Step 3) are the manual, per-project equivalent; run them from the target repository's root for the client you are running inside.
 
 <!-- Consistency contract: the command blocks, notes, and capability matrix below
      are defined in src/agent_chronicle/install_guide.py and embedded here verbatim.
@@ -17,7 +17,7 @@ agentacct is local-first Agent Work Intelligence for coding agents:
 Hard rules for this install:
 
 - Observe-only. NEVER store, request, or echo provider API keys — nothing in this install needs one.
-- No telemetry. All state stays local to this machine: in the project store under `.agent-sentinel/` (gitignored; the store directory keeps the pre-rename name `.agent-sentinel/` for compatibility with existing stores) by default, or in the global store directory if you follow the optional Global install section, plus the client config files named below.
+- No telemetry. All state stays local to this machine: `agentacct onboard` uses one global store by default; with `--scope project` it uses a per-repo store under `.agent-sentinel/` (gitignored; the directory keeps the pre-rename name `.agent-sentinel/` for compatibility with existing stores). Either way, only the client config files each path writes change.
 - Do not modify global/profile client configuration without showing the exact command and asking first.
 - If `agentacct` is not on PATH, run it via its durable absolute path — never a throwaway temp venv. MCP config writes embed the absolute executable automatically.
 
@@ -56,20 +56,20 @@ command -v agentacct
 
 If `command -v` prints nothing, use the absolute path for every command below: pipx installs to `$HOME/.local/bin/agentacct`; the dedicated-venv fallback is `$HOME/.agentacct/bin/agentacct`. Requires Python >= 3.11 on macOS or Linux (Windows via WSL).
 
-## Step 2 — preferred project onboarding
+## Step 2 — onboard (install once, global by default)
 
-From the target repository root, run:
+Run:
 
 ```bash
 agentacct onboard
 agentacct status
 ```
 
-`onboard` detects an importable local usage source, initializes the project-local store and recording configuration, performs one real local usage sync, and starts continuous sync plus the dashboard. It changes project-local files only: no provider keys, billing connection, or global client settings are required. To select a client explicitly, use `--agent codex` or `--agent claude-code`.
+`onboard` installs agentacct ONCE per machine and writes ZERO files into any repo: it registers a user-scope MCP server, hook, and standing instructions against one global store (default `~/.local/state/agentacct/state`; older `~/.agent-sentinel-global/state` stores are still recognized), performs one real local usage sync, and starts continuous sync plus the dashboard. It merges the hook and `ENABLE_TOOL_SEARCH` env into `~/.claude/settings.json` only with your ok (pass `--yes` for a non-interactive run). To select a client explicitly, use `--agent codex` or `--agent claude-code`. For the legacy per-repo install, add `--scope project`: it changes project-local files only and gives this repo its own `.agent-sentinel/` store (see Step 3 and "Global install by hand" below).
 
-The command finishing successfully means agentacct is configured; it does not mean a real Task has appeared. **Open a NEW agent session in this project after onboarding.** MCP servers and hooks bind when the client session starts, so the session that ran onboarding cannot see the newly registered tools. agentacct stays in an honest waiting state until a real recognized client session appears; a demo row does not count.
+The command finishing successfully means agentacct is configured; it does not mean a real Task has appeared. **Open a NEW agent session (in ANY repo) after onboarding.** MCP servers and hooks bind when the client session starts, so the session that ran onboarding cannot see the newly registered tools. agentacct stays in an honest waiting state until a real recognized client session appears; a demo row does not count.
 
-The managed local runtime survives the invoking shell and uses one project-local store. Its lifecycle is:
+The managed local runtime survives the invoking shell and uses one store. Its lifecycle is:
 
 ```bash
 agentacct start
@@ -83,7 +83,7 @@ agentacct repair
 - `stop` signals only processes whose complete agentacct ownership proof still matches.
 - `repair` clears dead or corrupt owned runtime state without adopting or killing an unknown process.
 
-The dashboard is at http://127.0.0.1:8765 by default. Everything stays local to this machine under `.agent-sentinel/` (gitignored); onboarding neither requests provider API keys nor uploads session data.
+The dashboard is at http://127.0.0.1:8765 by default. Everything stays local to this machine (the global store by default, or a per-repo `.agent-sentinel/` store under `--scope project`); onboarding neither requests provider API keys nor uploads session data.
 
 ## Migration notes (formerly Agent Sentinel)
 
@@ -94,9 +94,9 @@ agentacct was formerly Agent Sentinel; pre-rename installs keep working without 
 - Pre-rename `agent-sentinel` MCP registrations and `agent-sentinel:begin` instruction blocks stay recognized; stored data and the `.agent-sentinel/` store directories keep their pre-rename spellings forever (data format, not branding).
 - Caveat — foreign PyPI package collision: an unrelated PyPI project named `agent-sentinel` (0.5.0) also installs a `bin/agent-sentinel` script. If both packages land in the SAME environment, the later install silently overwrites that script (pip prints no warning), and `pip uninstall agent-sentinel` (the foreign package) deletes the alias out from under agentacct — pre-rename registrations and wrappers resolving the old binary name then fail until `pip install --force-reinstall agentacct`. Do not install both in one environment; pipx refuses the second install because the app names collide.
 
-## Step 3 — advanced manual client setup
+## Step 3 — advanced: manual per-project client setup
 
-Use this fallback when client auto-detection is unavailable or you need to configure integrations separately. Run everything from the target repository root.
+Use this per-repo (`--scope project`) path when client auto-detection is unavailable, when you want a repo to keep its own store, or when you need to configure integrations separately. Run everything from the target repository root.
 
 ### Claude Code
 
@@ -203,9 +203,9 @@ agentacct control launch --help
 
 `control launch` stays in the foreground until the attempt is terminal; the long-running dashboard owns the persistent web supervisor. An attempt freezes the current registered agent revision, and launch fails closed if that agent's argv changes after the attempt or approval was created; create a new attempt to authorize the new revision. Control status and product JSON are sanitized: they never return registered absolute paths, argv, PIDs/process groups, executable/cwd fingerprints, manifest ids, or ownership nonces.
 
-## Global install (single-user machine, optional)
+## Global install by hand (single-user machine)
 
-The per-agent sections above install agentacct per repository: each repo gets its own store, dashboard, and MCP registration. On a single-user machine you can instead register ONE user-scope MCP server, hook, and dashboard against ONE global store — machine-wide usage AND machine-wide work context on a single dashboard, no per-repo install step. State then lives in the global store directory below instead of each repository.
+This is what `agentacct onboard` does for you by default: it installs agentacct ONCE per machine — one user-scope MCP server, hook, and dashboard against ONE global store — so machine-wide usage AND machine-wide work context land on a single dashboard, with ZERO files written into any repo. The default onboard store is the XDG state dir (`~/.local/state/agentacct/state`); older global stores (`~/.agent-sentinel-global/state`) are still recognized. The runbook below is the do-it-by-hand equivalent — use it when you want to wire the registrations yourself or point them at an explicit store. The per-agent sections above are the other path: `--scope project` installs per repository, giving each repo its own store, dashboard, and MCP registration.
 
 ```bash
 mkdir -p "$HOME/.agent-sentinel-global/state"

--- a/README.md
+++ b/README.md
@@ -29,33 +29,34 @@ Requires Python >= 3.11 on macOS or Linux; Windows is supported only via WSL.
 
 ```bash
 pipx install agentacct
-agentacct onboard   # from your repo root
+agentacct onboard   # once per machine (global by default)
 ```
 
 No `pipx` yet? Install it first with `brew install pipx` (macOS) or `python3 -m pip install --user pipx` — or skip pipx entirely and use `uv tool install agentacct`. See [INSTALL.md](INSTALL.md) for a plain-`venv` fallback.
 
-`onboard` detects your local coding-agent logs, sets up the project-local store, runs a first usage sync, and starts the dashboard at `http://127.0.0.1:8765`. Then open a **new** agent session in the project — MCP servers and hooks bind at session start, so the session that ran onboarding cannot become the first recorded Task.
+`onboard` installs agentacct once per machine (global by default, writing zero files into your repo): it detects your local coding-agent logs, sets up a global store, runs a first usage sync, and starts the dashboard at `http://127.0.0.1:8765`. Then open a **new** agent session in any repo — MCP servers and hooks bind at session start, so the session that ran onboarding cannot become the first recorded Task. (Prefer a per-repo install? Run `agentacct onboard --scope project` instead.)
 
-Prefer to let the agent do it? Paste this into the coding agent working in your target repo:
+Prefer to let the agent do it? Paste this into your coding agent:
 
 ```text
-Install and set up agentacct in this repo — a local-first dashboard that reads my
+Install and set up agentacct — a local-first dashboard that reads my
 coding-agent logs read-only and shows honest token usage and cost.
 
 Run `pipx install agentacct`
 (or `pipx install git+https://github.com/mikehasa/agentacct`),
-then `agentacct onboard` from this repo root, then tell me the dashboard URL.
+then `agentacct onboard` (installs once per machine, global by default, zero
+files written into the repo), then tell me the dashboard URL.
 
 Observe-only: never store, request, or echo any API key; all state stays local
-under `.agent-sentinel/`. Don't modify my global client config without showing
-the exact command first.
+on this machine. Don't modify my global client config without showing the exact
+command first.
 ```
 
-The agent then follows [INSTALL.md](INSTALL.md), the canonical runbook: manual per-client setup, a machine-wide global install, and the full per-client capability matrix. `agentacct setup prompt --agent <client>` prints the same prompt.
+The agent then follows [INSTALL.md](INSTALL.md), the canonical runbook: the global install, the manual per-client setup, and the full per-client capability matrix. `agentacct setup prompt --agent <client>` prints the same prompt.
 
 Want to look around before touching your real data? `agentacct demo` runs a safe local walkthrough in a throwaway temporary store — no provider keys, no paid API calls.
 
-The managed runtime is controlled with `agentacct start` / `status` / `stop` / `repair`; all state lives in the project-local `.agent-sentinel/` directory (gitignored; the directory keeps its pre-rename spelling for data compatibility).
+The managed runtime is controlled with `agentacct start` / `status` / `stop` / `repair`; all state lives in the global store (by default `~/.local/state/agentacct/state`; older global stores under `~/.agent-sentinel-global/state` are still recognized). A `--scope project` install keeps its state in the repo's `.agent-sentinel/` directory instead (gitignored; the directory keeps its pre-rename spelling for data compatibility).
 
 ### Uninstall
 
@@ -65,7 +66,7 @@ agentacct uninstall-autostart  # only if you installed autostart
 pipx uninstall agentacct
 ```
 
-Then, per onboarded project: delete the `.agent-sentinel/` directory (that project's local ledger — keep it if you want the history) and remove the agentacct entries onboarding added to the client config (`.mcp.json` / `.claude/settings.local.json`, or `~/.codex/config.toml`). If you installed the standing instruction block, remove it first with `agentacct setup instructions --agent <client> --user --remove`.
+Then remove what onboarding added. For a global install (the default): delete the global store (`~/.local/state/agentacct/state` — keep it if you want the history) and the agentacct entries in your user config (`~/.claude.json`, the merged blocks in `~/.claude/settings.json`, the `~/.claude/hooks/` wrapper, and `~/.codex/config.toml`). For a `--scope project` install: delete that repo's `.agent-sentinel/` directory (that project's local ledger) and the agentacct entries onboarding added to `.mcp.json` / `.claude/settings.local.json` / `~/.codex/config.toml`. If you installed the standing instruction block, remove it first with `agentacct setup instructions --agent <client> --user --remove`.
 
 ## What it is honest about
 

--- a/src/agent_chronicle/api.py
+++ b/src/agent_chronicle/api.py
@@ -119,6 +119,7 @@ from .session_observations import (
 )
 from .source_discovery import UsageSourceDiscovery, discover_usage_sources
 from .storage import validate_run_id
+from .store_resolution import is_recognized_global_store
 from .supervisor import OwnedSupervisor, SupervisorAlreadyRunning, SupervisorError
 from .task_continuations import ClientSessionRef, ContinuationTaskError, ContinuationTaskStore
 from .task_identity import TaskIdentityCodec
@@ -185,10 +186,14 @@ MECHANICAL_CONFLICT_ROW_LIMIT = DEFAULT_MECHANICAL_CONFLICT_ROW_LIMIT
 
 
 def _is_documented_global_store(store_dir: Path | str) -> bool:
-    """Whether this is agentacct's frozen machine-wide store layout."""
+    """Whether this is one of agentacct's machine-wide store layouts.
 
-    path = Path(store_dir).expanduser()
-    return path.name == "state" and path.parent.name == ".agent-sentinel-global"
+    Recognizes the legacy ``-global`` dot family AND the new canonical
+    ``$XDG_STATE_HOME/agentacct/state`` location (delegated to the single
+    recognize-many source of truth in store_resolution).
+    """
+
+    return is_recognized_global_store(store_dir)
 
 
 def _store_scope_and_label(store_dir: Path | str) -> tuple[str, str | None]:

--- a/src/agent_chronicle/canonical/legacy_import.py
+++ b/src/agent_chronicle/canonical/legacy_import.py
@@ -930,6 +930,9 @@ class LegacyImporter:
             (".agent-sentinel-global", "state"),
             (".agent-chronicle", "state"),
             (".agent-chronicle-global", "state"),
+            # New canonical global store: match the agentacct/state pair (the bare
+            # name "agentacct" is too generic to forbid on its own).
+            ("agentacct", "state"),
         }
         if any(
             lowered_parts[index : index + 2] in forbidden_pairs

--- a/src/agent_chronicle/canonical/live_paths.py
+++ b/src/agent_chronicle/canonical/live_paths.py
@@ -14,6 +14,8 @@ from pathlib import Path
 _LIVE_ROOT_ENV_NAMES = (
     "AGENT_CHRONICLE_STORE_DIR",
     "AGENT_SENTINEL_STORE_DIR",
+    "AGENT_CHRONICLE_GLOBAL_STORE_DIR",
+    "AGENT_SENTINEL_GLOBAL_STORE_DIR",
     "CODEX_HOME",
 )
 
@@ -55,7 +57,15 @@ def configured_live_state_roots() -> tuple[Path, ...]:
         home / ".agent-chronicle",
         home / ".agent-chronicle-global" / "state",
         home / ".codex",
+        # New canonical global store (XDG-shaped). Concrete path, so no bare
+        # "agentacct" name enters the component-shape blocklists.
+        home / ".local" / "state" / "agentacct" / "state",
     }
+    xdg_state = (os.environ.get("XDG_STATE_HOME") or "").strip()
+    if xdg_state:
+        xdg_base = Path(xdg_state).expanduser()
+        if xdg_base.is_absolute():
+            roots.add(xdg_base / "agentacct" / "state")
     for variable in _LIVE_ROOT_ENV_NAMES:
         value = (os.environ.get(variable) or "").strip()
         if not value:

--- a/src/agent_chronicle/canonical/snapshot.py
+++ b/src/agent_chronicle/canonical/snapshot.py
@@ -40,6 +40,10 @@ _FORBIDDEN_STATE_COMPONENT_SEQUENCES = (
     (".agent-sentinel-global", "state"),
     (".agent-chronicle", "state"),
     (".agent-chronicle-global", "state"),
+    # New canonical global store ($XDG_STATE_HOME/agentacct/state). Matched as a
+    # PAIR: the bare name "agentacct" is too generic (pkg dir / repo dir) to add
+    # to the single-component root list below.
+    ("agentacct", "state"),
 )
 _FORBIDDEN_LIVE_ROOT_COMPONENTS = frozenset(
     {

--- a/src/agent_chronicle/cli.py
+++ b/src/agent_chronicle/cli.py
@@ -115,7 +115,7 @@ from .log_evidence import build_log_evidence_index, summarize_log_evidence_donor
 from . import install_guide
 from .install_guide import full_prompt as install_guide_full_prompt, one_line_prompt as install_guide_one_line_prompt
 from .mcp import DEGRADED_NO_STORE_MESSAGE, TOOLS, SentinelMCPServer, run_mcp_event_workflow_smoke, serve_stdio
-from .mcp_client_smoke import MCPClientSmokeError, assert_deepseek_mcp_client_smoke_passed, run_deepseek_mcp_client_smoke
+from .mcp_client_smoke import MCPClientSmokeError, assert_mcp_client_smoke_passed, run_mcp_client_smoke
 from .outcome import (
     apply_judge_result,
     apply_value_score,
@@ -147,6 +147,7 @@ from .store_resolution import (
     ENV_STORE_DIR,
     StoreResolution,
     StoreResolutionError,
+    canonical_global_store_dir,
     claude_worktree_owner_dir,
     resolve_dashboard_store_dir,
     resolve_store_dir,
@@ -331,10 +332,10 @@ def _has_agent_section(text: str) -> bool:
 def _agent_section(agent: str) -> str:
     return f"""{_agent_section_marker(agent)}
 
-Use agentacct in observe-only mode by default for this project.
+Use agentacct in observe-only mode.
 
 - Prefer `agentacct run -- <command>` for tracked local commands.
-- Keep `.agent-sentinel/state/` and local env files gitignored.
+- If a project-local store exists, keep `.agent-sentinel/state/` and local env files gitignored (a global install keeps its store outside any repo, so there is nothing to ignore).
 - Do not connect provider API keys unless the user explicitly asks for provider cost proxy/forwarding.
 - If the agentacct MCP tools are available, use them as the normal workflow ledger:
   - call `sentinel_attach_client_context` when local session, parent session, turn, request, or message IDs are known;
@@ -556,6 +557,17 @@ def _merge_claude_project_settings(project_dir: Path) -> tuple[Path, str]:
     if not example_path.exists():
         raise RuntimeManagerError("Claude Code hook settings example was not generated")
     target = project_dir / ".claude" / "settings.local.json"
+    return _merge_claude_settings_from_example(example_path, target)
+
+
+def _merge_claude_settings_from_example(example_path: Path, target: Path) -> tuple[Path, str]:
+    """Non-destructively merge a generated hook/env example into a settings file.
+
+    Shared by the project install (``.claude/settings.local.json``) and the
+    default-global install (user-level ``~/.claude/settings.json``): an env key is
+    never overwritten when the user set a different value, hook rows are deduped
+    by fingerprint, and the write is atomic + 0600.
+    """
     try:
         generated = json.loads(example_path.read_text(encoding="utf-8"))
         current = json.loads(target.read_text(encoding="utf-8")) if target.exists() else {}
@@ -638,6 +650,22 @@ def _resolve_mcp_command(value: str | None) -> str:
     if shutil.which("agent-sentinel"):
         # Pre-rename installs: only the oldest binary name is on PATH.
         return "agent-sentinel"
+    return _current_agent_chronicle_executable() or "agentacct"
+
+
+def _resolve_absolute_mcp_command() -> str:
+    """An ABSOLUTE path to the agentacct binary for user-scope registrations.
+
+    GUI-launched clients (Claude Code desktop, Codex.app) do NOT inherit the
+    shell PATH, so a bare ``agentacct`` command would fail to launch there. The
+    global install bakes the absolute path (like the manual runbook's
+    ``command -v agentacct``) instead. Falls back to the bare name only if no
+    absolute path can be found — never registers an empty command.
+    """
+    for name in ("agentacct", "agent-chronicle", "agent-sentinel"):
+        found = shutil.which(name)
+        if found:
+            return found
     return _current_agent_chronicle_executable() or "agentacct"
 
 
@@ -882,7 +910,10 @@ def _write_claude_mcp_config(project_dir: Path, config_store_dir: Path | str, *,
 
 
 def _write_codex_mcp_config(project_dir: Path, config_store_dir: Path | str, *, command: str = "agentacct") -> tuple[Path, str]:
-    config_path = project_dir / ".codex" / "config.toml"
+    return _write_codex_mcp_config_at(project_dir / ".codex" / "config.toml", config_store_dir, command=command)
+
+
+def _write_codex_mcp_config_at(config_path: Path, config_store_dir: Path | str, *, command: str = "agentacct") -> tuple[Path, str]:
     generated = _mcp_server_config(config_store_dir, command=command)
     env: dict[str, str] = {}
     if config_path.exists():
@@ -928,6 +959,88 @@ def _write_codex_mcp_config(project_dir: Path, config_store_dir: Path | str, *, 
             '[mcp_servers."agent-sentinel"]',
         },
     )
+    return config_path, action
+
+
+def _atomic_write_text(path: Path, text: str, *, mode: int = 0o600) -> None:
+    """Write ``text`` to ``path`` atomically (temp file + os.replace) at ``mode``.
+
+    Used for user-level config that a concurrently-running client may also
+    rewrite (notably ``~/.claude.json``): a torn read-modify-write would corrupt
+    the client's own state, so the swap is atomic and the file mode is preserved.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.parent / f".{path.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        try:
+            path.chmod(mode)
+        except OSError:
+            pass
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _write_user_claude_mcp_config(
+    config_path: Path, config_store_dir: Path | str, *, command: str = "agentacct"
+) -> tuple[Path, str]:
+    """Merge the agentacct server into the USER-level ``~/.claude.json``.
+
+    Unlike the project ``.mcp.json`` writer, this file is Claude Code's own
+    global state (caches, projects, account): we merge into the top-level
+    ``mcpServers`` object, PRESERVE every other top-level key AND every extra key
+    on the ``agentacct`` entry (e.g. ``alwaysLoad``), and only set
+    ``type``/``command``/``args``. User-scope entries use ``type: "stdio"``. The
+    write is atomic + 0600 because a live Claude session may rewrite this file.
+    """
+    existing: dict[str, object] = {}
+    mode = 0o600
+    if config_path.exists():
+        mode = (config_path.stat().st_mode & 0o777) or 0o600
+        try:
+            loaded = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise typer.BadParameter(
+                f"{config_path} could not be read as JSON ({type(exc).__name__}); refusing to overwrite it. "
+                "Fix or move the file, then re-run."
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise typer.BadParameter(f"{config_path} is not a JSON object; refusing to modify it.")
+        existing = loaded
+    servers = existing.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise typer.BadParameter(f"{config_path} has a non-object mcpServers; refusing to modify it.")
+
+    args = ["mcp", "serve", "--store-dir", str(config_store_dir)]
+    generated_for_match = {"command": command, "args": args}
+    # Collapse this tool's own prior name (always safe to replace); carry env.
+    # A CUSTOM pre-rename (old-name) entry is the user's — leave it + warn
+    # rather than clobber it (they may still run a second server; documented).
+    carried_env = dict(_registration_env(servers.pop("agent-chronicle", None)))
+    old_sentinel = servers.get("agent-sentinel")
+    if old_sentinel is not None:
+        if _pre_rename_registration_matches_generated(old_sentinel, generated_for_match):
+            carried_env.update(_registration_env(servers.pop("agent-sentinel")))
+        else:
+            console.print(_PRE_RENAME_CUSTOM_SETTINGS_NOTE)
+
+    entry_obj = servers.get("agentacct")
+    entry: dict[str, object] = dict(entry_obj) if isinstance(entry_obj, dict) else {}
+    action = "updated" if entry else "wrote"
+    merged_env = {**carried_env, **_registration_env(entry)}
+    entry["type"] = "stdio"
+    entry["command"] = command
+    entry["args"] = args
+    if merged_env:
+        entry["env"] = merged_env
+    servers["agentacct"] = entry
+
+    _atomic_write_text(config_path, json.dumps(existing, indent=2) + "\n", mode=mode)
     return config_path, action
 
 
@@ -1190,13 +1303,186 @@ def init_project(
     return install_receipts
 
 
+def _consent_to_write(prompt: str, *, assume_yes: bool) -> bool:
+    """Ask before writing a USER-owned file. --yes skips the prompt; a
+    non-interactive run without --yes declines (never touch a user file blindly)."""
+    if assume_yes:
+        return True
+    if not sys.stdin.isatty():
+        return False
+    return typer.confirm(prompt, default=True)
+
+
+def _onboard_global_claude(store_dir: Path, command: str, *, assume_yes: bool) -> bool:
+    """Configure Claude Code at USER scope (zero repo files). Returns readiness."""
+    home = Path.home()
+    # 1. standing "record your work" instructions -> ~/.claude/CLAUDE.md
+    setup_instructions(
+        agent="claude-code", user=True, path=None, remove=False, dry_run=False, store_dir=store_dir
+    )
+    # 2. hook wrapper OUTSIDE the store (~/.claude/hooks/) + user settings example
+    #    rendered with the wrapper's ABSOLUTE path and an embedded --store-dir.
+    install_claude_code_hook(
+        home, force=True, store_dir=store_dir, user_settings_example=True
+    )
+    _hook_path, example_path = claude_code_hook_paths(home)
+    # 3. merge the hook + ENABLE_TOOL_SEARCH env into ~/.claude/settings.json (consent)
+    settings_target = home / ".claude" / "settings.json"
+    if _consent_to_write(
+        f"Merge the agentacct hook + ENABLE_TOOL_SEARCH=auto into {settings_target}?",
+        assume_yes=assume_yes,
+    ):
+        try:
+            _merge_claude_settings_from_example(example_path, settings_target)
+            console.print(f"Merged Claude Code hook + env into {settings_target}")
+        except RuntimeManagerError as exc:
+            console.print(f"Left {settings_target} unchanged: {exc}")
+            console.print(f"Merge {example_path} into {settings_target} yourself to finish.")
+    else:
+        console.print(
+            f"Skipped {settings_target}. Merge the 'hooks' and 'env' blocks from "
+            f"{example_path} into it yourself (needed for recording)."
+        )
+    # 4. native user-scope MCP registration -> ~/.claude.json (merge, preserve keys)
+    path, action = _write_user_claude_mcp_config(home / ".claude.json", store_dir, command=command)
+    if action == "skipped":
+        return False
+    console.print(f"{action.capitalize()} Claude Code MCP server in {path}")
+    console.print("Start a NEW Claude Code session so it loads the server + hook.")
+    return True
+
+
+def _onboard_global_codex(store_dir: Path, command: str) -> bool:
+    """Configure Codex at USER scope (zero repo files). Returns readiness."""
+    home = Path.home()
+    setup_instructions(
+        agent="codex", user=True, path=None, remove=False, dry_run=False, store_dir=store_dir
+    )
+    path, action = _write_codex_mcp_config_at(home / ".codex" / "config.toml", store_dir, command=command)
+    if action == "skipped":
+        return False
+    console.print(f"{action.capitalize()} Codex MCP server block in {path}")
+    console.print("Start a NEW Codex session so it loads the server.")
+    return True
+
+
+def _print_opencode_global_preview(store_dir: Path, command: str) -> None:
+    console.print(
+        "OpenCode detected. agentacct does not write OpenCode config; run this to register the server:"
+    )
+    print(
+        f"opencode mcp add agentacct -- {shlex.quote(command)} mcp serve "
+        f"--store-dir {shlex.quote(str(store_dir))}"
+    )
+    console.print(
+        "OpenCode gets the 'record your work' instruction from the MCP server on connect (no AGENTS.md needed)."
+    )
+
+
+def _onboard_global(*, agent: str, port: int, start_runtime: bool, mcp: bool, assume_yes: bool) -> None:
+    """Install agentacct ONCE, machine-wide: user-scope MCP + hooks + instructions
+    against one global store, writing ZERO files into any repo."""
+    store_dir = canonical_global_store_dir()
+    store_dir.mkdir(parents=True, exist_ok=True)
+    # Absolute path: GUI clients do not inherit the shell PATH (see helper).
+    command = _resolve_absolute_mcp_command()
+
+    found = {row.client for row in discover_usage_sources() if row.status == "found"}
+    if agent in {"auto", "all"}:
+        targets = [client for client in ("claude-code", "codex") if client in found] or [
+            "claude-code",
+            "codex",
+        ]
+        opencode_detected = "opencode" in found
+    elif agent in {"claude-code", "codex"}:
+        targets = [agent]
+        opencode_detected = False
+    elif agent == "opencode":
+        targets = []
+        opencode_detected = True
+    else:
+        raise typer.BadParameter(
+            "global scope configures claude-code and codex (opencode is previewed). "
+            "Use --scope project for other clients."
+        )
+
+    console.print("agentacct global install: one machine-wide store, ZERO files written into any repo.")
+    console.print(f"- global store: {store_dir}")
+    console.print(f"- clients: {', '.join(targets) if targets else '(opencode preview only)'}")
+    console.print("- writes user-level MCP + hooks + instructions; merges ~/.claude/settings.json only with your ok")
+
+    recording_clients: list[str] = []
+    if mcp and "claude-code" in targets:
+        if _onboard_global_claude(store_dir, command, assume_yes=assume_yes):
+            recording_clients.append("claude-code")
+    if mcp and "codex" in targets:
+        if _onboard_global_codex(store_dir, command):
+            recording_clients.append("codex")
+    if opencode_detected:
+        _print_opencode_global_preview(store_dir, command)
+
+    imported = _local_usage_import_payload(
+        store_dir=store_dir,
+        client="all",
+        codex_home=None,
+        claude_home=None,
+        opencode_home=None,
+        hermes_home=None,
+        openclaw_home=None,
+        cursor_home=None,
+        limit_sessions=20,
+        dry_run=False,
+        estimate_costs=True,
+        refresh=True,
+    )
+    console.print(
+        "Initial local usage sync: "
+        f"imported={int(imported.get('imported_events', 0) or 0)} "
+        f"refreshed={int(imported.get('refreshed_events', 0) or 0)}"
+    )
+
+    if recording_clients:
+        try:
+            ActivationStateStore(store_dir).mark_configured(
+                project_dir=Path.home(), clients=recording_clients
+            )
+        except ActivationStateError as exc:
+            console.print(f"Onboarding stopped safely: {exc}")
+            raise typer.Exit(1) from exc
+
+    if start_runtime:
+        _health, external_watcher_running = _runtime_ingestion_health(store_dir)
+        try:
+            runtime_payload = _managed_runtime(store_dir, port=port, project_dir=None).start(
+                external_watcher_running=external_watcher_running
+            )
+        except RuntimeManagerError as exc:
+            console.print("Global install completed, but the managed runtime did not start.")
+            console.print(f"Cause: {exc}")
+            console.print("Next: run `agentacct start`.")
+            raise typer.Exit(1) from exc
+        console.print(f"Dashboard: {runtime_payload['dashboard_url']}")
+
+    if recording_clients:
+        console.print("Ready. Open a NEW agent session (in ANY repo) — recording is machine-wide now.")
+    else:
+        console.print("Local usage capture is ready; no semantic recording client was configured.")
+
+
 @app.command("onboard")
 def onboard(
-    project_dir: Annotated[Path, typer.Option(help="Project directory to connect.")] = Path("."),
+    project_dir: Annotated[Path, typer.Option(help="Project directory to connect (project scope only).")] = Path("."),
     agent: Annotated[
         str,
         typer.Option(help="Client to configure: auto, all, codex, claude-code, hermes, opencode, or openclaw."),
     ] = "auto",
+    scope: Annotated[
+        str,
+        typer.Option(
+            help="Install scope: 'global' (default) installs ONCE machine-wide with zero files in any repo; "
+            "'project' configures only this repo (legacy per-repo install)."
+        ),
+    ] = "global",
     port: Annotated[int, typer.Option(help="Managed localhost dashboard port.")] = 8765,
     start_runtime: Annotated[
         bool,
@@ -1204,10 +1490,30 @@ def onboard(
     ] = True,
     mcp: Annotated[
         bool,
-        typer.Option("--mcp/--no-mcp", help="Write implemented project-local MCP configuration."),
+        typer.Option("--mcp/--no-mcp", help="Write implemented MCP configuration."),
     ] = True,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Assume yes for the user-level ~/.claude/settings.json merge (global scope). "
+            "Required to merge it in a non-interactive run.",
+        ),
+    ] = False,
 ) -> None:
-    """Connect a project and get to the first real Task with one command."""
+    """Install agentacct once machine-wide (default), or connect a single project.
+
+    Global scope writes ZERO files into your repo: user-level MCP + hooks +
+    instructions against one machine-wide store. Use --scope project for the
+    legacy per-repo install.
+    """
+
+    if scope not in {"global", "project"}:
+        raise typer.BadParameter("scope must be 'global' or 'project'")
+    if scope == "global":
+        _onboard_global(agent=agent, port=port, start_runtime=start_runtime, mcp=mcp, assume_yes=yes)
+        return
 
     project_dir, remapped_worktree = _onboarding_project_dir(project_dir)
     if remapped_worktree is not None:
@@ -1927,28 +2233,44 @@ def smoke_all(
 @smoke_app.command("mcp-client")
 def smoke_mcp_client(
     client: Annotated[str, typer.Option(help="Client to test: hermes, opencode, openclaw, or all.")] = "all",
-    provider: Annotated[str, typer.Option(help="Provider to use. Currently only deepseek is supported.")] = "deepseek",
+    provider: Annotated[str, typer.Option(help="Provider: deepseek (default) or openai (opencode only).")] = "deepseek",
+    model: Annotated[Optional[str], typer.Option(help="Override the model id, e.g. openai/gpt-5.4-mini-fast.")] = None,
     store_dir: Annotated[Optional[Path], typer.Option(help="State directory for smoke artifacts. Defaults to a temporary directory per client.")] = None,
     deepseek_key_env: Annotated[str, typer.Option(help="Environment variable containing the DeepSeek API key.")] = "DEEPSEEK_API_KEY",
+    reuse_opencode_auth: Annotated[
+        bool,
+        typer.Option(
+            "--reuse-opencode-auth",
+            help="Let opencode authenticate with its OWN stored auth (~/.local/share/opencode/auth.json) "
+            "instead of an env API key. Needed for OAuth providers that have no plain API key.",
+        ),
+    ] = False,
     acknowledge_real_api: Annotated[bool, typer.Option("--i-understand-this-uses-real-api", help="Required acknowledgement: this command can spend real provider credits.")] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit machine-readable JSON.")] = False,
 ) -> None:
-    """Run real DeepSeek-backed MCP client smokes for Hermes/OpenCode/OpenClaw."""
-    if provider != "deepseek":
-        raise typer.BadParameter("only provider=deepseek is currently supported")
-    clients = ["hermes", "opencode", "openclaw"] if client == "all" else [client]
+    """Run real provider-backed MCP client smokes for Hermes/OpenCode/OpenClaw."""
+    if provider not in {"deepseek", "openai"}:
+        raise typer.BadParameter("provider must be deepseek or openai")
+    if client == "all":
+        clients = ["opencode"] if provider != "deepseek" else ["hermes", "opencode", "openclaw"]
+    else:
+        clients = [client]
+    key_env = deepseek_key_env if provider == "deepseek" else None
     results = []
     for item in clients:
         if item not in {"hermes", "opencode", "openclaw"}:
             raise typer.BadParameter("client must be hermes, opencode, openclaw, or all")
         try:
-            result = run_deepseek_mcp_client_smoke(
+            result = run_mcp_client_smoke(
                 item,  # type: ignore[arg-type]
+                provider=provider,
+                model=model,
+                key_env=key_env,
+                reuse_client_auth=reuse_opencode_auth and item == "opencode",
                 store_dir=store_dir,
-                deepseek_key_env=deepseek_key_env,
                 acknowledge_real_api=acknowledge_real_api,
             )
-            assert_deepseek_mcp_client_smoke_passed(result)
+            assert_mcp_client_smoke_passed(result)
         except MCPClientSmokeError as exc:
             raise typer.BadParameter(f"{item}: {exc}") from exc
         results.append(result)

--- a/src/agent_chronicle/install_guide.py
+++ b/src/agent_chronicle/install_guide.py
@@ -32,12 +32,12 @@ REPO_URL = "https://github.com/mikehasa/agentacct"
 # agentacct is published on PyPI; the git+https form installs the latest source
 # straight from the public repository.
 ONE_LINE_PROMPT = (
-    "Install and set up agentacct in this repo — a local-first dashboard that reads my coding-agent "
+    "Install and set up agentacct — a local-first dashboard that reads my coding-agent "
     "logs read-only and shows honest token usage and cost. Run `pipx install agentacct` "
-    "(or `pipx install git+https://github.com/mikehasa/agentacct`), then `agentacct onboard` from this "
-    "repo root, then tell me the dashboard URL. Observe-only: never store, request, or echo any API key; "
-    "all state stays local under `.agent-sentinel/`. Don't modify my global client config without showing "
-    "the exact command first."
+    "(or `pipx install git+https://github.com/mikehasa/agentacct`), then `agentacct onboard` "
+    "(installs once per machine, global by default, zero files written into the repo), then tell me the "
+    "dashboard URL. Observe-only: never store, request, or echo any API key; all state stays local on this "
+    "machine. Don't modify my global client config without showing the exact command first."
 )
 
 # Agents accepted by `setup prompt` / `setup mcp`. The last four share one
@@ -70,7 +70,7 @@ PREAMBLE_LINES = (
 
 GROUND_RULES = (
     "Observe-only. NEVER store, request, or echo provider API keys — nothing in this install needs one.",
-    "No telemetry. All state stays local to this machine: in the project store under `.agent-sentinel/` (gitignored; the store directory keeps the pre-rename name `.agent-sentinel/` for compatibility with existing stores) by default, or in the global store directory if you follow the optional Global install section, plus the client config files named below.",
+    "No telemetry. All state stays local to this machine: `agentacct onboard` uses one global store by default; with `--scope project` it uses a per-repo store under `.agent-sentinel/` (gitignored; the directory keeps the pre-rename name `.agent-sentinel/` for compatibility with existing stores). Either way, only the client config files each path writes change.",
     "Do not modify global/profile client configuration without showing the exact command and asking first.",
     "If `agentacct` is not on PATH, run it via its durable absolute path — never a throwaway temp venv. MCP config writes embed the absolute executable automatically.",
 )
@@ -190,13 +190,14 @@ SERVE_NOTE = (
 # clients (Claude Code desktop, Codex.app) do not inherit shell environment
 # variables, so env-var-based store selection cannot be the mechanism.
 
-GLOBAL_INSTALL_SECTION_TITLE = "## Global install (single-user machine, optional)"
+GLOBAL_INSTALL_SECTION_TITLE = "## Global install by hand (single-user machine)"
 
 GLOBAL_INSTALL_INTRO = (
-    "The per-agent sections above install agentacct per repository: each repo gets its own store, dashboard, and MCP registration. "
-    "On a single-user machine you can instead register ONE user-scope MCP server, hook, and dashboard against ONE global store — "
-    "machine-wide usage AND machine-wide work context on a single dashboard, no per-repo install step. "
-    "State then lives in the global store directory below instead of each repository."
+    "This is what `agentacct onboard` does for you by default: it installs agentacct ONCE per machine — one user-scope MCP server, hook, and dashboard against ONE global store — "
+    "so machine-wide usage AND machine-wide work context land on a single dashboard, with ZERO files written into any repo. "
+    "The default onboard store is the XDG state dir (`~/.local/state/agentacct/state`); older global stores (`~/.agent-sentinel-global/state`) are still recognized. "
+    "The runbook below is the do-it-by-hand equivalent — use it when you want to wire the registrations yourself or point them at an explicit store. "
+    "The per-agent sections above are the other path: `--scope project` installs per repository, giving each repo its own store, dashboard, and MCP registration."
 )
 
 # Store dir choice: NOT ~/.agent-sentinel — that path was older versions'
@@ -581,7 +582,7 @@ def full_prompt(agent: str) -> str:
     notes = "\n".join(f"- {note}" for note in agent_notes(agent))
     rules = "\n".join(f"- {rule}" for rule in GROUND_RULES)
     preamble = "\n".join(PREAMBLE_LINES)
-    return f"""Install and set up agentacct in this repository, in observe-only mode. agentacct is public: install it with `pipx install agentacct` (or `pipx install git+https://github.com/mikehasa/agentacct`). You are the installing agent: run the commands yourself, from the repository root.
+    return f"""Install and set up agentacct in observe-only mode. agentacct is public: install it with `pipx install agentacct` (or `pipx install git+https://github.com/mikehasa/agentacct`). The one-step setup is `agentacct onboard` — it installs agentacct once per machine (global by default) and writes zero files into the repo. You are the installing agent: the per-client steps below are the manual, per-project equivalent; run the commands yourself.
 
 {preamble}
 

--- a/src/agent_chronicle/mcp_client_smoke.py
+++ b/src/agent_chronicle/mcp_client_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -14,6 +15,21 @@ from agent_chronicle.mcp import SentinelMCPServer
 
 MCPClient = Literal["hermes", "opencode", "openclaw"]
 CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+# Standard env var each provider's key is read from (API-key providers).
+_PROVIDER_KEY_ENV = {"deepseek": "DEEPSEEK_API_KEY", "openai": "OPENAI_API_KEY"}
+# Default opencode model per provider (override with --model).
+_OPENCODE_DEFAULT_MODEL = {
+    "deepseek": "deepseek/deepseek-chat",
+    "openai": "openai/gpt-5.4-mini-fast",
+}
+
+
+def _default_opencode_auth_path() -> Path:
+    """Real opencode credential store (~/.local/share/opencode/auth.json)."""
+    base = os.environ.get("XDG_DATA_HOME")
+    root = Path(base) if base else Path.home() / ".local" / "share"
+    return root / "opencode" / "auth.json"
 
 
 @dataclass(frozen=True)
@@ -62,11 +78,11 @@ def _sentinel_module_command() -> list[str]:
     return [sys.executable, "-m", "agent_chronicle.cli"]
 
 
-def _prompt(client: str, source: str, run_id: str, marker: str) -> str:
+def _prompt(client: str, source: str, run_id: str, marker: str, provider: str = "deepseek") -> str:
     return (
-        "You are doing a tiny real agentacct DeepSeek MCP smoke test. "
+        f"You are doing a tiny real agentacct {provider} MCP smoke test. "
         "Use the agentacct MCP tool sentinel_record_section twice: "
-        f"first record section_id=mcp-client-smoke section_status=started source={source} run_id={run_id} summary=deepseek-mcp-client-smoke; "
+        f"first record section_id=mcp-client-smoke section_status=started source={source} run_id={run_id} summary={provider}-mcp-client-smoke; "
         f"then record section_id=mcp-client-smoke section_status=completed source={source} run_id={run_id} summary=MCP workflow ledger works for {client}. "
         f"Finally reply exactly {marker}."
     )
@@ -112,45 +128,63 @@ def _opencode_token_cost_observed(stdout: str) -> bool:
     return False
 
 
-def run_deepseek_mcp_client_smoke(
+def run_mcp_client_smoke(
     client: MCPClient,
     *,
+    provider: str = "deepseek",
+    model: str | None = None,
+    key_env: str | None = None,
+    reuse_client_auth: bool = False,
+    client_auth_src: Path | None = None,
     repo_dir: Path | None = None,
     store_dir: Path | None = None,
-    deepseek_key_env: str = "DEEPSEEK_API_KEY",
     acknowledge_real_api: bool = False,
     runner: CommandRunner = _default_runner,
     timeout_seconds: int = 420,
 ) -> MCPClientSmokeResult:
-    """Run a tiny real DeepSeek-backed MCP client smoke.
+    """Run a tiny real provider-backed MCP client smoke.
 
-    This is intentionally disabled unless acknowledge_real_api=True because it can
-    consume paid provider credits. Tests should inject a fake runner.
+    Disabled unless acknowledge_real_api=True (it can spend paid credits). Tests
+    inject a fake runner. ``reuse_client_auth`` copies the client's OWN stored
+    auth (e.g. opencode's OAuth ``auth.json``) into the isolated home instead of
+    requiring an API key in ``key_env`` — needed for OAuth providers that have no
+    plain API key. Non-deepseek providers are currently opencode-only.
     """
     if not acknowledge_real_api:
         raise MCPClientSmokeError("real client smoke is disabled; pass --i-understand-this-uses-real-api")
     if client not in {"hermes", "opencode", "openclaw"}:
         raise MCPClientSmokeError(f"unsupported client: {client}")
-    key = os.environ.get(deepseek_key_env)
-    if not key:
-        raise MCPClientSmokeError(f"missing required environment variable: {deepseek_key_env}")
+    if provider != "deepseek" and client != "opencode":
+        raise MCPClientSmokeError(f"provider {provider!r} is currently only supported for opencode")
+
+    key_env = key_env or _PROVIDER_KEY_ENV.get(provider)
+    key: str | None = None
+    if not reuse_client_auth:
+        if not key_env:
+            raise MCPClientSmokeError(
+                f"no key env known for provider {provider!r}; pass key_env or use reuse_client_auth"
+            )
+        key = os.environ.get(key_env)
+        if not key:
+            raise MCPClientSmokeError(f"missing required environment variable: {key_env}")
 
     repo = (repo_dir or Path.cwd()).resolve()
-    state = store_dir or Path(tempfile.mkdtemp(prefix=f"as-{client}-deepseek-smoke-store-"))
+    state = store_dir or Path(tempfile.mkdtemp(prefix=f"as-{client}-{provider}-smoke-store-"))
     state.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
-    env[deepseek_key_env] = key
-    source = f"{client}-deepseek-smoke"
-    run_id = f"{client}_deepseek_smoke_{int(time.time())}"
-    marker = f"AGENT_CHRONICLE_{client.upper()}_DEEPSEEK_MCP_OK".replace("-", "_")
-    prompt = _prompt(client, source, run_id, marker)
+    if key and key_env:
+        env[key_env] = key
+    source = f"{client}-{provider}-smoke"
+    run_id = f"{client}_{provider}_smoke_{int(time.time())}"
+    marker = f"AGENT_CHRONICLE_{client.upper()}_{provider.upper()}_MCP_OK".replace("-", "_")
+    prompt = _prompt(client, source, run_id, marker, provider)
     sentinel_cmd = _sentinel_module_command()
 
     isolated_home: str | None = None
     isolated_profile: str | None = None
     stdout = ""
     stderr = ""
-    model = "deepseek/deepseek-chat"
+    model = model or ""
 
     try:
         if client == "hermes":
@@ -168,7 +202,7 @@ def run_deepseek_mcp_client_smoke(
             )
             if add.returncode != 0:
                 raise MCPClientSmokeError((add.stderr or add.stdout)[-1000:])
-            model = "deepseek-v4-flash"
+            model = model or "deepseek-v4-flash"
             run = _run_checked(
                 runner,
                 # "agent-sentinel-smoke" is a frozen stored source string (pre-rename).
@@ -178,9 +212,20 @@ def run_deepseek_mcp_client_smoke(
                 timeout=timeout_seconds,
             )
         elif client == "opencode":
-            home = Path(tempfile.mkdtemp(prefix="as-opencode-deepseek-smoke-home-"))
+            home = Path(tempfile.mkdtemp(prefix=f"as-opencode-{provider}-smoke-home-"))
             isolated_home = str(home)
             env["HOME"] = str(home)
+            if reuse_client_auth:
+                # Copy opencode's OWN stored auth (e.g. OAuth) so the isolated run
+                # authenticates without any API key. Opaque file copy — the token
+                # is never read into this process.
+                src = Path(client_auth_src) if client_auth_src is not None else _default_opencode_auth_path()
+                if not src.exists():
+                    raise MCPClientSmokeError(f"opencode auth not found at {src}; cannot reuse client auth")
+                dst = home / ".local" / "share" / "opencode" / "auth.json"
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(src, dst)
+            model = model or _OPENCODE_DEFAULT_MODEL.get(provider, "deepseek/deepseek-chat")
             add = _run_checked(
                 runner,
                 ["opencode", "mcp", "add", "agent-chronicle", "--", *sentinel_cmd, "mcp", "serve", "--store-dir", str(state)],
@@ -200,6 +245,7 @@ def run_deepseek_mcp_client_smoke(
         else:
             profile = f"agent-chronicle-deepseek-smoke-{int(time.time())}"
             isolated_profile = profile
+            model = model or "deepseek/deepseek-chat"
             add = _run_checked(
                 runner,
                 ["openclaw", "--profile", profile, "mcp", "add", "agent-chronicle", "--command", sentinel_cmd[0], "--arg", sentinel_cmd[1], "--arg", sentinel_cmd[2], "--arg", "mcp", "--arg", "serve", "--arg", "--store-dir", "--arg", str(state), "--no-probe"],
@@ -211,7 +257,7 @@ def run_deepseek_mcp_client_smoke(
                 raise MCPClientSmokeError((add.stderr or add.stdout)[-1000:])
             provider = {
                 "baseUrl": "https://api.deepseek.com/v1",
-                "apiKey": {"source": "env", "provider": "default", "id": deepseek_key_env},
+                "apiKey": {"source": "env", "provider": "default", "id": key_env},
                 "auth": "api-key",
                 "api": "openai-completions",
                 "contextWindow": 64000,
@@ -235,7 +281,7 @@ def run_deepseek_mcp_client_smoke(
         status = "passed" if marker in (stdout + stderr) and event_count >= 2 else "failed"
         return MCPClientSmokeResult(
             client=client,
-            provider="deepseek",
+            provider=provider,
             model=model,
             status=status,
             marker_found=marker in (stdout + stderr),
@@ -251,7 +297,7 @@ def run_deepseek_mcp_client_smoke(
     except MCPClientSmokeError as exc:
         return MCPClientSmokeResult(
             client=client,
-            provider="deepseek",
+            provider=provider,
             model=model,
             status="failed",
             marker_found=marker in (stdout + stderr),
@@ -266,6 +312,33 @@ def run_deepseek_mcp_client_smoke(
         )
 
 
-def assert_deepseek_mcp_client_smoke_passed(result: MCPClientSmokeResult) -> None:
+def run_deepseek_mcp_client_smoke(
+    client: MCPClient,
+    *,
+    repo_dir: Path | None = None,
+    store_dir: Path | None = None,
+    deepseek_key_env: str = "DEEPSEEK_API_KEY",
+    acknowledge_real_api: bool = False,
+    runner: CommandRunner = _default_runner,
+    timeout_seconds: int = 420,
+) -> MCPClientSmokeResult:
+    """Back-compat wrapper: DeepSeek-backed smoke (see run_mcp_client_smoke)."""
+    return run_mcp_client_smoke(
+        client,
+        provider="deepseek",
+        key_env=deepseek_key_env,
+        repo_dir=repo_dir,
+        store_dir=store_dir,
+        acknowledge_real_api=acknowledge_real_api,
+        runner=runner,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def assert_mcp_client_smoke_passed(result: MCPClientSmokeResult) -> None:
     if result.status != "passed":
         raise MCPClientSmokeError(result.error or f"{result.client} smoke failed")
+
+
+# Back-compat alias.
+assert_deepseek_mcp_client_smoke_passed = assert_mcp_client_smoke_passed

--- a/src/agent_chronicle/store_resolution.py
+++ b/src/agent_chronicle/store_resolution.py
@@ -30,7 +30,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from .env_compat import legacy_env_name
+from .env_compat import legacy_env_name, read_env_alias
 from .policy import default_policy_path
 
 ENV_STORE_DIR = "AGENT_CHRONICLE_STORE_DIR"
@@ -39,8 +39,25 @@ ENV_STORE_DIR = "AGENT_CHRONICLE_STORE_DIR"
 LEGACY_ENV_STORE_DIR = legacy_env_name(ENV_STORE_DIR)
 # Frozen pre-rename directory name: existing global installs and registration
 # commands already point here. This is the documented machine-wide store, not
-# the retired silent ``~/.agent-sentinel`` fallback.
+# the retired silent ``~/.agent-sentinel`` fallback. It stays a RECOGNIZED read
+# location forever (dropping it would strand existing users' ledgers).
 GLOBAL_STORE_DIRNAME = ".agent-sentinel-global"
+
+# New canonical (XDG-shaped) global store, introduced with the default-global
+# install. WRITE-ONE-NEW: fresh installs create ``$XDG_STATE_HOME/agentacct/state``
+# (falling back to ``~/.local/state/agentacct/state``); the legacy dir names
+# above stay recognized for READS. Deliberately NOT ``~/.agentacct`` — that path
+# is already the CLI venv install dir, and a bare dotdir re-litters $HOME the
+# tiny-footprint pivot is trying to shrink.
+NEW_GLOBAL_STORE_APPNAME = "agentacct"
+# Operator override for the canonical global store (absolute path). Accepts the
+# pre-rename ``AGENT_SENTINEL_*`` alias forever, like every other env read.
+ENV_GLOBAL_STORE_DIR = "AGENT_CHRONICLE_GLOBAL_STORE_DIR"
+LEGACY_ENV_GLOBAL_STORE_DIR = legacy_env_name(ENV_GLOBAL_STORE_DIR)
+# Recognized-forever legacy global store dir NAMES (the ``-global`` dot family).
+# Matched structurally (location-independent) so a ``--store-dir`` pointed at one
+# of these anywhere still classifies as a machine-wide store.
+LEGACY_GLOBAL_STORE_DIRNAMES = (".agent-sentinel-global", ".agent-chronicle-global")
 
 
 @dataclass(frozen=True)
@@ -220,10 +237,117 @@ def resolve_store_dir(
 
 
 def default_global_store_dir(*, home: Path | None = None) -> Path:
-    """Return the documented machine-wide store path without creating it."""
+    """Return the LEGACY machine-wide store path without creating it.
+
+    This is the pre-rename ``~/.agent-sentinel-global/state`` location. It stays
+    a recognized read candidate forever; new installs write
+    :func:`canonical_global_store_dir` instead.
+    """
 
     home_dir = Path.home() if home is None else Path(home)
     return home_dir.expanduser() / GLOBAL_STORE_DIRNAME / "state"
+
+
+def canonical_global_store_dir(
+    *, env: Mapping[str, str] | None = None, home: Path | None = None
+) -> Path:
+    """The WRITE-ONE-NEW global store path (XDG-shaped), without creating it.
+
+    ``$XDG_STATE_HOME/agentacct/state`` when ``XDG_STATE_HOME`` is set to an
+    absolute path, else ``~/.local/state/agentacct/state``. Pure.
+    """
+
+    environment: Mapping[str, str] = os.environ if env is None else env
+    home_dir = (Path.home() if home is None else Path(home)).expanduser()
+    xdg_state = (environment.get("XDG_STATE_HOME") or "").strip()
+    if xdg_state:
+        base = Path(xdg_state).expanduser()
+        if base.is_absolute():
+            return base / NEW_GLOBAL_STORE_APPNAME / "state"
+    return home_dir / ".local" / "state" / NEW_GLOBAL_STORE_APPNAME / "state"
+
+
+def recognized_global_store_dirs(
+    *, env: Mapping[str, str] | None = None, home: Path | None = None
+) -> tuple[Path, ...]:
+    """Ordered global-store read candidates: override, new canonical, legacy.
+
+    The single source of truth for "which machine-wide stores do we recognize".
+    Order is preference order for reads; every entry is recognized forever so an
+    existing ledger keeps opening after the new canonical name lands. Pure.
+    """
+
+    environment: Mapping[str, str] = os.environ if env is None else env
+    home_dir = (Path.home() if home is None else Path(home)).expanduser()
+
+    ordered: list[Path] = []
+    override = read_env_alias(ENV_GLOBAL_STORE_DIR, environment)
+    if override and override.strip():
+        candidate = Path(override).expanduser()
+        if candidate.is_absolute():
+            ordered.append(candidate)
+    ordered.append(canonical_global_store_dir(env=environment, home=home_dir))
+    ordered.append(home_dir / GLOBAL_STORE_DIRNAME / "state")
+
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for path in ordered:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    return tuple(unique)
+
+
+def _store_has_records(path: Path) -> bool:
+    """Whether a store dir already holds data. A light stat, not a content read.
+
+    Lets an existing populated legacy store win over a freshly-created (empty)
+    canonical store during migration, so an upgrading user's dashboard does not
+    silently go blank before they merge.
+    """
+
+    try:
+        events = path / "events.jsonl"
+        if events.is_file() and events.stat().st_size > 0:
+            return True
+        if (path / "chronicle.sqlite3").is_file():
+            return True
+    except OSError:
+        return False
+    return False
+
+
+def _same_store_path(left: Path, right: Path) -> bool:
+    if left == right:
+        return True
+    try:
+        return left.resolve(strict=False) == right.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+
+
+def is_recognized_global_store(
+    store_dir: Path | str,
+    *,
+    env: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> bool:
+    """Whether a store path is one of agentacct's machine-wide stores.
+
+    True for the legacy ``-global`` dot family (matched structurally, so a
+    ``--store-dir`` at one of those anywhere counts) and for the new canonical /
+    operator-override location (matched by path, since ``agentacct/state`` is too
+    generic a shape to match structurally). Used for the "All projects" label.
+    """
+
+    path = Path(store_dir).expanduser()
+    if path.name == "state" and path.parent.name in LEGACY_GLOBAL_STORE_DIRNAMES:
+        return True
+    for candidate in recognized_global_store_dirs(env=env, home=home):
+        if _same_store_path(candidate, path):
+            return True
+    return False
 
 
 def resolve_dashboard_store_dir(
@@ -237,20 +361,27 @@ def resolve_dashboard_store_dir(
 
     Explicit flags and environment variables retain the shared resolver's
     precedence and validation. With neither override, an already-installed
-    machine-wide store becomes the product home; otherwise the normal project
-    walk-up/failure behavior remains unchanged. Pure: never creates state.
+    machine-wide store becomes the product home: the recognized global stores
+    are tried in preference order (operator override, new canonical, legacy),
+    and a store that already holds records wins over an empty one so an upgrade
+    that creates the new store does not blank out a populated legacy ledger.
+    Otherwise the normal project walk-up/failure behavior remains unchanged.
+    Pure: never creates state.
     """
 
     environment: Mapping[str, str] = os.environ if env is None else env
     if explicit is not None:
         return resolve_store_dir(explicit, cwd=cwd, env=environment)
     if store_env_dir_value(environment):
-        return resolve_store_dir(explicit, cwd=cwd, env=environment)
+        return resolve_store_dir(None, cwd=cwd, env=environment)
 
-    global_store = default_global_store_dir(home=home)
-    if global_store.is_dir():
+    candidates = recognized_global_store_dirs(env=environment, home=home)
+    existing = [path for path in candidates if path.is_dir()]
+    if existing:
+        with_records = [path for path in existing if _store_has_records(path)]
+        chosen = with_records[0] if with_records else existing[0]
         return StoreResolution(
-            path=global_store,
+            path=chosen,
             source="global",
             project_root=None,
             worktree_remapped=False,

--- a/tests/test_activation_cli.py
+++ b/tests/test_activation_cli.py
@@ -95,7 +95,7 @@ def test_onboard_auto_skips_detected_but_unimportable_opencode_db(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(tmp_path),
             "--agent",
@@ -131,7 +131,7 @@ def test_onboard_uses_one_absolute_store_and_requires_a_new_session(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(tmp_path),
             "--agent",
@@ -175,7 +175,7 @@ def test_onboard_from_claude_worktree_uses_one_owner_project_store(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(worktree),
             "--agent",
@@ -214,7 +214,7 @@ def test_onboard_runtime_failure_keeps_configuration_and_gives_recovery(
 
     result = CliRunner().invoke(
         app,
-        ["onboard", "--project-dir", str(tmp_path), "--agent", "codex"],
+        ["onboard", "--scope", "project", "--project-dir", str(tmp_path), "--agent", "codex"],
     )
 
     assert result.exit_code == 1
@@ -243,7 +243,7 @@ def test_onboard_retires_dead_external_watcher_before_starting_runtime(
 
     result = CliRunner().invoke(
         app,
-        ["onboard", "--project-dir", str(tmp_path), "--agent", "codex"],
+        ["onboard", "--scope", "project", "--project-dir", str(tmp_path), "--agent", "codex"],
     )
 
     assert result.exit_code == 0, result.output
@@ -286,7 +286,7 @@ def test_codex_no_mcp_does_not_claim_work_recording_is_configured(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(tmp_path),
             "--agent",
@@ -320,7 +320,7 @@ def test_claude_no_mcp_does_not_claim_work_recording_is_configured(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(tmp_path),
             "--agent",
@@ -352,7 +352,7 @@ def test_client_without_auto_recording_adapter_never_claims_ready(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(tmp_path),
             "--agent",
@@ -387,7 +387,7 @@ def test_codex_conflicting_existing_registration_never_claims_ready(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(tmp_path),
             "--agent",
@@ -427,7 +427,7 @@ def test_existing_but_invalid_claude_hook_never_claims_ready(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(tmp_path),
             "--agent",
@@ -456,7 +456,7 @@ def test_fresh_claude_hook_is_verified_before_ready(
     result = CliRunner().invoke(
         app,
         [
-            "onboard",
+            "onboard", "--scope", "project",
             "--project-dir",
             str(tmp_path),
             "--agent",

--- a/tests/test_live_paths.py
+++ b/tests/test_live_paths.py
@@ -78,3 +78,17 @@ def test_bare_live_component_is_rejected_without_state_suffix(tmp_path: Path) ->
         shaped = tmp_path / "project" / name / "scratch"
         with pytest.raises(LivePathSafetyError, match="may not be inside"):
             reject_live_state_overlap(shaped, label="scratch root")
+
+
+def test_new_global_store_env_override_is_a_protected_live_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The new canonical global store (via its env override) is a live root, so
+    the offline spike can never target it."""
+    gstore = tmp_path / "gstore" / "state"
+    gstore.mkdir(parents=True)
+    monkeypatch.setenv("AGENT_CHRONICLE_GLOBAL_STORE_DIR", str(gstore))
+
+    with pytest.raises(LivePathSafetyError, match="disjoint from every configured live state root"):
+        reject_live_state_overlap(gstore / "candidate", label="--candidate")

--- a/tests/test_mcp_client_smoke.py
+++ b/tests/test_mcp_client_smoke.py
@@ -9,7 +9,13 @@ from typer.testing import CliRunner
 
 from agent_chronicle.cli import app
 from agent_chronicle.mcp import SentinelMCPServer
-from agent_chronicle.mcp_client_smoke import MCPClientSmokeError, assert_deepseek_mcp_client_smoke_passed, run_deepseek_mcp_client_smoke
+from agent_chronicle.mcp_client_smoke import (
+    MCPClientSmokeError,
+    assert_deepseek_mcp_client_smoke_passed,
+    assert_mcp_client_smoke_passed,
+    run_deepseek_mcp_client_smoke,
+    run_mcp_client_smoke,
+)
 
 
 def test_deepseek_mcp_client_smoke_requires_acknowledgement(tmp_path, monkeypatch):
@@ -159,3 +165,84 @@ def test_openclaw_smoke_uses_isolated_profile_and_custom_deepseek_provider(tmp_p
     assert set(result.events) == {"section_started", "section_completed"}
     assert result.by_source == {"openclaw-deepseek-smoke": 2}
     assert any(call[0] == "openclaw" and "models.providers.deepseek" in call for call in calls)
+
+
+def test_opencode_openai_smoke_reuses_client_auth_and_default_model(tmp_path):
+    """openai provider (opencode only): default model + copies opencode's own
+    stored auth into the isolated home instead of needing an API key."""
+    auth_src = tmp_path / "auth.json"
+    auth_src.write_text('{"openai": {"type": "oauth"}}')
+    calls: list[list[str]] = []
+    store_holder: dict[str, Path] = {}
+
+    def fake_runner(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["opencode", "mcp", "add"]:
+            store_holder["store"] = Path(cmd[-1])
+            return subprocess.CompletedProcess(cmd, 0, stdout="server connected", stderr="")
+        if cmd[:2] == ["opencode", "run"]:
+            server = SentinelMCPServer(store_dir=store_holder["store"])
+            for section_status in ["started", "completed"]:
+                server.handle_message(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": section_status,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "sentinel_record_section",
+                            "arguments": {
+                                "source": "opencode-openai-smoke",
+                                "section_id": "mcp-client-smoke",
+                                "section_status": section_status,
+                                "run_id": "fake-openai-smoke",
+                            },
+                        },
+                    }
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="AGENT_CHRONICLE_OPENCODE_OPENAI_MCP_OK", stderr="")
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="unexpected command")
+
+    result = run_mcp_client_smoke(
+        "opencode",
+        provider="openai",
+        reuse_client_auth=True,
+        client_auth_src=auth_src,
+        repo_dir=tmp_path,
+        store_dir=tmp_path / "state",
+        acknowledge_real_api=True,
+        runner=fake_runner,
+    )
+
+    assert_mcp_client_smoke_passed(result)
+    assert result.provider == "openai"
+    assert result.model == "openai/gpt-5.4-mini-fast"  # provider default
+    assert result.by_source == {"opencode-openai-smoke": 2}
+    run_call = next(call for call in calls if call[:2] == ["opencode", "run"])
+    assert "--model" in run_call and "openai/gpt-5.4-mini-fast" in run_call
+    # opencode authenticated from the COPIED auth (no env key needed)
+    assert (Path(result.isolated_home) / ".local" / "share" / "opencode" / "auth.json").exists()
+
+
+def test_opencode_openai_smoke_fails_clearly_when_auth_missing(tmp_path):
+    result = run_mcp_client_smoke(
+        "opencode",
+        provider="openai",
+        reuse_client_auth=True,
+        client_auth_src=tmp_path / "nope.json",
+        repo_dir=tmp_path,
+        store_dir=tmp_path / "state",
+        acknowledge_real_api=True,
+        runner=lambda *a, **k: subprocess.CompletedProcess(a[0], 0, stdout="", stderr=""),
+    )
+    assert result.status == "failed"
+    assert "opencode auth not found" in (result.error or "")
+
+
+def test_openai_provider_rejected_for_non_opencode_clients(tmp_path):
+    with pytest.raises(MCPClientSmokeError, match="only supported for opencode"):
+        run_mcp_client_smoke(
+            "hermes",
+            provider="openai",
+            reuse_client_auth=True,
+            acknowledge_real_api=True,
+        )

--- a/tests/test_mcp_onboarding.py
+++ b/tests/test_mcp_onboarding.py
@@ -481,7 +481,7 @@ def test_readme_leads_with_the_one_line_install_prompt() -> None:
     # single ~500-char line overflows on GitHub); `setup prompt` still emits the
     # canonical single line (test_one_liner_is_a_single_public_install_line), so
     # here we assert the prompt's substance is present, not the exact one line.
-    assert "Install and set up agentacct in this repo" in text
+    assert "Install and set up agentacct" in text
     assert "pipx install agentacct" in text
     assert "agentacct onboard" in text
     assert "never store, request, or echo any API key" in text

--- a/tests/test_onboard_global.py
+++ b/tests/test_onboard_global.py
@@ -1,0 +1,84 @@
+"""Default-global onboard: install once, machine-wide, ZERO files in the repo.
+
+HOME is redirected to a tmp dir so this never touches the real ~/.claude*,
+~/.codex, or ~/.local/state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agent_chronicle.cli import app
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    return home
+
+
+def test_onboard_global_writes_zero_repo_files_and_configures_user_scope(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--yes", "--no-start"])
+    assert result.exit_code == 0, result.output
+
+    # 1. The repo we ran from is untouched — the whole point of default-global.
+    for leaked in (".agent-sentinel", ".mcp.json", ".codex", ".claude", "CLAUDE.md", "AGENTS.md"):
+        assert not (repo / leaked).exists(), f"{leaked} leaked into the repo"
+
+    # 2. Global store created at the XDG-shaped canonical location under HOME.
+    store = isolated_home / ".local" / "state" / "agentacct" / "state"
+    assert store.is_dir()
+
+    # 3. User-level MCP registration for both native clients.
+    claude_json = json.loads((isolated_home / ".claude.json").read_text())
+    server = claude_json["mcpServers"]["agentacct"]
+    assert server["type"] == "stdio"
+    assert str(store) in server["args"]
+    # GUI clients don't inherit shell PATH -> the command must be absolute.
+    assert Path(server["command"]).is_absolute(), server["command"]
+    assert "[mcp_servers.agentacct]" in (isolated_home / ".codex" / "config.toml").read_text()
+
+    # 4. Standing instructions + hook wrapper OUTSIDE the store.
+    assert (isolated_home / ".claude" / "CLAUDE.md").exists()
+    assert (isolated_home / ".codex" / "AGENTS.md").exists()
+    hook_wrapper = isolated_home / ".claude" / "hooks" / "claude_pre_tool_use.py"
+    assert hook_wrapper.exists()
+    assert store not in hook_wrapper.parents
+
+    # 5. --yes merged the hook + the load-bearing env into user settings.json.
+    settings = json.loads((isolated_home / ".claude" / "settings.json").read_text())
+    assert "PreToolUse" in settings.get("hooks", {})
+    assert settings.get("env", {}).get("ENABLE_TOOL_SEARCH") == "auto"
+
+
+def test_onboard_global_without_yes_is_non_interactive_safe(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --yes and no TTY, the run must NOT block or touch settings.json,
+    but must still register MCP + instructions (the recording primitives)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--no-start"])
+    assert result.exit_code == 0, result.output
+
+    # settings.json is user-owned: never written without explicit consent.
+    assert not (isolated_home / ".claude" / "settings.json").exists()
+    # but MCP registration still happened
+    claude_json = json.loads((isolated_home / ".claude.json").read_text())
+    assert "agentacct" in claude_json["mcpServers"]

--- a/tests/test_store_resolution.py
+++ b/tests/test_store_resolution.py
@@ -12,9 +12,14 @@ from pathlib import Path
 import pytest
 
 from agent_chronicle.store_resolution import (
+    ENV_GLOBAL_STORE_DIR,
     ENV_STORE_DIR,
     StoreResolutionError,
+    canonical_global_store_dir,
     claude_worktree_owner_dir,
+    is_recognized_global_store,
+    recognized_global_store_dirs,
+    resolve_dashboard_store_dir,
     resolve_store_dir,
     worktree_owner_root,
 )
@@ -206,3 +211,140 @@ def test_env_store_dir_expands_tilde(tmp_path: Path) -> None:
 
     assert resolution.path == Path(os.path.expanduser("~/sentinel-env-store"))
     assert resolution.source == "env"
+
+
+# --- recognize-many global store (default-global / XDG) ----------------------
+
+
+def _make_store(path: Path, *, data: bool = True) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    if data:
+        (path / "events.jsonl").write_text('{"event_id": "x"}\n', encoding="utf-8")
+    return path
+
+
+def test_canonical_global_store_defaults_to_xdg_state(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    assert canonical_global_store_dir(env={}, home=home) == (
+        home / ".local" / "state" / "agentacct" / "state"
+    )
+
+
+def test_canonical_global_store_honors_absolute_xdg_state_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    xdg = tmp_path / "xdg-state"
+    assert canonical_global_store_dir(env={"XDG_STATE_HOME": str(xdg)}, home=home) == (
+        xdg / "agentacct" / "state"
+    )
+
+
+def test_canonical_global_store_ignores_relative_xdg_state_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    assert canonical_global_store_dir(env={"XDG_STATE_HOME": "rel/state"}, home=home) == (
+        home / ".local" / "state" / "agentacct" / "state"
+    )
+
+
+def test_recognized_global_store_dirs_order_and_dedup(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    override = tmp_path / "override" / "state"
+    dirs = recognized_global_store_dirs(env={ENV_GLOBAL_STORE_DIR: str(override)}, home=home)
+    assert dirs == (
+        override,
+        home / ".local" / "state" / "agentacct" / "state",
+        home / ".agent-sentinel-global" / "state",
+    )
+
+
+def test_recognized_global_store_dirs_skips_relative_override(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    dirs = recognized_global_store_dirs(env={ENV_GLOBAL_STORE_DIR: "rel/state"}, home=home)
+    assert dirs == (
+        home / ".local" / "state" / "agentacct" / "state",
+        home / ".agent-sentinel-global" / "state",
+    )
+
+
+def test_dashboard_new_user_uses_canonical_store(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    canonical = _make_store(home / ".local" / "state" / "agentacct" / "state")
+    resolution = resolve_dashboard_store_dir(None, cwd=tmp_path, env={}, home=home)
+    assert resolution.path == canonical
+    assert resolution.source == "global"
+
+
+def test_dashboard_existing_user_uses_legacy_store(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    legacy = _make_store(home / ".agent-sentinel-global" / "state")
+    resolution = resolve_dashboard_store_dir(None, cwd=tmp_path, env={}, home=home)
+    assert resolution.path == legacy
+    assert resolution.source == "global"
+
+
+def test_dashboard_migrating_user_prefers_populated_legacy_over_empty_canonical(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    _make_store(home / ".local" / "state" / "agentacct" / "state", data=False)
+    legacy = _make_store(home / ".agent-sentinel-global" / "state", data=True)
+    resolution = resolve_dashboard_store_dir(None, cwd=tmp_path, env={}, home=home)
+    # data-first: do not blank the dashboard just because a fresh store dir exists
+    assert resolution.path == legacy
+
+
+def test_dashboard_prefers_canonical_when_both_have_data(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    canonical = _make_store(home / ".local" / "state" / "agentacct" / "state", data=True)
+    _make_store(home / ".agent-sentinel-global" / "state", data=True)
+    resolution = resolve_dashboard_store_dir(None, cwd=tmp_path, env={}, home=home)
+    assert resolution.path == canonical
+
+
+def test_dashboard_operator_override_wins(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    override = _make_store(tmp_path / "ops" / "state", data=True)
+    _make_store(home / ".agent-sentinel-global" / "state", data=True)
+    resolution = resolve_dashboard_store_dir(
+        None, cwd=tmp_path, env={ENV_GLOBAL_STORE_DIR: str(override)}, home=home
+    )
+    assert resolution.path == override
+    assert resolution.source == "global"
+
+
+def test_dashboard_explicit_store_env_still_wins_over_global(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _make_store(home / ".local" / "state" / "agentacct" / "state", data=True)
+    env_store = tmp_path / "env-store"
+    resolution = resolve_dashboard_store_dir(
+        None, cwd=tmp_path, env={ENV_STORE_DIR: str(env_store)}, home=home
+    )
+    assert resolution.path == env_store
+    assert resolution.source == "env"
+
+
+def test_dashboard_falls_through_to_strict_resolver_when_no_global(tmp_path: Path) -> None:
+    home = tmp_path / "home"  # nothing created under home
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    with pytest.raises(StoreResolutionError):
+        resolve_dashboard_store_dir(None, cwd=bare, env={}, home=home)
+
+
+def test_is_recognized_global_store(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    # legacy dot-global family: structural, location-independent
+    assert is_recognized_global_store(
+        tmp_path / "anywhere" / ".agent-sentinel-global" / "state", env={}, home=home
+    )
+    assert is_recognized_global_store(
+        tmp_path / "x" / ".agent-chronicle-global" / "state", env={}, home=home
+    )
+    # new canonical location
+    assert is_recognized_global_store(
+        home / ".local" / "state" / "agentacct" / "state", env={}, home=home
+    )
+    # project store and arbitrary custom stores are NOT machine-wide
+    assert not is_recognized_global_store(
+        tmp_path / "proj" / ".agent-sentinel" / "state", env={}, home=home
+    )
+    assert not is_recognized_global_store(tmp_path / "random" / "state", env={}, home=home)

--- a/tests/test_user_scope_mcp_writers.py
+++ b/tests/test_user_scope_mcp_writers.py
@@ -1,0 +1,132 @@
+"""Unit tests for the native user-scope MCP writers used by default-global onboard.
+
+Claude Code's ``~/.claude.json`` is the client's own global state; the writer
+must merge (preserve every other key) and use ``type: "stdio"``. Codex's
+``~/.codex/config.toml`` is an upsert that preserves other servers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_chronicle import cli
+
+
+def test_user_claude_mcp_fresh_file(tmp_path: Path) -> None:
+    config = tmp_path / ".claude.json"
+    path, action = cli._write_user_claude_mcp_config(config, "/global/store", command="agentacct")
+
+    assert path == config
+    assert action == "wrote"
+    data = json.loads(config.read_text())
+    assert data["mcpServers"]["agentacct"] == {
+        "type": "stdio",
+        "command": "agentacct",
+        "args": ["mcp", "serve", "--store-dir", "/global/store"],
+    }
+    assert (config.stat().st_mode & 0o777) == 0o600
+
+
+def test_user_claude_mcp_preserves_other_keys_and_extra_entry_keys(tmp_path: Path) -> None:
+    config = tmp_path / ".claude.json"
+    config.write_text(
+        json.dumps(
+            {
+                "userID": "abc",
+                "projects": {"/x": {}},
+                "mcpServers": {
+                    "gbrain": {"type": "stdio", "command": "g", "args": ["serve"]},
+                    "agentacct": {
+                        "type": "stdio",
+                        "command": "old",
+                        "args": ["mcp", "serve", "--store-dir", "/old"],
+                        "alwaysLoad": True,
+                    },
+                },
+            }
+        )
+    )
+    _path, action = cli._write_user_claude_mcp_config(config, "/new/store")
+
+    assert action == "updated"
+    data = json.loads(config.read_text())
+    # Claude Code's own top-level state is untouched
+    assert data["userID"] == "abc"
+    assert data["projects"] == {"/x": {}}
+    # other MCP servers untouched
+    assert data["mcpServers"]["gbrain"]["command"] == "g"
+    entry = data["mcpServers"]["agentacct"]
+    assert entry["args"][-1] == "/new/store"  # store path updated
+    assert entry["alwaysLoad"] is True  # extra entry key preserved
+    assert entry["type"] == "stdio"
+
+
+def test_user_claude_mcp_migrates_prior_own_name_and_carries_env(tmp_path: Path) -> None:
+    config = tmp_path / ".claude.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "agent-chronicle": {
+                        "command": "agentacct",
+                        "args": ["mcp", "serve", "--store-dir", "/old"],
+                        "env": {"X": "1"},
+                    }
+                }
+            }
+        )
+    )
+    _path, _action = cli._write_user_claude_mcp_config(config, "/new")
+
+    data = json.loads(config.read_text())
+    assert "agent-chronicle" not in data["mcpServers"]  # collapsed
+    entry = data["mcpServers"]["agentacct"]
+    assert entry["env"] == {"X": "1"}  # env carried forward
+    assert entry["args"][-1] == "/new"
+
+
+def test_user_claude_mcp_leaves_custom_pre_rename_sentinel(tmp_path: Path) -> None:
+    config = tmp_path / ".claude.json"
+    config.write_text(
+        json.dumps(
+            {"mcpServers": {"agent-sentinel": {"type": "stdio", "command": "custom", "args": ["weird"]}}}
+        )
+    )
+    _path, _action = cli._write_user_claude_mcp_config(config, "/new")
+
+    data = json.loads(config.read_text())
+    # user's custom pre-rename registration is never clobbered
+    assert data["mcpServers"]["agent-sentinel"]["command"] == "custom"
+    # but the new-name server is still registered
+    assert data["mcpServers"]["agentacct"]["args"][-1] == "/new"
+
+
+def test_user_claude_mcp_rejects_non_object(tmp_path: Path) -> None:
+    config = tmp_path / ".claude.json"
+    config.write_text("[]")
+    import pytest
+
+    with pytest.raises(Exception):
+        cli._write_user_claude_mcp_config(config, "/new")
+
+
+def test_user_codex_mcp_fresh_file(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    path, _action = cli._write_codex_mcp_config_at(config, "/global/store")
+
+    text = config.read_text()
+    assert path == config
+    assert "[mcp_servers.agentacct]" in text
+    assert '"--store-dir"' in text
+    assert "/global/store" in text
+
+
+def test_user_codex_mcp_preserves_other_servers(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[mcp_servers.other]\ncommand = "x"\nargs = ["y"]\n')
+    cli._write_codex_mcp_config_at(config, "/global/store")
+
+    text = config.read_text()
+    assert "[mcp_servers.other]" in text  # untouched
+    assert "[mcp_servers.agentacct]" in text


### PR DESCRIPTION
## What & why

Post-0.3.0 footprint fix: make **global the default install** so agentacct stops scattering files into users' repos (the main public critique).

`agentacct onboard` now defaults to `--scope global`:
- registers **user-level** MCP (`~/.claude.json`, `~/.codex/config.toml`), a hook wrapper **outside** the store (`~/.claude/hooks/`), and standing instructions;
- merges `~/.claude/settings.json` (hook + `ENABLE_TOOL_SEARCH=auto`) **only with consent** (`--yes` or a TTY prompt);
- writes **zero files into the repo**.

`--scope project` keeps the legacy per-repo install unchanged.

## Store location

New canonical global store at `$XDG_STATE_HOME/agentacct/state` (`~/.local/state/agentacct/state`). The dashboard resolver recognizes many global stores (env override → canonical → legacy `.agent-sentinel-global`) and prefers one that already holds data, so an upgrade never blanks a populated legacy ledger. Legacy names stay recognized for reads forever; canonical write-guards were extended to the new store. Frozen store/tool/env tokens are unchanged.

## GUI clients

MCP registrations bake an **absolute** agentacct path so desktop Claude/Codex (which don't inherit the shell `PATH`) can launch the server.

## opencode testing

- `smoke mcp-client` is now provider-generic (`run_mcp_client_smoke`): adds `--provider openai` and `--reuse-opencode-auth` (uses opencode's own stored auth — needed for OAuth providers with no plain API key).
- Verified real end-to-end: opencode 1.18.8 + OpenAI recorded 2 events via the agentacct MCP registration.

## Validation

- Full suite: **2888 passed, 1 skipped**.
- A fresh-machine harness (`scripts/cleanroom/`, kept local) asserts zero repo files, the global store, an MCP round-trip, user-level config with the hook outside the store, and opencode connectivity — all green.

## Deferred (follow-ups)

- Rename of cosmetic `agent-chronicle` / `sentinel` surface names (frozen data-compat tokens stay).
- opencode is previewed (`opencode mcp add`), not written; hermes/openclaw stay deepseek-only.
- Exhaustive `docs/*.md` prose sweep.
