### PR TITLE
refactor(agent_capabilities): clean up naming, add documentation and tests

### DIFF
--- a/src/agentacct/agent_capabilities.py
+++ b/src/agentacct/agent_capabilities.py
@@ -1,10 +1,63 @@
 """Static, evidence-backed capability manifest for coding-agent adapters.
 
-Runtime source discovery and ingestion health answer whether data is present on
-this machine right now.  This module answers a different question: which
-bounded integration paths agentacct implements, how they are activated, and
-what evidence verifies each path.  It intentionally has no whole-client
-``supported`` boolean.
+This is the single source of truth for "which coding-agent integrations
+agentacct supports, how strongly, and what evidence proves each one."  It rates
+every supported agent across eight capability lanes, and it deliberately has no
+whole-client ``supported`` boolean -- each lane is rated independently, because
+a client can be strong in one (e.g. usage) and weak in another (e.g. mechanical
+capture).
+
+This is the *static* half of agentacct's integration story: what it can do with
+each agent in principle.  The *dynamic* half -- is a given agent's data actually
+present on THIS machine right now? -- comes from runtime source discovery
+(``discover_usage_sources``) and ingestion health (``IngestionHealthStore``).
+``agent_capability_manifest()`` feeds the ``agentacct capabilities agents`` CLI
+command (``cli.py``), the dashboard's ``/capabilities/agents`` endpoint
+(``api.py``), and the HTML matrix renderer (``evidence_html.py``); it always
+returns a validated deep copy.  The evidence behind each rating lives in
+``docs/adapter-capability-evidence.md``.
+
+What's inside
+-------------
+1. Vocabulary (the frozensets below): the controlled words every entry uses.
+2. Factories (``_verification_record``, ``_stability_record``, ``_capability_record``): small dict
+   builders that keep the entries consistent and terse.
+3. ``_CLIENTS``: the table -- one block per coding agent, each declaring all
+   eight capabilities plus client-level metadata.  This is most of the file.
+4. ``validate_agent_capability_manifest``: the integrity rules -- rejects any
+   entry that overclaims (e.g. "verified" without real, dated evidence).
+5. ``agent_capability_manifest``: returns a validated deep copy for callers.
+
+Vocabulary (plain-English)
+--------------------------
+The 8 capability lanes every client is rated on:
+  session_discovery  find the agent's local session logs
+  usage_import       read token totals from those logs
+  mechanical_capture observe tool/lifecycle events via hooks
+  mcp_semantics      record work meaning over MCP (sections, checks)
+  model_attribution  attribute tokens to a model
+  cache_read         read cache-hit tokens
+  cache_write        read cache-creation tokens
+  automatic_install  install the integration with one command
+
+State -- how real a lane is:
+  unavailable        not implemented
+  experimental       implemented, but only tested with synthetic data
+  verified_partial   works, with real evidence but narrow scope
+  verified           works, with real evidence
+
+Verification level -- what proves the state:
+  none               no evidence
+  synthetic_fixture  a unit-test fixture (can prove "experimental", never "verified")
+  real_fixture       evidence captured from a real local run
+  live_smoke         observed on a live machine on a dated day
+
+Activation -- how a user turns a lane on:
+  none | manual_manifest | manual_profile | opt_in_project | one_command_project
+
+The honesty rule: a "verified*" state requires real, dated evidence, and a
+synthetic fixture can never prove a verified state.  The validator enforces
+this, so the published matrix cannot overclaim.
 """
 
 from __future__ import annotations
@@ -66,13 +119,14 @@ _CLIENT_KEYS = frozenset(
 )
 
 
