### PR TITLE
fix(onboard): reuse an existing global store instead of stranding history

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -103,6 +103,7 @@ from .cost import (
 )
 from .context_bridge import build_client_context_join_health
 from .hooks import (
+    CLAUDE_HOOK_RELATIVE_PATH,
     capture_claude_code_client_context,
     claude_code_hook_context_status,
     claude_code_hook_doctor_checks,
@@ -148,6 +149,7 @@ from .store_resolution import (
     StoreResolution,
     StoreResolutionError,
     canonical_global_store_dir,
+    onboard_global_store_dir,
     claude_worktree_owner_dir,
     resolve_dashboard_store_dir,
     resolve_store_dir,
@@ -1379,10 +1381,76 @@ def _print_opencode_global_preview(store_dir: Path, command: str) -> None:
     )
 
 
+def _warn_global_store_mismatches(store_dir: Path, command: str) -> None:
+    """Warn when a surface agentacct does NOT rewrite still points elsewhere.
+
+    Global onboard writes Claude Code and Codex config, but the OpenCode
+    registration and an already-merged Claude hook command are the user's to
+    update. Silently leaving one pointed at a different store splits recording
+    across two ledgers (the hook writes join context to store A while MCP
+    records work in store B), which reads as "attribution mysteriously got
+    worse". Detection is best-effort and never fails onboarding.
+    """
+
+    target = str(store_dir)
+
+    opencode_config = Path.home() / ".config" / "opencode" / "opencode.jsonc"
+    try:
+        if opencode_config.is_file():
+            text = opencode_config.read_text(encoding="utf-8")
+            if "agentacct" in text and target not in text:
+                console.print(
+                    "OpenCode is registered against a DIFFERENT store than this install. "
+                    "agentacct cannot rewrite OpenCode config — re-register it:"
+                )
+                print(
+                    f"opencode mcp remove agentacct; opencode mcp add agentacct -- "
+                    f"{shlex.quote(command)} mcp serve --store-dir {shlex.quote(target)}"
+                )
+    except OSError:
+        pass
+
+    settings = Path.home() / ".claude" / "settings.json"
+    try:
+        if settings.is_file():
+            payload = json.loads(settings.read_text(encoding="utf-8"))
+            commands = [
+                str(entry.get("command") or "")
+                for rows in (payload.get("hooks") or {}).values()
+                if isinstance(rows, list)
+                for row in rows
+                if isinstance(row, dict)
+                for entry in (row.get("hooks") or [])
+                if isinstance(entry, dict)
+            ]
+            stale = [
+                text
+                for text in commands
+                if CLAUDE_HOOK_RELATIVE_PATH.name in text
+                and str(Path.home() / ".claude" / "hooks") not in text
+            ]
+            if stale:
+                console.print(
+                    f"Your ~/.claude/settings.json runs a hook wrapper from outside ~/.claude/hooks/ "
+                    f"({stale[0].split()[-1]}). It may capture join context into another store — "
+                    f"re-point it at the wrapper this install manages:"
+                )
+                print(
+                    f"agentacct hooks claude-code install --project-dir {shlex.quote(str(Path.home()))} "
+                    f"--store-dir {shlex.quote(target)} --user-settings-example --force"
+                )
+    except (OSError, json.JSONDecodeError):
+        pass
+
+
 def _onboard_global(*, agent: str, port: int, start_runtime: bool, mcp: bool, assume_yes: bool) -> None:
     """Install agentacct ONCE, machine-wide: user-scope MCP + hooks + instructions
     against one global store, writing ZERO files into any repo."""
-    store_dir = canonical_global_store_dir()
+    # An upgrading user's ledger may already live in a recognized global store
+    # (e.g. the pre-rename ~/.agent-sentinel-global). Keep using it instead of
+    # silently repointing every client at a new, empty store — that strands the
+    # history and splits clients across two ledgers.
+    store_dir, store_pre_existing = onboard_global_store_dir()
     store_dir.mkdir(parents=True, exist_ok=True)
     # Absolute path: GUI clients do not inherit the shell PATH (see helper).
     command = _resolve_absolute_mcp_command()
@@ -1408,6 +1476,8 @@ def _onboard_global(*, agent: str, port: int, start_runtime: bool, mcp: bool, as
 
     console.print("agentacct global install: one machine-wide store, ZERO files written into any repo.")
     console.print(f"- global store: {store_dir}")
+    if store_pre_existing:
+        console.print("  (existing global store with recorded history — reusing it, not starting a new one)")
     console.print(f"- clients: {', '.join(targets) if targets else '(opencode preview only)'}")
     console.print("- writes user-level MCP + hooks + instructions; merges ~/.claude/settings.json only with your ok")
 
@@ -1462,6 +1532,11 @@ def _onboard_global(*, agent: str, port: int, start_runtime: bool, mcp: bool, as
             console.print("Next: run `agentacct start`.")
             raise typer.Exit(1) from exc
         console.print(f"Dashboard: {runtime_payload['dashboard_url']}")
+
+    # Surfaces agentacct does NOT rewrite (OpenCode config, an already-merged
+    # hook command) can still point at another store — say so loudly rather than
+    # let recording silently split across two ledgers.
+    _warn_global_store_mismatches(store_dir, command)
 
     if recording_clients:
         console.print("Ready. Open a NEW agent session (in ANY repo) — recording is machine-wide now.")

--- a/src/agentacct/store_resolution.py
+++ b/src/agentacct/store_resolution.py
@@ -335,6 +335,26 @@ def _same_store_path(left: Path, right: Path) -> bool:
         return False
 
 
+def onboard_global_store_dir(
+    *, env: Mapping[str, str] | None = None, home: Path | None = None
+) -> tuple[Path, bool]:
+    """The global store a global install should USE, plus whether it pre-existed.
+
+    Fresh machine -> the new canonical (XDG) store. But when a recognized global
+    store ALREADY holds records (an upgrading user whose ledger lives in the
+    pre-rename ``~/.agent-sentinel-global``), keep using THAT one: silently
+    pointing an upgrade at a different, empty store strands the user's history
+    and splits their clients across two ledgers.
+
+    Returns ``(store_dir, pre_existing)``. Pure: never creates anything.
+    """
+
+    for candidate in recognized_global_store_dirs(env=env, home=home):
+        if candidate.is_dir() and _store_has_records(candidate):
+            return candidate, True
+    return canonical_global_store_dir(env=env, home=home), False
+
+
 def is_recognized_global_store(
     store_dir: Path | str,
     *,

--- a/tests/test_onboard_global.py
+++ b/tests/test_onboard_global.py
@@ -82,3 +82,112 @@ def test_onboard_global_without_yes_is_non_interactive_safe(
     # but MCP registration still happened
     claude_json = json.loads((isolated_home / ".claude.json").read_text())
     assert "agentacct" in claude_json["mcpServers"]
+
+
+# --- upgrade path: an existing global store must not be silently abandoned ----
+# The regression this covers: global onboard used to ALWAYS target the new
+# canonical (XDG) store, so an upgrading user whose ledger lived in the
+# pre-rename ~/.agent-sentinel-global got every client repointed at a new empty
+# store — history apparently gone, and clients split across two ledgers.
+
+
+def _seed_store(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "events.jsonl").write_text('{"event_id": "evt_seed"}\n', encoding="utf-8")
+    return path
+
+
+def test_onboard_global_reuses_an_existing_populated_legacy_store(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    legacy = _seed_store(isolated_home / ".agent-sentinel-global" / "state")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--yes", "--no-start"])
+    assert result.exit_code == 0, result.output
+
+    # Every client registration points at the EXISTING ledger, not a new one.
+    claude_json = json.loads((isolated_home / ".claude.json").read_text())
+    assert str(legacy) in claude_json["mcpServers"]["agentacct"]["args"]
+    assert str(legacy) in (isolated_home / ".codex" / "config.toml").read_text()
+    # ...and the empty canonical store was not adopted as the target.
+    assert str(isolated_home / ".local" / "state" / "agentacct" / "state") not in claude_json["mcpServers"][
+        "agentacct"
+    ]["args"]
+    assert "reusing it" in result.output
+
+
+def test_onboard_global_uses_canonical_store_on_a_fresh_machine(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--yes", "--no-start"])
+    assert result.exit_code == 0, result.output
+
+    canonical = isolated_home / ".local" / "state" / "agentacct" / "state"
+    claude_json = json.loads((isolated_home / ".claude.json").read_text())
+    assert str(canonical) in claude_json["mcpServers"]["agentacct"]["args"]
+    assert "reusing it" not in result.output
+
+
+def test_onboard_global_ignores_an_existing_but_EMPTY_legacy_store(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty legacy dir carries no history, so the canonical store still wins."""
+    (isolated_home / ".agent-sentinel-global" / "state").mkdir(parents=True)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--yes", "--no-start"])
+    assert result.exit_code == 0, result.output
+
+    canonical = isolated_home / ".local" / "state" / "agentacct" / "state"
+    claude_json = json.loads((isolated_home / ".claude.json").read_text())
+    assert str(canonical) in claude_json["mcpServers"]["agentacct"]["args"]
+
+
+def test_onboard_global_warns_when_opencode_points_at_another_store(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    other = _seed_store(tmp_path / "elsewhere" / "state")
+    config = isolated_home / ".config" / "opencode" / "opencode.jsonc"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps({"mcp": {"agentacct": {"type": "local", "command": ["agentacct", "mcp", "serve", "--store-dir", str(other)]}}}),
+        encoding="utf-8",
+    )
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--yes", "--no-start"])
+    assert result.exit_code == 0, result.output
+    assert "OpenCode is registered against a DIFFERENT store" in result.output
+    assert "opencode mcp add agentacct" in result.output
+
+
+def test_onboard_global_warns_when_hook_wrapper_lives_outside_claude_hooks(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stale = isolated_home / ".agent-sentinel-global" / ".agent-sentinel" / "hooks" / "claude_pre_tool_use.py"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("# stale wrapper\n", encoding="utf-8")
+    settings = isolated_home / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        json.dumps({"hooks": {"PreToolUse": [{"matcher": "*", "hooks": [{"type": "command", "command": f"python3 {stale}"}]}]}}),
+        encoding="utf-8",
+    )
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--yes", "--no-start"])
+    assert result.exit_code == 0, result.output
+    assert "outside ~/.claude/hooks/" in result.output


### PR DESCRIPTION
## The bug

Global `onboard` always targeted the new canonical (XDG) store. Re-running it on a machine that already had a populated global store — e.g. the pre-rename `~/.agent-sentinel-global` — silently repointed Claude Code and Codex at a **new, empty** store. The user's recorded history looked gone, and their clients ended up split across two ledgers.

Upgrading users hit this on **exactly the step the 0.5.0 release notes tell them to run**. Found by dogfooding: my own machine ended up with 7258 events in the old store and 1116 in the new one, with OpenCode and the Claude hook still writing to the old one while MCP wrote to the new one.

## The fix

- `onboard_global_store_dir()` returns the recognized global store that **already holds records**, and only falls back to the canonical XDG store on a fresh machine. Global onboard uses it, and prints when it's reusing an existing store.
- **Warn about the two surfaces onboard does not rewrite** when they point elsewhere: an OpenCode registration (agentacct never writes OpenCode config) and a hook command running a wrapper from outside `~/.claude/hooks/`. Either one silently splits recording between two stores — which reads as "attribution mysteriously got worse".

No data migration machinery: reuse-in-place plus a loud warning and a copy-paste recovery command.

## Why it slipped through

Every install test — unit and cleanroom — only covered a **fresh** machine. There was no upgrade scenario anywhere.

- 5 new onboard tests: reuse a populated legacy store, canonical on fresh, ignore an *empty* legacy dir, and both mismatch warnings. Verified non-vacuous (revert the fix → the reuse test fails).
- Cleanroom gained `UPGRADE=1` mode + **INV6**: the install must adopt the existing ledger.

## Validation

- Full suite: **2894 passed, 1 skipped**.
- Cleanroom `INSTALL_METHOD=onboard UPGRADE=1`: INV1–INV6 all pass. Fresh mode still all pass.