### PR TITLE
feat: make the SQLite event log the default authoritative backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,39 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- agentacct can now keep its event ledger in SQLite instead of the flat
-  `events.jsonl` file. A new SQLite event log (`events.sqlite3`) mirrors the
-  ledger line-for-line and can be promoted to the sole store so the flat file is
-  deleted entirely — the foundation for a fast local CLI and live view that no
-  longer re-parse a growing text file on every read. Three commands drive it:
-  `agentacct event verify-log` proves the SQLite copy matches the flat file line
-  for line; `agentacct event drop-flat-ledger --confirm` cuts the store over and
-  deletes `events.jsonl`; and `agentacct canonical rebuild-store` (re)builds the
-  SQLite usage index from the ledger. The cutover is durable — a persistent
-  store marker keeps it in effect across restarts with no environment variable,
-  so no later open can revert or wipe it — and it fails loud rather than ever
-  serving an empty or half-migrated store. Off by default: until you cut over,
-  the flat file stays authoritative and the SQLite log is a proven mirror.
+- **agentacct now keeps its event ledger in SQLite by default.** The event log
+  (`events.sqlite3`) is the authoritative store: a fresh install is SQLite-only
+  from its first event, and an existing `events.jsonl` store auto-adopts the log
+  the next time it is opened — reconciling the log from the flat file, then
+  leaving that file behind as a backup. The upgrade is safe even with daemons
+  running: while an older, not-yet-restarted process keeps appending to
+  `events.jsonl`, the new code drains those straggler writes into the log, so a
+  rolling upgrade never splits events between the two ledgers or loses one.
+  Reads and writes no longer re-parse a growing text file on every access, the
+  foundation for a fast local CLI and live view. Three commands give explicit
+  control over the flat file:
+  `agentacct event verify-log` proves the SQLite copy matches a flat file line
+  for line; `agentacct event drop-flat-ledger --confirm` deletes the leftover
+  `events.jsonl` backup once a store has cut over; and `agentacct canonical
+  rebuild-store` (re)builds the SQLite usage index from the ledger. The cutover
+  is durable — a persistent store marker keeps it in effect across restarts with
+  no environment variable, so no later open can revert or wipe it — and it fails
+  loud rather than ever serving an empty or half-migrated store. Set
+  `AGENTACCT_EVENT_LOG_AUTHORITATIVE=0` to opt back into the legacy flat-file
+  mode, where `events.jsonl` stays authoritative and the SQLite log is a proven
+  mirror.
 - `agentacct canonical rebuild-store` rebuilds the canonical SQLite index
   (per-day usage and per-task rollups) directly from your event ledger in about
   a second, so the fast usage/cost read path has a store to serve even on a
   machine that never ran the background writer.
 
 ### Fixed
+- `agentacct mcp doctor` now reports **store writability** for a SQLite-backed
+  store. The writability probe previously ran only when a flat `events.jsonl`
+  existed, so once a store used the SQLite log (now the default) the doctor
+  silently dropped that diagnostic. It now checks the log's writability without
+  writing any bytes, keeping the doctor read-only while restoring the check for
+  every store.
 - The canonical usage importer no longer counts non-usage events as usage. Any
   event whose type merely contained the substring "usage" — most importantly
   `agent_usage_debug_reported`, the debug snapshot that is explicitly *not*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,8 +206,10 @@ Current MCP tools are safe/local:
 - `agentacct_prepare_judge`
 - `agentacct_compute_value`
 
-The event tools continue to write/read `events.jsonl` and shadow normalized
-claims into Evidence v2. Public `sentinel_*` names do not change. Local usage
+The event tools read and write the v1 event ledger — by default the SQLite event
+log (`events.sqlite3`); set `AGENTACCT_EVENT_LOG_AUTHORITATIVE=0` for the legacy
+flat `events.jsonl` — and shadow normalized claims into Evidence v2. Public
+`sentinel_*` names do not change. Local usage
 import remains the token/cost source of truth; MCP remains the highest-value
 source for semantic context and join keys such as client session, parent
 session, turn id, request id, and message id. It is not treated as provider

--- a/src/agentacct/canonical/rebuild.py
+++ b/src/agentacct/canonical/rebuild.py
@@ -136,19 +136,25 @@ def rebuild_live_store_from_events(store_dir: Path | str) -> RebuildReport:
 
     store_dir = Path(store_dir).expanduser()
     events_path = store_dir / EVENTS_FILENAME
-    if events_path.is_file():
-        content = events_path.read_bytes()
-    else:
-        # Cut-over store: reconstruct the ledger bytes from the SQLite event log.
-        from ..event_log import RAW_EVENT_LOG_FILENAME, RawEventLog
+    from ..event_log import AUTHORITATIVE_MARKER_FILENAME, RAW_EVENT_LOG_FILENAME, RawEventLog
 
-        log_path = store_dir / RAW_EVENT_LOG_FILENAME
-        if not log_path.is_file():
-            raise FileNotFoundError(
-                f"no events ledger at {events_path} and no SQLite log at {log_path}"
-            )
+    log_path = store_dir / RAW_EVENT_LOG_FILENAME
+    authoritative = (store_dir / AUTHORITATIVE_MARKER_FILENAME).exists()
+    if log_path.is_file() and (authoritative or not events_path.is_file()):
+        # The SQLite event log is the authoritative ledger — a store that has
+        # been adopted (marker written) or fully cut over (flat file deleted).
+        # Any events.jsonl still present is a FROZEN pre-cutover backup the log
+        # has grown past; reading it would silently drop every event recorded
+        # after adoption. Reconstruct the ledger bytes from the log instead.
         lines = RawEventLog(log_path).read_lines()
         content = ("".join(line + "\n" for line in lines)).encode("utf-8")