-def _verification(
+def _verification_record(
     level: str,
     *,
     verified_at: str | None = None,
     client_versions: tuple[str, ...] = (),
     evidence_refs: tuple[str, ...] = (),
 ) -> dict[str, Any]:
+    """Build a verification-evidence record: the level, date, client versions, and doc refs."""
     return {
         "level": level,
         "verified_at": verified_at,
@@ -81,7 +135,7 @@ def _verification(
     }
 
 
-def _stability(
+def _stability_record(
     level: str,
     *,
     verified_at: str | None = None,
@@ -89,6 +143,7 @@ def _stability(
     evidence_refs: tuple[str, ...] = (),
     limitations: tuple[str, ...] = (),
 ) -> dict[str, Any]:
+    """Build a client-level stability record: how broadly the client has been observed."""
     return {
         "level": level,
         "verified_at": verified_at,
@@ -98,7 +153,7 @@ def _stability(
     }
 
 
-def _capability(
+def _capability_record(
     state: str,
     scope: str,
     *,
@@ -108,77 +163,79 @@ def _capability(
     usage_basis: str = "unknown",
     cost_basis: str = "unknown",
 ) -> dict[str, Any]:
+    """Build one capability cell: state, bounded scope, activation, evidence, and usage/cost basis."""
     return {
         "state": state,
         "scope": scope,
         "activation": activation,
-        "verification": dict(verification or _verification("none")),
+        "verification": dict(verification or _verification_record("none")),
         "limitations": list(limitations),
         "usage_basis": usage_basis,
         "cost_basis": cost_basis,
     }
 
 
-def _unavailable(scope: str) -> dict[str, Any]:
-    return _capability("unavailable", scope, activation="none")
+def _unavailable_capability(scope: str) -> dict[str, Any]:
+    """Build an unavailable capability cell: not implemented, no activation, no evidence."""
+    return _capability_record("unavailable", scope, activation="none")
 
 
-_P5_LIVE = _verification(
+_LOCAL_IMPORT_LIVE = _verification_record(
     "live_smoke",
     verified_at="2026-07-17",
     evidence_refs=("docs/adapter-capability-evidence.md#2026-07-17-local-import-and-dashboard-observation",),
 )
-_CORE_MCP_LIVE = _verification(
+_CORE_MCP_LIVE = _verification_record(
     "live_smoke",
     verified_at="2026-07-02",
     evidence_refs=("docs/live-mcp-client-smoke-results.md#2026-07-02-semantic-context-dogfood-result",),
 )
-_SMALL_CLIENT_MCP_LIVE = _verification(
+_SMALL_CLIENT_MCP_LIVE = _verification_record(
     "live_smoke",
     verified_at="2026-06-28",
     evidence_refs=("docs/coding-agent-integrations.md#maintainer-real-client-smoke-results",),
 )
-_CAPTURE_FIXTURE = _verification(
+_CAPTURE_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=("tests/test_capture_adapters.py::test_versioned_fixtures_normalize_to_expected_canonical_events",),
 )
-_CLAUDE_USAGE_FIXTURE = _verification(
+_CLAUDE_USAGE_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=(
         "tests/test_client_usage.py::test_discover_claude_code_usage_sums_assistant_usage_without_transcript",
     ),
 )
-_CLAUDE_ONBOARD_FIXTURE = _verification(
+_CLAUDE_ONBOARD_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=(
         "tests/test_activation_cli.py::test_fresh_claude_hook_is_verified_before_ready",
     ),
 )
-_CODEX_USAGE_FIXTURE = _verification(
+_CODEX_USAGE_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=(
         "tests/test_client_usage.py::test_discover_codex_usage_reads_non_cached_input_and_cache_metadata",
     ),
 )
-_CODEX_CACHE_WRITE_FIXTURE = _verification(
+_CODEX_CACHE_WRITE_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=(
         "tests/test_client_usage.py::test_discover_codex_usage_uses_row_level_cache_write_capability",
     ),
 )
-_HERMES_USAGE_FIXTURE = _verification(
+_HERMES_USAGE_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=(
         "tests/test_client_usage.py::test_discover_hermes_usage_reads_state_db_sessions_and_client_cost",
     ),
 )
-_HERMES_SESSION_FIXTURE = _verification(
+_HERMES_SESSION_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=(
@@ -186,14 +243,14 @@ _HERMES_SESSION_FIXTURE = _verification(
         "tests/test_client_usage.py::test_hermes_multiple_env_homes_fail_closed_until_explicit_selection",
     ),
 )
-_OPENCODE_USAGE_FIXTURE = _verification(
+_OPENCODE_USAGE_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=(
         "tests/test_client_usage.py::test_discover_opencode_usage_reads_json_event_stream_tokens_and_cost",
     ),
 )
-_OPENCODE_DB_FIXTURE = _verification(
+_OPENCODE_DB_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-29",
     evidence_refs=(
@@ -202,14 +259,14 @@ _OPENCODE_DB_FIXTURE = _verification(
         "tests/test_client_usage.py::test_discover_opencode_usage_presence_flags_track_schema_columns",
     ),
 )
-_OPENCLAW_USAGE_FIXTURE = _verification(
+_OPENCLAW_USAGE_FIXTURE = _verification_record(
     "synthetic_fixture",
     verified_at="2026-07-17",
     evidence_refs=(
         "tests/test_client_usage.py::test_discover_openclaw_usage_reads_jsonl_tokens_and_cost",
     ),
 )
-_CURSOR_LIVE = _verification(
+_CURSOR_LIVE = _verification_record(
     "live_smoke",
     verified_at="2026-07-17",
     client_versions=("3.9.16",),
@@ -228,50 +285,50 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
         "session_scope": "Root and child transcripts, including sessions with no token row yet.",
         "zero_usage_observation": "verified",
         "namespace_hardening": "namespaced_fail_closed",
-        "verified_stability": _stability(
+        "verified_stability": _stability_record(
             "single_machine_live_observation",
             verified_at="2026-07-17",
             evidence_refs=("docs/adapter-capability-evidence.md#2026-07-17-local-import-and-dashboard-observation",),
             limitations=("One live machine plus deterministic tests; multi-version stability is not claimed.",),
         ),
         "capabilities": {
-            "session_discovery": _capability(
+            "session_discovery": _capability_record(
                 "verified_partial",
                 "Local projects JSONL root and child transcript identities, including zero-token observations.",
                 activation="opt_in_project",
-                verification=_P5_LIVE,
+                verification=_LOCAL_IMPORT_LIVE,
                 limitations=("Only declared local Claude Code stores are scanned.",),
             ),
-            "usage_import": _capability(
+            "usage_import": _capability_record(
                 "verified_partial",
                 "Client-reported input and output token totals from local assistant-message rows.",
                 activation="opt_in_project",
-                verification=_P5_LIVE,
+                verification=_LOCAL_IMPORT_LIVE,
                 limitations=("Client-reported usage is not provider billing.",),
                 usage_basis="client_reported",
             ),
-            "mechanical_capture": _capability(
+            "mechanical_capture": _capability_record(
                 "experimental",
                 "Metadata-only Evidence v2 normalizer; the separate legacy bridge supplies join context.",
                 activation="manual_manifest",
                 verification=_CAPTURE_FIXTURE,
                 limitations=("Generic Evidence v2 hook manifests are not installed by onboarding.",),
             ),
-            "mcp_semantics": _capability(
+            "mcp_semantics": _capability_record(
                 "verified",
                 "Project MCP config plus semantic sections, events, checks, and explicit client context.",
                 activation="one_command_project",
                 verification=_CORE_MCP_LIVE,
                 limitations=("Semantic reports do not prove token usage or cost.",),
             ),
-            "model_attribution": _capability(
+            "model_attribution": _capability_record(
                 "experimental",
                 "Model lanes read from assistant usage messages within each transcript.",
                 activation="opt_in_project",
                 verification=_CLAUDE_USAGE_FIXTURE,
                 limitations=("Field-level evidence is synthetic; unknown or missing client model fields remain unattributed.",),
             ),
-            "cache_read": _capability(
+            "cache_read": _capability_record(
                 "experimental",
                 "Cache-read tokens when the client reports the field.",
                 activation="opt_in_project",
@@ -279,7 +336,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Field-level evidence is synthetic; missing fields remain unknown, never inferred as zero.",),
                 usage_basis="client_reported",
             ),
-            "cache_write": _capability(
+            "cache_write": _capability_record(
                 "experimental",
                 "Cache-creation tokens, including reported 5-minute and 1-hour splits.",
                 activation="opt_in_project",
@@ -287,7 +344,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Field-level evidence is synthetic; missing fields remain unknown, never inferred as zero.",),
                 usage_basis="client_reported",
             ),
-            "automatic_install": _capability(
+            "automatic_install": _capability_record(
                 "experimental",
                 "`agentacct onboard --agent claude-code` writes project MCP config, installs the context/directive hook bridge, merges hooks and env into `.claude/settings.local.json`, and verifies the bridge before marking recording ready.",
                 activation="one_command_project",
@@ -309,49 +366,49 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
         "session_scope": "State database and rollout-only root/child sessions, including zero-token observations.",
         "zero_usage_observation": "verified",
         "namespace_hardening": "namespaced_fail_closed",
-        "verified_stability": _stability(
+        "verified_stability": _stability_record(
             "single_machine_live_observation",
             verified_at="2026-07-17",
             evidence_refs=("docs/adapter-capability-evidence.md#2026-07-17-local-import-and-dashboard-observation",),
             limitations=("One live machine plus deterministic tests; multi-version stability is not claimed.",),
         ),
         "capabilities": {
-            "session_discovery": _capability(
+            "session_discovery": _capability_record(
                 "verified_partial",
                 "State database and rollout JSONL identities, including rollout-only and zero-token sessions.",
                 activation="opt_in_project",
-                verification=_P5_LIVE,
+                verification=_LOCAL_IMPORT_LIVE,
                 limitations=("Only declared local Codex stores are scanned.",),
             ),
-            "usage_import": _capability(
+            "usage_import": _capability_record(
                 "verified_partial",
                 "Rollout token-count events with a conservative SQLite fallback.",
                 activation="opt_in_project",
-                verification=_P5_LIVE,
+                verification=_LOCAL_IMPORT_LIVE,
                 limitations=("Replay-like descendant rows can be held as non-additive instead of counted.",),
                 usage_basis="client_reported",
             ),
-            "mechanical_capture": _capability(
+            "mechanical_capture": _capability_record(
                 "experimental",
                 "Metadata-only Evidence v2 normalizer for lifecycle, tool, and check payloads.",
                 activation="manual_manifest",
                 verification=_CAPTURE_FIXTURE,
                 limitations=("No native hook is installed by onboarding.",),
             ),
-            "mcp_semantics": _capability(
+            "mcp_semantics": _capability_record(
                 "verified",
                 "Project MCP config and client-log-evidenced semantic reporting.",
                 activation="one_command_project",
                 verification=_CORE_MCP_LIVE,
                 limitations=("Client-log joins are high confidence, never exact.",),
             ),
-            "model_attribution": _capability(
+            "model_attribution": _capability_record(
                 "experimental",
                 "Session or rollout model metadata, with provenance-labeled exact-parent inheritance only.",
                 activation="opt_in_project",
                 limitations=("No field-level live evidence is recorded; internal workflow labels are not accepted as models.",),
             ),
-            "cache_read": _capability(
+            "cache_read": _capability_record(
                 "experimental",
                 "Cached-input tokens when rollout rows report them.",
                 activation="opt_in_project",
@@ -359,7 +416,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Field-level evidence is synthetic; SQLite-only fallback keeps the split unknown.",),
                 usage_basis="client_reported",
             ),
-            "cache_write": _capability(
+            "cache_write": _capability_record(
                 "experimental",
                 "Cache-write tokens only on rollout rows that expose the field.",
                 activation="opt_in_project",
@@ -367,7 +424,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Only a synthetic field-presence fixture proves this path; current live rows did not report it.",),
                 usage_basis="client_reported",
             ),
-            "automatic_install": _capability(
+            "automatic_install": _capability_record(
                 "verified_partial",
                 "agentacct can write project MCP config and workflow instructions.",
                 activation="one_command_project",
@@ -385,44 +442,44 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
         "session_scope": "Modeled state.db session rows, including rows with no positive usage yet.",
         "zero_usage_observation": "verified",
         "namespace_hardening": "namespaced_fail_closed",
-        "verified_stability": _stability(
+        "verified_stability": _stability_record(
             "single_machine_live_observation",
             verified_at="2026-07-17",
             evidence_refs=("docs/adapter-capability-evidence.md#2026-07-17-local-import-and-dashboard-observation",),
             limitations=("Usage-bearing rows worked on one live store; zero-token observation and multi-home fail-closed behavior have deterministic fixture evidence only.",),
         ),
         "capabilities": {
-            "session_discovery": _capability(
+            "session_discovery": _capability_record(
                 "experimental",
                 "Modeled rows in one selected Hermes state database, including zero-token session observations.",
                 activation="opt_in_project",
                 verification=_HERMES_SESSION_FIXTURE,
                 limitations=("Zero-token and multi-home behavior is fixture-verified; only usage-bearing rows have live evidence.",),
             ),
-            "usage_import": _capability(
+            "usage_import": _capability_record(
                 "verified_partial",
                 "Client-reported input and output token totals from usage-bearing state.db rows.",
                 activation="opt_in_project",
-                verification=_P5_LIVE,
+                verification=_LOCAL_IMPORT_LIVE,
                 limitations=("Optional model/cache/cost fields have synthetic evidence only; schema drift can collapse to an empty result.",),
                 usage_basis="client_reported",
             ),
-            "mechanical_capture": _unavailable("No Hermes mechanical hook or plugin adapter is implemented."),
-            "mcp_semantics": _capability(
+            "mechanical_capture": _unavailable_capability("No Hermes mechanical hook or plugin adapter is implemented."),
+            "mcp_semantics": _capability_record(
                 "verified_partial",
                 "Manual Hermes profile registration can expose agentacct semantic tools.",
                 activation="manual_profile",
                 verification=_SMALL_CLIENT_MCP_LIVE,
                 limitations=("The dated smoke proves MCP calls, not usage import stability.",),
             ),
-            "model_attribution": _capability(
+            "model_attribution": _capability_record(
                 "experimental",
                 "Model and billing provider columns on usage-bearing session rows.",
                 activation="opt_in_project",
                 verification=_HERMES_USAGE_FIXTURE,
                 limitations=("Field-level evidence is synthetic; zero-token rows expose an observed model without claiming usage.",),
             ),
-            "cache_read": _capability(
+            "cache_read": _capability_record(
                 "experimental",
                 "cache_read_tokens when present in the expected state.db schema.",
                 activation="opt_in_project",
@@ -430,7 +487,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Field-level evidence is synthetic; older schemas are not degraded field-by-field.",),
                 usage_basis="client_reported",
             ),
-            "cache_write": _capability(
+            "cache_write": _capability_record(
                 "experimental",
                 "cache_write_tokens when present in the expected state.db schema.",
                 activation="opt_in_project",
@@ -438,7 +495,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Field-level evidence is synthetic; the live store did not provide positive cache-write proof.",),
                 usage_basis="client_reported",
             ),
-            "automatic_install": _unavailable(
+            "automatic_install": _unavailable_capability(
                 "agentacct can render the setup command but does not write the active Hermes profile."
             ),
         },
@@ -452,7 +509,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
         "session_scope": "Usage-bearing session rollups (SQLite) or step-finish exports.",
         "zero_usage_observation": "unavailable",
         "namespace_hardening": "not_hardened",
-        "verified_stability": _stability(
+        "verified_stability": _stability_record(
             "dated_mcp_smoke_only",
             verified_at="2026-06-28",
             client_versions=("1.17.11",),
@@ -460,14 +517,14 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
             limitations=("Only the MCP lane had a real-client smoke; usage parsing remains synthetic-fixture only.",),
         ),
         "capabilities": {
-            "session_discovery": _capability(
+            "session_discovery": _capability_record(
                 "experimental",
                 "Session IDs from the native opencode.db session rollup, or captured/exported JSON step-finish streams as a fallback.",
                 activation="opt_in_project",
                 verification=_OPENCODE_DB_FIXTURE,
                 limitations=("Only usage-bearing sessions are emitted; zero-token sessions are absent.",),
             ),
-            "usage_import": _capability(
+            "usage_import": _capability_record(
                 "experimental",
                 "Per-session input, output, reasoning, and cache token totals from the native SQLite session rollup (JSON export fallback); cost recomputed from tokens when the store records none.",
                 activation="opt_in_project",
@@ -479,22 +536,22 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 usage_basis="client_reported",
                 cost_basis="estimated_from_tokens",
             ),
-            "mechanical_capture": _unavailable("No realtime OpenCode plugin adapter is implemented."),
-            "mcp_semantics": _capability(
+            "mechanical_capture": _unavailable_capability("No realtime OpenCode plugin adapter is implemented."),
+            "mcp_semantics": _capability_record(
                 "verified_partial",
                 "Manual OpenCode user-config registration can expose agentacct semantic tools.",
                 activation="manual_profile",
                 verification=_SMALL_CLIENT_MCP_LIVE,
                 limitations=("The dated DeepSeek smoke does not verify OpenAI or Anthropic paths or usage import.",),
             ),
-            "model_attribution": _capability(
+            "model_attribution": _capability_record(
                 "experimental",
                 "Model id and provider id parsed from the session rollup's model JSON (JSON-export model field as fallback).",
                 activation="opt_in_project",
                 verification=_OPENCODE_DB_FIXTURE,
                 limitations=("Per-message model binding is not imported; the session rollup carries one model per session.",),
             ),
-            "cache_read": _capability(
+            "cache_read": _capability_record(
                 "experimental",
                 "tokens.cache.read when the export reports it.",
                 activation="opt_in_project",
@@ -502,7 +559,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Synthetic fixture only; missing remains unknown.",),
                 usage_basis="client_reported",
             ),
-            "cache_write": _capability(
+            "cache_write": _capability_record(
                 "experimental",
                 "tokens.cache.write when the export reports it.",
                 activation="opt_in_project",
@@ -510,7 +567,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Synthetic fixture only; missing remains unknown.",),
                 usage_basis="client_reported",
             ),
-            "automatic_install": _unavailable(
+            "automatic_install": _unavailable_capability(
                 "agentacct renders the setup command but does not write OpenCode user config or install a plugin."
             ),
         },
@@ -524,7 +581,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
         "session_scope": "Usage-bearing assistant rows in session log files only.",
         "zero_usage_observation": "unavailable",
         "namespace_hardening": "not_hardened",
-        "verified_stability": _stability(
+        "verified_stability": _stability_record(
             "dated_mcp_smoke_only",
             verified_at="2026-06-28",
             client_versions=("2026.6.10",),
@@ -532,14 +589,14 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
             limitations=("Only the MCP lane had a real-client smoke; usage parsing remains synthetic-fixture only.",),
         ),
         "capabilities": {
-            "session_discovery": _capability(
+            "session_discovery": _capability_record(
                 "experimental",
                 "Session IDs derived from JSONL filenames that contain usage-bearing assistant rows.",
                 activation="opt_in_project",
                 verification=_OPENCLAW_USAGE_FIXTURE,
                 limitations=("sessions.json routing and zero-token sessions are not integrated.",),
             ),
-            "usage_import": _capability(
+            "usage_import": _capability_record(
                 "experimental",
                 "Input, output, cache, and optional client cost from assistant usage rows.",
                 activation="opt_in_project",
@@ -548,22 +605,22 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 usage_basis="client_reported",
                 cost_basis="client_reported",
             ),
-            "mechanical_capture": _unavailable("No typed OpenClaw plugin-hook adapter is implemented."),
-            "mcp_semantics": _capability(
+            "mechanical_capture": _unavailable_capability("No typed OpenClaw plugin-hook adapter is implemented."),
+            "mcp_semantics": _capability_record(
                 "verified_partial",
                 "Manual OpenClaw profile registration can expose agentacct semantic tools.",
                 activation="manual_profile",
                 verification=_SMALL_CLIENT_MCP_LIVE,
                 limitations=("The dated DeepSeek smoke does not verify the blocked Claude CLI profile path.",),
             ),
-            "model_attribution": _capability(
+            "model_attribution": _capability_record(
                 "experimental",
                 "Model/provider snapshots or assistant-row fields within one JSONL file.",
                 activation="opt_in_project",
                 verification=_OPENCLAW_USAGE_FIXTURE,
                 limitations=("A multi-model session is currently aggregated under the final/current model.",),
             ),
-            "cache_read": _capability(
+            "cache_read": _capability_record(
                 "experimental",
                 "cacheRead when an assistant usage row reports it.",
                 activation="opt_in_project",
@@ -571,7 +628,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Synthetic fixture only; missing remains unknown.",),
                 usage_basis="client_reported",
             ),
-            "cache_write": _capability(
+            "cache_write": _capability_record(
                 "experimental",
                 "cacheWrite when an assistant usage row reports it.",
                 activation="opt_in_project",
@@ -579,7 +636,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                 limitations=("Synthetic fixture only; missing remains unknown.",),
                 usage_basis="client_reported",
             ),
-            "automatic_install": _unavailable(
+            "automatic_install": _unavailable_capability(
                 "agentacct renders the setup command but does not write OpenClaw profile config or install typed hooks."
             ),
         },
@@ -596,7 +653,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
         "session_scope": "Metadata-only root/child composer observations; no prompt, message, title, token, or cost fields.",
         "zero_usage_observation": "verified",
         "namespace_hardening": "namespaced_fail_closed",
-        "verified_stability": _stability(
+        "verified_stability": _stability_record(
             "single_machine_live_observation",
             verified_at="2026-07-17",
             client_versions=("3.9.16",),
@@ -608,7 +665,7 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
             ),
         ),
         "capabilities": {
-            "session_discovery": _capability(
+            "session_discovery": _capability_record(
                 "verified_partial",
                 "Primary state.vscdb composer identities, timestamps, allowlisted model metadata, and exact child links.",
                 activation="opt_in_project",
@@ -619,21 +676,21 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                     "One real Cursor 3.9.16 store was exercised; multi-version stability is not claimed.",
                 ),
             ),
-            "usage_import": _unavailable("No official local Cursor token importer is claimed."),
-            "mechanical_capture": _capability(
+            "usage_import": _unavailable_capability("No official local Cursor token importer is claimed."),
+            "mechanical_capture": _capability_record(
                 "experimental",
                 "Metadata-only lifecycle, turn, tool, subagent, artifact, and machine-check normalization.",
                 activation="manual_manifest",
                 verification=_CAPTURE_FIXTURE,
                 limitations=("The manifest is render-only and onboarding does not activate it.",),
             ),
-            "mcp_semantics": _capability(
+            "mcp_semantics": _capability_record(
                 "experimental",
                 "A portable generic MCP definition may be configured manually.",
                 activation="manual_profile",
                 limitations=("No real Cursor MCP smoke has been recorded.",),
             ),
-            "model_attribution": _capability(
+            "model_attribution": _capability_record(
                 "verified_partial",
                 "Allowlisted modelConfig.modelName from each composer row; missing/default values remain unknown.",
                 activation="opt_in_project",
@@ -643,9 +700,9 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
                     "One real Cursor 3.9.16 store was exercised; missing/default models remain unattributed.",
                 ),
             ),
-            "cache_read": _unavailable("Hook payload normalization does not report token usage."),
-            "cache_write": _unavailable("Hook payload normalization does not report token usage."),
-            "automatic_install": _unavailable("agentacct does not install Cursor hooks or client config."),
+            "cache_read": _unavailable_capability("Hook payload normalization does not report token usage."),
+            "cache_write": _unavailable_capability("Hook payload normalization does not report token usage."),
+            "automatic_install": _unavailable_capability("agentacct does not install Cursor hooks or client config."),
         },
         "limitations": [
             "Activity observations never fabricate token usage, cache usage, cost, titles, projects, or semantic work descriptions."
@@ -660,9 +717,9 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
             "session_scope": "No adapter implementation or verified fixture exists yet.",
             "zero_usage_observation": "unavailable",
             "namespace_hardening": "not_applicable",
-            "verified_stability": _stability("not_verified"),
+            "verified_stability": _stability_record("not_verified"),
             "capabilities": {
-                name: _unavailable("Roadmap entry only; no implementation or verification exists.")
+                name: _unavailable_capability("Roadmap entry only; no implementation or verification exists.")
                 for name in CAPABILITY_NAMES
             },
             "limitations": ["Generic MCP availability does not upgrade this named client without a real client smoke."],
@@ -679,7 +736,39 @@ _CLIENTS: tuple[dict[str, Any], ...] = (
 
 
 def validate_agent_capability_manifest(manifest: Mapping[str, Any]) -> None:
-    """Reject ambiguous or overclaimed capability data."""
+    """Validate the manifest's integrity, rejecting any overclaim.
+
+    Enforces the honesty contract: every claim must be backed by evidence
+    proportional to its strength.  Called automatically by
+    :func:`agent_capability_manifest` before it returns, and directly by tests
+    that mutate the manifest to exercise rejection paths.
+
+    Raises :class:`ValueError` (with a message naming the client, and the
+    capability lane when relevant) if any of these hold:
+
+      - **Shape**: wrong schema version, ``clients`` not a list, a row or
+        capability cell that is not an object or does not use the canonical
+        field set.
+      - **Client id**: missing, empty, or duplicated.
+      - **Client metadata**: a value outside the controlled vocabulary for
+        roadmap phase, zero-usage observation, namespace hardening, or
+        stability level.
+      - **Evidence vs state**: a ``verified`` or ``verified_partial`` state
+        without real (``real_fixture`` / ``live_smoke``), dated evidence; or a
+        ``synthetic_fixture`` used to back a verified state.
+      - **Unavailable overclaim**: an ``unavailable`` lane that claims
+        activation, verification, or a usage/cost basis.
+      - **Per-lane basis**: a mechanical or MCP lane claiming a usage/cost
+        basis (they carry no tokens); a usage or cache lane not marked
+        ``client_reported``; an ``automatic_install`` lane labelled with a
+        manual activation mode.
+
+    Args:
+      manifest: the manifest dict to check.
+
+    Raises:
+      ValueError: if any rule above is violated.
+    """
 
     if manifest.get("schema_version") != SCHEMA_VERSION:
         raise ValueError("invalid agent capability schema version")
@@ -714,6 +803,8 @@ def validate_agent_capability_manifest(manifest: Mapping[str, Any]) -> None:
         capabilities = row.get("capabilities")
         if not isinstance(capabilities, Mapping) or set(capabilities) != set(CAPABILITY_NAMES):
             raise ValueError(f"{client} must declare the canonical capability set")
+
+        # Per-capability checks: each lane must be honest about its evidence and basis.
         for name, capability in capabilities.items():
             if not isinstance(capability, Mapping):
                 raise ValueError(f"{client}.{name} must be an object")
@@ -767,6 +858,22 @@ def validate_agent_capability_manifest(manifest: Mapping[str, Any]) -> None:
 
 
 def _validate_dated_evidence(evidence: Mapping[str, Any], *, context: str) -> None:
+    """Check that dated evidence has a real ISO date and non-empty relative refs.
+
+    Used by :func:`validate_agent_capability_manifest` for any verified-state
+    claim or stability record.  ``verified_at`` must parse as an ISO calendar
+    date (e.g. ``"2026-07-17"``), and ``evidence_refs`` must be a non-empty
+    list of relative paths -- no leading ``/`` or ``..`` traversal, so the
+    references stay inside the repo's docs.
+
+    Args:
+      evidence: the dict carrying ``verified_at`` and ``evidence_refs``.
+      context: a label (e.g. ``"claude-code.usage_import"``) prefixed onto the
+        error message so the caller knows which claim failed.
+
+    Raises:
+      ValueError: if the date is missing/invalid or the refs are absent/absolute.
+    """
     verified_at = evidence.get("verified_at")
     refs = evidence.get("evidence_refs")
     try:
@@ -783,7 +890,29 @@ def _validate_dated_evidence(evidence: Mapping[str, Any], *, context: str) -> No
 
 
 def agent_capability_manifest() -> dict[str, Any]:
-    """Return a defensive copy of the canonical static manifest."""
+    """Return the canonical, validated capability manifest (a defensive deep copy).
+
+    The manifest is rebuilt from the ``_CLIENTS`` table on every call and
+    validated before returning, so callers can never see an internally
+    inconsistent matrix.
+
+    Returns:
+      A dict containing:
+
+      - ``schema_version`` -- the manifest format version (frozen for compat).
+      - ``last_reviewed_at`` -- the date the evidence was last reviewed.
+      - ``support_policy`` -- a short statement of the per-lane independence rule.
+      - ``runtime_truth`` -- pointers to the live endpoints that complement this
+        static manifest (source detection, ingestion health, evidence).
+      - ``clients`` -- one entry per supported agent, each with eight capability
+        cells plus client-level metadata.
+
+      The returned dict is a deep copy; mutating it does not affect future calls.
+
+    Callers: ``cli.py`` (the ``agentacct capabilities agents`` command),
+    ``api.py`` (the ``/capabilities/agents`` endpoint), and ``evidence_html.py``
+    (the matrix renderer).
+    """
 
     manifest = {
         "schema_version": SCHEMA_VERSION,

--- a/tests/test_agent_capabilities.py
+++ b/tests/test_agent_capabilities.py
@@ -1,3 +1,19 @@
+"""Tests for the static capability manifest and its integrity validator.
+
+The manifest is a table of "what agentacct can do with each coding agent, how
+strongly, and what evidence proves it" (see ``agent_capabilities.py`` for the
+full model and vocabulary).  These tests cover:
+
+- manifest structure (all clients, all 8 lanes, no ``supported`` badge);
+- cross-registry consistency (manifest matches the usage/capture client lists);
+- per-client evidence (specific agents' states and evidence refs);
+- the validator's rejection rules (every overclaim path pinned);
+- the public surfaces (API endpoint, CLI command, dashboard HTML, XSS escape).
+
+How to read the validator tests: each mutates ONE field of an otherwise-valid
+manifest and asserts ``ValueError`` with the expected message substring.
+"""
+
 from __future__ import annotations
 
 import json
@@ -21,10 +37,17 @@ from agentacct.usage_cube import KNOWN_USAGE_CLIENTS
 
 
 def _client_rows() -> dict[str, dict]:
+    """Return ``{client_id: client_entry}`` from the canonical manifest."""
     return {row["client"]: row for row in agent_capability_manifest()["clients"]}
 
 
+# ---------------------------------------------------------------------------
+# Manifest structure: every client, every lane, no "supported" badge.
+# ---------------------------------------------------------------------------
+
+
 def test_manifest_has_stable_independent_lanes_and_no_supported_badge() -> None:
+    """All clients appear in a stable order, each with the 8 canonical lanes, and no whole-client supported boolean."""
     manifest = agent_capability_manifest()
     rows = manifest["clients"]
 
@@ -47,6 +70,7 @@ def test_manifest_has_stable_independent_lanes_and_no_supported_badge() -> None:
 
 
 def test_manifest_matches_usage_and_capture_registries_without_promoting_cursor() -> None:
+    """Clients with usage/capture must match the usage + capture registries exactly."""
     rows = _client_rows()
     usage_clients = {
         client
@@ -65,7 +89,13 @@ def test_manifest_matches_usage_and_capture_registries_without_promoting_cursor(
     assert rows["cursor"]["capabilities"]["usage_import"]["state"] == "unavailable"
 
 
+# ---------------------------------------------------------------------------
+# Per-client evidence: specific agents' states and verification refs.
+# ---------------------------------------------------------------------------
+
+
 def test_hermes_manifest_matches_observation_and_namespace_fixture_scope() -> None:
+    """Hermes uses synthetic fixtures and a namespaced fail-closed observation path."""
     hermes = _client_rows()["hermes"]
 
     assert hermes["zero_usage_observation"] == "verified"
@@ -81,6 +111,7 @@ def test_hermes_manifest_matches_observation_and_namespace_fixture_scope() -> No
 
 
 def test_cursor_manifest_is_observation_only_and_single_version_bounded() -> None:
+    """Cursor is observation-only, single-version bounded, with unavailable usage/cache."""
     cursor = _client_rows()["cursor"]
 
     assert cursor["zero_usage_observation"] == "verified"
@@ -104,6 +135,7 @@ def test_cursor_manifest_is_observation_only_and_single_version_bounded() -> Non
 
 
 def test_claude_one_command_install_is_scoped_to_onboard_and_fixture_only() -> None:
+    """Claude Code's auto-install is experimental (fixture), scoped to onboard, one command."""
     rows = _client_rows()
     capability = rows["claude-code"]["capabilities"]["automatic_install"]
 
@@ -130,6 +162,7 @@ def test_claude_one_command_install_is_scoped_to_onboard_and_fixture_only() -> N
 
 
 def test_manifest_validator_rejects_overclaims() -> None:
+    """Five core overclaim scenarios the validator must catch (verified-without-evidence, synthetic-verified, unavailable-activated, mcp-usage, manual-auto)."""
     missing_evidence = agent_capability_manifest()
     capability = missing_evidence["clients"][0]["capabilities"]["session_discovery"]
     capability["verification"]["evidence_refs"] = []
@@ -160,7 +193,13 @@ def test_manifest_validator_rejects_overclaims() -> None:
         validate_agent_capability_manifest(manual_automatic_install)
 
 
+# ---------------------------------------------------------------------------
+# Public surfaces: API, CLI, dashboard, security.
+# ---------------------------------------------------------------------------
+
+
 def test_manifest_returns_a_defensive_copy() -> None:
+    """Mutating a returned manifest must not affect future calls (deep copy)."""
     first = agent_capability_manifest()
     first["clients"][0]["display_name"] = "MUTATED"
 
@@ -168,6 +207,7 @@ def test_manifest_returns_a_defensive_copy() -> None:
 
 
 def test_agent_capability_api_is_static_read_only_and_path_safe(tmp_path) -> None:
+    """The /capabilities/agents endpoint serves the manifest without writing to disk or leaking paths."""
     state = tmp_path / "state"
     client = TestClient(create_local_api_app(store_dir=state))
     before = sorted(path.relative_to(state) for path in state.rglob("*")) if state.exists() else []
@@ -184,6 +224,7 @@ def test_agent_capability_api_is_static_read_only_and_path_safe(tmp_path) -> Non
 
 
 def test_agent_capability_cli_emits_machine_readable_manifest() -> None:
+    """``capabilities agents --json`` emits the exact manifest, valid for machine parsing."""
     result = CliRunner().invoke(app, ["capabilities", "agents", "--json"])
 
     assert result.exit_code == 0, result.output
@@ -193,6 +234,7 @@ def test_agent_capability_cli_emits_machine_readable_manifest() -> None:
 
 
 def test_agent_capability_cli_human_output_keeps_states_distinct() -> None:
+    """Human-readable CLI output shows all four state words distinctly."""
     result = CliRunner().invoke(app, ["capabilities", "agents"])
 
     assert result.exit_code == 0, result.output
@@ -203,6 +245,7 @@ def test_agent_capability_cli_human_output_keeps_states_distinct() -> None:
 
 
 def test_advanced_dashboard_renders_manifest_and_keeps_runtime_wording_honest(tmp_path) -> None:
+    """The dashboard renders the full matrix and never uses whole-client "supported" language."""
     client = TestClient(create_local_api_app(store_dir=tmp_path / "state"))
 
     advanced = client.get("/advanced").text
@@ -235,6 +278,7 @@ def test_advanced_dashboard_renders_manifest_and_keeps_runtime_wording_honest(tm
 
 
 def test_capability_renderer_escapes_scope_and_agent_labels() -> None:
+    """The HTML renderer must HTML-escape agent names and scope text (XSS defense)."""
     manifest = deepcopy(agent_capability_manifest())
     manifest["clients"][0]["display_name"] = '<script id="agent-canary">'
     manifest["clients"][0]["capabilities"]["usage_import"]["scope"] = '<img src=x onerror="scope-canary">'
@@ -245,3 +289,177 @@ def test_capability_renderer_escapes_scope_and_agent_labels() -> None:
     assert '<img src=x onerror="scope-canary">' not in html
     assert "&lt;script id=&quot;agent-canary&quot;&gt;" in html
     assert "&lt;img src=x onerror=&quot;scope-canary&quot;&gt;" in html
+
+
+# ---------------------------------------------------------------------------
+# validate_agent_capability_manifest: every rejection rule pinned.
+#
+# The validator is the manifest's integrity guarantee -- it stops the published
+# capability matrix from overclaiming. Each case mutates ONE field of an
+# otherwise-valid manifest and asserts the validator rejects it for the right
+# reason. A fresh deep copy is used per case so cases stay independent.
+# ---------------------------------------------------------------------------
+
+
+def _valid_manifest() -> dict:
+    """A fresh deep copy of the canonical manifest; safe to mutate per case."""
+    return agent_capability_manifest()
+
+
+def test_validator_rejects_malformed_manifest_and_client_shape() -> None:
+    """Top-level manifest shape and the per-client row contract."""
+    bad_schema = _valid_manifest()
+    bad_schema["schema_version"] = "agentacct.agent-capabilities.v999"
+    with pytest.raises(ValueError, match="schema version"):
+        validate_agent_capability_manifest(bad_schema)
+
+    not_a_list = _valid_manifest()
+    not_a_list["clients"] = {}
+    with pytest.raises(ValueError, match="clients must be a list"):
+        validate_agent_capability_manifest(not_a_list)
+
+    row_not_object = _valid_manifest()
+    row_not_object["clients"][0] = "not-a-mapping"
+    with pytest.raises(ValueError, match="row must be an object"):
+        validate_agent_capability_manifest(row_not_object)
+
+    extra_client_field = _valid_manifest()
+    extra_client_field["clients"][0]["unexpected"] = True
+    with pytest.raises(ValueError, match="canonical fields"):
+        validate_agent_capability_manifest(extra_client_field)
+
+    duplicate_client_id = _valid_manifest()
+    duplicate_client_id["clients"][1]["client"] = duplicate_client_id["clients"][0]["client"]
+    with pytest.raises(ValueError, match="unique non-empty"):
+        validate_agent_capability_manifest(duplicate_client_id)
+
+
+def test_validator_rejects_bad_client_metadata() -> None:
+    """Per-client metadata: roadmap phase, zero-usage, namespace, stability, capability set."""
+    bad_phase = _valid_manifest()
+    bad_phase["clients"][0]["roadmap_phase"] = "bogus"
+    with pytest.raises(ValueError, match="roadmap phase"):
+        validate_agent_capability_manifest(bad_phase)
+
+    bad_zero_usage = _valid_manifest()
+    bad_zero_usage["clients"][0]["zero_usage_observation"] = "bogus"
+    with pytest.raises(ValueError, match="zero-usage observation"):
+        validate_agent_capability_manifest(bad_zero_usage)
+
+    bad_namespace = _valid_manifest()
+    bad_namespace["clients"][0]["namespace_hardening"] = "bogus"
+    with pytest.raises(ValueError, match="namespace hardening"):
+        validate_agent_capability_manifest(bad_namespace)
+
+    bad_stability = _valid_manifest()
+    bad_stability["clients"][0]["verified_stability"]["level"] = "bogus"
+    with pytest.raises(ValueError, match="verified stability"):
+        validate_agent_capability_manifest(bad_stability)
+
+    # A dated client-smoke stability claim must name at least one client version.
+    smoke_no_versions = _valid_manifest()
+    smoke_no_versions["clients"][0]["verified_stability"] = {
+        "level": "dated_mcp_smoke_only",
+        "verified_at": "2026-07-17",
+        "client_versions": [],
+        "evidence_refs": ["docs/adapter-capability-evidence.md"],
+        "limitations": [],
+    }
+    with pytest.raises(ValueError, match="dated client smoke requires a client version"):
+        validate_agent_capability_manifest(smoke_no_versions)
+
+    wrong_capability_set = _valid_manifest()
+    wrong_capability_set["clients"][0]["capabilities"]["extra_capability"] = {}
+    with pytest.raises(ValueError, match="canonical capability set"):
+        validate_agent_capability_manifest(wrong_capability_set)
+
+
+def test_validator_rejects_bad_capability_fields() -> None:
+    """Each capability must use the canonical fields with valid enum values."""
+    capability_not_object = _valid_manifest()
+    capability_not_object["clients"][0]["capabilities"]["session_discovery"] = "not-a-mapping"
+    with pytest.raises(ValueError, match="must be an object"):
+        validate_agent_capability_manifest(capability_not_object)
+
+    extra_capability_field = _valid_manifest()
+    extra_capability_field["clients"][0]["capabilities"]["session_discovery"]["extra"] = True
+    with pytest.raises(ValueError, match="canonical capability fields"):
+        validate_agent_capability_manifest(extra_capability_field)
+
+    bad_state = _valid_manifest()
+    bad_state["clients"][0]["capabilities"]["session_discovery"]["state"] = "bogus"
+    with pytest.raises(ValueError, match="invalid state"):
+        validate_agent_capability_manifest(bad_state)
+
+    bad_activation = _valid_manifest()
+    bad_activation["clients"][0]["capabilities"]["session_discovery"]["activation"] = "bogus"
+    with pytest.raises(ValueError, match="invalid activation"):
+        validate_agent_capability_manifest(bad_activation)
+
+    empty_scope = _valid_manifest()
+    empty_scope["clients"][0]["capabilities"]["session_discovery"]["scope"] = "  "
+    with pytest.raises(ValueError, match="bounded scope"):
+        validate_agent_capability_manifest(empty_scope)
+
+    bad_verification_level = _valid_manifest()
+    bad_verification_level["clients"][0]["capabilities"]["session_discovery"]["verification"]["level"] = "bogus"
+    with pytest.raises(ValueError, match="invalid verification"):
+        validate_agent_capability_manifest(bad_verification_level)
+
+    bad_usage_basis = _valid_manifest()
+    bad_usage_basis["clients"][0]["capabilities"]["session_discovery"]["usage_basis"] = "bogus"
+    with pytest.raises(ValueError, match="invalid usage or cost basis"):
+        validate_agent_capability_manifest(bad_usage_basis)
+
+
+def test_validator_rejects_capability_specific_overclaims() -> None:
+    """Per-capability honesty rules: basis claims must match the capability type."""
+    # A synthetic-fixture claim must cite exact tests (refs containing "::test_").
+    synthetic_without_test_ref = _valid_manifest()
+    capability = synthetic_without_test_ref["clients"][0]["capabilities"]["mechanical_capture"]
+    capability["state"] = "experimental"
+    capability["verification"] = {
+        "level": "synthetic_fixture",
+        "verified_at": None,
+        "client_versions": [],
+        "evidence_refs": ["docs/no-test-name-here.md"],
+    }
+    with pytest.raises(ValueError, match="must name exact tests"):
+        validate_agent_capability_manifest(synthetic_without_test_ref)
+
+    # An unavailable capability cannot claim a usage/cost basis.
+    unavailable_with_usage_basis = _valid_manifest()
+    capability = unavailable_with_usage_basis["clients"][-1]["capabilities"]["mechanical_capture"]
+    capability["state"] = "unavailable"
+    capability["activation"] = "none"
+    capability["verification"] = {"level": "none", "verified_at": None, "client_versions": [], "evidence_refs": []}
+    capability["usage_basis"] = "client_reported"
+    with pytest.raises(ValueError, match="unavailable state cannot claim usage"):
+        validate_agent_capability_manifest(unavailable_with_usage_basis)
+
+    # usage_import (when not unavailable) must be client_reported.
+    usage_import_unknown_basis = _valid_manifest()
+    usage_import_unknown_basis["clients"][0]["capabilities"]["usage_import"]["usage_basis"] = "unknown"
+    with pytest.raises(ValueError, match="must declare client-reported usage basis"):
+        validate_agent_capability_manifest(usage_import_unknown_basis)
+
+    # cache_read / cache_write (when not unavailable) must be client_reported.
+    cache_unknown_basis = _valid_manifest()
+    cache_unknown_basis["clients"][0]["capabilities"]["cache_read"]["usage_basis"] = "unknown"
+    with pytest.raises(ValueError, match="must declare the cache usage basis"):
+        validate_agent_capability_manifest(cache_unknown_basis)
+
+
+def test_validator_rejects_malformed_dated_evidence() -> None:
+    """A verified claim's evidence must carry a real ISO date and relative refs."""
+    bad_date = _valid_manifest()
+    bad_date["clients"][0]["capabilities"]["session_discovery"]["verification"]["verified_at"] = "not-a-date"
+    with pytest.raises(ValueError, match="requires dated evidence refs"):
+        validate_agent_capability_manifest(bad_date)
+
+    absolute_ref = _valid_manifest()
+    absolute_ref["clients"][0]["capabilities"]["session_discovery"]["verification"]["evidence_refs"] = [
+        "/absolute/path.md"
+    ]
+    with pytest.raises(ValueError, match="non-empty relative paths"):
+        validate_agent_capability_manifest(absolute_ref)


### PR DESCRIPTION
## Summary
Readability, naming, documentation, and test-coverage cleanup of `agent_capabilities.py` and its test file. **No behavior change** — same test pass/fail as baseline.

## What changed

**Naming (cognitive load):**
- `_P5_LIVE` → `_LOCAL_IMPORT_LIVE` (was totally opaque — "P5" had no meaning).
- 4 noun-factories → record-builders: `_verification` → `_verification_record`, `_stability` → `_stability_record`, `_capability` → `_capability_record`, `_unavailable` → `_unavailable_capability`.

**Documentation:**
- Module docstring: concept guide (what it's for, where it fits as the static half vs runtime detection, how it's used by 3 callers with file refs, what's inside) + plain-English glossary of every vocabulary term (8 lanes, 4 states, 4 verification levels, activation modes) + the honesty rule.
- `validate_agent_capability_manifest`: detailed docstring — 7 rule categories, when called, `Args`/`Raises`.
- `agent_capability_manifest`: detailed docstring — return shape (5 keys), deep-copy guarantee, callers (cli.py, api.py, evidence_html.py).
- `_validate_dated_evidence` + 4 factories: docstrings added.
- Validator section signpost (per-capability checks).

**Tests (`test_agent_capabilities.py`, 12 → 17):**
- Coverage: **80% → 98.5%** (+5 grouped rejection tests covering the validator's 24 reachable missing branches).
- Found 2 dead-code lines (696, 744: unreachable redundant checks — earlier checks catch those cases first).
- Module docstring + 4 section headers + per-test docstrings on all 17 tests + helper documentation.

## Verification
- `pytest tests/ -q`: **2885 passed**, 14 failed = the known macOS-only process-control set (identical to baseline), 1 skipped. **No regressions.**
- `py_compile` clean; `git diff --check` clean.

## Notes
- 3 substring-collision casualties from the initial rename (`agent_capability_manifest`, a test-name evidence-ref string, the `verified_stability` dict key) were all caught and fixed during the session.
- The 2 dead-code lines (696, 744) are flagged for optional removal in a follow-up.
