### PR TITLE
fix: stop showing a fixed check as an unresolved finding

### DIFF
--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -461,7 +461,7 @@ class FindingDispositionRequest(BaseModel):
     # Shape validation belongs to the opaque resolver so malformed and stale
     # tokens share one generic 404 instead of exposing token internals.
     finding_token: str = Field(min_length=1, max_length=128, pattern=r"^[^\r\n\x00]+$")
-    action: str = Field(pattern=r"^(?:mark_reviewed|resolve|reopen)$")
+    action: str = Field(pattern=r"^(?:mark_reviewed|resolve|reopen|reinstate)$")
     expected_revision: int = Field(ge=0)
     note: str = Field(default="", max_length=1200, pattern=r"^[^\r\n\x00]*$")
 
@@ -7011,7 +7011,7 @@ def _work_action_html(item: Mapping[str, Any], state: Mapping[str, Any], esc: An
             '<div class="work-feed-finding-head"><strong>Resolved in a later check</strong></div>'
             + "".join(rows)
             + '<p class="work-feed-finding-context">agentacct keeps the failed check in history. '
-            "It is not attention and it is not a verified outcome; reopen it if the later pass was unrelated.</p></div>"
+            "It is not attention and it is not a verified outcome; reinstate it if the later pass was unrelated.</p></div>"
         )
     resolution = (
         item.get("blocker_resolution")
@@ -7816,7 +7816,7 @@ def _finding_episode_controls_html(
         if superseded:
             truth_copy = (
                 "A later same-scope check passed. The failed result stays in history; "
-                "reopen it here if that later pass was unrelated."
+                "reinstate it to attention here if that later pass was unrelated."
             )
         elif state == "reviewed":
             truth_copy = "Reviewed by you; no passing rerun has been recorded."
@@ -7856,6 +7856,18 @@ def _finding_episode_controls_html(
                     + common
                     + hidden("action", "reopen")
                     + '<button class="task-control-button is-danger" type="submit">Reopen</button></form>'
+                )
+            elif superseded:
+                # An automatically superseded finding sits at disposition_state
+                # ``open`` but carries no attention. If the later pass was
+                # unrelated, one reinstate brings it back to Needs attention —
+                # this is the control the "reopen it here" copy promises.
+                forms.append(
+                    '<form method="post" action="/findings/disposition">'
+                    + common
+                    + hidden("action", "reinstate")
+                    + '<button class="task-control-button is-danger" type="submit">'
+                    + "Reinstate to attention</button></form>"
                 )
             controls = '<div class="finding-review-actions">' + "".join(forms) + "</div>"
         elif not chain_valid:

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -3493,6 +3493,7 @@ _DASHBOARD_STYLE = """    :root {
       .work-feed-item.action-required { background: rgba(248, 113, 113, 0.07); border-color: rgba(248, 113, 113, 0.3); }
       .work-feed-action { background: rgba(251, 146, 60, 0.09); border-color: rgba(251, 146, 60, 0.28); }
       .work-feed-finding { background: rgba(251, 191, 36, 0.09); border-color: rgba(251, 191, 36, 0.28); }
+      .work-feed-finding.work-feed-finding-superseded { background: rgba(134, 239, 172, 0.10); border-color: rgba(134, 239, 172, 0.28); }
     }
     * { box-sizing: border-box; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; color: var(--color-text); background: var(--color-bg); }
@@ -3575,6 +3576,7 @@ _DASHBOARD_STYLE = """    :root {
     .work-overview-stat span { color: #cbd5e1; font-size: var(--font-xs); }
     .work-overview-stat.finding strong { color: #fcd34d; }
     .work-overview-stat.action strong { color: #fca5a5; }
+    .work-overview-stat.superseded strong { color: #86efac; }
     .usage-pulse { align-items: stretch; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 16px; box-shadow: 0 8px 24px rgba(15,23,42,0.05); display: grid; gap: 0; grid-template-columns: minmax(205px, 0.68fr) minmax(0, 1.7fr); margin-bottom: var(--space-6); overflow: hidden; }
     .usage-pulse-copy { background: linear-gradient(155deg, #ecfeff, #f8fafc); border-right: 1px solid var(--color-border); padding: 1.1rem 1.25rem; }
     .usage-pulse-copy h2 { font-size: 1.18rem; }
@@ -3661,6 +3663,10 @@ _DASHBOARD_STYLE = """    :root {
     .work-feed-finding-head span { color: var(--color-text-faint); font-size: var(--font-xs); }
     .work-feed-finding > p { line-height: 1.45; margin-top: var(--space-2); }
     .work-feed-finding-context { color: var(--color-text-muted); font-size: var(--font-note); }
+    .work-feed-finding.work-feed-finding-superseded { background: rgba(134, 239, 172, 0.10); border-color: rgba(134, 239, 172, 0.30); }
+    .work-feed-finding-superseded-row { border-top: 1px solid rgba(148, 163, 184, 0.25); margin-top: var(--space-3); padding-top: var(--space-3); }
+    .work-feed-finding-pass { border-left: 3px solid #86efac; margin-top: var(--space-2); padding-left: var(--space-3); }
+    .work-feed-finding-pass strong { color: #16a34a; font-size: var(--font-xs); text-transform: uppercase; }
     .task-work-preview { background: linear-gradient(145deg, #f8fafc, #f1f5f9); border: 1px solid var(--color-border); border-radius: 10px; display: grid; gap: 0; margin-top: var(--space-5); overflow: hidden; }
     .task-work-preview-head { align-items: center; background: rgba(255,255,255,0.66); border-bottom: 1px solid var(--color-border); display: flex; justify-content: space-between; padding: 0.58rem 0.68rem; }
     .task-work-preview-head strong { color: var(--color-text-secondary); font-size: var(--font-xs); text-transform: uppercase; }
@@ -6210,6 +6216,7 @@ def _latest_actionable_failed_check(item: Mapping[str, Any]) -> Mapping[str, Any
         (observed_at, event)
         for event, observed_at in _latest_machine_check_events(item)
         if str(event.get("result") or "unknown").lower() in {"failed", "error"}
+        and str(event.get("supersession_state") or "") != "superseded"
         and episode_states.get(str(finding_target_digest(event) or ""), "open") == "open"
     ]
     return max(failures, key=lambda entry: entry[0])[1] if failures else None
@@ -6266,6 +6273,17 @@ def _work_product_state(item: Mapping[str, Any]) -> dict[str, Any]:
         for event, _observed_at in latest_check_events
         if str(event.get("result") or "unknown").lower() in {"failed", "error"}
     ]
+    # A superseded failure is contradicted by a later same-scope pass. It stays
+    # in the check set (never removed, so it can never fall through to Verified),
+    # but it is not a standing finding and it never carries attention.
+    superseded_present = any(
+        str(event.get("supersession_state") or "") == "superseded" for event in failed_events
+    )
+    standing_failed_events = [
+        event
+        for event in failed_events
+        if str(event.get("supersession_state") or "") != "superseded"
+    ]
     if failed_events:
         episode_states = {
             str(episode.get("target_digest")): str(episode.get("disposition_state") or "open")
@@ -6278,9 +6296,22 @@ def _work_product_state(item: Mapping[str, Any]) -> dict[str, Any]:
         }
         finding_states = [
             episode_states.get(str(finding_target_digest(event) or ""), "open")
-            for event in failed_events
+            for event in standing_failed_events
         ]
-        if "open" not in finding_states:
+        if "open" in finding_states:
+            return {
+                "key": "open_finding",
+                "label": "Open finding",
+                "css": "status-finding",
+                "action_required": False,
+                "finding_open": True,
+                "rank": 2,
+                "why": (
+                    "An agent-reported check found an issue in the work. agentacct preserves that evidence; "
+                    "it is not a agentacct system failure or an inferred user assignment."
+                ),
+            }
+        if standing_failed_events:
             reviewed = "reviewed" in finding_states
             return {
                 "key": "finding_reviewed" if reviewed else "finding_resolved",
@@ -6296,16 +6327,18 @@ def _work_product_state(item: Mapping[str, Any]) -> dict[str, Any]:
                     else "The dashboard user marked this finding resolved; this is not machine verification."
                 ),
             }
+        # Only superseded failures remain: resolved in a later same-scope check.
         return {
-            "key": "open_finding",
-            "label": "Open finding",
-            "css": "status-finding",
+            "key": "finding_superseded",
+            "label": "Finding · resolved in a later check",
+            "css": "status-missing",
             "action_required": False,
-            "finding_open": True,
+            "finding_open": False,
+            "finding_present": True,
             "rank": 2,
             "why": (
-                "An agent-reported check found an issue in the work. agentacct preserves that evidence; "
-                "it is not a agentacct system failure or an inferred user assignment."
+                "A recorded check failed, but a later same-scope check passed. agentacct keeps the "
+                "failure in history; it is not attention and it is not a verified outcome."
             ),
         }
     if status in {"started", "checkpoint", "active", "in_progress"}:
@@ -6319,7 +6352,11 @@ def _work_product_state(item: Mapping[str, Any]) -> dict[str, Any]:
         }
     latest_checks_all_pass = bool(latest_checks) and all(result == "passed" for result, _ in latest_checks)
     projected_checks = isinstance(item.get("current_check_events"), list)
-    if status in {"completed", "passed"} and (
+    # A demoted-but-present failure can never upgrade the item to Verified. This
+    # is redundant with the failed-events branch above returning first, but it is
+    # stated explicitly so a later "just hide the failure" refactor cannot let a
+    # superseded failure silently become the product's strongest claim.
+    if status in {"completed", "passed"} and not superseded_present and (
         latest_checks_all_pass
         or (evidence == "strong" and not latest_checks and not projected_checks)
     ):
@@ -6812,6 +6849,12 @@ def _run_flow_html(*, state_key: str, has_work: bool, esc: Any) -> str:
             "Activity and task recorded; the failed check remains objective evidence, "
             "and its attention state was reviewed without creating a verified outcome."
         )
+    elif state_key == "finding_superseded":
+        classes = ("is-done", "is-done", "is-reported", "")
+        description = (
+            "Activity and task recorded; a failed check was contradicted by a later same-scope pass. "
+            "The failure stays in history and the outcome is not verified."
+        )
     elif state_key == "blocked":
         classes = ("is-done", "is-warning", "", "is-warning")
         description = "Activity recorded; task is blocked before a verified outcome."
@@ -6898,11 +6941,78 @@ def _run_card_html(
     """
 
 
+def _check_event_index(item: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    """Map event_id -> check event across the item's current/evidence checks."""
+
+    index: dict[str, Mapping[str, Any]] = {}
+    for key in ("current_check_events", "evidence_events"):
+        rows = item.get(key)
+        if not isinstance(rows, list):
+            continue
+        for event in rows:
+            if isinstance(event, Mapping) and event.get("event_id"):
+                index.setdefault(str(event.get("event_id")), event)
+    return index
+
+
+def _superseded_pairs(item: Mapping[str, Any]) -> list[tuple[Mapping[str, Any], Mapping[str, Any] | None]]:
+    """Return (failure_event, later_passing_event) for each superseded finding."""
+
+    episodes = item.get("finding_episodes") if isinstance(item.get("finding_episodes"), list) else []
+    index = _check_event_index(item)
+    pairs: list[tuple[Mapping[str, Any], Mapping[str, Any] | None]] = []
+    for episode in episodes:
+        if not isinstance(episode, Mapping):
+            continue
+        if str(episode.get("supersession_state") or "") != "superseded":
+            continue
+        failure = episode.get("failure_event") if isinstance(episode.get("failure_event"), Mapping) else {}
+        passing = index.get(str(episode.get("superseded_by_event_id") or "")) or (
+            index.get(str(failure.get("superseded_by_event_id") or "")) if failure else None
+        )
+        pairs.append((failure, passing))
+    return pairs
+
+
 def _work_action_html(item: Mapping[str, Any], state: Mapping[str, Any], esc: Any) -> str:
     action_parts: list[str] = []
     blocker = str(item.get("blocker") or "").strip()
     next_step = str(item.get("next_step") or "").strip()
     state_key = str(state.get("key") or "")
+    if state_key == "finding_superseded":
+        pairs = _superseded_pairs(item)
+        rows: list[str] = []
+        for failure, passing in pairs:
+            evidence_label = _display_count_label(str(failure.get("evidence_type") or "check"))
+            failure_summary = str(failure.get("summary") or "").strip() or (
+                "An agent-reported check found an issue in the work being reviewed."
+            )
+            failure_time = _fmt_time(failure.get("created_at"))
+            pass_block = ""
+            if isinstance(passing, Mapping):
+                pass_summary = str(passing.get("summary") or "").strip() or "A later same-scope check passed."
+                pass_time = _fmt_time(passing.get("created_at"))
+                pass_block = (
+                    '<div class="work-feed-finding-pass"><strong>Later check passed'
+                    f'{(" · " + esc(pass_time)) if pass_time else ""}</strong>'
+                    f"<p>{esc(pass_summary)}</p></div>"
+                )
+            rows.append(
+                '<div class="work-feed-finding-superseded-row">'
+                '<div class="work-feed-finding-head"><strong>Failed check'
+                f'{(" · " + esc(failure_time)) if failure_time else ""}</strong>'
+                f"<span>{esc(evidence_label)} check</span></div>"
+                f"<p>{esc(failure_summary)}</p>{pass_block}</div>"
+            )
+        # Drop "No follow-up action was recorded." here: a later same-scope pass
+        # is the follow-up. The failed check stays visible above the pass.
+        return (
+            '<div class="work-feed-finding work-feed-finding-superseded">'
+            '<div class="work-feed-finding-head"><strong>Resolved in a later check</strong></div>'
+            + "".join(rows)
+            + '<p class="work-feed-finding-context">agentacct keeps the failed check in history. '
+            "It is not attention and it is not a verified outcome; reopen it if the later pass was unrelated.</p></div>"
+        )
     resolution = (
         item.get("blocker_resolution")
         if isinstance(item.get("blocker_resolution"), Mapping)
@@ -6933,6 +7043,16 @@ def _work_action_html(item: Mapping[str, Any], state: Mapping[str, Any], esc: An
             "An agent-reported check found an issue in the work being reviewed."
         )
         evidence_label = _display_count_label(str(finding.get("evidence_type") or "check"))
+        # An unconfirmed finding has a later same-scope pass agentacct cannot
+        # prove is the same check. It stays a standing finding, but the later
+        # pass is disclosed inline so the reader sees the ambiguity.
+        unconfirmed_note = ""
+        if str(finding.get("supersession_state") or "") == "unconfirmed":
+            unconfirmed_note = (
+                '<p class="work-feed-finding-context work-feed-finding-unconfirmed">'
+                f"A later {esc(str(finding.get('evidence_type') or 'check'))} check passed; "
+                "agentacct cannot prove it is the same check, so this finding stays open.</p>"
+            )
         return (
             '<div class="work-feed-finding">'
             '<div class="work-feed-finding-head"><strong>Agent finding</strong>'
@@ -6940,7 +7060,8 @@ def _work_action_html(item: Mapping[str, Any], state: Mapping[str, Any], esc: An
             f"<p>{esc(finding_summary)}</p>"
             '<p class="work-feed-finding-context">This finding is about the work being reviewed, '
             "not agentacct health. No follow-up action was recorded. agentacct does not "
-            "guess who should act next.</p></div>"
+            "guess who should act next.</p>"
+            f"{unconfirmed_note}</div>"
         )
     elif next_step and state_key in {"blocked", "in_progress"}:
         label = "Decision needed" if state_key == "blocked" else "Next"
@@ -7350,6 +7471,23 @@ def _task_product_state(
             state,
             check_carrier,
         )
+    if outcome_key == "finding_superseded":
+        return (
+            {
+                "key": "finding_superseded",
+                "label": "Finding · resolved in a later check",
+                "css": "status-missing",
+                "rank": 2,
+                "action_required": False,
+                "finding_open": False,
+                "finding_present": True,
+                "why": (
+                    "A recorded check failed, but a later same-scope check passed. agentacct keeps the "
+                    "failure in history; it is not attention and it is not a verified outcome."
+                ),
+            },
+            check_carrier,
+        )
     if outcome_key == "observed":
         return (
             {
@@ -7654,11 +7792,20 @@ def _finding_episode_controls_html(
             else {}
         )
         state = str(episode.get("disposition_state") or "open")
-        label = {
-            "reviewed": "Reviewed",
-            "resolved": "Marked resolved",
-        }.get(state, "Open finding")
-        css = "status-finding" if state == "open" else "status-missing"
+        # A superseded episode is not attention: a later same-scope pass
+        # contradicted it. It stays visible (and reopenable via the same
+        # controls), but it must never read as an "Open finding".
+        superseded = str(episode.get("supersession_state") or "") == "superseded" and not episode.get(
+            "attention_open"
+        )
+        if superseded:
+            label = "Resolved in a later check"
+        else:
+            label = {
+                "reviewed": "Reviewed",
+                "resolved": "Marked resolved",
+            }.get(state, "Open finding")
+        css = "status-finding" if (state == "open" and not superseded) else "status-missing"
         summary = str(event.get("summary") or "").strip() or "A failed check was recorded."
         evidence_label = _display_count_label(str(event.get("evidence_type") or "check"))
         observed = _fmt_time(event.get("created_at"))
@@ -7666,7 +7813,12 @@ def _finding_episode_controls_html(
         revision = int(episode.get("revision") or 0)
         note = str(disposition.get("note") or "").strip()
         note_html = f'<p><strong>Disposition note:</strong> {esc(note)}</p>' if note else ""
-        if state == "reviewed":
+        if superseded:
+            truth_copy = (
+                "A later same-scope check passed. The failed result stays in history; "
+                "reopen it here if that later pass was unrelated."
+            )
+        elif state == "reviewed":
             truth_copy = "Reviewed by you; no passing rerun has been recorded."
         elif state == "resolved":
             truth_copy = "Marked resolved by you; this is not machine verification."
@@ -8027,6 +8179,10 @@ def _task_feed_item_html(
         or state.get("key") == "resolved"
     ):
         action_html += _work_action_html(state_item, state, esc)
+    elif state.get("key") == "finding_superseded":
+        # Render the superseded failure and its later passing check adjacently
+        # off the Task's own episodes + check events.
+        action_html += _work_action_html(task, state, esc)
     # Inline finding review + resolve/reopen in the visible card body, not the
     # details expander, so the disposition action is one click away.
     action_html += _finding_episode_controls_html(
@@ -8162,7 +8318,11 @@ def _visible_attention_entries(
         and (
             entry["state"].get("action_required")
             or entry["state"].get("finding_open")
-            or entry["state"].get("finding_present")
+            # A superseded finding is present but not attention: it must not pin.
+            or (
+                entry["state"].get("finding_present")
+                and entry["state"].get("key") != "finding_superseded"
+            )
         )
     }
     selected_ids = set(required_ids)
@@ -9370,13 +9530,23 @@ def _apply_finding_dispositions_to_projection(
             seen.add(target_digest)
             disposition = disposition_for_event(event, disposition_projection)
             token = _finding_form_token(form_secret, event)
+            superseded = str(event.get("supersession_state") or "") == "superseded"
+            # A superseded failure carries no attention on its own, but stays
+            # reopenable: once the user has explicitly acted on it (revision > 0),
+            # their disposition wins over the automatic supersession.
+            attention_open = (disposition.state == "open") and (
+                not superseded or int(disposition.revision or 0) > 0
+            )
             episodes.append(
                 {
                     "target_digest": target_digest,
                     "finding_token": token,
                     "objective_state": "current_failure",
                     "disposition_state": disposition.state,
-                    "attention_open": disposition.state == "open",
+                    "attention_open": attention_open,
+                    "supersession_state": str(event.get("supersession_state") or "") or None,
+                    "superseded_by_event_id": event.get("superseded_by_event_id"),
+                    "supersession_basis": event.get("supersession_basis"),
                     "revision": disposition.revision,
                     "failure_event": dict(event),
                     "latest_disposition": disposition.to_dict(),
@@ -9541,6 +9711,12 @@ def _apply_finding_dispositions_to_projection(
     open_count = sum(bool(episode.get("attention_open")) for episode in all_episodes)
     reviewed_count = sum(episode.get("disposition_state") == "reviewed" for episode in all_episodes)
     resolved_count = sum(episode.get("disposition_state") == "resolved" for episode in all_episodes)
+    # A superseded finding gets its own bucket and count -- never folded into
+    # "Open findings", never dropped from history.
+    superseded_count = sum(
+        str(episode.get("supersession_state") or "") == "superseded" and not episode.get("attention_open")
+        for episode in all_episodes
+    )
     summary = projection.get("summary") if isinstance(projection.get("summary"), dict) else {}
     projection["summary"] = {
         **summary,
@@ -9552,6 +9728,7 @@ def _apply_finding_dispositions_to_projection(
         ),
         "unassigned_open_finding_count": len(open_unassigned),
         "total_open_finding_count": open_count,
+        "superseded_finding_count": superseded_count,
         "current_finding_count": len(all_episodes),
         "reviewed_finding_count": reviewed_count,
         "resolved_finding_count": resolved_count,
@@ -10247,6 +10424,18 @@ def _overview_body(
     )
     assigned_finding_count = task_finding_count + unresolved_finding_count
     finding_count = assigned_finding_count + len(unassigned_findings)
+    # A superseded finding is resolved-in-a-later-check: its own tile, never
+    # folded into "Open findings", never counted as needing input.
+    superseded_finding_count = int(
+        (projection.get("summary") or {}).get("superseded_finding_count") or 0
+    )
+    superseded_stat_html = (
+        '<div class="work-overview-stat superseded">'
+        f"<strong>{esc(_fmt_int(superseded_finding_count))}</strong>"
+        "<span>Resolved in later check</span></div>"
+        if superseded_finding_count
+        else ""
+    )
     verified_count = sum(1 for state in states if state.get("key") == "verified")
     if action_count:
         headline = f"{_fmt_int(action_count)} {'task needs' if action_count == 1 else 'tasks need'} input"
@@ -10392,6 +10581,7 @@ def _overview_body(
           <div class="work-overview-stat"><strong>{esc(_fmt_int(in_progress_count))}</strong><span>In progress</span></div>
           <div class="work-overview-stat finding"><strong>{esc(_fmt_int(finding_count))}</strong><span>Open findings</span></div>
           <div class="work-overview-stat action"><strong>{esc(_fmt_int(action_count))}</strong><span>Needs input</span></div>
+          {superseded_stat_html}
         </div>
       </div>
     </section>

--- a/src/agentacct/finding_disposition.py
+++ b/src/agentacct/finding_disposition.py
@@ -24,7 +24,7 @@ FINDING_DISPOSITION_SOURCE = "agent-chronicle-dashboard"
 FINDING_DISPOSITION_AUTHORITY_SCOPE = "finding_attention_only"
 FINDING_TARGET_SCHEMA = "agent-chronicle.finding-target.v1"
 
-FINDING_ACTIONS = {"mark_reviewed", "resolve", "reopen"}
+FINDING_ACTIONS = {"mark_reviewed", "resolve", "reopen", "reinstate"}
 FINDING_STATES = {"open", "reviewed", "resolved"}
 _HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 
@@ -151,6 +151,15 @@ def disposition_transition(prior_state: str, action: str) -> str | None:
     if action == "resolve" and prior_state in {"open", "reviewed"}:
         return "resolved"
     if action == "reopen" and prior_state in {"reviewed", "resolved"}:
+        return "open"
+    if action == "reinstate" and prior_state == "open":
+        # Reinstate is the dispute path for an automatically superseded finding:
+        # the failure sits at disposition_state ``open`` with no attention (a
+        # later same-scope pass demoted it). The state stays ``open`` but the
+        # bumped revision makes the user's explicit choice win over the automatic
+        # supersession, so the finding returns to Needs attention. It is distinct
+        # from ``reopen`` (which pulls a reviewed/resolved finding back) so the
+        # reopen contract and its state-machine tests are untouched.
         return "open"
     return None
 

--- a/src/agentacct/mcp.py
+++ b/src/agentacct/mcp.py
@@ -97,13 +97,29 @@ TOOLS: list[dict[str, Any]] = [
             "type": "object",
             "properties": {
                 "run_id": {"type": "string", "default": "latest"},
-                "name": {"type": "string", "default": "check"},
+                "name": {
+                    "type": "string",
+                    "default": "check",
+                    "description": (
+                        "Human name of the exact check. Reusing the SAME name (and command) across a "
+                        "re-run is what lets a later passing check supersede an earlier failure of the "
+                        "same check; a different name/command reads as a different check."
+                    ),
+                },
                 "before_exit_code": {"type": ["integer", "null"]},
                 "after_exit_code": {"type": ["integer", "null"]},
                 "before_summary": {"type": ["string", "null"]},
                 "after_summary": {"type": ["string", "null"]},
                 "source": {"type": ["string", "null"], "maxLength": 80},
-                "section_id": {"type": ["string", "null"], "maxLength": 120},
+                "section_id": {
+                    "type": ["string", "null"],
+                    "maxLength": 120,
+                    "description": (
+                        "Identifies the one step this check belongs to; keep it stable across the step's "
+                        "started/checkpoint/completed reports. Do not reuse a section_id as a project id "
+                        "or across unrelated work -- a check only supersedes a failure in the same section."
+                    ),
+                },
                 "work_id": {"type": ["string", "null"], "maxLength": 120},
                 "evidence_type": {"type": ["string", "null"], "enum": ["test", "build", "lint", "typecheck", "smoke", "benchmark", "browser", "security", "artifact", "other", None]},
                 "result": {"type": ["string", "null"], "enum": ["passed", "failed", "skipped", "error", "unknown", None]},
@@ -121,6 +137,16 @@ TOOLS: list[dict[str, Any]] = [
                 "resolves_blocked_event_id": {"type": ["string", "null"], "maxLength": 240},
                 "resolution_scope": {"type": ["string", "null"], "enum": ["full", "partial", None]},
                 "resolution_summary": {"type": ["string", "null"], "maxLength": 1200},
+                "supersedes_check_event_id": {
+                    "type": ["string", "null"],
+                    "maxLength": 240,
+                    "description": (
+                        "Optional, forward-only: on a PASSING check, the event_id of the earlier FAILED "
+                        "check (same source/section/project/type) this run fixes. It only lets the failure "
+                        "be shown as resolved-in-a-later-check; it never mutates section status and is not "
+                        "a blocker resolution."
+                    ),
+                },
             },
             "additionalProperties": False,
         },
@@ -180,7 +206,16 @@ TOOLS: list[dict[str, Any]] = [
             "type": "object",
             "properties": {
                 "source": {"type": "string", "minLength": 1, "maxLength": 80},
-                "section_id": {"type": "string", "minLength": 1, "maxLength": 120},
+                "section_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120,
+                    "description": (
+                        "Stable id for ONE step of work; keep it identical across this step's "
+                        "started/checkpoint/completed reports so its reports and checks group together. "
+                        "Do not reuse it as a project id or across unrelated work."
+                    ),
+                },
                 "section_status": {"type": "string", "enum": ["started", "checkpoint", "completed", "blocked"]},
                 "run_id": {"type": ["string", "null"], "maxLength": 128, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"},
                 "section_title": {
@@ -1144,6 +1179,7 @@ class SentinelMCPServer:
                     "resolves_blocked_event_id",
                     "resolution_scope",
                     "resolution_summary",
+                    "supersedes_check_event_id",
                 },
             )
             payload: dict[str, Any] = {}
@@ -1169,6 +1205,7 @@ class SentinelMCPServer:
                     "resolves_blocked_event_id",
                     "resolution_scope",
                     "resolution_summary",
+                    "supersedes_check_event_id",
                 }
             )
             has_outcome_fields = any(key in arguments for key in {"before_exit_code", "after_exit_code", "before_summary", "after_summary"}) or not has_evidence_fields
@@ -1229,6 +1266,18 @@ class SentinelMCPServer:
                     raise InvalidParams(
                         "resolves_blocked_event_id, resolution_scope, and resolution_summary must be supplied together"
                     )
+                # Forward-only agent-declared supersession. Only a PASSING check
+                # may name the earlier failed check it fixes. This never routes
+                # through the blocker-resolution path (which would mutate section
+                # status) -- it is honored solely by the read-time supersession
+                # gate, and only when scope also matches.
+                supersedes_check_event_id = _optional_limited_str(
+                    arguments, "supersedes_check_event_id", None, max_length=240
+                )
+                if supersedes_check_event_id is not None and result != "passed":
+                    raise InvalidParams(
+                        "supersedes_check_event_id requires result=passed (only a passing check may supersede a failure)"
+                    )
                 evidence_exit_code = _optional_nullable_int(arguments, "exit_code")
                 resolution_objective_basis: str | None = None
                 if resolution_requested:
@@ -1286,6 +1335,7 @@ class SentinelMCPServer:
                     "resolution_scope": resolution_scope,
                     "resolution_summary": resolution_summary,
                     "resolution_objective_basis": resolution_objective_basis,
+                    "supersedes_check_event_id": supersedes_check_event_id,
                     # Server-authored; listed even when empty so a caller cannot
                     # stamp the marker through free-form metadata.
                     MANGLED_TOOL_CALL_METADATA_KEY: mangled_fields or None,

--- a/src/agentacct/service.py
+++ b/src/agentacct/service.py
@@ -1379,7 +1379,7 @@ class SentinelService:
         revision, transition, and append are checked under one ledger lock.
         """
 
-        if action not in {"mark_reviewed", "resolve", "reopen"}:
+        if action not in {"mark_reviewed", "resolve", "reopen", "reinstate"}:
             raise FindingDispositionConflict("unsupported finding disposition action")
         if isinstance(expected_revision, bool) or not isinstance(expected_revision, int) or expected_revision < 0:
             raise FindingDispositionConflict("finding revision must be a non-negative integer")
@@ -1601,7 +1601,7 @@ class SentinelService:
         the finding. Only server-trusted disposition rows participate.
         """
 
-        if action not in {"mark_reviewed", "resolve", "reopen"}:
+        if action not in {"mark_reviewed", "resolve", "reopen", "reinstate"}:
             raise FindingDispositionConflict("unsupported finding disposition action")
         if isinstance(expected_revision, bool) or not isinstance(expected_revision, int) or expected_revision < 0:
             raise FindingDispositionConflict("finding revision must be a non-negative integer")

--- a/src/agentacct/supersession.py
+++ b/src/agentacct/supersession.py
@@ -1,0 +1,290 @@
+"""Read-time supersession model for agent-reported machine checks.
+
+A failed/error check that a later *same-scope* passing check contradicts is
+demoted out of the pinned "Needs attention" strip into an explicit
+``superseded`` state.  It is never hidden, never deleted from the check set,
+never upgraded to "Verified", and always reopenable.  Failures that are only
+ambiguously contradicted become ``unconfirmed`` and stay standing findings.
+
+This is a retroactive, read-time projection computed where evidence events are
+built, BEFORE the raw command/name are redacted out of the projection.  It is
+deliberately shaped as a single pairwise gate so a future canonical
+``scope_revisions`` / attempt-boundary primitive can REPLACE it rather than be
+duplicated into it: nothing here is persisted and nothing infers beyond the
+measured gate.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+import unicodedata
+from typing import Any, Mapping
+
+
+SUPERSEDED = "superseded"
+UNCONFIRMED = "unconfirmed"
+
+_FAILED_RESULTS = {"failed", "error"}
+_CHECK_RESULTS = {"passed", "failed", "error"}
+
+# Basis precedence, strongest first. An explicit agent-declared link is the most
+# trustworthy signal; an exact command match beats a shape match beats a name
+# match. When several later passes qualify, the strongest basis wins.
+_BASIS_RANK = {
+    "agent_declared": 3,
+    "same_command": 2,
+    "command_shape": 1,
+    "check_name": 0,
+}
+
+_COMMAND_JACCARD_THRESHOLD = 0.8
+_NAME_RATIO_THRESHOLD = 0.8
+
+_ALNUM_RUN = re.compile(r"[^\W_]+", re.UNICODE)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _num(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (OverflowError, TypeError, ValueError):
+        return 0.0
+
+
+def _result(event: Mapping[str, Any]) -> str:
+    return _text(event.get("result")).lower()
+
+
+def _is_cjk(char: str) -> bool:
+    """True for the ideographic / kana / hangul ranges we tokenize per-character."""
+
+    code = ord(char)
+    return (
+        0x4E00 <= code <= 0x9FFF  # CJK Unified Ideographs
+        or 0x3400 <= code <= 0x4DBF  # CJK Extension A
+        or 0x20000 <= code <= 0x2A6DF  # CJK Extension B
+        or 0xF900 <= code <= 0xFAFF  # CJK Compatibility Ideographs
+        or 0x3040 <= code <= 0x30FF  # Hiragana + Katakana
+        or 0xAC00 <= code <= 0xD7A3  # Hangul syllables
+    )
+
+
+def _command_tokens(command: str) -> frozenset[str]:
+    """NFKC/casefolded alphanumeric runs, plus each CJK codepoint on its own.
+
+    CJK text has no whitespace between words, so alphanumeric-run splitting alone
+    would collapse a whole phrase into one token; adding per-character tokens
+    lets Jaccard measure character-level overlap the way it measures word-level
+    overlap for space-delimited commands.
+    """
+
+    normalized = unicodedata.normalize("NFKC", command).casefold()
+    tokens = set(_ALNUM_RUN.findall(normalized))
+    tokens.update(char for char in normalized if _is_cjk(char))
+    return frozenset(tokens)
+
+
+def _jaccard(left: frozenset[str], right: frozenset[str]) -> float:
+    if not left or not right:
+        return 0.0
+    union = left | right
+    return len(left & right) / len(union) if union else 0.0
+
+
+def _normalized_name(name: str) -> str:
+    """Collapsed-whitespace, NFKC/casefolded name for SequenceMatcher."""
+
+    return re.sub(r"\s+", " ", unicodedata.normalize("NFKC", name)).strip().casefold()
+
+
+def _name_ratio(left: str, right: str) -> float:
+    normalized_left = _normalized_name(left)
+    normalized_right = _normalized_name(right)
+    if not normalized_left or not normalized_right:
+        return 0.0
+    return difflib.SequenceMatcher(None, normalized_left, normalized_right).ratio()
+
+
+def _pair_basis(
+    failure_command: str | None,
+    failure_name: str | None,
+    candidate_command: str | None,
+    candidate_name: str | None,
+    *,
+    agent_declared: bool,
+) -> str | None:
+    """Strongest similarity basis for one (failure, candidate) pair, or None."""
+
+    if agent_declared:
+        return "agent_declared"
+    if failure_command and candidate_command and failure_command == candidate_command:
+        return "same_command"
+    if (
+        failure_command
+        and candidate_command
+        and _jaccard(_command_tokens(failure_command), _command_tokens(candidate_command))
+        >= _COMMAND_JACCARD_THRESHOLD
+    ):
+        return "command_shape"
+    if (
+        failure_name
+        and candidate_name
+        and _name_ratio(failure_name, candidate_name) >= _NAME_RATIO_THRESHOLD
+    ):
+        return "check_name"
+    return None
+
+
+def _scope_key(event: Mapping[str, Any]) -> tuple[str, ...]:
+    """Pairwise scope identity. A pass in a different project / session / section
+    can never supersede: this subsumes any "section maps to one project" guard,
+    because a reused section_id across projects has mixed project_identity here.
+    """
+
+    return (
+        _text(event.get("source")),
+        _text(event.get("client")),
+        _text(event.get("namespace_fingerprint") or event.get("session_namespace_fingerprint")),
+        _text(event.get("project_identity")),
+        _text(event.get("section_id")),
+        _text(event.get("evidence_type")),
+    )
+
+
+def _order_key(event: Mapping[str, Any]) -> tuple[float, str]:
+    return (_num(event.get("created_at")), _text(event.get("event_id")))
+
+
+def _exit_code_asserts_defect(event: Mapping[str, Any]) -> bool:
+    """True only when exit_code is a real non-zero integer.
+
+    An exit-0 failure means the command ran fine and the check is ASSERTING a
+    defect; no later command that exits 0 retires it. A missing exit_code is
+    equally never demoted -- missing beats wrong.
+    """
+
+    exit_code = event.get("exit_code")
+    return isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0
+
+
+def annotate_supersession(
+    evidence_events: list[dict[str, Any]],
+    *,
+    raw_command_by_id: Mapping[str, str | None],
+    raw_name_by_id: Mapping[str, str | None],
+) -> None:
+    """Stamp ``supersession_state`` / ``superseded_by_event_id`` /
+    ``supersession_basis`` onto every failed/error evidence event in place.
+
+    Never removes an event from ``evidence_events``: demotion is a state stamp,
+    not a deletion, so the failure stays inspectable, keeps its finding episode,
+    and can never fall through to a verified outcome.
+    """
+
+    groups: dict[tuple[str, ...], list[dict[str, Any]]] = {}
+    for event in evidence_events:
+        if not isinstance(event, dict):
+            continue
+        groups.setdefault(_scope_key(event), []).append(event)
+
+    for group in groups.values():
+        ordered = sorted(group, key=_order_key)
+        for failure in ordered:
+            if _result(failure) not in _FAILED_RESULTS:
+                continue
+            _stamp_failure(failure, ordered, raw_command_by_id, raw_name_by_id)
+
+
+def _stamp_failure(
+    failure: dict[str, Any],
+    ordered_group: list[dict[str, Any]],
+    raw_command_by_id: Mapping[str, str | None],
+    raw_name_by_id: Mapping[str, str | None],
+) -> None:
+    # Conservative default: a demotion never happens unless the full gate fires.
+    failure["supersession_state"] = None
+    failure["superseded_by_event_id"] = None
+    failure["supersession_basis"] = None
+
+    if not _exit_code_asserts_defect(failure):
+        return
+
+    failure_created = _num(failure.get("created_at"))
+    failure_id = _text(failure.get("event_id"))
+    failure_command = raw_command_by_id.get(failure_id)
+    failure_name = raw_name_by_id.get(failure_id)
+
+    # Same-scope is guaranteed by the group; only the time ordering remains.
+    later_events = [
+        event for event in ordered_group if _num(event.get("created_at")) > failure_created
+    ]
+    later_passes = [event for event in later_events if _result(event) == "passed"]
+    if not later_passes:
+        # No later same-scope pass at all: the finding stands unchanged.
+        return
+
+    def basis_for(candidate: Mapping[str, Any]) -> str | None:
+        candidate_id = _text(candidate.get("event_id"))
+        agent_declared = (
+            _result(candidate) == "passed"
+            and bool(failure_id)
+            and _text(candidate.get("supersedes_check_event_id")) == failure_id
+        )
+        return _pair_basis(
+            failure_command,
+            failure_name,
+            raw_command_by_id.get(candidate_id),
+            raw_name_by_id.get(candidate_id),
+            agent_declared=agent_declared,
+        )
+
+    gate_passes = [
+        (candidate, basis)
+        for candidate in later_passes
+        if (basis := basis_for(candidate)) is not None
+    ]
+    if not gate_passes:
+        # A later same-scope pass exists, but none is provably the same check.
+        failure["supersession_state"] = UNCONFIRMED
+        return
+
+    # Regression guard: the most recent later same-scope check that matches the
+    # failure by the gate must itself be a PASS, not a re-failure.
+    matching_later = [
+        candidate
+        for candidate in later_events
+        if _result(candidate) in _CHECK_RESULTS and basis_for(candidate) is not None
+    ]
+    most_recent = max(matching_later, key=_order_key)
+    if _result(most_recent) != "passed":
+        failure["supersession_state"] = UNCONFIRMED
+        return
+
+    gate_passes.sort(
+        key=lambda pair: (-_BASIS_RANK[pair[1]], _order_key(pair[0])),
+    )
+    chosen_pass, chosen_basis = gate_passes[0]
+    failure["supersession_state"] = SUPERSEDED
+    failure["superseded_by_event_id"] = _text(chosen_pass.get("event_id")) or None
+    failure["supersession_basis"] = chosen_basis
+
+
+def is_superseded(event: Mapping[str, Any]) -> bool:
+    return _text(event.get("supersession_state")).lower() == SUPERSEDED
+
+
+def is_unconfirmed(event: Mapping[str, Any]) -> bool:
+    return _text(event.get("supersession_state")).lower() == UNCONFIRMED
+
+
+__all__ = [
+    "SUPERSEDED",
+    "UNCONFIRMED",
+    "annotate_supersession",
+    "is_superseded",
+    "is_unconfirmed",
+]

--- a/src/agentacct/supersession.py
+++ b/src/agentacct/supersession.py
@@ -16,7 +16,6 @@ measured gate.
 
 from __future__ import annotations
 
-import difflib
 import re
 import unicodedata
 from typing import Any, Mapping
@@ -29,17 +28,25 @@ _FAILED_RESULTS = {"failed", "error"}
 _CHECK_RESULTS = {"passed", "failed", "error"}
 
 # Basis precedence, strongest first. An explicit agent-declared link is the most
-# trustworthy signal; an exact command match beats a shape match beats a name
-# match. When several later passes qualify, the strongest basis wins.
+# trustworthy signal; an exact command match beats a shape match. When several
+# later passes qualify, the strongest basis wins.
+#
+# A name-only basis was deliberately removed: SequenceMatcher on free-text names
+# cannot tell sibling checks apart (a passing "test auth logout flow" would
+# demote a still-failing "test auth login flow" at ratio 0.88 while their
+# commands agree only 0.67, below the shape gate). Demoting a genuinely-open
+# failure out of Needs attention on a name coincidence is the exact dishonesty
+# this module exists to avoid, and the name arm bought only 2 of 34 demotions on
+# the real store. Such pairs now stay "unconfirmed" — visible, with the later
+# pass shown inline — which is the honest treatment for "similar name, unproven
+# same check".
 _BASIS_RANK = {
     "agent_declared": 3,
     "same_command": 2,
     "command_shape": 1,
-    "check_name": 0,
 }
 
 _COMMAND_JACCARD_THRESHOLD = 0.8
-_NAME_RATIO_THRESHOLD = 0.8
 
 _ALNUM_RUN = re.compile(r"[^\W_]+", re.UNICODE)
 
@@ -95,25 +102,9 @@ def _jaccard(left: frozenset[str], right: frozenset[str]) -> float:
     return len(left & right) / len(union) if union else 0.0
 
 
-def _normalized_name(name: str) -> str:
-    """Collapsed-whitespace, NFKC/casefolded name for SequenceMatcher."""
-
-    return re.sub(r"\s+", " ", unicodedata.normalize("NFKC", name)).strip().casefold()
-
-
-def _name_ratio(left: str, right: str) -> float:
-    normalized_left = _normalized_name(left)
-    normalized_right = _normalized_name(right)
-    if not normalized_left or not normalized_right:
-        return 0.0
-    return difflib.SequenceMatcher(None, normalized_left, normalized_right).ratio()
-
-
 def _pair_basis(
     failure_command: str | None,
-    failure_name: str | None,
     candidate_command: str | None,
-    candidate_name: str | None,
     *,
     agent_declared: bool,
 ) -> str | None:
@@ -130,12 +121,6 @@ def _pair_basis(
         >= _COMMAND_JACCARD_THRESHOLD
     ):
         return "command_shape"
-    if (
-        failure_name
-        and candidate_name
-        and _name_ratio(failure_name, candidate_name) >= _NAME_RATIO_THRESHOLD
-    ):
-        return "check_name"
     return None
 
 
@@ -175,7 +160,6 @@ def annotate_supersession(
     evidence_events: list[dict[str, Any]],
     *,
     raw_command_by_id: Mapping[str, str | None],
-    raw_name_by_id: Mapping[str, str | None],
 ) -> None:
     """Stamp ``supersession_state`` / ``superseded_by_event_id`` /
     ``supersession_basis`` onto every failed/error evidence event in place.
@@ -196,14 +180,13 @@ def annotate_supersession(
         for failure in ordered:
             if _result(failure) not in _FAILED_RESULTS:
                 continue
-            _stamp_failure(failure, ordered, raw_command_by_id, raw_name_by_id)
+            _stamp_failure(failure, ordered, raw_command_by_id)
 
 
 def _stamp_failure(
     failure: dict[str, Any],
     ordered_group: list[dict[str, Any]],
     raw_command_by_id: Mapping[str, str | None],
-    raw_name_by_id: Mapping[str, str | None],
 ) -> None:
     # Conservative default: a demotion never happens unless the full gate fires.
     failure["supersession_state"] = None
@@ -216,7 +199,6 @@ def _stamp_failure(
     failure_created = _num(failure.get("created_at"))
     failure_id = _text(failure.get("event_id"))
     failure_command = raw_command_by_id.get(failure_id)
-    failure_name = raw_name_by_id.get(failure_id)
 
     # Same-scope is guaranteed by the group; only the time ordering remains.
     later_events = [
@@ -236,9 +218,7 @@ def _stamp_failure(
         )
         return _pair_basis(
             failure_command,
-            failure_name,
             raw_command_by_id.get(candidate_id),
-            raw_name_by_id.get(candidate_id),
             agent_declared=agent_declared,
         )
 

--- a/src/agentacct/task_intelligence.py
+++ b/src/agentacct/task_intelligence.py
@@ -109,7 +109,8 @@ def _state_axes(
     canonical_outcome = str(reduce_task_outcome(task).get("key") or "observed")
     outcome = (
         canonical_outcome
-        if canonical_outcome in {"finding", "blocked", "verified", "reported", "resolved"}
+        if canonical_outcome
+        in {"finding", "finding_superseded", "blocked", "verified", "reported", "resolved"}
         else "unknown"
     )
 
@@ -147,6 +148,10 @@ def _decision_brief(
     statement = {
         "verified": "Recorded machine evidence verifies the latest outcome.",
         "finding": "A recorded check found an issue in the work being reviewed.",
+        "finding_superseded": (
+            "A recorded check failed, but a later same-scope check passed; the finding "
+            "is kept in history and is not a verified outcome."
+        ),
         "blocked": "The agent recorded a blocker for this Task.",
         "resolved": "A later passed check explicitly reports the exact blocker resolved; this is not a verified completion.",
         "reported": "The agent reported completing work; no linked passing check verifies it yet.",
@@ -158,7 +163,10 @@ def _decision_brief(
         )
     elif outcome == "finding" and attention_state == "resolved":
         statement = "You marked the recorded finding resolved; this is not machine verification."
-    proof_event = verification or finding
+    # A failure is never "strongest proof": only a positive verification can be.
+    # A finding / superseded-finding Task therefore has no positive proof rather
+    # than a failed check masquerading as the strongest evidence.
+    proof_event = verification
     proof = _proof_summary(proof_event) if proof_event is not None else None
     finding_summary = _proof_summary(finding) if finding is not None else None
     return {

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -237,36 +237,63 @@ def reduce_task_outcome(task: Mapping[str, Any]) -> dict[str, Any]:
         if _text(event.get("result")).lower() in {"failed", "error"}
     ]
     if current_failures:
-        episodes = task.get("finding_episodes") if isinstance(task.get("finding_episodes"), list) else []
-        dispositions = {
-            str(episode.get("target_digest")): str(episode.get("disposition_state") or "open")
-            for episode in episodes
-            if isinstance(episode, Mapping) and episode.get("target_digest")
-        }
-        failure_states = [
-            dispositions.get(str(finding_target_digest(event) or ""), "open")
+        # A superseded failure is contradicted by a later same-scope pass. It is
+        # never removed from the check set (so it can never fall through to a
+        # verified outcome and stays reopenable), but it is not a standing
+        # finding. Only non-superseded failures pin the Task as an open finding.
+        standing_failures = [
+            event
             for event in current_failures
+            if _text(event.get("supersession_state")).lower() != "superseded"
         ]
-        attention_state = (
-            "open"
-            if "open" in failure_states
-            else "reviewed"
-            if "reviewed" in failure_states
-            else "resolved"
-        )
-        return {
-            "key": "finding",
-            "finding": max(
-                current_failures,
-                key=lambda event: (
-                    _number(event.get("created_at") or event.get("occurred_at") or event.get("time")),
-                    _integer(event.get("arrival_sequence")),
+        superseded_failures = [
+            event
+            for event in current_failures
+            if _text(event.get("supersession_state")).lower() == "superseded"
+        ]
+        if standing_failures:
+            episodes = task.get("finding_episodes") if isinstance(task.get("finding_episodes"), list) else []
+            dispositions = {
+                str(episode.get("target_digest")): str(episode.get("disposition_state") or "open")
+                for episode in episodes
+                if isinstance(episode, Mapping) and episode.get("target_digest")
+            }
+            failure_states = [
+                dispositions.get(str(finding_target_digest(event) or ""), "open")
+                for event in standing_failures
+            ]
+            attention_state = (
+                "open"
+                if "open" in failure_states
+                else "reviewed"
+                if "reviewed" in failure_states
+                else "resolved"
+            )
+            return {
+                "key": "finding",
+                "finding": max(
+                    standing_failures,
+                    key=lambda event: (
+                        _number(event.get("created_at") or event.get("occurred_at") or event.get("time")),
+                        _integer(event.get("arrival_sequence")),
+                    ),
                 ),
-            ),
+                "verification": None,
+                "latest_checks": checks,
+                "findings": standing_failures,
+                "finding_attention_state": attention_state,
+                "max_work_updated_at": max_work_updated_at,
+            }
+        # Every current failure was superseded by a later same-scope pass: the
+        # Task drops out of "Needs attention" into its own resolved-in-a-later-
+        # check state, still visible and counted, never verified.
+        return {
+            "key": "finding_superseded",
+            "finding": None,
             "verification": None,
             "latest_checks": checks,
-            "findings": current_failures,
-            "finding_attention_state": attention_state,
+            "findings": superseded_failures,
+            "superseded_findings": superseded_failures,
             "max_work_updated_at": max_work_updated_at,
         }
     if statuses and any(status == _RESOLVED_STATUS for status in statuses) and all(

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -24,6 +24,7 @@ from .log_evidence import (
     summarize_log_evidence_donor_rows,
 )
 from .store_resolution import claude_worktree_owner_path_text
+from .supersession import annotate_supersession
 from .usage_cube import usage_bucket_date
 from .usage_truth import (
     INSTRUMENTATION_MARKER_EVENT_TYPE,
@@ -735,10 +736,30 @@ def build_evidence_events(
     log_evidence_index: dict[str, list[dict[str, Any]]] | None = None,
     log_evidence_counters: dict[str, int] | None = None,
 ) -> list[dict[str, Any]]:
-    evidence = [_evidence_event(event) for event in events if _is_evidence_event(event)]
-    evidence_events = [event for event in evidence if event is not None]
+    # Keep the raw command/name alongside each projection while the whole cohort
+    # is in hand: supersession similarity needs them, but they are redacted out
+    # of the projection itself, so they never leave this function.
+    raw_command_by_id: dict[str, str | None] = {}
+    raw_name_by_id: dict[str, str | None] = {}
+    evidence_events: list[dict[str, Any]] = []
+    for event in events:
+        if not _is_evidence_event(event):
+            continue
+        projected = _evidence_event(event)
+        if projected is None:
+            continue
+        metadata = _metadata(event)
+        event_id = str(projected.get("event_id") or "")
+        raw_command_by_id[event_id] = _optional_str(metadata.get("command"))
+        raw_name_by_id[event_id] = _optional_str(metadata.get("name"))
+        evidence_events.append(projected)
     evidence_events.extend(_run_report_evidence_events(run_reports or []))
     evidence_events = sorted(evidence_events, key=lambda event: float(event.get("created_at") or 0.0), reverse=True)
+    annotate_supersession(
+        evidence_events,
+        raw_command_by_id=raw_command_by_id,
+        raw_name_by_id=raw_name_by_id,
+    )
     index = log_evidence_index if log_evidence_index is not None else build_log_evidence_index(events)
     counters = apply_log_evidence_to_snapshots(evidence_events, index)
     if log_evidence_counters is not None:
@@ -1138,6 +1159,15 @@ def apply_blocker_resolutions(
         for item in work_items
         if item.get("work_id")
     }
+    # A resolution may only clear a blocked WORK section, never a failed CHECK
+    # (that would be a privilege escalation). A pointer at a failed check used to
+    # reject as a generic "target_missing"; surface it as its own diagnostic so
+    # the swallow is visible.
+    failed_check_event_ids = {
+        str(event.get("event_id") or "")
+        for event in evidence_events
+        if str(event.get("result") or "").lower() in {"failed", "error"} and event.get("event_id")
+    }
     snapshots_by_event_id: dict[str, list[dict[str, Any]]] = {}
     snapshots_by_work_id: dict[str, list[dict[str, Any]]] = {}
     for snapshot in work_events:
@@ -1172,6 +1202,7 @@ def apply_blocker_resolutions(
             target_candidate_count=len(candidates),
             item=item,
             snapshots_by_work_id=snapshots_by_work_id,
+            target_points_at_failed_check=target_id in failed_check_event_ids,
         )
         attempt_summary = {
             "event_id": evidence.get("event_id"),
@@ -1243,8 +1274,13 @@ def _blocker_resolution_rejection_reason(
     target_candidate_count: int,
     item: dict[str, Any] | None,
     snapshots_by_work_id: dict[str, list[dict[str, Any]]],
+    target_points_at_failed_check: bool = False,
 ) -> str | None:
     if target_candidate_count != 1:
+        if target_candidate_count == 0 and target_points_at_failed_check:
+            # A failed check is not a blocker episode. A later same-scope pass is
+            # the supersession path; a blocker resolution can never clear it.
+            return "target_is_failed_check"
         return "target_missing" if target_candidate_count == 0 else "target_not_unique"
     assert target is not None
     if target.get("status") != "blocked":
@@ -3937,6 +3973,20 @@ def _evidence_event(event: dict[str, Any]) -> dict[str, Any] | None:
         "check_identity": check_identity,
         "check_identity_basis": check_identity_basis,
         "check_identity_stable": check_identity_stable,
+        # Read-time supersession stamps (computed in build_evidence_events once
+        # the whole cohort is known). Defaults keep every failure a standing
+        # finding until the pairwise gate proves a later same-scope pass.
+        "supersession_state": None,
+        "superseded_by_event_id": None,
+        "supersession_basis": None,
+        # Stage 2, forward-only: a later PASSING check may name the exact failed
+        # check it fixes. Validated at write time; honored read-time as the
+        # strongest supersession basis. 0 stored events carry it today.
+        "supersedes_check_event_id": (
+            _optional_str(metadata.get("supersedes_check_event_id"))
+            if result == "passed"
+            else None
+        ),
         "result": result,
         "summary": _optional_str(metadata.get("summary")) or _optional_str(metadata.get("after_summary")) or _optional_str(metadata.get("name")),
         "command": None,
@@ -4306,9 +4356,18 @@ def _evidence_run_context_compatible(
 
 
 def _evidence_status(evidence_events: list[dict[str, Any]], files: Any) -> str:
-    results = {str(event.get("result") or "unknown") for event in evidence_events}
-    if results & {"failed", "error"}:
+    # A superseded failure is historical evidence, not a current failure: a later
+    # same-scope pass contradicted it. It must not read as "failed evidence" on
+    # secondary chips, but demotion is a state stamp, so the event is still here.
+    active_failures = [
+        event
+        for event in evidence_events
+        if str(event.get("result") or "unknown") in {"failed", "error"}
+        and str(event.get("supersession_state") or "") != "superseded"
+    ]
+    if active_failures:
         return "failed"
+    results = {str(event.get("result") or "unknown") for event in evidence_events}
     if "passed" in results:
         return "strong"
     if evidence_events:

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -736,11 +736,10 @@ def build_evidence_events(
     log_evidence_index: dict[str, list[dict[str, Any]]] | None = None,
     log_evidence_counters: dict[str, int] | None = None,
 ) -> list[dict[str, Any]]:
-    # Keep the raw command/name alongside each projection while the whole cohort
-    # is in hand: supersession similarity needs them, but they are redacted out
-    # of the projection itself, so they never leave this function.
+    # Keep the raw command alongside each projection while the whole cohort is in
+    # hand: supersession similarity needs it, but it is redacted out of the
+    # projection itself, so it never leaves this function.
     raw_command_by_id: dict[str, str | None] = {}
-    raw_name_by_id: dict[str, str | None] = {}
     evidence_events: list[dict[str, Any]] = []
     for event in events:
         if not _is_evidence_event(event):
@@ -751,14 +750,12 @@ def build_evidence_events(
         metadata = _metadata(event)
         event_id = str(projected.get("event_id") or "")
         raw_command_by_id[event_id] = _optional_str(metadata.get("command"))
-        raw_name_by_id[event_id] = _optional_str(metadata.get("name"))
         evidence_events.append(projected)
     evidence_events.extend(_run_report_evidence_events(run_reports or []))
     evidence_events = sorted(evidence_events, key=lambda event: float(event.get("created_at") or 0.0), reverse=True)
     annotate_supersession(
         evidence_events,
         raw_command_by_id=raw_command_by_id,
-        raw_name_by_id=raw_name_by_id,
     )
     index = log_evidence_index if log_evidence_index is not None else build_log_evidence_index(events)
     counters = apply_log_evidence_to_snapshots(evidence_events, index)

--- a/tests/test_dashboard_supersession.py
+++ b/tests/test_dashboard_supersession.py
@@ -86,6 +86,50 @@ def test_superseded_failure_leaves_needs_attention_but_stays_visible(tmp_path: P
     assert "No follow-up action was recorded." not in html
 
 
+def test_a_superseded_finding_can_be_reinstated_to_attention_in_one_click(tmp_path: Path) -> None:
+    store_root = tmp_path / "state"
+    service = SentinelService(store_root)
+    session = "yc-session"
+    project = str(tmp_path / "yc")
+    _section(service, section_id="yc-build", status="started", session=session, title="Ship YC countdown", project_dir=project)
+    _check(service, section_id="yc-build", session=session, result="failed", name="首次应用包构建与严格签名验证", command=_FAIL_CMD, exit_code=1, project=project)
+    _check(service, section_id="yc-build", session=session, result="passed", name="应用包构建与签名验证", command=_PASS_CMD, exit_code=0, project=project)
+    _section(service, section_id="yc-build", status="completed", session=session, title="Ship YC countdown", project_dir=project)
+
+    client = TestClient(create_local_api_app(store_dir=store_root))
+
+    # It starts demoted out of Needs attention, and the card offers a one-click
+    # reinstate (not the two-step "mark reviewed then reopen" dance).
+    assert "<strong>0</strong><span>Open findings</span>" in client.get("/").text
+    assert "Reinstate to attention" in client.get("/").text
+
+    payload = client.get("/tasks").json()
+    episode = next(
+        ep
+        for task in payload["tasks"]
+        for ep in task.get("finding_episodes", [])
+        if ep.get("finding_token")
+    )
+    response = client.post(
+        "/findings/disposition",
+        data={
+            "csrf_token": payload["csrf_token"],
+            "finding_token": episode["finding_token"],
+            "action": "reinstate",
+            "expected_revision": str(episode["revision"]),
+            "note": "",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code in (200, 303)
+
+    # The user's explicit choice now wins over the automatic supersession: the
+    # failure is back in Needs attention as an open finding.
+    html = client.get("/").text
+    assert '<span class="status status-finding">Open finding</span>' in html
+    assert "<strong>1</strong><span>Open findings</span>" in html
+
+
 def test_unconfirmed_failure_stays_open_with_inline_disclosure(tmp_path: Path) -> None:
     store_root = tmp_path / "state"
     service = SentinelService(store_root)

--- a/tests/test_dashboard_supersession.py
+++ b/tests/test_dashboard_supersession.py
@@ -1,0 +1,190 @@
+"""End-to-end supersession behavior on the served dashboard and MCP writers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from agentacct.api import create_local_api_app
+from agentacct.mcp import SentinelMCPServer
+from agentacct.service import SentinelService
+from agentacct.work_ledger import build_work_ledger
+
+
+_FAIL_CMD = "./build.sh && plutil -lint Info.plist && codesign --verify --deep --strict YCCountdown.app"
+_PASS_CMD = (
+    "./build.sh && plutil -lint YCCountdown.app/Contents/Info.plist "
+    "&& codesign --verify --deep --strict --verbose=2 YCCountdown.app"
+)
+
+
+def _section(service: SentinelService, *, section_id: str, status: str, session: str, title: str, **extra) -> None:
+    service.record_event(
+        {
+            "source": "codex",
+            "event_type": f"section_{status}",
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "section_id": section_id,
+                "section_status": status,
+                "section_title": title,
+                "client": "codex",
+                "client_session_id": session,
+                **extra,
+            },
+        }
+    )
+
+
+def _check(service: SentinelService, *, section_id: str, session: str, result: str, name: str, command: str, exit_code: int, project: str) -> dict:
+    return service.record_event(
+        {
+            "source": "codex",
+            "event_type": "machine_check",
+            "metadata": {
+                "sentinel_semantic_kind": "evidence",
+                "section_id": section_id,
+                "evidence_type": "build",
+                "result": result,
+                "name": name,
+                "command": command,
+                "exit_code": exit_code,
+                "client": "codex",
+                "client_session_id": session,
+                "project_dir": project,
+                "summary": f"{name}: {result}",
+            },
+        }
+    )
+
+
+def test_superseded_failure_leaves_needs_attention_but_stays_visible(tmp_path: Path) -> None:
+    store_root = tmp_path / "state"
+    service = SentinelService(store_root)
+    session = "yc-session"
+    project = str(tmp_path / "yc")
+    _section(service, section_id="yc-build", status="started", session=session, title="Ship YC countdown", project_dir=project)
+    _check(service, section_id="yc-build", session=session, result="failed", name="首次应用包构建与严格签名验证", command=_FAIL_CMD, exit_code=1, project=project)
+    _check(service, section_id="yc-build", session=session, result="passed", name="应用包构建与签名验证", command=_PASS_CMD, exit_code=0, project=project)
+    _section(service, section_id="yc-build", status="completed", session=session, title="Ship YC countdown", project_dir=project)
+
+    html = TestClient(create_local_api_app(store_dir=store_root)).get("/").text
+
+    # Dropped out of "Needs attention": not an open finding, not verified.
+    assert '<span class="status status-finding">Open finding</span>' not in html
+    assert '<span class="status status-found">Verified</span>' not in html
+    # Its own explicit state, counted in its own tile, not folded into Open findings.
+    assert "Finding · resolved in a later check" in html
+    assert "<strong>0</strong><span>Open findings</span>" in html
+    assert "<strong>1</strong><span>Resolved in later check</span>" in html
+    # The failed check and its later passing check are rendered adjacently, and
+    # the "No follow-up action was recorded" copy is dropped.
+    assert "Resolved in a later check" in html
+    assert "Later check passed" in html
+    assert "No follow-up action was recorded." not in html
+
+
+def test_unconfirmed_failure_stays_open_with_inline_disclosure(tmp_path: Path) -> None:
+    store_root = tmp_path / "state"
+    service = SentinelService(store_root)
+    session = "market-session"
+    project = str(tmp_path / "market")
+    _section(service, section_id="market", status="started", session=session, title="Prediction market", project_dir=project)
+    _check(service, section_id="market", session=session, result="failed", name="share boundary probe", command="./probe.sh --shares", exit_code=1, project=project)
+    _check(service, section_id="market", session=session, result="passed", name="unrelated lint", command="ruff check src", exit_code=0, project=project)
+    _section(service, section_id="market", status="completed", session=session, title="Prediction market", project_dir=project)
+
+    html = TestClient(create_local_api_app(store_dir=store_root)).get("/").text
+
+    # A later same-scope pass exists but is not provably the same check: the
+    # finding stays open, with the ambiguity disclosed inline.
+    assert '<span class="status status-finding">Open finding</span>' in html
+    assert "agentacct cannot prove it is the same check" in html
+    assert "<strong>1</strong><span>Open findings</span>" in html
+    assert "Resolved in later check" not in html
+
+
+def test_supersedes_check_event_id_requires_a_passing_result(tmp_path: Path) -> None:
+    server = SentinelMCPServer(store_dir=tmp_path / "state")
+
+    def call(arguments: dict) -> dict:
+        return server.handle_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "agentacct_record_machine_check", "arguments": arguments},
+            }
+        )
+
+    base = {
+        "source": "codex",
+        "section_id": "s",
+        "project_dir": "/tmp/p",
+        "evidence_type": "build",
+        "supersedes_check_event_id": "evt_earlier_failure",
+    }
+    rejected = call({**base, "result": "failed", "exit_code": 1})
+    assert rejected["error"]["code"] == -32602
+
+    accepted = call({**base, "result": "passed", "exit_code": 0})
+    assert "error" not in accepted
+    text = accepted["result"]["content"][0]["text"]
+    assert "evt_earlier_failure" in text
+
+
+def test_resolution_pointing_at_a_failed_check_surfaces_its_own_diagnostic(tmp_path: Path) -> None:
+    server = SentinelMCPServer(store_dir=tmp_path / "state")
+    project = "/tmp/proj"
+
+    def call(msg_id: int, arguments: dict) -> dict:
+        return server.handle_message(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "method": "tools/call",
+                "params": {"name": "agentacct_record_machine_check", "arguments": arguments},
+            }
+        )
+
+    failed = call(
+        1,
+        {
+            "source": "codex",
+            "section_id": "review",
+            "project_dir": project,
+            "evidence_type": "test",
+            "result": "failed",
+            "name": "probe",
+            "command": "./probe.sh",
+            "exit_code": 1,
+        },
+    )
+    failed_id = json.loads(failed["result"]["content"][0]["text"])["event"]["event_id"]
+
+    # A passing check that (wrongly) tries to clear the FAILED CHECK as if it
+    # were a blocker episode. The server stamps the resolution contract; at read
+    # time it must reject with a distinct diagnostic, not silently vanish.
+    resolution = call(
+        2,
+        {
+            "source": "codex",
+            "section_id": "review",
+            "project_dir": project,
+            "evidence_type": "artifact",
+            "result": "passed",
+            "name": "fix",
+            "exit_code": 0,
+            "summary": "fixed",
+            "resolves_blocked_event_id": failed_id,
+            "resolution_scope": "full",
+            "resolution_summary": "The probe passes now.",
+        },
+    )
+    assert "error" not in resolution
+
+    ledger = build_work_ledger(server.service.list_all_events())
+    reasons = ledger["insights"]["blocker_resolution"]["rejected_by_reason"]
+    assert reasons.get("target_is_failed_check", 0) >= 1

--- a/tests/test_supersession.py
+++ b/tests/test_supersession.py
@@ -80,8 +80,24 @@ def test_edited_command_and_name_supersedes_failure_via_command_shape() -> None:
     failure = projected["fail"]
     assert failure["supersession_state"] == "superseded"
     assert failure["superseded_by_event_id"] == "pass"
-    # command_shape wins over check_name even though both would match.
+    # The edited command still shares enough shape to demote; the name arm was
+    # removed as too loose, so command_shape is what carries the reference case.
     assert failure["supersession_basis"] == "command_shape"
+
+
+def test_name_similarity_alone_never_supersedes() -> None:
+    # Sibling checks: names are 0.88 similar but the commands run different tests
+    # (Jaccard ~0.67, below the shape gate). A passing "logout" check must not
+    # demote a still-failing "login" check out of Needs attention on the name
+    # coincidence alone; it stays a standing finding, shown with the later pass.
+    events = [
+        _raw_check(event_id="fail", created_at=1000.0, result="failed", name="test auth login flow", command="pytest tests/test_login.py", exit_code=1),
+        _raw_check(event_id="pass", created_at=1044.0, result="passed", name="test auth logout flow", command="pytest tests/test_logout.py", exit_code=0),
+    ]
+    projected = _by_id(build_evidence_events(events))
+    failure = projected["fail"]
+    assert failure["supersession_state"] == "unconfirmed"
+    assert failure["supersession_basis"] is None
 
 
 def test_cross_project_pass_never_supersedes() -> None:

--- a/tests/test_supersession.py
+++ b/tests/test_supersession.py
@@ -1,0 +1,267 @@
+"""Read-time supersession gate and the six deciders that layer the new state.
+
+Each test targets behavior that did not exist before the supersession model:
+without the fix the failure carries no ``supersession_state`` and the reducers
+return ``finding`` / ``verified`` instead of ``finding_superseded``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentacct.api import _work_product_state
+from agentacct.task_intelligence import build_task_intelligence
+from agentacct.task_outcome import reduce_task_outcome
+from agentacct.work_ledger import build_evidence_events
+
+
+# The reference case from the store: same section/project/type, edited command
+# and name across the fix. Token-Jaccard(command) ~= 0.80, name ratio ~= 0.833.
+_YC_FAIL_CMD = "./build.sh && plutil -lint Info.plist && codesign --verify --deep --strict YCCountdown.app"
+_YC_PASS_CMD = (
+    "./build.sh && plutil -lint YCCountdown.app/Contents/Info.plist "
+    "&& codesign --verify --deep --strict --verbose=2 YCCountdown.app"
+)
+_YC_FAIL_NAME = "首次应用包构建与严格签名验证"
+_YC_PASS_NAME = "应用包构建与签名验证"
+
+
+def _raw_check(
+    *,
+    event_id: str,
+    created_at: float,
+    result: str,
+    name: str | None,
+    command: str | None,
+    exit_code: int | None,
+    section: str | None = "yc-build",
+    project: str | None = "/repo/yc",
+    etype: str = "build",
+    source: str = "codex",
+    client: str = "codex",
+    session: str = "sess-1",
+    **extra: Any,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "sentinel_semantic_kind": "evidence",
+        "evidence_type": etype,
+        "result": result,
+        "name": name,
+        "command": command,
+        "exit_code": exit_code,
+        "client": client,
+        "client_session_id": session,
+    }
+    if section is not None:
+        metadata["section_id"] = section
+    if project is not None:
+        metadata["project_dir"] = project
+    metadata.update(extra)
+    return {
+        "event_id": event_id,
+        "source": source,
+        "event_type": "machine_check",
+        "created_at": created_at,
+        "metadata": metadata,
+    }
+
+
+def _by_id(events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {str(event.get("event_id")): event for event in events}
+
+
+def test_edited_command_and_name_supersedes_failure_via_command_shape() -> None:
+    events = [
+        _raw_check(event_id="fail", created_at=1000.0, result="failed", name=_YC_FAIL_NAME, command=_YC_FAIL_CMD, exit_code=1),
+        _raw_check(event_id="pass", created_at=1044.0, result="passed", name=_YC_PASS_NAME, command=_YC_PASS_CMD, exit_code=0),
+    ]
+    projected = _by_id(build_evidence_events(events))
+
+    failure = projected["fail"]
+    assert failure["supersession_state"] == "superseded"
+    assert failure["superseded_by_event_id"] == "pass"
+    # command_shape wins over check_name even though both would match.
+    assert failure["supersession_basis"] == "command_shape"
+
+
+def test_cross_project_pass_never_supersedes() -> None:
+    events = [
+        _raw_check(event_id="fail", created_at=1000.0, result="failed", name="build", command="make", exit_code=1, project="/repo/a"),
+        _raw_check(event_id="pass", created_at=1044.0, result="passed", name="build", command="make", exit_code=0, project="/repo/b"),
+    ]
+    projected = _by_id(build_evidence_events(events))
+    assert projected["fail"]["supersession_state"] is None
+
+
+def test_cross_section_pass_never_supersedes() -> None:
+    events = [
+        _raw_check(event_id="fail", created_at=1000.0, result="failed", name="build", command="make", exit_code=1, section="step-a"),
+        _raw_check(event_id="pass", created_at=1044.0, result="passed", name="build", command="make", exit_code=0, section="step-b"),
+    ]
+    projected = _by_id(build_evidence_events(events))
+    assert projected["fail"]["supersession_state"] is None
+
+
+def test_exit_zero_failure_is_never_demoted() -> None:
+    # An exit-0 failure asserts a defect; no later exit-0 command retires it.
+    events = [
+        _raw_check(event_id="fail", created_at=1000.0, result="failed", name="probe", command="make", exit_code=0),
+        _raw_check(event_id="pass", created_at=1044.0, result="passed", name="probe", command="make", exit_code=0),
+    ]
+    projected = _by_id(build_evidence_events(events))
+    assert projected["fail"]["supersession_state"] is None
+
+
+def test_unrelated_later_pass_leaves_failure_unconfirmed() -> None:
+    events = [
+        _raw_check(event_id="fail", created_at=1000.0, result="failed", name="security boundary probe", command="./probe.sh", exit_code=1),
+        _raw_check(event_id="pass", created_at=1044.0, result="passed", name="unrelated lint", command="ruff check", exit_code=0),
+    ]
+    projected = _by_id(build_evidence_events(events))
+    failure = projected["fail"]
+    assert failure["supersession_state"] == "unconfirmed"
+    assert failure["superseded_by_event_id"] is None
+
+
+def test_regression_after_the_fixing_pass_keeps_the_finding_standing() -> None:
+    # fail -> pass (same command) -> fail again (same command): the most recent
+    # gate-matching check is a FAIL, so the first failure is not superseded.
+    events = [
+        _raw_check(event_id="fail1", created_at=1000.0, result="failed", name="suite", command="pytest", exit_code=1),
+        _raw_check(event_id="pass", created_at=1044.0, result="passed", name="suite", command="pytest", exit_code=0),
+        _raw_check(event_id="fail2", created_at=1100.0, result="failed", name="suite", command="pytest", exit_code=1),
+    ]
+    projected = _by_id(build_evidence_events(events))
+    # A later same-scope pass exists, but regression guard fails -> unconfirmed.
+    assert projected["fail1"]["supersession_state"] == "unconfirmed"
+
+
+def test_agent_declared_supersession_is_the_strongest_basis() -> None:
+    events = [
+        _raw_check(event_id="fail", created_at=1000.0, result="failed", name="alpha", command="cmd-a", exit_code=1),
+        _raw_check(
+            event_id="pass",
+            created_at=1044.0,
+            result="passed",
+            name="totally different",
+            command="cmd-z",
+            exit_code=0,
+            supersedes_check_event_id="fail",
+        ),
+    ]
+    projected = _by_id(build_evidence_events(events))
+    failure = projected["fail"]
+    assert failure["supersession_state"] == "superseded"
+    assert failure["supersession_basis"] == "agent_declared"
+
+
+def test_agent_declared_link_is_ignored_across_scope() -> None:
+    # A passing check may only supersede an earlier same-scope failure; a
+    # cross-project declared link must be structurally ignored.
+    events = [
+        _raw_check(event_id="fail", created_at=1000.0, result="failed", name="a", command="x", exit_code=1, project="/repo/a"),
+        _raw_check(event_id="pass", created_at=1044.0, result="passed", name="b", command="y", exit_code=0, project="/repo/b", supersedes_check_event_id="fail"),
+    ]
+    projected = _by_id(build_evidence_events(events))
+    assert projected["fail"]["supersession_state"] is None
+
+
+# --- reducer / decider parity -------------------------------------------------
+
+
+def _check_row(
+    *,
+    result: str,
+    created_at: float,
+    event_id: str,
+    identity: str,
+    supersession_state: str | None = None,
+    superseded_by_event_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "check_identity": identity,
+        "check_identity_stable": True,
+        "result": result,
+        "created_at": created_at,
+        "summary": f"{result} {event_id}",
+        "evidence_type": "build",
+        "supersession_state": supersession_state,
+        "superseded_by_event_id": superseded_by_event_id,
+    }
+
+
+def _task_with_checks(checks: list[dict[str, Any]], *, status: str = "completed") -> dict[str, Any]:
+    return {
+        "work_items": [
+            {
+                "latest_status": status,
+                "updated_at": 100.0,
+                "evidence_status": "strong",
+                "evidence_events": list(checks),
+            }
+        ],
+        "task_evidence_events": [],
+        "sessions": [],
+        "usage": {"rows": 0},
+    }
+
+
+def test_reduce_task_outcome_superseded_failure_is_its_own_state_not_verified() -> None:
+    checks = [
+        _check_row(result="failed", created_at=100.0, event_id="fail", identity="check:a", supersession_state="superseded", superseded_by_event_id="pass"),
+        _check_row(result="passed", created_at=144.0, event_id="pass", identity="check:b"),
+    ]
+    outcome = reduce_task_outcome(_task_with_checks(checks))
+    assert outcome["key"] == "finding_superseded"
+    assert outcome["verification"] is None
+    # The failed event is never removed from the check set.
+    assert any(str(c.get("result")) == "failed" for c in outcome["latest_checks"])
+
+
+def test_reduce_task_outcome_standing_failure_is_still_a_finding() -> None:
+    checks = [
+        _check_row(result="failed", created_at=100.0, event_id="fail", identity="check:a"),
+        _check_row(result="passed", created_at=144.0, event_id="pass", identity="check:b"),
+    ]
+    outcome = reduce_task_outcome(_task_with_checks(checks))
+    assert outcome["key"] == "finding"
+
+
+def test_work_product_state_superseded_failure_can_never_become_verified() -> None:
+    superseded = _check_row(result="failed", created_at=100.0, event_id="fail", identity="check:a", supersession_state="superseded", superseded_by_event_id="pass")
+    passing = _check_row(result="passed", created_at=144.0, event_id="pass", identity="check:b")
+
+    item = {
+        "latest_status": "completed",
+        "evidence_status": "strong",
+        "current_check_events": [superseded, passing],
+    }
+    state = _work_product_state(item)
+    assert state["key"] == "finding_superseded"
+    assert state["finding_open"] is False
+    assert state["finding_present"] is True
+    assert state["action_required"] is False
+
+    # The failure is load-bearing: drop it and the very same item verifies. This
+    # is exactly what the present-but-superseded guard must prevent.
+    verified_item = {**item, "current_check_events": [passing]}
+    assert _work_product_state(verified_item)["key"] == "verified"
+
+
+def test_strongest_proof_is_never_a_failure() -> None:
+    finding_checks = [_check_row(result="failed", created_at=100.0, event_id="fail", identity="check:a")]
+    brief = build_task_intelligence(
+        _task_with_checks(finding_checks), public_task_id="t", title="t"
+    )["decision_brief"]
+    assert brief["strongest_proof"] is None
+    assert brief["unresolved_finding"] is not None
+
+    superseded_checks = [
+        _check_row(result="failed", created_at=100.0, event_id="fail", identity="check:a", supersession_state="superseded", superseded_by_event_id="pass"),
+        _check_row(result="passed", created_at=144.0, event_id="pass", identity="check:b"),
+    ]
+    superseded_brief = build_task_intelligence(
+        _task_with_checks(superseded_checks), public_task_id="t2", title="t2"
+    )["decision_brief"]
+    assert superseded_brief["strongest_proof"] is None


### PR DESCRIPTION
## What

A check that **failed and was then fixed** still shows up as a standing, unresolved "Agent finding" pinned in "Needs attention" — even after the same work recorded a later passing check and completed.

Reference case (real, from the store): building the YC-countdown menu-bar app, one step's app-signing check failed at 17:07, the agent fixed it, and a passing signing check landed 44 seconds later. The dashboard still shows the *failed* check's summary as an open finding, captioned "No follow-up action was recorded" — when the follow-up was recorded, and passed.

## Root cause

The retire-on-rerun mechanism already exists, but it keys check identity on `sha256(evidence_type + name + command)`. **Fixing a build almost always edits the command** (here, correcting the plist path), so the passing re-run hashes to a different identity and cannot supersede the failure. Measured hit rate on the real store: 5 of 68 failed→later-passed pairs actually retired.

## How

A read-time supersession model (`src/agentacct/supersession.py`) computed where evidence events are built. Every failed/error check is stamped `supersession_state` (`superseded` / `unconfirmed` / `None`) via a **deliberately conservative pairwise gate**: a failure is `superseded` only when a later check of the **same** `(source, client, namespace, project_identity, section_id, evidence_type)` passes, the failure has a **non-zero** exit code, and the commands match exactly / by token-shape (≥0.8) — or the agent explicitly declared the link.

- **A `superseded` failure drops out of "Needs attention"** into a new `finding_superseded` state ("Finding · resolved in a later check"): the failed and later-passing checks render adjacently, it gets its own counter tile, and it is **one-click reinstatable** if the later pass was unrelated.
- **The failure is never removed from the check set**, so it can never be hidden and can never let the item read "Verified" (the verified branch additionally guards against a superseded-but-present failure).
- **Never demoted:** exit-code-0 failures (a check *asserting a defect*, e.g. a found private key), cross-project/cross-section passes, or a name-only coincidence (the name-similarity arm was dropped in review — a passing "logout" test must not demote a still-failing "login" test). Those stay standing; an ambiguous later pass leaves the finding `unconfirmed` (still shown, with the later pass disclosed inline).

Retroactive and derived — no migration, no new stored events. It fixes every existing finding of this shape, not just new ones. Stage 2 also makes the MCP schema self-documenting about `name`/`section_id` reuse and accepts an explicit agent-declared `supersedes_check_event_id`.

## Verification

- Full suite (CI way, `.venv/bin/pytest -q`): **3005 passed, 1 skipped**.
- Two independent adversarial review passes returned **ship**; new tests proven non-vacuous by breaking each production line.
- The three guardrail tests (a same-section unrelated pass must NOT close a named failure, section-completion must NOT hide a failure) pass **unedited**.
- Real-store re-measure via the production path: **32** superseded, **21** unconfirmed, **62** standing, **27** exit-0 asserted-defect failures never demoted, **0** cross-project matches; the YC reference case is fixed via `command_shape`.

## Scope note

This fixes the **stale-finding** bug specifically. It does **not** address the separate "task card stuck in progress / progress strip stuck at task / steps mostly grey agent-reported" behaviour — that is a distinct spine/state-model issue with its own diagnosis and open product decisions, deliberately not bundled here. One small pre-existing cross-surface label inconsistency for reinstated findings is documented as a follow-up under that spine work.