+    elif events_path.is_file():
+        # Legacy mirror mode: the flat file is authoritative.
+        content = events_path.read_bytes()
+    else:
+        raise FileNotFoundError(
+            f"no events ledger at {events_path} and no SQLite log at {log_path}"
+        )
 
     # Resolve symlink components (e.g. macOS /var -> /private/var): the
     # importer's candidate path is validated to contain no symlink component.

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -3955,6 +3955,20 @@ def mcp_doctor(
                     checks.append(
                         {"name": "store readability", "status": "fail", "details": f"events.sqlite3 is not readable: {exc}"}
                     )
+                # Writability WITHOUT writing bytes: the SQLite log (WAL mode)
+                # needs both the DB file and its directory writable to append.
+                # Pure os.access permission checks keep the doctor read-only,
+                # the same guarantee the events.jsonl append-probe gives — and a
+                # SQLite-authoritative store (the default) must still be told
+                # whether its ledger is writable.
+                if os.access(log_path, os.W_OK) and os.access(store_root, os.W_OK):
+                    checks.append(
+                        {"name": "store writability", "status": "ok", "details": "events.sqlite3 is writable (no bytes were written)"}
+                    )
+                else:
+                    checks.append(
+                        {"name": "store writability", "status": "fail", "details": "events.sqlite3 (or its directory) is not append-writable"}
+                    )
             else:
                 checks.append({"name": "store readability", "status": "ok", "details": "store file absent (created on first recorded event)"})
         else:
@@ -4365,6 +4379,13 @@ def event_drop_flat_ledger(
             return
         if not already_authoritative:
             service.mark_authoritative()
+        elif events_path.exists():
+            # Already authoritative: the log leads the frozen file. An old
+            # mirror-mode process may have written a straggler to events.jsonl
+            # between this service opening and this lock; drain it into the log
+            # before deleting the file, so the cutover never discards an
+            # un-absorbed event (the drain empties the file under this lock).
+            service._absorb_flat_stragglers()
         events_path.unlink(missing_ok=True)
     payload = {"deleted": str(events_path), "log_events": service.event_log.count()}
     if json_output:

--- a/src/agentacct/event_log.py
+++ b/src/agentacct/event_log.py
@@ -25,6 +25,7 @@ Design contract during the mirror phase:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from contextlib import contextmanager
@@ -41,17 +42,31 @@ RAW_EVENT_LOG_FILENAME = "events.sqlite3"
 # env var (a mirror-mode open of a cut-over store would otherwise wipe the log).
 AUTHORITATIVE_MARKER_FILENAME = "events.authoritative"
 
-# When set, the SQLite log is the AUTHORITATIVE event store: every ledger read
-# and write goes to it and the flat events.jsonl is neither read nor written
-# (and can be deleted). Default OFF — the flat file stays authoritative and the
-# log is a proven mirror. The migration cutover flips this only after parity.
+# The SQLite log is the AUTHORITATIVE event store: every ledger read and write
+# goes to it and the flat events.jsonl is neither read nor written (and can be
+# deleted). Default ON — a fresh store is SQLite-only from the first event, and
+# an existing events.jsonl store auto-adopts the log on open (reconciling the log
+# from the file, then leaving the file behind as a backup). Set
+# AGENTACCT_EVENT_LOG_AUTHORITATIVE=0 (or false/no/off) to opt back into the
+# legacy flat-file mode, where events.jsonl stays authoritative and the log is a
+# proven mirror. That opt-out exists for the mirror-mode/parity tests and for
+# recovering a store on an older runtime.
 EVENT_LOG_AUTHORITATIVE_ENV = "AGENTACCT_EVENT_LOG_AUTHORITATIVE"
 _TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
 
 
 def event_log_authoritative() -> bool:
+    """Whether the SQLite event log is the authoritative ledger (the default).
+
+    True unless ``AGENTACCT_EVENT_LOG_AUTHORITATIVE`` is set to an explicit
+    falsey value (``0``/``false``/``no``/``off``). Unset — and any unrecognized
+    value — means authoritative: the flip to SQLite is the product default, and
+    only a deliberate opt-out returns to the flat-file mirror mode.
+    """
+
     value = read_env_alias(EVENT_LOG_AUTHORITATIVE_ENV)
-    return str(value or "").strip().lower() in _TRUE_VALUES
+    return str(value or "").strip().lower() not in _FALSE_VALUES
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS event_lines (
@@ -64,6 +79,11 @@ CREATE TABLE IF NOT EXISTS event_lines (
 );
 CREATE INDEX IF NOT EXISTS idx_event_lines_run ON event_lines(run_id);
 CREATE INDEX IF NOT EXISTS idx_event_lines_event_id ON event_lines(event_id);
+-- Durable record of every flat-file line already drained into the log during a
+-- rolling upgrade (see absorb_new_events). Its keys OUTLIVE a log rewrite that
+-- removes the row, which is what stops a deliberately-removed event from being
+-- resurrected out of the frozen events.jsonl backup on a later absorb.
+CREATE TABLE IF NOT EXISTS absorbed_flat (key TEXT PRIMARY KEY);
 """
 
 
@@ -248,6 +268,95 @@ class RawEventLog:
         else:
             self.replace_all(file_lines)
         return self.verify_against_file(events_path)
+
+    def absorb_new_events(self, events_path: Path) -> int:
+        """Append flat-file events the log has never absorbed; return the count.
+
+        The rolling-upgrade drain. After a store cuts over to the log, a
+        not-yet-restarted OLD mirror-mode process (a 0.5.x daemon that predates
+        the SQLite log) may keep writing to events.jsonl — appending new events,
+        or even rewriting the whole file. Those events must reach the
+        authoritative log or a rolling upgrade would split writes between the two
+        ledgers, but events.jsonl is left INTACT (a read/dry-run of a store must
+        not mutate it, and it stays a backup until the deliberate cutover).
+
+        Idempotence and no-resurrection come from a durable membership set,
+        ``absorbed_flat``, keyed by event_id (``id:<eid>``) or, for a
+        corrupt/legacy line with no id, a content hash (``ln:<sha1>``). On the
+        FIRST sighting of a flat-file event its key is recorded — WHETHER OR NOT
+        it is appended. An event already in the log is not re-appended, but its
+        key is still recorded, because it may have reached the log via a path
+        that does not populate ``absorbed_flat`` (a mirror-mode
+        ``reconcile_from_file``, or a restored older store) — every pre-existing
+        store upgrades through exactly that state. Because ``absorbed_flat``
+        OUTLIVES a log rewrite (redaction / dedup / usage-refresh replace) that
+        deletes the row, an event the log deliberately removed is never
+        re-absorbed from the frozen file. And because membership is by
+        id/content, not by file position, an old process rewriting or reordering
+        events.jsonl cannot smuggle an already-seen event back in or hide a
+        genuinely new one.
+
+        Known limit (union, never truncation): an old process DELETING a row from
+        events.jsonl during the transition is not propagated to the log — the row
+        lingers until the deliberate cutover. Usage accounting dedupes superseded
+        snapshots by session identity, and the window closes when the old
+        processes are restarted, so this does not corrupt totals in practice.
+        """
+
+        if not events_path.exists():
+            return 0
+        file_lines = _read_file_lines(events_path)
+        if not file_lines:
+            return 0
+        with self._connect() as connection:
+            log_ids = {
+                str(row[0])
+                for row in connection.execute(
+                    "SELECT event_id FROM event_lines WHERE event_id IS NOT NULL"
+                )
+            }
+            absorbed = {str(row[0]) for row in connection.execute("SELECT key FROM absorbed_flat")}
+            log_lines_set: set[str] | None = None  # log's verbatim lines, lazily, for id-less dedup
+            to_add: list[str] = []
+            new_keys: list[str] = []
+            for line in file_lines:
+                event_id, *_ = _extract_columns(line)
+                if event_id is not None:
+                    key = "id:" + event_id
+                    already_in_log = event_id in log_ids
+                else:
+                    key = "ln:" + hashlib.sha1(line.encode("utf-8")).hexdigest()
+                    if log_lines_set is None:
+                        log_lines_set = {
+                            str(row[0]) for row in connection.execute("SELECT line FROM event_lines")
+                        }
+                    already_in_log = line in log_lines_set
+                if key in absorbed:
+                    continue  # already recorded as seen-from-the-flat-file
+                # First sighting of this event from events.jsonl. RECORD its key
+                # unconditionally — even when it is already in the log via a
+                # mirror-mode reconcile or a restore (which do NOT populate
+                # absorbed_flat) — so that if a later rewrite removes the row, a
+                # subsequent absorb cannot resurrect it from the retained backup.
+                # Append to the log only when it is not already present.
+                absorbed.add(key)
+                new_keys.append(key)
+                if not already_in_log:
+                    to_add.append(line)
+                    if event_id is None and log_lines_set is not None:
+                        log_lines_set.add(line)
+            if to_add:
+                connection.executemany(
+                    "INSERT INTO event_lines(event_id, run_id, event_type, created_at, line) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    [(*_extract_columns(line), line) for line in to_add],
+                )
+            if new_keys:
+                connection.executemany(
+                    "INSERT OR IGNORE INTO absorbed_flat(key) VALUES (?)",
+                    [(key,) for key in new_keys],
+                )
+        return len(to_add)
 
     def verify_against_file(self, events_path: Path) -> ParityResult:
         """Compare the log to the flat file line for line — the parity proof."""

--- a/src/agentacct/service.py
+++ b/src/agentacct/service.py
@@ -992,6 +992,14 @@ class SentinelService:
                 return True
         except OSError:
             pass
+        # The product default makes a store authoritative — but only a store that
+        # actually has a log to be authoritative over. If the log never opened (a
+        # create=False probe of a not-yet-created store), there is nothing to be
+        # authoritative about: report non-authoritative so reads return [] and a
+        # nonexistent store never fails loud. A genuinely cut-over store is caught
+        # above by its marker (and by the fail-loud guard in _init_event_log).
+        if self.event_log is None:
+            return False
         return event_log_authoritative()
 
     def _init_event_log(self) -> None:
@@ -1026,7 +1034,12 @@ class SentinelService:
             self.event_log = RawEventLog(log_db_path)
         except Exception:
             self.event_log = None
-            if marker_exists or event_log_authoritative():
+            # A store that does not exist on disk (a create=False existence probe
+            # of a not-yet-initialized directory) is EMPTY, not a broken
+            # authoritative ledger — its log "failing to open" is only the missing
+            # directory. Fail loud ONLY for a store that truly exists (or bears the
+            # cutover marker) yet cannot open its log.
+            if marker_exists or (self.store.root.exists() and event_log_authoritative()):
                 raise EventLogUnavailable(
                     "the SQLite event log is the authoritative ledger but could not be opened"
                 )
@@ -1036,26 +1049,34 @@ class SentinelService:
         authoritative = marker_exists or event_log_authoritative() or (not flat_exists and log_has_data)
         self._is_authoritative = authoritative
         if authoritative:
-            if not marker_exists:
-                # ADOPTION transition (env flag, or a healed/lost marker). The
-                # flat file is STILL the authority at this instant, so fully sync
-                # the log from it FIRST — a partially-synced mirror log must not
-                # freeze and abandon the file's un-absorbed tail — then persist
-                # the marker so all future opens read the log. Under the write
-                # lock, and only while the file exists (absent ⇒ the log already
-                # is the sole ledger). Once the marker exists this branch never
-                # runs again, so the log (which then LEADS the frozen file) is
-                # never reconciled back down to the stale file.
-                # Reconcile AND mark under one lock hold so they are atomic: a
-                # concurrent mirror append cannot land in events.jsonl in the
-                # gap between the sync and the marker and then be abandoned.
-                with self._events_write_lock():
-                    if flat_exists:
-                        self.event_log.reconcile_from_file(self.events_path)
+            # Absorb whatever the flat file holds into the authoritative log — a
+            # UNION by event_id, never a truncation. This is atomic and unified
+            # across every authoritative open:
+            #   * fresh store — no events.jsonl, nothing to absorb;
+            #   * first adoption — the log is empty, so absorb fills it from the
+            #     file (then the marker is written so future opens read the log);
+            #   * re-open of an adopted store — the frozen backup's ids are all in
+            #     the log already, so absorb is a no-op;
+            #   * ROLLING UPGRADE — a not-yet-restarted OLD (mirror-mode) daemon
+            #     keeps appending to events.jsonl after cutover; absorb drains
+            #     those stragglers into the log so writes never split between the
+            #     two ledgers, and no post-cutover event is stranded.
+            # Under the write lock so a concurrent flat-file append cannot be read
+            # torn, and so absorb + marker are one atomic step.
+            with self._events_write_lock():
+                if self.events_path.exists():
+                    self._absorb_flat_stragglers()
+                if not marker_exists:
                     try:
                         self.mark_authoritative()
                     except OSError:
                         pass
+                # Capture the change stamp UNDER the lock, after absorbing, so a
+                # straggler an old process writes in the release→stat window is
+                # not masked as already-synced and stranded for this process's
+                # whole life (it would then be drained only on a later change or
+                # restart). Mirrors _sync_event_log's in-lock capture.
+                self._event_log_synced_signature = self._events_file_signature()
             return
         # Mirror mode: the flat file is the authority.
         self.event_log.reconcile_from_file(self.events_path)
@@ -1081,6 +1102,25 @@ class SentinelService:
         """Persist that this store's ledger is the SQLite log (the cutover)."""
 
         self._authoritative_marker_path.write_text("1\n", encoding="utf-8")
+
+    def _absorb_flat_stragglers(self) -> None:
+        """Drain events an OLD (mirror-mode) process wrote to events.jsonl into
+        the authoritative log — the rolling-upgrade safety net so writes never
+        split between the two ledgers.
+
+        The caller holds the write lock (serialized with 0.5.x writers, which
+        take the same events.jsonl.lock). events.jsonl is left INTACT — a read or
+        dry-run of a store must not mutate it, and it stays a backup until the
+        deliberate cutover. Re-absorption stays safe via the log's durable
+        ``absorbed_flat`` membership set (see RawEventLog.absorb_new_events): a
+        removed event is never resurrected and a straggler is never duplicated,
+        regardless of how often this runs or whether an old process rewrote the
+        file.
+        """
+
+        if self.event_log is None or not self.events_path.exists():
+            return
+        self.event_log.absorb_new_events(self.events_path)
 
     def _ledger_lines(self) -> list[str]:
         """Non-blank ledger lines in file order, from the authoritative source
@@ -1125,13 +1165,38 @@ class SentinelService:
         return (stat.st_mtime_ns, stat.st_size)
 
     def _sync_event_log(self) -> None:
-        """Refresh the mirror from the flat file if it changed, fail-open.
+        """Keep the log current with the flat file if it changed, fail-open.
 
-        No-op in authoritative mode: there the log IS the authority, so
-        reconciling from a stale/absent flat file would corrupt it.
+        In MIRROR mode the flat file is the authority and the log is reconciled
+        to mirror it exactly. In AUTHORITATIVE mode the log is the authority, so
+        the flat file is never reconciled DOWN — but during a rolling upgrade a
+        not-yet-restarted OLD mirror-mode process may keep appending to
+        events.jsonl after cutover, so we ABSORB (union by event_id, never a
+        truncation) any such straggler writes into the log. Both branches only
+        touch the file when its signature actually changed, so a steady-state
+        store (a frozen backup, or no flat file at all) costs one stat().
         """
 
-        if self.event_log is None or self._authoritative():
+        if self.event_log is None:
+            return
+        if self._authoritative():
+            # Drain any straggler an old mirror-mode process wrote to events.jsonl
+            # since the last check. Only when the file changed (cheap stat), and
+            # the change stamp is captured UNDER the lock — after the absorb — so
+            # a write landing between the absorb and the stamp is not masked and
+            # gets drained on the next check.
+            if not self.events_path.exists():
+                return
+            signature = self._events_file_signature()
+            if signature == self._event_log_synced_signature:
+                return
+            try:
+                with self._events_write_lock():
+                    self._absorb_flat_stragglers()
+                    captured = self._events_file_signature()
+                self._event_log_synced_signature = captured
+            except Exception:  # noqa: BLE001 - straggler drain is best-effort.
+                pass
             return
         signature = self._events_file_signature()
         if signature == self._event_log_synced_signature:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,23 @@ def _pin_canonical_read_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _pin_event_log_authoritative_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test at the product default: the SQLite log is authoritative.
+
+    ``AGENTACCT_EVENT_LOG_AUTHORITATIVE`` defaults to ON, so a fresh store is
+    SQLite-only and an existing events.jsonl store auto-adopts the log. Clearing
+    the var (and its pre-rename aliases) insulates the suite from a developer
+    shell that exported ``=0``, which would otherwise silently flip every store
+    back to flat-file mirror mode. Tests that specifically exercise mirror mode
+    opt in with ``monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")``.
+    """
+
+    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)
+    monkeypatch.delenv("AGENT_CHRONICLE_EVENT_LOG_AUTHORITATIVE", raising=False)
+    monkeypatch.delenv("AGENT_SENTINEL_EVENT_LOG_AUTHORITATIVE", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _allow_test_client_host(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep Starlette TestClient's default ``Host: testserver`` working.
 

--- a/tests/test_canonical_rebuild.py
+++ b/tests/test_canonical_rebuild.py
@@ -146,6 +146,38 @@ def test_rebuild_absorbs_new_events_appended_to_the_ledger(tmp_path: Path) -> No
     assert report.session_count == 2
 
 
+def test_rebuild_reads_the_authoritative_log_not_a_frozen_events_jsonl_backup(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # An adopted store keeps events.jsonl as a FROZEN pre-cutover backup while the
+    # SQLite log keeps growing. rebuild-store must reconstruct from the
+    # authoritative log, not the stale flat file, or every event recorded after
+    # adoption is silently dropped from the rebuilt index.
+    from agentacct.service import SentinelService
+
+    store_dir = tmp_path / "adopted"
+    store_dir.mkdir(mode=0o700)
+    # Seed an existing events.jsonl store in mirror mode, then adopt it by opening
+    # under the authoritative default; the flat file is kept as a frozen backup.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
+    seeder = SentinelService(store_dir)
+    seeder.append_events_preserving_identity([_usage_event(event_id="u1", session_id="s1")])
+    seeder.list_all_events()
+
+    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)  # authoritative default
+    adopted = SentinelService(store_dir)
+    assert adopted._authoritative()
+    # events.jsonl stays a frozen 1-session backup; the second session goes only
+    # to the log.
+    adopted.append_events_preserving_identity([_usage_event(event_id="u2", session_id="s2")])
+    assert len((store_dir / EVENTS_FILENAME).read_text(encoding="utf-8").splitlines()) == 1
+
+    report = rebuild_live_store_from_events(store_dir)
+    # Both sessions present => the rebuild read the authoritative log, not the
+    # frozen 1-session flat backup.
+    assert report.session_count == 2
+
+
 def test_rebuild_leaves_no_stale_wal_sidecars_from_a_prior_store(tmp_path: Path) -> None:
     # A prior live store can leave an uncheckpointed chronicle.sqlite3-wal. A
     # rebuild replaces only the main file, so the fresh store must not inherit

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,11 @@ import pytest
 from typer.testing import CliRunner
 
 from agentacct.cli import _exit_if_unsupported_platform, app
+from agentacct.event_log import RAW_EVENT_LOG_FILENAME, RawEventLog
+
+
+def _ledger_text(store_dir):
+    return "\n".join(RawEventLog(Path(store_dir) / RAW_EVENT_LOG_FILENAME).read_lines())
 
 
 def test_win32_platform_fails_fast_with_one_actionable_sentence(capsys):
@@ -242,7 +247,7 @@ def test_event_cli_records_lists_and_redacts_events(tmp_path):
     assert event["estimated_cost_usd"] == 0.00012
     assert event["metadata"]["summary"] == "first event"
     assert event["metadata"]["api_key"] == "[REDACTED]"
-    assert "fake-secret-for-redaction" not in (store_dir / "events.jsonl").read_text(encoding="utf-8")
+    assert "fake-secret-for-redaction" not in _ledger_text(store_dir)
 
     listed = CliRunner().invoke(app, ["event", "list", "--store-dir", str(store_dir), "--json"])
     assert listed.exit_code == 0, listed.output
@@ -258,7 +263,11 @@ def test_event_cli_records_lists_and_redacts_events(tmp_path):
     assert "first event" in human.output
 
 
-def test_event_summary_counts_recent_events_cost_and_tokens(tmp_path):
+def test_event_summary_counts_recent_events_cost_and_tokens(tmp_path, monkeypatch):
+    # Hand-seeds malformed/oversized raw lines directly into events.jsonl to test
+    # summary tolerance of torn flat-file records — flat-file mechanics only present
+    # in legacy mirror mode.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     store_dir = tmp_path / "state"
     runner = CliRunner()
 
@@ -455,7 +464,7 @@ def test_event_note_redacts_secret_shaped_summary_in_storage_and_output(tmp_path
     # Only the secret span is replaced now: the surrounding note survives.
     assert "called [REDACTED_SECRET]" in record.output
     assert secretish not in record.output
-    stored = (store_dir / "events.jsonl").read_text(encoding="utf-8")
+    stored = _ledger_text(store_dir)
     assert "called [REDACTED_SECRET]" in stored
     assert secretish not in stored
 

--- a/tests/test_client_usage.py
+++ b/tests/test_client_usage.py
@@ -4741,7 +4741,7 @@ def test_usage_import_local_persists_zero_token_session_without_usage(tmp_path):
         "usage_confidence",
         "cost_confidence",
     }.intersection(stored[0])
-    ledger_bytes = (store_dir / "events.jsonl").read_bytes()
+    ledger_lines = SentinelService(store_dir).event_log.read_lines()
 
     second = runner.invoke(app, args)
 
@@ -4749,7 +4749,7 @@ def test_usage_import_local_persists_zero_token_session_without_usage(tmp_path):
     second_payload = json.loads(second.output)
     assert second_payload["imported_events"] == 0
     assert second_payload["imported_session_observations"] == 0
-    assert (store_dir / "events.jsonl").read_bytes() == ledger_bytes
+    assert SentinelService(store_dir).event_log.read_lines() == ledger_lines
 
 
 def test_usage_import_local_persists_hermes_zero_token_observation_only(
@@ -5100,7 +5100,10 @@ def test_usage_watch_once_imports_and_exits(tmp_path):
     payload = json.loads(result.output)
     assert payload["imported_events"] == 1
     assert payload["usage_totals"]["cached_input_tokens"] == 108938
-    assert (store_dir / "events.jsonl").exists()
+    assert any(
+        event.get("event_type") == "model_usage"
+        for event in SentinelService(store_dir).list_all_events()
+    )
 
 
 def test_usage_import_local_skips_incompatible_codex_schema(tmp_path):
@@ -5366,7 +5369,7 @@ def test_usage_import_local_model_switch_does_not_double_count(tmp_path):
     assert payload["imported_events"] == 1
     assert payload["migrated_events"] == 0
     assert payload["superseded_legacy_rows"] == 0
-    stored = [json.loads(line) for line in (store_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    stored = SentinelService(store_dir).list_all_events()
     usage_rows = [event for event in stored if event["event_type"] == "model_usage"]
     assert len(usage_rows) == 2
     assert {row["metadata"]["client_session_id"] for row in usage_rows} == {"claude-session"}
@@ -5408,7 +5411,7 @@ def test_usage_import_local_migrates_legacy_model_suffixed_rows(tmp_path):
     assert payload["imported_events"] == 2
     assert payload["migrated_events"] == 2
     assert payload["superseded_legacy_rows"] == 3
-    stored = [json.loads(line) for line in (store_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    stored = SentinelService(store_dir).list_all_events()
     usage_rows = [event for event in stored if event["event_type"] == "model_usage"]
     assert len(usage_rows) == 2
     assert not any(str(event["event_id"]).startswith("evt_legacy_") for event in stored)
@@ -5437,7 +5440,7 @@ def test_usage_import_local_never_refreshes_lane_tagged_rows_but_binds_source_on
     store_dir.mkdir(parents=True)
     stale = _stored_claude_import_row("evt_stale_lane", "claude-session", model="claude-opus-4-8", lane="model:claude-opus-4-8")
     (store_dir / "events.jsonl").write_text(json.dumps(stale) + "\n", encoding="utf-8")
-    before = (store_dir / "events.jsonl").read_bytes()
+    before = SentinelService(store_dir).event_log.read_lines()
 
     result = CliRunner().invoke(app, _claude_import_args(store_dir, claude_home))
 
@@ -5447,9 +5450,9 @@ def test_usage_import_local_never_refreshes_lane_tagged_rows_but_binds_source_on
     assert payload["imported_events"] == 0
     assert payload["migrated_events"] == 0
     assert payload["source_namespace_adoptions"] == 1
-    after = (store_dir / "events.jsonl").read_bytes()
+    after = SentinelService(store_dir).event_log.read_lines()
     assert after != before
-    stored = json.loads(after)
+    stored = SentinelService(store_dir).list_all_events()[0]
     assert stored["event_id"] == "evt_stale_lane"
     assert stored["created_at"] == 1
     assert stored["metadata"]["source_namespace_binding"] == "tofu_explicit_scan_v1"
@@ -5463,7 +5466,7 @@ def test_usage_import_local_skips_untagged_pre_lane_row_but_binds_source_once(tm
     # derived from the row's model so re-import must classify it as refresh.
     stale = _stored_claude_import_row("evt_pre_lane", "claude-session", model="claude-opus-4-8")
     (store_dir / "events.jsonl").write_text(json.dumps(stale) + "\n", encoding="utf-8")
-    before = (store_dir / "events.jsonl").read_bytes()
+    before = SentinelService(store_dir).event_log.read_lines()
 
     result = CliRunner().invoke(app, _claude_import_args(store_dir, claude_home))
 
@@ -5473,9 +5476,9 @@ def test_usage_import_local_skips_untagged_pre_lane_row_but_binds_source_once(tm
     assert payload["imported_events"] == 0
     assert payload["migrated_events"] == 0
     assert payload["source_namespace_adoptions"] == 1
-    after = (store_dir / "events.jsonl").read_bytes()
+    after = SentinelService(store_dir).event_log.read_lines()
     assert after != before
-    stored = json.loads(after)
+    stored = SentinelService(store_dir).list_all_events()[0]
     assert stored["event_id"] == "evt_pre_lane"
     assert stored["created_at"] == 1
     assert stored["metadata"]["source_namespace_binding"] == "tofu_explicit_scan_v1"
@@ -5529,7 +5532,7 @@ def test_usage_import_local_keeps_raced_in_duplicate_new_row_without_duplicating
     assert result.exit_code == 0, result.output
     # The raced-in row already exists, so the never-refresh default writes nothing.
     assert json.loads(result.output)["imported_events"] == 0
-    stored = [json.loads(line) for line in (store_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    stored = SentinelService(store_dir).list_all_events()
     usage_rows = [event for event in stored if event["event_type"] == "model_usage"]
     # Exactly one row (no duplicate), carrying the correct totals.
     assert len(usage_rows) == 1
@@ -5668,7 +5671,7 @@ def test_usage_import_local_refresh_replaces_grown_session_totals(tmp_path):
     assert payload["usage_totals"]["input_tokens"] == 130
     assert payload["usage_totals"]["output_tokens"] == 62
 
-    stored = [json.loads(line) for line in (store_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    stored = SentinelService(store_dir).list_all_events()
     usage_rows = [event for event in stored if event["event_type"] == "model_usage"]
     assert len(usage_rows) == 1
     row = usage_rows[0]
@@ -5711,7 +5714,7 @@ def test_usage_watch_refresh_replaces_grown_session_totals(tmp_path):
     assert payload["refresh"] is True
     assert payload["imported_events"] == 1
     assert payload["refreshed_events"] == 1
-    stored = [json.loads(line) for line in (store_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    stored = SentinelService(store_dir).list_all_events()
     usage_rows = [event for event in stored if event["event_type"] == "model_usage"]
     assert len(usage_rows) == 1
     assert usage_rows[0]["estimated_input_tokens"] == 130
@@ -5729,7 +5732,7 @@ def test_usage_watch_refresh_skips_unchanged_rows_without_reissuing_event_id(tmp
 
     first = runner.invoke(app, _claude_import_args(store_dir, claude_home))
     assert first.exit_code == 0, first.output
-    before_bytes = (store_dir / "events.jsonl").read_bytes()
+    before_lines = SentinelService(store_dir).event_log.read_lines()
     before_ids = [e["event_id"] for e in SentinelService(store_dir).list_all_events() if e["event_type"] == "model_usage"]
 
     refreshed = runner.invoke(app, _claude_import_args(store_dir, claude_home, "--refresh"))
@@ -5737,7 +5740,7 @@ def test_usage_watch_refresh_skips_unchanged_rows_without_reissuing_event_id(tmp
     payload = json.loads(refreshed.output)
     assert payload["imported_events"] == 0
     assert payload["refreshed_events"] == 0
-    assert (store_dir / "events.jsonl").read_bytes() == before_bytes
+    assert SentinelService(store_dir).event_log.read_lines() == before_lines
     after_ids = [e["event_id"] for e in SentinelService(store_dir).list_all_events() if e["event_type"] == "model_usage"]
     assert after_ids == before_ids
 
@@ -5872,11 +5875,7 @@ def test_usage_import_refresh_carries_forward_migration_provenance(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["refreshed_events"] == 1
-    usage_rows = [
-        json.loads(line)
-        for line in (store_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
-        if json.loads(line)["event_type"] == "model_usage"
-    ]
+    usage_rows = _stored_usage_rows(store_dir)
     assert len(usage_rows) == 1
     row = usage_rows[0]
     assert row["estimated_input_tokens"] == 30  # refreshed to fresh totals
@@ -5905,12 +5904,11 @@ def _codex_import_args(store_dir: Path, codex_home: Path, *extra: str) -> list[s
 
 
 def _stored_usage_rows(store_dir: Path) -> list[dict]:
-    rows = []
-    for line in (store_dir / "events.jsonl").read_text(encoding="utf-8").splitlines():
-        event = json.loads(line)
-        if event.get("event_type") == "model_usage":
-            rows.append(event)
-    return rows
+    return [
+        event
+        for event in SentinelService(store_dir).list_all_events()
+        if event.get("event_type") == "model_usage"
+    ]
 
 
 def _write_gpt56_snapshot(store_dir: Path, *, input_cost: float = 0.000005) -> Path:

--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -20,6 +20,7 @@ from agentacct.client_usage import (
 )
 from agentacct.api import UsageDiscoveryConfig, create_local_api_app
 from agentacct.ingestion_health import IngestionHealthStore, health_scan_results
+from agentacct.event_log import RAW_EVENT_LOG_FILENAME, RawEventLog
 from agentacct.service import SentinelService
 from agentacct.source_discovery import discover_usage_sources
 from agentacct.usage_truth import is_local_session_observation_event
@@ -612,13 +613,13 @@ def test_cursor_cli_persists_observation_only_idempotently(tmp_path: Path) -> No
         "usage_confidence",
         "cost_confidence",
     }.intersection(stored[0])
-    ledger = (store / "events.jsonl").read_bytes()
+    ledger = RawEventLog(store / RAW_EVENT_LOG_FILENAME).read_lines()
 
     second = CliRunner().invoke(app, args)
 
     assert second.exit_code == 0, second.output
     assert json.loads(second.output)["imported_session_observations"] == 0
-    assert (store / "events.jsonl").read_bytes() == ledger
+    assert RawEventLog(store / RAW_EVENT_LOG_FILENAME).read_lines() == ledger
 
     human = CliRunner().invoke(app, [arg for arg in args if arg != "--json"])
     assert human.exit_code == 0, human.output

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -132,3 +132,48 @@ def test_corrupt_and_nonobject_lines_are_mirrored_verbatim(tmp_path: Path) -> No
     assert log.count() == 4
     # Parsed reads skip the corrupt/non-object lines, exactly like the file reader.
     assert log.read_events() == [_event("e0"), _event("e1")]
+
+
+def test_absorb_new_events_unions_by_id_and_never_truncates(tmp_path: Path) -> None:
+    # absorb is the rolling-upgrade drain: it appends events the file has but the
+    # log lacks (by event_id), never removes an event the log already leads with.
+    log = RawEventLog(tmp_path / "events.sqlite3")
+    for event in (_event("a"), _event("b"), _event("c")):
+        log.append_event(event)  # log leads: a, b, c
+
+    ledger = tmp_path / "events.jsonl"
+    # File shares a/b (already in the log) and adds a straggler d; it does NOT
+    # contain c — absorb must NOT drop c just because the file lacks it.
+    _write_ledger(ledger, [_event("a"), _event("b"), _event("d")])
+
+    assert log.absorb_new_events(ledger) == 1  # only d absorbed
+    assert [event["event_id"] for event in log.read_events()] == ["a", "b", "c", "d"]
+    # Idempotent: re-absorbing the same file adds nothing.
+    assert log.absorb_new_events(ledger) == 0
+    assert log.count() == 4
+
+
+def test_absorb_new_events_dedupes_idless_lines_by_content(tmp_path: Path) -> None:
+    log = RawEventLog(tmp_path / "events.sqlite3")
+    ledger = tmp_path / "events.jsonl"
+    # A line with no event_id (corrupt/legacy) must absorb once and not duplicate
+    # on a repeat absorb.
+    ledger.write_text(serialize_event(_event("a")) + "\n" + "{not-json\n", encoding="utf-8")
+    assert log.absorb_new_events(ledger) == 2
+    assert log.absorb_new_events(ledger) == 0  # neither the id'd nor the id-less line re-added
+    assert log.count() == 2
+
+
+def test_absorb_does_not_duplicate_lines_already_in_the_log_via_reconcile(tmp_path: Path) -> None:
+    # A mirror-mode reconcile copies every line into the log WITHOUT recording an
+    # absorbed_flat key. A later authoritative absorb of the same file must not
+    # duplicate them — id-bearing lines are caught by the log's ids, and id-less
+    # (corrupt/legacy) lines by the log's verbatim content.
+    ledger = tmp_path / "events.jsonl"
+    ledger.write_text(serialize_event(_event("a")) + "\n" + "{not-json\n", encoding="utf-8")
+    log = RawEventLog(tmp_path / "events.sqlite3")
+    log.reconcile_from_file(ledger)  # mirror path: both lines in the log, absorbed_flat empty
+    assert log.count() == 2
+
+    assert log.absorb_new_events(ledger) == 0  # the id-less line is NOT re-added
+    assert log.count() == 2

--- a/tests/test_event_log_cli.py
+++ b/tests/test_event_log_cli.py
@@ -18,7 +18,10 @@ def _seed(store_dir: Path, n: int) -> None:
     service.list_all_events()  # sync the mirror
 
 
-def test_verify_log_reports_parity(tmp_path: Path) -> None:
+def test_verify_log_reports_parity(tmp_path: Path, monkeypatch) -> None:
+    # Mirror mode: verify-log genuinely compares the flat file to the log (in the
+    # default authoritative mode there is no flat file left to prove parity against).
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     store_dir = tmp_path / "store"
     store_dir.mkdir()
     _seed(store_dir, 3)
@@ -30,10 +33,12 @@ def test_verify_log_reports_parity(tmp_path: Path) -> None:
 
 
 def test_drop_flat_ledger_cutover_survives_reopen_without_env(tmp_path: Path, monkeypatch) -> None:
-    # The blocker fix: the cutover writes a PERSISTENT marker (no env var needed)
-    # so a later open of the store — without AGENTACCT_EVENT_LOG_AUTHORITATIVE —
-    # keeps reading the log and does NOT wipe it or resurrect events.jsonl.
-    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)
+    # The blocker fix: the cutover writes a PERSISTENT marker so that even a later
+    # open in explicit mirror mode (env=0) keeps reading the log and does NOT wipe
+    # it or resurrect events.jsonl — the marker, not the env, is the authority
+    # signal. Mirror mode is pinned throughout so the store starts flat-file-
+    # authoritative, giving drop-flat-ledger a real events.jsonl to cut over.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     store_dir = tmp_path / "store"
     store_dir.mkdir()
     _seed(store_dir, 4)
@@ -50,8 +55,9 @@ def test_drop_flat_ledger_cutover_survives_reopen_without_env(tmp_path: Path, mo
     assert (store_dir / "events.authoritative").exists()
     assert (store_dir / "events.jsonl.lock").exists()
 
-    # A fresh service with NO env var still sees all 4 events (no wipe) and a
-    # new write goes to the log, not a resurrected flat file.
+    # A fresh service in explicit mirror mode still sees all 4 events (no wipe)
+    # and a new write goes to the log, not a resurrected flat file — the marker
+    # overrides the mirror-mode env.
     reopened = SentinelService(store_dir)
     assert reopened._authoritative()
     assert len(reopened.list_all_events()) == 4

--- a/tests/test_event_log_service.py
+++ b/tests/test_event_log_service.py
@@ -27,7 +27,8 @@ def _parity(service: SentinelService) -> dict:
     return service.verify_event_log_parity()
 
 
-def test_mirror_tracks_appends_and_serves_identical_events(tmp_path: Path) -> None:
+def test_mirror_tracks_appends_and_serves_identical_events(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror mode: flat file authoritative
     service = SentinelService(tmp_path / "store")
     assert service.event_log is not None
 
@@ -42,7 +43,8 @@ def test_mirror_tracks_appends_and_serves_identical_events(tmp_path: Path) -> No
     assert service.event_log.read_events() == service.list_all_events()
 
 
-def test_mirror_tracks_verbatim_identity_appends(tmp_path: Path) -> None:
+def test_mirror_tracks_verbatim_identity_appends(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror mode: flat file authoritative
     service = SentinelService(tmp_path / "store")
     service.record_event(_note("first"))
 
@@ -59,7 +61,8 @@ def test_mirror_tracks_verbatim_identity_appends(tmp_path: Path) -> None:
     assert service.event_log.read_events() == service.list_all_events()
 
 
-def test_mirror_heals_after_a_whole_file_rewrite(tmp_path: Path) -> None:
+def test_mirror_heals_after_a_whole_file_rewrite(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror mode: flat file authoritative
     service = SentinelService(tmp_path / "store")
     for i in range(5):
         service.record_event(_note(f"n{i}"))
@@ -135,9 +138,11 @@ def test_authoritative_mode_rewrite_operates_on_the_log(tmp_path: Path, monkeypa
 
 
 def test_env_adoption_persists_a_marker_so_a_no_env_reopen_does_not_wipe(tmp_path: Path, monkeypatch) -> None:
-    # A store adopted via the env flag must persist a marker, so a later open
-    # WITHOUT the env var stays authoritative and never mirror-reconciles the
-    # log back down to a stale/absent flat file (the re-review's worst defect).
+    # A store adopted via the env flag must persist a marker, so a later open in
+    # explicit mirror mode (env=0) stays authoritative via the marker alone and
+    # never mirror-reconciles the log back down to a stale/absent flat file (the
+    # re-review's worst defect). Pinning the reopen to mirror mode proves the
+    # marker — not the now-default authoritative mode — is what protects the log.
     store_root = tmp_path / "store"
     store_root.mkdir()
     monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "1")
@@ -147,9 +152,9 @@ def test_env_adoption_persists_a_marker_so_a_no_env_reopen_does_not_wipe(tmp_pat
     assert len(adopter.list_all_events()) == 5
     assert (store_root / "events.authoritative").exists()  # env adoption persisted a marker
 
-    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     reopened = SentinelService(store_root)
-    assert reopened._authoritative()
+    assert reopened._authoritative()  # the marker overrides the mirror-mode env
     assert len(reopened.list_all_events()) == 5  # nothing wiped
 
 
@@ -157,7 +162,7 @@ def test_adoption_fully_syncs_a_stale_mirror_log_before_freezing(tmp_path: Path,
     # Adopting authoritative must sync the log FULLY from the still-authoritative
     # flat file first — a mirror log that is behind the file must not be frozen
     # (abandoning the file's un-absorbed tail) just because it is non-empty.
-    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)  # mirror-mode setup
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror-mode setup: flat file authoritative
     store_root = tmp_path / "store"
     store_root.mkdir()
     seeder = SentinelService(store_root)
@@ -178,7 +183,7 @@ def test_adoption_fully_syncs_a_stale_mirror_log_before_freezing(tmp_path: Path,
 
 
 def test_a_cutover_store_with_a_lost_marker_self_heals(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)  # mirror-mode setup
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror-mode setup: flat file authoritative
     store_root = tmp_path / "store"
     store_root.mkdir()
     service = SentinelService(store_root)
@@ -198,7 +203,7 @@ def test_a_cutover_store_with_a_lost_marker_self_heals(tmp_path: Path, monkeypat
 
 
 def test_a_cutover_store_missing_its_log_db_fails_loud(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)  # mirror-mode setup
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror-mode setup: flat file authoritative
     store_root = tmp_path / "store"
     store_root.mkdir()
     service = SentinelService(store_root)
@@ -214,7 +219,8 @@ def test_a_cutover_store_missing_its_log_db_fails_loud(tmp_path: Path, monkeypat
         SentinelService(store_root)
 
 
-def test_a_fresh_service_backfills_the_mirror_from_an_existing_ledger(tmp_path: Path) -> None:
+def test_a_fresh_service_backfills_the_mirror_from_an_existing_ledger(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror mode: the flat ledger is authoritative
     store_root = tmp_path / "store"
     # Prime a service and write events, then drop the mirror db to simulate a
     # store that has a ledger but no SQLite mirror yet (the real XDG store).
@@ -229,3 +235,189 @@ def test_a_fresh_service_backfills_the_mirror_from_an_existing_ledger(tmp_path: 
     result = _parity(reopened)
     assert result["matches"], result
     assert result["log_lines"] == 6
+
+
+def test_a_lost_marker_does_not_truncate_a_log_that_leads_its_frozen_backup(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # An adopted store keeps events.jsonl as a FROZEN backup while the SQLite log
+    # keeps growing. If the authoritative marker is later lost (a swallowed
+    # mark_authoritative error, or the marker deleted out of band) the store is
+    # still opened authoritative by default and re-enters adoption's reconcile
+    # with the log AHEAD of the frozen file. That reconcile must PRESERVE the
+    # leading log, never rebuild it down to the shorter backup (silent data loss).
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror-mode seed
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    seeder = SentinelService(store_root)
+    for i in range(3):
+        seeder.record_event(_note(f"old{i}"))
+    seeder.list_all_events()  # events.jsonl now has 3 lines
+
+    # Adopt under the default, then grow the log to 8 while events.jsonl stays 3.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "1")
+    adopted = SentinelService(store_root)
+    assert adopted._authoritative()
+    for i in range(5):
+        adopted.record_event(_note(f"new{i}"))
+    assert len(adopted.list_all_events()) == 8
+    # events.jsonl stays the frozen 3-line backup; the 5 new records went to the log.
+    assert len(_events_file(store_root).read_text(encoding="utf-8").splitlines()) == 3
+
+    # Marker lost; reopen at the product default re-enters adoption with the log
+    # LEADING the frozen file. absorb must neither truncate the log down to the
+    # 3-line backup nor resurrect anything (all 3 ids are already known).
+    (store_root / "events.authoritative").unlink()
+    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)
+    reopened = SentinelService(store_root)
+    assert reopened._authoritative()
+    assert len(reopened.list_all_events()) == 8  # the 5 post-adoption events survive
+    assert (store_root / "events.authoritative").exists()  # marker self-healed
+
+
+def test_an_empty_but_present_events_file_does_not_wipe_a_populated_log(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # The no-wipe guard must cover an events.jsonl that EXISTS yet is empty, not
+    # only a missing file: an out-of-band truncation of the frozen backup must
+    # not empty the authoritative log on the next adoption reconcile.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "1")
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    service = SentinelService(store_root)
+    for i in range(4):
+        service.record_event(_note(f"n{i}"))
+    assert len(service.list_all_events()) == 4
+
+    # Truncate the backup to empty, drop the marker, reopen at the default.
+    _events_file(store_root).write_text("", encoding="utf-8")
+    (store_root / "events.authoritative").unlink()
+    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)
+    reopened = SentinelService(store_root)
+    assert len(reopened.list_all_events()) == 4  # not wiped by the empty backup
+
+
+def test_authoritative_open_absorbs_straggler_events_jsonl_writes_from_an_old_process(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Rolling upgrade (0.5.x -> SQLite default): after a store cuts over to the
+    # log, a not-yet-restarted OLD mirror-mode process keeps appending to
+    # events.jsonl. Those straggler events must be drained into the authoritative
+    # log (a union by event_id), so writes never split between the two ledgers and
+    # no post-cutover event is stranded.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # existing mirror-mode store
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    seeder = SentinelService(store_root)
+    for i in range(3):
+        seeder.record_event(_note(f"old{i}"))
+    seeder.list_all_events()  # events.jsonl has 3
+
+    # New code adopts and records 2 events straight to the log.
+    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)
+    new_process = SentinelService(store_root)
+    assert new_process._authoritative()
+    for i in range(2):
+        new_process.record_event(_note(f"new{i}"))
+    assert len(new_process.list_all_events()) == 5
+    # events.jsonl is left INTACT (a backup, not mutated by adoption); the new
+    # records went to the log, not the file.
+    assert len(_events_file(store_root).read_text(encoding="utf-8").splitlines()) == 3
+
+    # An OLD process, unaware of the marker/log, writes stragglers to events.jsonl.
+    with _events_file(store_root).open("a", encoding="utf-8") as handle:
+        for i in range(2):
+            handle.write(
+                json.dumps({"event_id": f"strag{i}", "event_type": "note", "created_at": 100.0 + i}) + "\n"
+            )
+
+    # Any new-code open/read drains the stragglers into the log — nothing split —
+    # while leaving events.jsonl itself untouched.
+    reader = SentinelService(store_root)
+    events = reader.list_all_events()
+    ids = {event.get("event_id") for event in events}
+    assert len(events) == 7
+    assert {"strag0", "strag1"} <= ids
+    assert len(_events_file(store_root).read_text(encoding="utf-8").splitlines()) == 5
+    # Idempotent: a second read does not re-absorb / duplicate.
+    assert len(SentinelService(store_root).list_all_events()) == 7
+
+
+def test_a_reconcile_adopted_event_removed_by_a_rewrite_is_not_resurrected(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # An event adopted into the log via mirror-mode reconcile (how EVERY existing
+    # store upgrades) has no absorbed_flat key of its own. After the flip to
+    # authoritative, the first absorb must record every retained-backup event's
+    # key, so that when a later rewrite (redaction / dedup / supersession) removes
+    # one, a subsequent absorb does NOT resurrect it from the frozen events.jsonl.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # mirror: reconcile adopts, absorbed_flat empty
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    seeder = SentinelService(store_root)
+    for i in range(3):
+        seeder.record_event(_note(f"keep{i}"))
+    events = seeder.list_all_events()  # log mirrors 3 via reconcile; absorbed_flat empty
+    victim_id = events[1]["event_id"]
+
+    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)
+    service = SentinelService(store_root)  # adoption absorb records all 3 keys
+    assert service._authoritative()
+
+    # An authoritative rewrite drops the middle event from the LOG; the retained
+    # events.jsonl backup still holds it.
+    with service._events_write_lock():
+        parsed, preserved = service._partition_existing_for_rewrite()
+        kept = [event for event in parsed if event.get("event_id") != victim_id]
+        service._write_event_partition_unlocked(kept, preserved)
+    assert victim_id not in {event.get("event_id") for event in service.list_all_events()}
+
+    # A fresh process re-absorbs the retained backup — the removed event must NOT
+    # come back (its key is in absorbed_flat from adoption).
+    reopened = SentinelService(store_root)
+    ids = {event.get("event_id") for event in reopened.list_all_events()}
+    assert victim_id not in ids
+    assert len(reopened.list_all_events()) == 2
+
+
+def test_a_straggler_written_after_open_is_drained_on_the_next_read(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # A long-lived authoritative process must pick up a straggler an old process
+    # writes to events.jsonl AFTER it opened — the init-time change stamp is
+    # captured under the lock, so a later write changes the signature and the
+    # next read drains it (rather than being masked as already-synced).
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")  # existing mirror-mode store
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    seeder = SentinelService(store_root)
+    for i in range(2):
+        seeder.record_event(_note(f"old{i}"))
+    seeder.list_all_events()
+
+    monkeypatch.delenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", raising=False)
+    service = SentinelService(store_root)  # adopt; init stamp captured under the lock
+    assert len(service.list_all_events()) == 2
+
+    # An old process appends a straggler after this service opened.
+    with _events_file(store_root).open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"event_id": "strag", "event_type": "note", "created_at": 9.0}) + "\n")
+
+    # The next read on the SAME service drains it (signature changed).
+    events = service.list_all_events()
+    assert len(events) == 3
+    assert "strag" in {event.get("event_id") for event in events}
+
+
+def test_a_create_false_probe_of_a_nonexistent_store_is_empty_not_a_failure(
+    tmp_path: Path,
+) -> None:
+    # Probing a not-yet-created store (create=False) under the authoritative
+    # default must read as EMPTY and never raise EventLogUnavailable — otherwise
+    # `agentacct setup instructions` / `hooks install`, which existence-probe
+    # their target store before recording, crash when it does not exist yet.
+    missing = tmp_path / "never-created"
+    service = SentinelService(missing, create=False)
+    assert service.list_all_events() == []
+    assert service._authoritative() is False
+    assert not missing.exists()  # the probe created nothing

--- a/tests/test_evidence_api.py
+++ b/tests/test_evidence_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from agentacct.api import create_local_api_app
+from agentacct.service import SentinelService
 
 
 def test_work_event_http_transport_writes_v1_and_v2(tmp_path) -> None:
@@ -36,8 +37,8 @@ def test_work_event_http_transport_writes_v1_and_v2(tmp_path) -> None:
     assert payload["v1_event"]["metadata"]["client_event_timestamp"] == 1_783_900_123.5
     assert payload["v1_event"]["metadata"]["source_event_id"] == "codex-section-implementation-1"
     assert retry.json()["v1_event"]["event_id"] == payload["v1_event"]["event_id"]
-    assert (store / "events.jsonl").is_file()
-    assert len((store / "events.jsonl").read_text(encoding="utf-8").splitlines()) == 1
+    v1_events = SentinelService(store).list_all_events()
+    assert len(v1_events) == 1
     assert (store / "evidence-v2" / "spool.jsonl").is_file()
 
     evidence = client.get("/evidence/events").json()["evidence"]
@@ -169,7 +170,7 @@ def test_evidence_kill_switch_leaves_v1_endpoint_working(tmp_path, monkeypatch) 
     )
 
     assert response.status_code == 200
-    assert (store / "events.jsonl").is_file()
+    assert SentinelService(store).list_all_events()
     assert not (store / "evidence-v2").exists()
     assert client.get("/evidence/status").json()["enabled"] is False
 

--- a/tests/test_evidence_cli.py
+++ b/tests/test_evidence_cli.py
@@ -54,8 +54,8 @@ def test_evidence_work_event_preserves_v1_and_adds_v2(tmp_path) -> None:
     assert payload["v1_event"]["event_type"] == "section_completed"
     assert payload["v1_event"]["metadata"]["client_event_timestamp"] == 1_783_900_123.5
     assert json.loads(retry.output)["v1_event"]["event_id"] == payload["v1_event"]["event_id"]
-    assert (store / "events.jsonl").is_file()
-    assert len((store / "events.jsonl").read_text(encoding="utf-8").splitlines()) == 1
+    v1_events = SentinelService(store).list_all_events()
+    assert len(v1_events) == 1
     assert (store / "evidence-v2" / "spool.jsonl").is_file()
 
     listing = runner.invoke(app, ["evidence", "list", "--store-dir", str(store), "--json"])

--- a/tests/test_evidence_runtime.py
+++ b/tests/test_evidence_runtime.py
@@ -146,7 +146,8 @@ def test_disabled_service_keeps_v1_recording_unchanged_and_creates_no_v2_store(t
     )
 
     assert service.list_all_events() == [recorded]
-    assert service.events_path.is_file()
+    assert service.event_log is not None
+    assert len(service.event_log.read_lines()) == 1
     assert not (tmp_path / "evidence-v2").exists()
 
 

--- a/tests/test_finding_disposition.py
+++ b/tests/test_finding_disposition.py
@@ -344,7 +344,10 @@ def test_generic_record_rewrite_and_cross_store_merge_strip_trusted_marker(
     assert appended[0]["metadata"]["reserved_finding_disposition_provenance_stripped"] is True
 
 
-def test_corrupt_trusted_chain_fails_open_and_blocks_new_mutation(tmp_path: Path) -> None:
+def test_corrupt_trusted_chain_fails_open_and_blocks_new_mutation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     service = SentinelService(tmp_path / "state")
     target = _record_failure(service)
     target_digest = finding_target_digest(target)
@@ -391,8 +394,9 @@ def test_corrupt_trusted_chain_fails_open_and_blocks_new_mutation(tmp_path: Path
 
 
 def test_corrupt_target_digest_invalidates_the_reconstructed_real_episode(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch
 ) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     service = SentinelService(tmp_path / "state")
     target = _record_failure(service)
     target_digest = finding_target_digest(target)
@@ -436,7 +440,10 @@ def test_corrupt_target_digest_invalidates_the_reconstructed_real_episode(
         )
 
 
-def test_unreadable_ledger_line_fails_closed_without_rewrite(tmp_path: Path) -> None:
+def test_unreadable_ledger_line_fails_closed_without_rewrite(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     service = SentinelService(tmp_path / "state")
     target = _record_failure(service)
     with service.events_path.open("a", encoding="utf-8") as handle:
@@ -454,7 +461,10 @@ def test_unreadable_ledger_line_fails_closed_without_rewrite(tmp_path: Path) -> 
     assert service.events_path.read_bytes() == before
 
 
-def test_persisted_revision_fields_reject_coerced_numbers(tmp_path: Path) -> None:
+def test_persisted_revision_fields_reject_coerced_numbers(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     service = SentinelService(tmp_path / "state")
     target = _record_failure(service)
     target_digest = finding_target_digest(target)

--- a/tests/test_finding_disposition_api.py
+++ b/tests/test_finding_disposition_api.py
@@ -123,7 +123,7 @@ def test_finding_post_rejects_bad_parser_csrf_and_token_without_writing(
     payload = client.get("/tasks").json()
     episode = _unassigned_episode(payload)
     valid = _form(payload, episode, action="mark_reviewed")
-    events_before = service.events_path.read_bytes()
+    events_before = service.event_log.read_lines()
 
     missing_csrf = dict(valid)
     missing_csrf.pop("csrf_token")
@@ -162,7 +162,7 @@ def test_finding_post_rejects_bad_parser_csrf_and_token_without_writing(
     ).status_code == 422
     assert client.get("/findings/disposition").status_code == 405
 
-    assert service.events_path.read_bytes() == events_before
+    assert service.event_log.read_lines() == events_before
 
 
 def test_resolve_retry_collision_reopen_and_truth_rendering(tmp_path: Path) -> None:

--- a/tests/test_instrumentation_markers.py
+++ b/tests/test_instrumentation_markers.py
@@ -37,10 +37,9 @@ runner = CliRunner()
 
 
 def _store_events(store_dir: Path) -> list[dict]:
-    events_path = store_dir / "events.jsonl"
-    if not events_path.is_file():
+    if not Path(store_dir).is_dir():
         return []
-    return [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return SentinelService(store_dir).list_all_events()
 
 
 def _store_markers(store_dir: Path) -> list[dict]:

--- a/tests/test_legacy_model_key_shadowing.py
+++ b/tests/test_legacy_model_key_shadowing.py
@@ -166,12 +166,17 @@ def _make_claude_home(root: Path) -> Path:
     return claude_home
 
 
-def test_migration_yields_the_same_totals_the_read_time_rule_reported(tmp_path: Path) -> None:
+def test_migration_yields_the_same_totals_the_read_time_rule_reported(tmp_path: Path, monkeypatch) -> None:
     """Store the legacy pairing exactly as pre-fix imports produced it (stale
     partial base row + suffixed rows matching the transcripts), read totals
     BEFORE any migration, then run the real `usage import-local` migration and
     assert the attributed totals are unchanged and the exclusion counter drops
-    to zero."""
+    to zero.
+
+    Hand-seeds the legacy on-disk pairing by writing raw lines to events.jsonl
+    and reads the exact after-state back from it — flat-file mechanics only
+    present in legacy mirror mode."""
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     from agentacct.client_usage import discover_claude_code_usage
 
     claude_home = _make_claude_home(tmp_path)

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 from agentacct.api import UsageDiscoveryConfig, create_local_api_app
 from agentacct.cli import app
 from agentacct.cost import CostLedger, UsageEstimate
+from agentacct.event_log import RAW_EVENT_LOG_FILENAME, RawEventLog
 from agentacct.mcp import SentinelMCPServer
 from agentacct.outcome import apply_judge_result, write_outcome
 from agentacct.pricing_catalog import default_pricing_catalog_snapshot_path
@@ -404,9 +405,10 @@ def test_local_api_records_and_lists_redacted_events(tmp_path):
     listed = client.get("/events")
     assert listed.status_code == 200
     assert listed.json()["events"][0]["event_id"] == event["event_id"]
-    assert "fake-api-key-for-redaction-test" not in (store_root / "events.jsonl").read_text(encoding="utf-8")
-    assert "aws-secret-canary" not in (store_root / "events.jsonl").read_text(encoding="utf-8")
-    assert "client-secret-canary" not in (store_root / "events.jsonl").read_text(encoding="utf-8")
+    ledger_text = "\n".join(RawEventLog(store_root / RAW_EVENT_LOG_FILENAME).read_lines())
+    assert "fake-api-key-for-redaction-test" not in ledger_text
+    assert "aws-secret-canary" not in ledger_text
+    assert "client-secret-canary" not in ledger_text
 
 
 def test_service_redacts_secret_keys_nested_in_tuples(tmp_path):
@@ -427,10 +429,12 @@ def test_service_redacts_secret_keys_nested_in_tuples(tmp_path):
 
     assert recorded["metadata"]["items"][0]["apiToken"] == "[REDACTED]"
     assert recorded["metadata"]["items"][0]["safe"] == "kept"
-    assert "TUPLE_SECRET_CANARY" not in (store / "events.jsonl").read_text(encoding="utf-8")
+    ledger_text = "\n".join(RawEventLog(store / RAW_EVENT_LOG_FILENAME).read_lines())
+    assert "TUPLE_SECRET_CANARY" not in ledger_text
 
 
-def test_local_api_event_summary_counts_without_metadata_leakage(tmp_path):
+def test_local_api_event_summary_counts_without_metadata_leakage(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     store_root, result = _make_run(tmp_path)
     client = TestClient(create_local_api_app(store_dir=store_root))
     secretish = "bearer-redaction-fixture-local-summary-placeholder-1234567890"
@@ -729,7 +733,7 @@ def test_local_dashboard_refresh_and_save_imports_usage_to_activity_log(tmp_path
     assert "openai / gpt-5-mini" in client.get("/tokens?days=all").text
     assert "Session time" in raw_page.text
 
-    before_duplicate = (store_root / "events.jsonl").read_bytes()
+    before_duplicate = RawEventLog(store_root / RAW_EVENT_LOG_FILENAME).read_lines()
     duplicate = run_dashboard_refresh(client)
 
     assert duplicate.status_code == 303
@@ -738,7 +742,7 @@ def test_local_dashboard_refresh_and_save_imports_usage_to_activity_log(tmp_path
     assert "imported=0" in refresh_flash_qs(duplicate)
     assert "refreshed=0" in refresh_flash_qs(duplicate)
     assert client.get("/events/summary").json()["summary"]["event_count"] == 3
-    assert (store_root / "events.jsonl").read_bytes() == before_duplicate
+    assert RawEventLog(store_root / RAW_EVENT_LOG_FILENAME).read_lines() == before_duplicate
 
 
 def test_refresh_uses_a_clean_url_and_a_one_time_flash_cookie(tmp_path, monkeypatch):
@@ -869,7 +873,7 @@ def test_dashboard_noop_refresh_reconciles_evidence_and_surfaces_failure(
     )
     initial = run_dashboard_refresh(client)
     assert initial.status_code == 303
-    before = (store_root / "events.jsonl").read_bytes()
+    before = RawEventLog(store_root / RAW_EVENT_LOG_FILENAME).read_lines()
     calls: list[tuple[bool, str | None]] = []
 
     def failed_reconcile(_service, *, complete=True, transport="internal"):
@@ -904,7 +908,7 @@ def test_dashboard_noop_refresh_reconciles_evidence_and_surfaces_failure(
     # The surfaced summary must never leak a private/sqlite projection path.
     assert "private" not in flash
     assert "sqlite" not in flash
-    assert (store_root / "events.jsonl").read_bytes() == before
+    assert RawEventLog(store_root / RAW_EVENT_LOG_FILENAME).read_lines() == before
 
     # Loading "/" once consumes the flash cookie and shows the attention banner.
     page = client.get("/")
@@ -1140,8 +1144,7 @@ def _codex_only_dashboard_client(tmp_path, monkeypatch, *, model="gpt-5.6-sol"):
 
 def _stored_usage_rows(store_root):
     rows = []
-    for line in (store_root / "events.jsonl").read_text(encoding="utf-8").splitlines():
-        event = json.loads(line)
+    for event in SentinelService(store_root).list_all_events():
         if event.get("event_type") == "model_usage":
             rows.append(event)
     return rows
@@ -1417,7 +1420,8 @@ def test_local_api_redacts_secret_shaped_string_values(tmp_path):
     # Only the secret span goes; the prose around it is ledger data and stays.
     assert event["metadata"]["summary"] == "called with [REDACTED_SECRET]"
     assert event["metadata"]["value_redaction_applied"] is True
-    assert secretish not in (tmp_path / "state" / "events.jsonl").read_text(encoding="utf-8")
+    ledger_text = "\n".join(RawEventLog(tmp_path / "state" / RAW_EVENT_LOG_FILENAME).read_lines())
+    assert secretish not in ledger_text
 
 
 def test_local_api_validates_event_run_id_and_metadata_size(tmp_path):
@@ -2214,7 +2218,7 @@ def test_dashboard_import_replaces_legacy_alias_rows_once(tmp_path, monkeypatch)
     page = client.get(response.headers["location"])
     assert page.status_code == 200
     assert "replaced legacy per-model session keys" in page.text
-    stored = [json.loads(line) for line in (store_root / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    stored = SentinelService(store_root).list_all_events()
     usage_rows = [event for event in stored if event["event_type"] == "model_usage"]
     assert len(usage_rows) == 2
     assert not any(str(event["event_id"]).startswith("evt_legacy_") for event in stored)
@@ -2253,7 +2257,7 @@ def test_dashboard_import_refreshes_matching_lane_and_appends_new_lane(tmp_path,
 
     assert response.status_code == 303
     assert "migrated=0" in refresh_flash_qs(response)
-    stored = [json.loads(line) for line in (store_root / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    stored = SentinelService(store_root).list_all_events()
     usage_rows = [event for event in stored if event["event_type"] == "model_usage"]
     assert len(usage_rows) == 2
     assert not any(str(event["event_id"]) == "evt_stale_opus" for event in stored)

--- a/tests/test_mcp_onboarding.py
+++ b/tests/test_mcp_onboarding.py
@@ -619,22 +619,25 @@ def test_readme_links_coding_agent_integration_guide() -> None:
 
 def test_mcp_doctor_is_read_only_by_default(tmp_path: Path) -> None:
     from agentacct.mcp import SentinelMCPServer
+    from agentacct.event_log import RAW_EVENT_LOG_FILENAME, RawEventLog
 
     server = SentinelMCPServer(store_dir=tmp_path)
     server.call_tool("agentacct_record_event", {"source": "codex", "event_type": "note", "metadata": {"summary": "seed"}})
-    events_path = tmp_path / "events.jsonl"
-    before_bytes = events_path.read_bytes()
+    # SQLite is the authoritative ledger by default: "read-only" means the log is
+    # byte-for-byte unchanged and never receives the doctor's probe event.
+    log = RawEventLog(tmp_path / RAW_EVENT_LOG_FILENAME)
+    before_lines = log.read_lines()
 
     result = runner.invoke(app, ["mcp", "doctor", "--store-dir", str(tmp_path)])
 
     assert result.exit_code == 0, result.output
-    assert events_path.read_bytes() == before_bytes
+    assert log.read_lines() == before_lines
     normalized = " ".join(result.output.split())
     assert "agentacct_record_event" in normalized
     assert "agentacct_list_events" in normalized
     assert "Read-only diagnostics: no events were written." in normalized
     assert "--write-probe" in normalized
-    assert "mcp_doctor_test" not in events_path.read_text(encoding="utf-8")
+    assert not any("mcp_doctor_test" in line for line in log.read_lines())
 
 
 def test_mcp_doctor_read_only_does_not_create_store_dirs(tmp_path: Path) -> None:

--- a/tests/test_refreshable_usage_runtime.py
+++ b/tests/test_refreshable_usage_runtime.py
@@ -979,7 +979,11 @@ def test_service_refresh_remints_v1_arrival_but_not_evidence_revision(tmp_path: 
     assert refreshable.superseded_revisions == 1
 
 
-def test_service_withholds_complete_deletion_when_v1_has_unparseable_line(tmp_path: Path) -> None:
+def test_service_withholds_complete_deletion_when_v1_has_unparseable_line(tmp_path: Path, monkeypatch) -> None:
+    # Hand-seeds a torn/unparseable raw line into events.jsonl to exercise the
+    # snapshot's parse-completeness gate — flat-file mechanics only present in
+    # legacy mirror mode.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     service = SentinelService(tmp_path)
     service.replace_events(
         lambda _event: False,

--- a/tests/test_secret_value_redaction.py
+++ b/tests/test_secret_value_redaction.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from agentacct.event_log import RAW_EVENT_LOG_FILENAME, RawEventLog
 from agentacct.service import (
     RESERVED_VALUE_REDACTION_KEYS,
     SentinelService,
@@ -256,7 +257,8 @@ def _session_observation(*, title: str) -> dict:
 
 
 def _stored_text(store: Path) -> str:
-    return (store / "events.jsonl").read_text(encoding="utf-8")
+    lines = RawEventLog(store / RAW_EVENT_LOG_FILENAME).read_lines()
+    return "".join(line + "\n" for line in lines)
 
 
 def _stored_events(store: Path) -> list[dict]:

--- a/tests/test_service_concurrency.py
+++ b/tests/test_service_concurrency.py
@@ -94,10 +94,14 @@ def test_concurrent_append_during_replace_is_not_lost(tmp_path: Path) -> None:
     assert sessions == {"replacement-session"}
 
 
-def test_concurrent_replace_events_do_not_corrupt_or_leave_tmp_debris(tmp_path: Path) -> None:
+def test_concurrent_replace_events_do_not_corrupt_or_leave_tmp_debris(tmp_path: Path, monkeypatch) -> None:
     """Two writers looping replace_events (plus one appender) on one store:
     every iteration completes, the final file is valid JSONL, appended
-    sections all survive, and no per-writer temp files are left behind."""
+    sections all survive, and no per-writer temp files are left behind.
+
+    Asserts on the flat file's atomic-rewrite temp-file debris — flat-file
+    mechanics only present in legacy mirror mode."""
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     store = tmp_path / "state"
     writer_a = SentinelService(store)
     writer_b = SentinelService(store)

--- a/tests/test_source_namespace_binding.py
+++ b/tests/test_source_namespace_binding.py
@@ -182,7 +182,7 @@ def test_foreign_scoped_member_rejects_the_entire_component_without_writing(
     )
     for candidate in (root, child, foreign_sibling):
         _record_usage(service, candidate)
-    before = service.events_path.read_bytes()
+    before = service.event_log.read_lines()
 
     accepted, adopted, conflicts, adoption_counts = (
         bind_discovered_usage_source_namespaces(
@@ -195,7 +195,7 @@ def test_foreign_scoped_member_rejects_the_entire_component_without_writing(
     assert adopted == []
     assert [candidate.client_session_id for candidate in conflicts] == ["child"]
     assert adoption_counts == {}
-    assert service.events_path.read_bytes() == before
+    assert service.event_log.read_lines() == before
 
 
 def test_conflicting_targets_that_normalize_to_one_claude_key_fail_closed(
@@ -212,7 +212,7 @@ def test_conflicting_targets_that_normalize_to_one_claude_key_fail_closed(
             lane="model:opus",
         ),
     )
-    before = service.events_path.read_bytes()
+    before = service.event_log.read_lines()
 
     outcome = service.bind_local_usage_source_namespaces(
         {
@@ -225,7 +225,7 @@ def test_conflicting_targets_that_normalize_to_one_claude_key_fail_closed(
     assert outcome["bound_rows_by_client"] == {}
     assert outcome["bound_identities"] == set()
     assert outcome["conflict_bases"] == {("claude-code", "session")}
-    assert service.events_path.read_bytes() == before
+    assert service.event_log.read_lines() == before
 
 
 def test_concurrent_conflicting_binders_have_one_winner_and_one_conflict(

--- a/tests/test_source_paths.py
+++ b/tests/test_source_paths.py
@@ -1411,7 +1411,7 @@ def test_dashboard_binds_unchanged_legacy_row_once_without_reissuing_identity(
         legacy_event,
         trusted_usage_import=True,
     )
-    before_bytes = (store / "events.jsonl").read_bytes()
+    before_bytes = SentinelService(store).event_log.read_lines()
     config = UsageDiscoveryConfig(
         enabled=True,
         codex_home=codex_home,
@@ -1427,7 +1427,7 @@ def test_dashboard_binds_unchanged_legacy_row_once_without_reissuing_identity(
     assert response.status_code == 303
     assert "refreshed=0" in refresh_flash_qs(response)
     assert "source_namespace_adoptions=1" in refresh_flash_qs(response)
-    after_bytes = (store / "events.jsonl").read_bytes()
+    after_bytes = SentinelService(store).event_log.read_lines()
     assert after_bytes != before_bytes
     after = SentinelService(store).list_all_events()[0]
     assert after["event_id"] == saved["event_id"]
@@ -1439,4 +1439,4 @@ def test_dashboard_binds_unchanged_legacy_row_once_without_reissuing_identity(
 
     assert second.status_code == 303
     assert "source_namespace_adoptions=0" in refresh_flash_qs(second)
-    assert (store / "events.jsonl").read_bytes() == after_bytes
+    assert SentinelService(store).event_log.read_lines() == after_bytes

--- a/tests/test_store_merge.py
+++ b/tests/test_store_merge.py
@@ -34,15 +34,12 @@ runner = CliRunner()
 
 
 def _read(store: Path) -> list[dict]:
-    events_path = store / "events.jsonl"
-    if not events_path.is_file():
+    # Read the authoritative ledger (SQLite log by default; events.jsonl in
+    # mirror mode). Returns parsed event dicts in ledger order, exactly what the
+    # old direct events.jsonl read returned before SQLite became authoritative.
+    if not store.exists():
         return []
-    out = []
-    for line in events_path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if line:
-            out.append(json.loads(line))
-    return out
+    return SentinelService(store, create=False).list_all_events()
 
 
 def _write_store(store: Path, events: list[dict]) -> None:
@@ -490,6 +487,10 @@ def test_kind_all_skips_older_but_preserves_conflicting_observation(
         watermark=1_700_000_200.0,
         title="Conflicting",
     )
+    # Re-seed via a FRESH source store: the first merge already opened `source`
+    # and adopted [older] into its authoritative log, so rewriting its
+    # events.jsonl (now a frozen backup) would be ignored by the log-backed read.
+    source = tmp_path / "from-conflict" / "state"
     _write_store(source, [conflicting])
     conflict = runner.invoke(
         app,
@@ -1046,10 +1047,13 @@ def test_generic_event_id_cannot_preoccupy_truth_and_remerge_is_idempotent(
 # --- FIX 3 (minor — torn JSONL on append) ------------------------------------
 
 
-def test_append_guards_missing_trailing_newline(tmp_path: Path) -> None:
+def test_append_guards_missing_trailing_newline(tmp_path: Path, monkeypatch) -> None:
     """A target whose last line has NO trailing newline must not tear on append:
     every pre-existing row AND every appended row parses (no `}{`, no dropped
     row)."""
+    # This pins flat-file append mechanics (a hand-seeded events.jsonl with no
+    # trailing newline), which only exist in legacy mirror mode.
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "0")
     store = tmp_path / "target"
     (store / "runs").mkdir(parents=True, exist_ok=True)
     pre_existing = _usage_row("evt_notrailing00", "codex-pre-1")

--- a/tests/test_task_dashboard_phase8.py
+++ b/tests/test_task_dashboard_phase8.py
@@ -16,6 +16,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from agentacct.api import DASHBOARD_CSP, create_local_api_app
+from agentacct.event_log import RAW_EVENT_LOG_FILENAME, RawEventLog
 from agentacct.service import SentinelService
 from agentacct.task_continuations import (
     CONTINUATION_ACTIONS_FILENAME,
@@ -155,7 +156,7 @@ def test_task_mutations_reject_missing_or_invalid_csrf_without_writing(tmp_path:
     initial = _tasks(client)
     assert initial["summary"]["task_count"] == 2
 
-    events_before = service.events_path.read_bytes()
+    events_before = RawEventLog(store_root / RAW_EVENT_LOG_FILENAME).read_lines()
     actions_path = store_root / CONTINUATION_STORE_DIRNAME / CONTINUATION_ACTIONS_FILENAME
     assert not actions_path.exists()
 
@@ -194,7 +195,7 @@ def test_task_mutations_reject_missing_or_invalid_csrf_without_writing(tmp_path:
     )
     assert duplicate_json_response.status_code == 422
 
-    assert service.events_path.read_bytes() == events_before
+    assert RawEventLog(store_root / RAW_EVENT_LOG_FILENAME).read_lines() == events_before
     assert not actions_path.exists()
     unchanged = _tasks(client)
     assert unchanged["tasks"] == initial["tasks"]


### PR DESCRIPTION
Makes the SQLite event log the **default authoritative backend** and retires the flat-file read path, and makes the upgrade **rolling-upgrade safe**. This is the change that justifies **0.6.0**.

## What changes

- **`event_log_authoritative()` now defaults ON.** A fresh install is SQLite-only from its first event; an existing `events.jsonl` store auto-adopts the log on open (the flat file is kept as a backup, never deleted on adopt). Set `AGENTACCT_EVENT_LOG_AUTHORITATIVE=0` to opt back into the legacy flat-file mirror mode.

- **Rolling-upgrade safety.** Upgrading `0.5.x` → this build with daemons still running: a not-yet-restarted old (mirror-mode) process may keep writing to `events.jsonl` after a new process cuts the store over. The new code **drains those straggler writes into the authoritative log**, so a rolling upgrade never splits events between the two ledgers or loses one. The drain is a union keyed by a durable membership set (`absorbed_flat`, a table inside `events.sqlite3`): every event seen from the flat file is recorded on first sighting — whether or not it is appended — so an event a later rewrite (redaction / dedup / usage-refresh replace) removes is never resurrected from the retained backup, and membership is by id/content (not file position) so an old process rewriting or reordering the file cannot smuggle a seen event back in. `events.jsonl` is never mutated by a read, dry-run, or absorb; it stays a backup until the deliberate `event drop-flat-ledger`, which does a final locked drain before deleting it.

  *Known limit (deliberate, union-only):* a deletion an old process makes in `events.jsonl` during the window is not propagated to the log; usage accounting dedupes superseded snapshots by session identity, and the window closes when the old processes are restarted.

## Data-path fixes the flip exposed (found by adversarial audit, fixed + regression-tested)

- A `create=False` existence probe of a not-yet-created store now reads as empty instead of raising `EventLogUnavailable`, so `setup instructions` / `hooks claude-code install` no longer crash on a store that does not exist yet.
- `canonical rebuild-store` reconstructs from the authoritative log, not a frozen `events.jsonl` backup, once a store has adopted.
- `mcp doctor` reports store writability for a SQLite-backed store (the probe was previously skipped whenever `events.jsonl` was absent).

## Tests

- ~100 tests that read `events.jsonl` directly now read the authoritative ledger via the service/log API, or pin `AGENTACCT_EVENT_LOG_AUTHORITATIVE=0` when they assert flat-file mechanics; every assertion is preserved.
- `conftest` pins the authoritative default so the suite is insulated from an ambient opt-out.
- Full suite: **3056 passed, 1 skipped**. New regression tests cover each fix and the rolling-upgrade drain.

## Deferred (out of scope)

- The evidence-v2 offline rebuild still reads `events.jsonl` from sealed snapshots (a separate, owner-gated DR subsystem) — needs the same SQLite-log awareness `canonical/rebuild.py` got.

## After merge

Cut 0.6.0 (bump `pyproject`, date the CHANGELOG, tag, GitHub Release → PyPI), then deploy by pulling and restarting the daemons. Existing stores auto-adopt to SQLite on the next open, and the rolling restart is now safe.
