### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-01
+
 ### Added
 - **agentacct now keeps its event ledger in SQLite by default.** The event log
   (`events.sqlite3`) is the authoritative store: a fresh install is SQLite-only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentacct"
-version = "0.5.3"
+version = "0.6.0"
 description = "Local-first Agent Work Intelligence for coding agents: usage truth, recorded work, and honest joins"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release prep for 0.6.0: bump `pyproject.toml` 0.5.3 → 0.6.0 and roll CHANGELOG `[Unreleased]` into `[0.6.0] - 2026-08-01`.

Contents (already merged to main): #37 SQLite event log becomes the default authoritative backend (rolling-upgrade safe) + #38 retire the offline Evidence v2 rebuild subsystem, plus the mcp-doctor writability and rebuild-store fixes.

Publish pre-flight (local, mirrors the CI build job): `uv build` produced the 0.6.0 sdist + wheel, `twine check` PASSED on both, and the wheel installs into a clean venv with a working `agentacct` entry point reporting 0.6.0. After merge: tag `v0.6.0` (TestPyPI rehearsal) then publish the GitHub Release (real PyPI).