### PR TITLE
feat: agentacct limits — provider rate-limit foundation (Codex + Claude, local files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **`agentacct limits` — provider-reported usage limits, read from local files.**
+  A new foundation records real rate-limit snapshots as `rate_limit_observed`
+  events and renders them: for each client, the 5-hour and weekly (7-day) windows
+  with the provider's own used-percentage, reset countdown (when the provider
+  reports one), plan, and credits. Data is read **passively from local files —
+  no credentials, no API calls, no CLI scraping**:
+  - **Codex** from `~/.codex/sessions/**/rollout-*.jsonl` (`rate_limits` on
+    `token_count` events: used percent, window length, reset time, credits, plan).
+  - **Claude Code (desktop app)** from `~/Library/Application Support/Claude/plan-usage-history.json`
+    (the desktop app's rolling 5-hour / 7-day utilization series; Pro/Max only).
+  Snapshots are captured as a no-cost side effect of `agentacct usage import-local`
+  and `agentacct usage watch`, and recorded idempotently — an unchanged limit
+  re-observed on every scan is a no-op, so a new event is written only when a
+  percentage, window, or credit value actually changes. `agentacct limits`
+  supports `--json` and `--client`. Reading limits is best-effort and never fails
+  a usage import.
+
 ## [0.6.0] - 2026-08-01
 
 ### Added

--- a/src/agentacct/canonical/lane_inventory.py
+++ b/src/agentacct/canonical/lane_inventory.py
@@ -155,6 +155,13 @@ V1_ONLY_RETAINED: dict[str, str] = {
         "not a usage measurement and has no canonical payload lane. Retained in "
         "v1."
     ),
+    "rate_limit_observed": (
+        "a provider-reported rate-limit/quota snapshot (5-hour/weekly windows with "
+        "used_percent + reset time, plan, credits) read passively from local Codex "
+        "session files and the Claude desktop plan-usage history. Observational "
+        "telemetry, not a usage measurement and not a work claim; no canonical "
+        "payload lane. Retained in v1."
+    ),
 }
 
 

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -6143,6 +6143,58 @@ def _local_usage_import_payload(
                     recorded_session_observations.append(recorded_observation)
                     if recorded_observation.get("event_id"):
                         existing_event_ids.add(str(recorded_observation["event_id"]))
+        # Provider rate-limit snapshots (CLI phase B foundation): passively read
+        # the provider-reported usage-limit windows Codex writes to its session
+        # rollout files and the Claude desktop app writes to its plan-usage
+        # history, and record them as rate_limit_observed events. Best-effort and
+        # content-idempotent (record_event dedups an unchanged snapshot via its
+        # idempotency_key), so it is safe on every watch tick and can never fail
+        # the usage import it rides along with.
+        rate_limit_snapshots_recorded = 0
+        if not dry_run:
+            from . import rate_limits as _rate_limits
+
+            _global_scan = _rate_limits.global_limit_scan_enabled()
+            _rl_snapshots: list[Any] = []
+            try:
+                if client in ("all", "codex"):
+                    # Codex honors codex_home directly: an explicit home is a
+                    # hermetic local scan (always allowed); only the default read
+                    # of the real ~/.codex is gated behind the global-scan knob.
+                    if codex_home is not None or _global_scan:
+                        _codex_rl = _rate_limits.read_codex_rate_limits_latest(codex_home)
+                        if _codex_rl is not None:
+                            _rl_snapshots.append(_codex_rl)
+                # The Claude desktop plan-usage file is a fixed machine-global path
+                # (not under claude_home / CLAUDE_CONFIG_DIR). Read it only on a
+                # genuinely default scan: no Claude-home relocation (the param OR
+                # the CLAUDE_CONFIG_DIR env the import itself honors) and the
+                # global-scan knob on. This keeps hermetic/custom scans from ever
+                # reaching into the developer's real machine file.
+                if (
+                    client in ("all", "claude-code")
+                    and claude_home is None
+                    and not os.environ.get("CLAUDE_CONFIG_DIR")
+                    and _global_scan
+                ):
+                    _rl_snapshots.extend(_rate_limits.read_claude_plan_usage_latest())
+            except Exception:  # noqa: BLE001 - a limits read must never break the usage import.
+                _rl_snapshots = []
+            if _rl_snapshots:
+                try:
+                    # Transition-based dedup: record a snapshot only when its
+                    # stream's state changed since the last recorded one, so an
+                    # unchanged limit re-seen every tick is a no-op but a decline
+                    # or reset is recorded with a fresh observation time.
+                    rate_limit_snapshots_recorded = (
+                        _rate_limits.record_snapshots_transitionally(
+                            _rl_snapshots,
+                            existing_events=service.list_all_events(),
+                            record=service.record_event,
+                        )
+                    )
+                except Exception:  # noqa: BLE001 - best-effort; recording must not fail import.
+                    rate_limit_snapshots_recorded = 0
         if dry_run:
             projectable_observation_identities: set[tuple[str, str, str]] = set()
             observation_conflict_identities = 0
@@ -6429,6 +6481,7 @@ def _local_usage_import_payload(
             "sessions_without_usage": len(session_observation_candidates),
             "eligible_session_observations": len(session_observation_candidates),
             "imported_session_observations": len(recorded_session_observations),
+            "rate_limit_snapshots_recorded": rate_limit_snapshots_recorded,
             "resolved_session_observation_conflicts": len(
                 resolved_session_observation_conflicts
             ),
@@ -7846,6 +7899,181 @@ def _select_serve_port(
         if _probe_port_free(host, candidate):
             return candidate
     raise OSError(errno.EADDRINUSE, f"no free port in range {port}-{port + max_offset}")
+
+
+def _rl_bar(used_percent: float, width: int = 20) -> str:
+    pct = max(0.0, min(100.0, float(used_percent)))
+    filled = int(round(pct / 100.0 * width))
+    return "█" * filled + "░" * (width - filled)
+
+
+def _rl_humanize_seconds(seconds: float) -> str:
+    total = int(max(0, seconds))
+    days, rem = divmod(total, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, _ = divmod(rem, 60)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m"
+    return "<1m"
+
+
+def _rl_window_label(window: Mapping[str, Any]) -> str:
+    labels = {"5h": "5-hour", "7d": "7-day"}
+    kind = str(window.get("kind") or "")
+    if kind in labels:
+        return labels[kind]
+    minutes = window.get("window_minutes")
+    if isinstance(minutes, (int, float)):
+        return f"{int(minutes)}m"
+    return "window"
+
+
+def _rl_latest_snapshots(
+    service: "SentinelService", *, client: str | None
+) -> list[dict[str, Any]]:
+    """Latest rate_limit_observed event per (client, org, run_id)."""
+
+    from .rate_limits import EVENT_TYPE as _RL_EVENT_TYPE
+
+    latest: dict[tuple[Any, Any, Any], tuple[float, dict[str, Any]]] = {}
+    for event in service.list_all_events():
+        if event.get("event_type") != _RL_EVENT_TYPE:
+            continue
+        metadata = event.get("metadata") or {}
+        event_client = metadata.get("client")
+        if client and event_client != client:
+            continue
+        key = (event_client, metadata.get("org"), event.get("run_id"))
+        captured = metadata.get("captured_at")
+        if not isinstance(captured, (int, float)) or isinstance(captured, bool):
+            created = event.get("created_at")
+            captured = float(created) if isinstance(created, (int, float)) else 0.0
+        ordering = float(captured)
+        current = latest.get(key)
+        if current is None or ordering >= current[0]:
+            latest[key] = (ordering, event)
+    return [
+        event
+        for _key, (_ordering, event) in sorted(
+            latest.items(), key=lambda item: (str(item[0][0]), str(item[0][1]))
+        )
+    ]
+
+
+def _rl_json_entry(event: Mapping[str, Any]) -> dict[str, Any]:
+    metadata = event.get("metadata") or {}
+    return {
+        "client": metadata.get("client"),
+        "plan_type": metadata.get("plan_type"),
+        "org": metadata.get("org"),
+        "captured_at": metadata.get("captured_at"),
+        "windows": metadata.get("windows") or [],
+        "credits": metadata.get("credits"),
+        "reached_type": metadata.get("reached_type"),
+        "source_file": metadata.get("source_file"),
+    }
+
+
+@app.command("limits")
+def limits(
+    store_dir: Annotated[Optional[Path], typer.Option(help=_STORE_DIR_HELP)] = None,
+    client: Annotated[
+        Optional[str],
+        typer.Option(help="Filter to one client: all (default), codex, or claude-code."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit machine-readable JSON.")] = False,
+) -> None:
+    """Show provider-reported usage limits (5-hour / weekly windows).
+
+    Read passively from local files — no credentials, no API calls. Codex limits
+    come from ~/.codex session files; Claude limits from the Claude desktop app's
+    local plan-usage history (Pro/Max subscriptions only). Populate them by using
+    your agents, or by running ``agentacct usage watch``. Percentages are the
+    provider's own reported utilization; reset times are shown when the provider
+    records them (Codex).
+    """
+
+    # Normalize/validate the client selector the same way the rest of the CLI
+    # does: None/"all" means no filter; only the two clients that emit limits are
+    # valid. (A bare unknown value must error, not silently render "no data".)
+    if client is None or client == "all":
+        effective_client: str | None = None
+    elif client in ("codex", "claude-code"):
+        effective_client = client
+    else:
+        raise typer.BadParameter("--client must be one of: all, codex, claude-code")
+
+    resolved_store_dir = _resolve_cli_store_dir(store_dir).path
+    service = SentinelService(resolved_store_dir, create=False)
+    snapshots = _rl_latest_snapshots(service, client=effective_client)
+
+    if json_output:
+        print(
+            json.dumps(
+                {"limits": [_rl_json_entry(e) for e in snapshots]},
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+        )
+        return
+
+    if not snapshots:
+        console.print("No provider limit data recorded yet.")
+        console.print("  • Codex: run a codex session, or `agentacct usage watch`.")
+        console.print(
+            "  • Claude (desktop app, Pro/Max): use Claude, or `agentacct usage watch`."
+        )
+        return
+
+    now = time.time()
+    console.print(
+        "Provider-reported usage limits — local files, no API. Provider estimates, not billing.\n"
+    )
+    for event in snapshots:
+        metadata = event.get("metadata") or {}
+        event_client = metadata.get("client") or "?"
+        header = str(event_client)
+        plan = metadata.get("plan_type")
+        if plan:
+            header += f"  plan: {plan}"
+        org = metadata.get("org")
+        if org:
+            header += f"  org: {str(org)[:8]}"
+        captured = metadata.get("captured_at")
+        if not isinstance(captured, (int, float)) or isinstance(captured, bool):
+            created = event.get("created_at")
+            captured = created if isinstance(created, (int, float)) else None
+        if isinstance(captured, (int, float)):
+            header += f"  (as of {_rl_humanize_seconds(now - captured)} ago)"
+        console.print(header)
+        windows = metadata.get("windows")
+        for window in windows if isinstance(windows, list) else []:
+            if not isinstance(window, Mapping):
+                continue
+            used = window.get("used_percent")
+            used_value = float(used) if isinstance(used, (int, float)) and not isinstance(used, bool) else 0.0
+            line = f"  {_rl_window_label(window):>7}  {_rl_bar(used_value)}  {used_value:5.1f}%"
+            resets_at = window.get("resets_at")
+            if isinstance(resets_at, (int, float)) and not isinstance(resets_at, bool) and resets_at > 0:
+                delta = resets_at - now
+                line += (
+                    f"  · resets in {_rl_humanize_seconds(delta)}"
+                    if delta > 0
+                    else "  · resets now"
+                )
+            console.print(line)
+        credits = metadata.get("credits")
+        if isinstance(credits, Mapping) and credits.get("has_credits"):
+            console.print(f"  credits: {credits.get('balance')}")
+        reached = metadata.get("reached_type")
+        if reached:
+            console.print(f"  ⚠ limit reached: {reached}")
+        console.print()
 
 
 @app.command("serve")

--- a/src/agentacct/rate_limits.py
+++ b/src/agentacct/rate_limits.py
@@ -1,0 +1,629 @@
+"""Provider rate-limit / quota snapshots, read passively from local files.
+
+No credentials, no API calls, no PTY, no statusline: agentacct reads the same
+local files the coding agents already write, extracts the provider-reported
+usage-limit windows, and records them as ``rate_limit_observed`` events into the
+authoritative event log. ``agentacct limits`` renders the latest snapshot.
+
+Sources (both confirmed to carry real, provider-reported data):
+
+* **Codex** — ``~/.codex/sessions/**/rollout-*.jsonl`` ``token_count`` events carry
+  a ``payload.rate_limits`` object: ``primary``/``secondary`` windows with
+  ``used_percent`` + ``window_minutes`` + ``resets_at``, plus ``credits``,
+  ``plan_type`` and ``rate_limit_reached_type``.
+* **Claude (desktop app)** — ``~/Library/Application Support/Claude/plan-usage-history.json``
+  is the desktop app's rolling series: ``samples: [{t, org, u: {fh, sd}}]`` where
+  ``fh`` = 5-hour window used %, ``sd`` = 7-day window used %. No reset time, plan,
+  or credits are recorded there — only the two percentages.
+
+Design notes:
+
+* The two ``read_*`` functions touch the filesystem and **fail soft** (return
+  ``None``/``[]`` on any absence, wrong OS, or parse error): a limits read must
+  never break a usage import that calls it best-effort.
+* Recording is **transition-based** (see ``record_snapshots_transitionally``): a
+  snapshot is written only when its state SIGNATURE differs from the most recent
+  snapshot already recorded for the same stream. So an unchanged limit re-seen on
+  every watch tick is a no-op, but a value that changes — including a decline or a
+  window reset back to a previously-seen value — is always recorded with a fresh
+  observation time, so ``agentacct limits`` shows the CURRENT reading, not a
+  high-water mark. The signature deliberately excludes the observation time AND
+  the volatile ``credits.balance`` (which drifts every scan) so neither mints a
+  spurious snapshot; the full ``credits`` dict is still kept in metadata for
+  display.
+* Codex limits are account-wide (``limit_id == "codex"``), so the codex stream
+  uses one stable ``run_id``; Claude's series is per-org.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+EVENT_TYPE = "rate_limit_observed"
+
+CODEX_SOURCE = "codex-local-rate-limit"
+CLAUDE_SOURCE = "claude-desktop-plan-usage"
+
+CODEX_RUN_ID = "codex_rate_limit"
+
+# Canonical rolling-window lengths (minutes) used to label windows.
+FIVE_HOUR_MINUTES = 300
+SEVEN_DAY_MINUTES = 10080
+
+# Env knob: reading the machine-GLOBAL provider files (the real ~/.codex when no
+# codex_home is given, and the Claude desktop plan-usage file) can be disabled by
+# setting this to a falsey value. The test suite pins it off so hermetic scans
+# never read the developer's real machine; production leaves it on.
+GLOBAL_LIMIT_SCAN_ENV = "AGENTACCT_SCAN_GLOBAL_LIMITS"
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def global_limit_scan_enabled() -> bool:
+    value = os.environ.get(GLOBAL_LIMIT_SCAN_ENV)
+    if value is None:
+        return True
+    return value.strip().lower() not in _FALSE_VALUES
+
+
+# ---------------------------------------------------------------------------
+# data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RateLimitWindow:
+    """One provider rate-limit window (a rolling quota bucket)."""
+
+    kind: str  # "5h" | "7d" | "other"
+    used_percent: float
+    window_minutes: int | None = None
+    resets_at: int | None = None  # epoch seconds when the window resets, if known
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "used_percent": self.used_percent,
+            "window_minutes": self.window_minutes,
+            "resets_at": self.resets_at,
+        }
+
+
+@dataclass(frozen=True)
+class RateLimitSnapshot:
+    """A single provider-reported limit observation for one client."""
+
+    client: str  # "codex" | "claude-code"
+    windows: tuple[RateLimitWindow, ...]
+    captured_at: float | None = None  # provider sample/event time, epoch seconds
+    plan_type: str | None = None
+    credits: Mapping[str, Any] | None = None
+    reached_type: str | None = None
+    org: str | None = None
+    source_session_id: str | None = None
+    source_file: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
+
+
+def _str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):  # bool is an int subclass; never a window size
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        # Guard non-finite (json.loads accepts bare Infinity/NaN): int(inf) and
+        # int(nan) raise, which would abort the whole scan.
+        if not math.isfinite(value):
+            return None
+        return int(value)
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        # A non-finite percentage would produce non-conformant JSON and an
+        # "inf%" render; drop it at the source.
+        if not math.isfinite(number):
+            return None
+        return number
+    return None
+
+
+def _epoch_seconds(value: Any) -> float | None:
+    """Best-effort conversion of a provider timestamp to epoch seconds.
+
+    Codex writes ISO-8601 strings (``2026-07-25T10:37:02.336Z``); a numeric
+    value is assumed to already be epoch seconds.
+    """
+
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value) if math.isfinite(float(value)) else None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            return datetime.fromisoformat(text).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _window_kind(window_minutes: int | None) -> str:
+    if window_minutes == FIVE_HOUR_MINUTES:
+        return "5h"
+    if window_minutes == SEVEN_DAY_MINUTES:
+        return "7d"
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# normalization (pure)
+# ---------------------------------------------------------------------------
+
+
+def normalize_codex_rate_limits(
+    rate_limits: Any,
+    *,
+    captured_at: Any = None,
+    session_id: str | None = None,
+    source_file: str | None = None,
+) -> RateLimitSnapshot | None:
+    """Turn a Codex ``payload.rate_limits`` object into a snapshot, or ``None``.
+
+    Returns ``None`` when the object is missing/malformed or carries no window
+    with a usable ``used_percent``.
+    """
+
+    if not isinstance(rate_limits, Mapping):
+        return None
+    windows: list[RateLimitWindow] = []
+    for slot in ("primary", "secondary"):
+        window = rate_limits.get(slot)
+        if not isinstance(window, Mapping):
+            continue
+        used = _float_or_none(window.get("used_percent"))
+        if used is None:
+            continue
+        window_minutes = _int_or_none(window.get("window_minutes"))
+        windows.append(
+            RateLimitWindow(
+                kind=_window_kind(window_minutes),
+                used_percent=used,
+                window_minutes=window_minutes,
+                resets_at=_int_or_none(window.get("resets_at")),
+            )
+        )
+    if not windows:
+        return None
+    credits_raw = rate_limits.get("credits")
+    credits = dict(credits_raw) if isinstance(credits_raw, Mapping) else None
+    return RateLimitSnapshot(
+        client="codex",
+        windows=tuple(windows),
+        captured_at=_epoch_seconds(captured_at),
+        plan_type=_str_or_none(rate_limits.get("plan_type")),
+        credits=credits,
+        reached_type=_str_or_none(rate_limits.get("rate_limit_reached_type")),
+        source_session_id=session_id,
+        source_file=source_file,
+    )
+
+
+def normalize_claude_plan_usage_sample(
+    sample: Any,
+    *,
+    source_file: str | None = None,
+) -> RateLimitSnapshot | None:
+    """Turn one ``plan-usage-history.json`` sample into a snapshot, or ``None``.
+
+    A sample is ``{"t": <epoch ms>, "org": <id>, "u": {"fh": <5h %>, "sd": <7d %>}}``.
+    """
+
+    if not isinstance(sample, Mapping):
+        return None
+    usage = sample.get("u")
+    if not isinstance(usage, Mapping):
+        return None
+    windows: list[RateLimitWindow] = []
+    five_hour = _float_or_none(usage.get("fh"))
+    if five_hour is not None:
+        windows.append(
+            RateLimitWindow(
+                kind="5h",
+                used_percent=five_hour,
+                window_minutes=FIVE_HOUR_MINUTES,
+                resets_at=None,
+            )
+        )
+    seven_day = _float_or_none(usage.get("sd"))
+    if seven_day is not None:
+        windows.append(
+            RateLimitWindow(
+                kind="7d",
+                used_percent=seven_day,
+                window_minutes=SEVEN_DAY_MINUTES,
+                resets_at=None,
+            )
+        )
+    if not windows:
+        return None
+    millis = sample.get("t")
+    captured_at = (
+        float(millis) / 1000.0
+        if isinstance(millis, (int, float)) and not isinstance(millis, bool) and math.isfinite(float(millis))
+        else None
+    )
+    return RateLimitSnapshot(
+        client="claude-code",
+        windows=tuple(windows),
+        captured_at=captured_at,
+        org=_str_or_none(sample.get("org")),
+        source_file=source_file,
+    )
+
+
+# ---------------------------------------------------------------------------
+# event building + transition dedup (pure)
+# ---------------------------------------------------------------------------
+
+
+def snapshot_run_id(snapshot: RateLimitSnapshot) -> str:
+    """A stable per-stream run_id.
+
+    Codex limits are account-wide, so all codex snapshots share one run_id;
+    Claude's series is per-org. Both are stable across scans so consecutive
+    unchanged snapshots collapse to one recorded event.
+    """
+
+    if snapshot.client == "codex":
+        return CODEX_RUN_ID
+    org = snapshot.org or "unknown"
+    return f"claude_plan_usage_{org}"
+
+
+def _snapshot_source(client: str) -> str:
+    return CODEX_SOURCE if client == "codex" else CLAUDE_SOURCE
+
+
+def snapshot_state_signature(snapshot: RateLimitSnapshot) -> str:
+    """Content hash over the limit-STATE values that matter.
+
+    Excludes the observation time (so re-seeing the same state is a no-op) AND
+    the volatile ``credits.balance`` (which drifts on every scan for pay-as-you-go
+    accounts and would otherwise mint a snapshot every tick). Two snapshots with
+    the same signature represent the same limit state; a change in any window
+    percent/size/reset, plan, reached-state, or credit availability changes it.
+    """
+
+    payload = {
+        "client": snapshot.client,
+        "run_id": snapshot_run_id(snapshot),
+        "windows": [
+            [w.kind, w.used_percent, w.window_minutes, w.resets_at] for w in snapshot.windows
+        ],
+        "plan_type": snapshot.plan_type,
+        "reached_type": snapshot.reached_type,
+        # Only the STABLE credit flags, never the drifting balance.
+        "credits": (
+            [bool(snapshot.credits.get("has_credits")), bool(snapshot.credits.get("unlimited"))]
+            if isinstance(snapshot.credits, Mapping)
+            else None
+        ),
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:32]
+    return f"rl_{digest}"
+
+
+def snapshot_to_event(snapshot: RateLimitSnapshot) -> dict[str, Any]:
+    """Build the ``record_event`` payload for a snapshot (no trusted flags).
+
+    Carries a ``state_signature`` in metadata so the transition-dedup can tell
+    whether a stream's state changed. Deliberately sets NO ``idempotency_key`` —
+    dedup is transition-based (against the last recorded snapshot of the stream),
+    not content-against-all-history, so a value that changes then returns is still
+    recorded as the current state.
+    """
+
+    metadata: dict[str, Any] = {
+        "client": snapshot.client,
+        "captured_at": snapshot.captured_at,
+        "windows": [w.to_dict() for w in snapshot.windows],
+        "plan_type": snapshot.plan_type,
+        "credits": dict(snapshot.credits) if snapshot.credits else None,
+        "reached_type": snapshot.reached_type,
+        "org": snapshot.org,
+        "source_client_session_id": snapshot.source_session_id,
+        "source_file": snapshot.source_file,
+        "state_signature": snapshot_state_signature(snapshot),
+    }
+    return {
+        "source": _snapshot_source(snapshot.client),
+        "event_type": EVENT_TYPE,
+        "run_id": snapshot_run_id(snapshot),
+        "provider": None,
+        "model": None,
+        "estimated_input_tokens": None,
+        "estimated_output_tokens": None,
+        "estimated_cost_usd": None,
+        "usage_confidence": None,
+        "cost_confidence": None,
+        "metadata": metadata,
+    }
+
+
+def _event_ordering(event: Mapping[str, Any]) -> float:
+    metadata = event.get("metadata") or {}
+    captured = metadata.get("captured_at")
+    if isinstance(captured, (int, float)) and not isinstance(captured, bool) and math.isfinite(float(captured)):
+        return float(captured)
+    created = event.get("created_at")
+    return float(created) if isinstance(created, (int, float)) and not isinstance(created, bool) else 0.0
+
+
+def record_snapshots_transitionally(
+    snapshots: Iterable[RateLimitSnapshot],
+    *,
+    existing_events: Iterable[Mapping[str, Any]],
+    record: Callable[[dict[str, Any]], Any],
+) -> int:
+    """Record each snapshot only if it changes its stream's latest state.
+
+    ``existing_events`` is the current event list (any types; only
+    ``rate_limit_observed`` are considered). ``record`` appends one event. Returns
+    the number of events actually written. Unchanged consecutive states are a
+    no-op; a changed state (including a decline or a reset back to a previously
+    seen value) is written with its fresh observation time.
+    """
+
+    last_by_stream: dict[tuple[Any, Any], tuple[float, Any]] = {}
+    for event in existing_events:
+        if event.get("event_type") != EVENT_TYPE:
+            continue
+        metadata = event.get("metadata") or {}
+        key = (event.get("source"), event.get("run_id"))
+        ordering = _event_ordering(event)
+        current = last_by_stream.get(key)
+        if current is None or ordering >= current[0]:
+            last_by_stream[key] = (ordering, metadata.get("state_signature"))
+
+    written = 0
+    for snapshot in snapshots:
+        event = snapshot_to_event(snapshot)
+        key = (event["source"], event["run_id"])
+        signature = event["metadata"]["state_signature"]
+        previous = last_by_stream.get(key)
+        if previous is not None and previous[1] == signature:
+            continue
+        record(event)
+        written += 1
+        last_by_stream[key] = (_event_ordering(event), signature)
+    return written
+
+
+# ---------------------------------------------------------------------------
+# readers (touch the filesystem; fail soft)
+# ---------------------------------------------------------------------------
+
+
+def _codex_sessions_roots(codex_home: Path | str | None = None) -> list[Path]:
+    """Resolve codex ``sessions`` roots.
+
+    An explicit ``codex_home`` is a single root. Otherwise ``CODEX_HOME`` is
+    honored the same way the rest of agentacct does — a comma-separated list of
+    roots — falling back to ``~/.codex``.
+    """
+
+    if codex_home is not None:
+        return [Path(codex_home).expanduser() / "sessions"]
+    env_home = os.environ.get("CODEX_HOME")
+    if env_home:
+        roots = [part.strip() for part in env_home.split(",") if part.strip()]
+        if roots:
+            return [Path(part).expanduser() / "sessions" for part in roots]
+    return [Path.home() / ".codex" / "sessions"]
+
+
+def default_codex_sessions_root(codex_home: Path | str | None = None) -> Path:
+    """The first resolved codex sessions root (kept for callers/tests)."""
+
+    return _codex_sessions_roots(codex_home)[0]
+
+
+def default_claude_plan_usage_path() -> Path:
+    return (
+        Path.home()
+        / "Library"
+        / "Application Support"
+        / "Claude"
+        / "plan-usage-history.json"
+    )
+
+
+def _codex_session_id_from_path(path: Path) -> str | None:
+    # rollout-2026-07-25T18-36-58-019f98d9-a3d7-7c73-91dc-90f8f31227d7.jsonl
+    stem = path.stem
+    if stem.startswith("rollout-"):
+        return stem[len("rollout-") :] or None
+    return stem or None
+
+
+def _read_codex_file_latest_rate_limits(path: Path) -> RateLimitSnapshot | None:
+    """Latest ``rate_limits`` snapshot in one rollout file (chronological), or None."""
+
+    latest: RateLimitSnapshot | None = None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                # Cheap pre-filter: only token_count lines carry rate_limits.
+                if '"rate_limits"' not in line:
+                    continue
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(obj, Mapping):
+                    continue
+                payload = obj.get("payload")
+                if not isinstance(payload, Mapping):
+                    continue
+                try:
+                    snapshot = normalize_codex_rate_limits(
+                        payload.get("rate_limits"),
+                        captured_at=obj.get("timestamp"),
+                        session_id=_codex_session_id_from_path(path),
+                        source_file=str(path),
+                    )
+                except Exception:  # noqa: BLE001 - one poison line must not abort the file/scan.
+                    continue
+                if snapshot is not None:
+                    latest = snapshot  # file is chronological; keep the last
+    except OSError:
+        return None
+    return latest
+
+
+def read_codex_rate_limits_latest(
+    codex_home: Path | str | None = None,
+    *,
+    max_files: int = 8,
+) -> RateLimitSnapshot | None:
+    """The freshest account-wide Codex limit snapshot from recent session files.
+
+    Scans the ``max_files`` most-recently-modified rollout files across every
+    resolved codex root (the active session's file carries the newest limits) and
+    returns the snapshot with the latest ``captured_at``. Returns ``None`` if no
+    rollout carries rate limits.
+    """
+
+    rollouts: list[Path] = []
+    for root in _codex_sessions_roots(codex_home):
+        try:
+            rollouts.extend(root.rglob("rollout-*.jsonl"))
+        except OSError:
+            continue
+    if not rollouts:
+        return None
+
+    def _mtime(p: Path) -> float:
+        try:
+            return p.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    rollouts.sort(key=_mtime, reverse=True)
+    best: RateLimitSnapshot | None = None
+    best_key = float("-inf")
+    for path in rollouts[: max(1, max_files)]:
+        try:
+            snapshot = _read_codex_file_latest_rate_limits(path)
+        except Exception:  # noqa: BLE001 - fail soft per the module contract.
+            continue
+        if snapshot is None:
+            continue
+        key = snapshot.captured_at if snapshot.captured_at is not None else 0.0
+        if key > best_key:
+            best = snapshot
+            best_key = key
+    return best
+
+
+def read_claude_plan_usage_latest(
+    path: Path | str | None = None,
+) -> list[RateLimitSnapshot]:
+    """The latest limit snapshot per org from the desktop app's usage history.
+
+    Returns ``[]`` when the file is absent (non-desktop / non-macOS) or malformed.
+    """
+
+    target = Path(path).expanduser() if path is not None else default_claude_plan_usage_path()
+    try:
+        raw = target.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return []
+    samples = data.get("samples") if isinstance(data, Mapping) else None
+    if not isinstance(samples, Sequence):
+        return []
+    latest_by_org: dict[Any, Mapping[str, Any]] = {}
+    for sample in samples:
+        if not isinstance(sample, Mapping):
+            continue
+        org = sample.get("org")
+        millis = sample.get("t")
+        current = latest_by_org.get(org)
+        if current is None:
+            latest_by_org[org] = sample
+            continue
+        prev_millis = current.get("t")
+        if (
+            isinstance(millis, (int, float))
+            and not isinstance(millis, bool)
+            and (
+                not isinstance(prev_millis, (int, float))
+                or isinstance(prev_millis, bool)
+                or millis >= prev_millis
+            )
+        ):
+            latest_by_org[org] = sample
+    snapshots: list[RateLimitSnapshot] = []
+    for sample in latest_by_org.values():
+        snapshot = normalize_claude_plan_usage_sample(sample, source_file=str(target))
+        if snapshot is not None:
+            snapshots.append(snapshot)
+    return snapshots
+
+
+__all__ = [
+    "CLAUDE_SOURCE",
+    "CODEX_RUN_ID",
+    "CODEX_SOURCE",
+    "EVENT_TYPE",
+    "FIVE_HOUR_MINUTES",
+    "GLOBAL_LIMIT_SCAN_ENV",
+    "SEVEN_DAY_MINUTES",
+    "RateLimitSnapshot",
+    "RateLimitWindow",
+    "default_claude_plan_usage_path",
+    "default_codex_sessions_root",
+    "global_limit_scan_enabled",
+    "normalize_claude_plan_usage_sample",
+    "normalize_codex_rate_limits",
+    "read_claude_plan_usage_latest",
+    "read_codex_rate_limits_latest",
+    "record_snapshots_transitionally",
+    "snapshot_run_id",
+    "snapshot_state_signature",
+    "snapshot_to_event",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,22 @@ def _pin_event_log_authoritative_default(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.fixture(autouse=True)
+def _disable_global_provider_limit_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the machine-GLOBAL provider-limit file scan off for every test.
+
+    The rate-limit foundation reads global provider files (the real ``~/.codex``
+    when no codex_home is given, and the Claude desktop plan-usage history) as a
+    side effect of a usage import. Hermetic tests must never touch the developer's
+    real machine, so ``AGENTACCT_SCAN_GLOBAL_LIMITS`` is pinned off here (an
+    explicit codex_home is still scanned — that is a local, isolated path). A test
+    that specifically exercises the global scan opts in with
+    ``monkeypatch.setenv("AGENTACCT_SCAN_GLOBAL_LIMITS", "1")``.
+    """
+
+    monkeypatch.setenv("AGENTACCT_SCAN_GLOBAL_LIMITS", "0")
+
+
+@pytest.fixture(autouse=True)
 def _allow_test_client_host(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep Starlette TestClient's default ``Host: testserver`` working.
 

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -1,0 +1,439 @@
+"""Tests for the provider rate-limit foundation (`rate_limit_observed`)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from agentacct import rate_limits as rl
+from agentacct.cli import app
+from agentacct.service import SentinelService
+
+
+# --------------------------------------------------------------------------- #
+# normalization
+# --------------------------------------------------------------------------- #
+
+
+def test_normalize_codex_full_object():
+    raw = {
+        "limit_id": "codex",
+        "primary": {"used_percent": 52.0, "window_minutes": 10080, "resets_at": 1785259795},
+        "secondary": {"used_percent": 12.5, "window_minutes": 300, "resets_at": 1785000000},
+        "credits": {"has_credits": False, "unlimited": False, "balance": "0"},
+        "plan_type": "pro",
+        "rate_limit_reached_type": None,
+    }
+    snap = rl.normalize_codex_rate_limits(
+        raw, captured_at="2026-07-25T10:37:02.336Z", session_id="sess-1", source_file="/x.jsonl"
+    )
+    assert snap is not None
+    assert snap.client == "codex"
+    assert snap.plan_type == "pro"
+    assert snap.credits == {"has_credits": False, "unlimited": False, "balance": "0"}
+    kinds = {w.kind: w for w in snap.windows}
+    assert set(kinds) == {"7d", "5h"}
+    assert kinds["7d"].used_percent == 52.0
+    assert kinds["7d"].resets_at == 1785259795
+    assert kinds["5h"].window_minutes == 300
+    # ISO-8601 with a trailing Z parses to a real epoch.
+    assert snap.captured_at is not None and snap.captured_at > 1_700_000_000
+
+
+def test_normalize_codex_rejects_empty_and_malformed():
+    assert rl.normalize_codex_rate_limits(None) is None
+    assert rl.normalize_codex_rate_limits({}) is None
+    assert rl.normalize_codex_rate_limits({"primary": {"window_minutes": 300}}) is None  # no used_percent
+    # A window with no usable percent is skipped, not crashed on.
+    snap = rl.normalize_codex_rate_limits(
+        {"primary": {"used_percent": None}, "secondary": {"used_percent": 5.0, "window_minutes": 300}}
+    )
+    assert snap is not None
+    assert [w.kind for w in snap.windows] == ["5h"]
+
+
+def test_normalize_claude_sample():
+    snap = rl.normalize_claude_plan_usage_sample(
+        {"t": 1785677629903, "org": "org-1", "u": {"fh": 5, "sd": 24}}, source_file="/p.json"
+    )
+    assert snap is not None
+    assert snap.client == "claude-code"
+    assert snap.org == "org-1"
+    kinds = {w.kind: w for w in snap.windows}
+    assert kinds["5h"].used_percent == 5.0 and kinds["5h"].window_minutes == rl.FIVE_HOUR_MINUTES
+    assert kinds["7d"].used_percent == 24.0 and kinds["7d"].resets_at is None
+    assert snap.captured_at == pytest.approx(1785677629.903, rel=1e-9)
+
+
+def test_normalize_claude_rejects_malformed():
+    assert rl.normalize_claude_plan_usage_sample(None) is None
+    assert rl.normalize_claude_plan_usage_sample({"t": 1, "org": "o"}) is None  # no u
+    assert rl.normalize_claude_plan_usage_sample({"u": {}}) is None  # no windows
+
+
+# --------------------------------------------------------------------------- #
+# idempotency + event building
+# --------------------------------------------------------------------------- #
+
+
+def _codex_snapshot(used=52.0, captured=1000.0):
+    return rl.normalize_codex_rate_limits(
+        {"primary": {"used_percent": used, "window_minutes": 10080, "resets_at": 42}, "plan_type": "pro"},
+        captured_at=captured,
+    )
+
+
+def test_state_signature_ignores_time_and_balance_but_tracks_values():
+    a = _codex_snapshot(used=52.0, captured=1000.0)
+    b = _codex_snapshot(used=52.0, captured=9999.0)  # same values, later time
+    c = _codex_snapshot(used=53.0, captured=1000.0)  # changed value
+    assert rl.snapshot_state_signature(a) == rl.snapshot_state_signature(b)
+    assert rl.snapshot_state_signature(a) != rl.snapshot_state_signature(c)
+    # A drifting credits.balance must NOT change the signature (else a pay-as-you-go
+    # account floods the ledger with a snapshot every scan).
+    d = rl.normalize_codex_rate_limits(
+        {
+            "primary": {"used_percent": 52.0, "window_minutes": 10080, "resets_at": 42},
+            "plan_type": "pro",
+            "credits": {"has_credits": True, "unlimited": False, "balance": "10.00"},
+        },
+        captured_at=1000.0,
+    )
+    e = rl.normalize_codex_rate_limits(
+        {
+            "primary": {"used_percent": 52.0, "window_minutes": 10080, "resets_at": 42},
+            "plan_type": "pro",
+            "credits": {"has_credits": True, "unlimited": False, "balance": "9.50"},
+        },
+        captured_at=2000.0,
+    )
+    assert rl.snapshot_state_signature(d) == rl.snapshot_state_signature(e)
+
+
+def test_snapshot_to_event_shape_and_writer_invariants():
+    codex_event = rl.snapshot_to_event(_codex_snapshot())
+    assert codex_event["event_type"] == "rate_limit_observed"
+    assert codex_event["event_type"].split("_")[0] not in {"section", "task"}
+    assert codex_event["source"] == rl.CODEX_SOURCE
+    assert codex_event["run_id"] == rl.CODEX_RUN_ID  # codex limits are account-wide
+    md = codex_event["metadata"]
+    assert md["client"] == "codex"
+    assert "state_signature" in md
+    assert "idempotency_key" not in md  # dedup is transition-based, not global
+    assert "sentinel_semantic_kind" not in md  # must not be swept into the work feed
+    # numbers live in metadata, never in the top-level usage fields
+    assert codex_event["estimated_input_tokens"] is None
+    assert codex_event["estimated_output_tokens"] is None
+
+    claude_snap = rl.normalize_claude_plan_usage_sample({"t": 1, "org": "abc", "u": {"fh": 1, "sd": 2}})
+    claude_event = rl.snapshot_to_event(claude_snap)
+    assert claude_event["run_id"] == "claude_plan_usage_abc"  # per-org stream
+    assert claude_event["source"] == rl.CLAUDE_SOURCE
+
+
+# --------------------------------------------------------------------------- #
+# readers (filesystem, fail-soft)
+# --------------------------------------------------------------------------- #
+
+
+def test_read_claude_plan_usage_latest_per_org(tmp_path):
+    path = tmp_path / "plan-usage-history.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "samples": [
+                    {"t": 100, "org": "A", "u": {"fh": 10, "sd": 10}},
+                    {"t": 300, "org": "A", "u": {"fh": 40, "sd": 20}},  # latest for A
+                    {"t": 200, "org": "B", "u": {"fh": 5, "sd": 5}},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    snaps = rl.read_claude_plan_usage_latest(path)
+    by_org = {s.org: s for s in snaps}
+    assert set(by_org) == {"A", "B"}
+    a_five = {w.kind: w.used_percent for w in by_org["A"].windows}["5h"]
+    assert a_five == 40.0  # the later sample won
+
+
+def test_read_claude_plan_usage_missing_and_malformed(tmp_path):
+    assert rl.read_claude_plan_usage_latest(tmp_path / "nope.json") == []
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert rl.read_claude_plan_usage_latest(bad) == []
+    empty = tmp_path / "empty.json"
+    empty.write_text(json.dumps({"version": 2, "samples": []}), encoding="utf-8")
+    assert rl.read_claude_plan_usage_latest(empty) == []
+
+
+def _write_codex_rollout(root, day, name, *, timestamp, rate_limits):
+    d = root / "sessions" / "2026" / "07" / day
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / f"rollout-{name}.jsonl"
+    line = {
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {"total_token_usage": {"input_tokens": 1, "total_tokens": 1}},
+            "rate_limits": rate_limits,
+        },
+    }
+    f.write_text(json.dumps(line) + "\n", encoding="utf-8")
+    return f
+
+
+def test_read_codex_rate_limits_latest_picks_freshest(tmp_path):
+    home = tmp_path / "codex"
+    _write_codex_rollout(
+        home, "28", "old",
+        timestamp="2026-07-28T10:00:00.000Z",
+        rate_limits={"primary": {"used_percent": 10.0, "window_minutes": 10080, "resets_at": 1}},
+    )
+    _write_codex_rollout(
+        home, "29", "new",
+        timestamp="2026-07-29T10:00:00.000Z",
+        rate_limits={"primary": {"used_percent": 88.0, "window_minutes": 10080, "resets_at": 2}, "plan_type": "pro"},
+    )
+    snap = rl.read_codex_rate_limits_latest(home)
+    assert snap is not None
+    assert snap.plan_type == "pro"
+    assert snap.windows[0].used_percent == 88.0  # the later-captured file won
+
+
+def test_read_codex_rate_limits_missing_root(tmp_path):
+    assert rl.read_codex_rate_limits_latest(tmp_path / "no-codex") is None
+
+
+def test_read_codex_rollout_without_rate_limits_is_ignored(tmp_path):
+    home = tmp_path / "codex"
+    d = home / "sessions" / "2026" / "07" / "30"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "rollout-x.jsonl").write_text(
+        json.dumps({"timestamp": "2026-07-30T10:00:00Z", "payload": {"type": "token_count", "info": {"total_token_usage": {}}}}) + "\n",
+        encoding="utf-8",
+    )
+    assert rl.read_codex_rate_limits_latest(home) is None
+
+
+# --------------------------------------------------------------------------- #
+# classification: stored, not usage, not work-feed, retained in v1
+# --------------------------------------------------------------------------- #
+
+
+def test_event_classification_is_safe():
+    from agentacct.canonical.lane_inventory import (
+        canonical_lanes_for_event,
+        must_retain_in_v1,
+        retention_reason,
+    )
+    from agentacct.usage_truth import is_local_usage_import_event
+
+    event = rl.snapshot_to_event(_codex_snapshot())
+    assert is_local_usage_import_event(event) is False  # never counted as usage
+    assert must_retain_in_v1(event) is True  # stored, never dropped
+    assert retention_reason("rate_limit_observed")  # honestly registered
+    lanes = canonical_lanes_for_event(event)
+    assert "usage" not in lanes
+    assert "work_claim" not in lanes
+
+
+def test_not_swept_into_work_feed():
+    from agentacct.work_ledger import _is_work_event
+
+    event = rl.snapshot_to_event(_codex_snapshot())
+    assert _is_work_event(event) is False
+
+
+# --------------------------------------------------------------------------- #
+# recording is idempotent end-to-end
+# --------------------------------------------------------------------------- #
+
+
+def _count_rate_limit_events(service):
+    return sum(1 for e in service.list_all_events() if e.get("event_type") == "rate_limit_observed")
+
+
+def test_transition_dedup_records_only_on_change_including_return():
+    recorded: list = []
+
+    def record(event):
+        recorded.append(event)
+
+    # first ever → recorded
+    n = rl.record_snapshots_transitionally(
+        [_codex_snapshot(used=52.0, captured=1000.0)], existing_events=[], record=record
+    )
+    assert n == 1 and len(recorded) == 1
+    # unchanged since last recorded → no-op
+    n = rl.record_snapshots_transitionally(
+        [_codex_snapshot(used=52.0, captured=2000.0)], existing_events=list(recorded), record=record
+    )
+    assert n == 0 and len(recorded) == 1
+    # changed value → recorded
+    n = rl.record_snapshots_transitionally(
+        [_codex_snapshot(used=60.0, captured=3000.0)], existing_events=list(recorded), record=record
+    )
+    assert n == 1 and len(recorded) == 2
+    # value RETURNS to a previously-seen 52 (a decline/reset). This is the bug the
+    # adversarial review caught: global dedup would drop it and `limits` would show
+    # the 60 high-water mark forever. Transition dedup records it.
+    n = rl.record_snapshots_transitionally(
+        [_codex_snapshot(used=52.0, captured=4000.0)], existing_events=list(recorded), record=record
+    )
+    assert n == 1 and len(recorded) == 3
+    # and the newest recorded event carries the fresh observation time
+    assert (recorded[-1]["metadata"]["captured_at"]) == 4000.0
+
+
+def test_transition_dedup_ignores_credit_balance_drift():
+    recorded: list = []
+
+    def snap(balance):
+        return rl.normalize_codex_rate_limits(
+            {
+                "primary": {"used_percent": 10.0, "window_minutes": 10080, "resets_at": 7},
+                "credits": {"has_credits": True, "unlimited": False, "balance": balance},
+            },
+            captured_at=1000.0,
+        )
+
+    rl.record_snapshots_transitionally([snap("10.00")], existing_events=[], record=recorded.append)
+    # balance drifts but the rate-limit window is unchanged → no new event
+    rl.record_snapshots_transitionally([snap("9.98")], existing_events=list(recorded), record=recorded.append)
+    rl.record_snapshots_transitionally([snap("9.90")], existing_events=list(recorded), record=recorded.append)
+    assert len(recorded) == 1
+
+
+def test_non_finite_values_fail_soft(tmp_path):
+    # int(inf)/int(nan) would raise; the reader must fail soft and drop the field.
+    snap = rl.normalize_codex_rate_limits(
+        {"primary": {"used_percent": 50.0, "window_minutes": float("inf"), "resets_at": float("nan")}}
+    )
+    assert snap is not None
+    window = snap.windows[0]
+    assert window.used_percent == 50.0
+    assert window.window_minutes is None and window.resets_at is None
+    # a non-finite used_percent drops that window entirely (keeps the finite one)
+    claude = rl.normalize_claude_plan_usage_sample({"t": 1, "org": "o", "u": {"fh": float("nan"), "sd": 20}})
+    assert [w.kind for w in claude.windows] == ["7d"]
+    # and a non-finite value never reaches the JSON output as a NaN/Infinity token
+    service = SentinelService(tmp_path)
+    service.record_event(rl.snapshot_to_event(claude))
+    js = CliRunner().invoke(app, ["limits", "--store-dir", str(tmp_path), "--json"])
+    assert js.exit_code == 0
+    assert "NaN" not in js.stdout and "Infinity" not in js.stdout
+    json.loads(js.stdout)  # strict parse must succeed
+
+
+def test_codex_home_env_is_comma_split(tmp_path, monkeypatch):
+    root_b = tmp_path / "b"
+    _write_codex_rollout(
+        root_b, "29", "s",
+        timestamp="2026-07-29T10:00:00Z",
+        rate_limits={"primary": {"used_percent": 33.0, "window_minutes": 10080, "resets_at": 1}},
+    )
+    monkeypatch.setenv("CODEX_HOME", f"{tmp_path / 'a'},{root_b}")
+    snap = rl.read_codex_rate_limits_latest()  # codex_home=None → CODEX_HOME env
+    assert snap is not None and snap.windows[0].used_percent == 33.0
+
+
+# --------------------------------------------------------------------------- #
+# the `limits` command
+# --------------------------------------------------------------------------- #
+
+
+def test_import_with_relocated_homes_does_not_leak_real_machine(tmp_path, monkeypatch):
+    """A hermetic import that relocates the homes must record NO rate-limit events
+    from the developer's real ~/.codex or ~/Library Claude files — even with the
+    global-limit scan explicitly turned ON (the per-home gates still hold)."""
+    from agentacct.cli import _local_usage_import_payload
+
+    monkeypatch.setenv("AGENTACCT_SCAN_GLOBAL_LIMITS", "1")  # override the test default
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    codex_home = tmp_path / "codex"
+    (codex_home / "sessions").mkdir(parents=True)
+    claude_home = tmp_path / "claude"
+    claude_home.mkdir()
+    store_dir = tmp_path / "state"
+
+    _local_usage_import_payload(
+        store_dir=store_dir,
+        client="all",
+        codex_home=codex_home,
+        claude_home=claude_home,
+    )
+    service = SentinelService(store_dir)
+    assert _count_rate_limit_events(service) == 0
+
+
+def test_claude_config_dir_env_blocks_global_read(tmp_path, monkeypatch):
+    """Relocating the Claude home via CLAUDE_CONFIG_DIR (the env the import itself
+    honors) must also stop the machine-global desktop plan-usage read, even with
+    the global scan on and claude_home param None."""
+    from agentacct.cli import _local_usage_import_payload
+
+    monkeypatch.setenv("AGENTACCT_SCAN_GLOBAL_LIMITS", "1")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "hermetic-claude"))
+    codex_home = tmp_path / "codex"
+    (codex_home / "sessions").mkdir(parents=True)
+    store_dir = tmp_path / "state"
+
+    _local_usage_import_payload(
+        store_dir=store_dir,
+        client="claude-code",
+        codex_home=codex_home,
+        claude_home=None,
+    )
+    service = SentinelService(store_dir)
+    assert _count_rate_limit_events(service) == 0
+
+
+def test_limits_command_empty(tmp_path):
+    result = CliRunner().invoke(app, ["limits", "--store-dir", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "No provider limit data" in result.stdout
+
+
+def test_limits_command_renders_and_json(tmp_path):
+    service = SentinelService(tmp_path)
+    service.record_event(rl.snapshot_to_event(_codex_snapshot(used=52.0)))
+    service.record_event(
+        rl.snapshot_to_event(
+            rl.normalize_claude_plan_usage_sample({"t": 1785677629903, "org": "org-1", "u": {"fh": 6, "sd": 25}})
+        )
+    )
+
+    human = CliRunner().invoke(app, ["limits", "--store-dir", str(tmp_path)])
+    assert human.exit_code == 0
+    assert "codex" in human.stdout
+    assert "claude-code" in human.stdout
+    assert "5-hour" in human.stdout and "7-day" in human.stdout
+
+    js = CliRunner().invoke(app, ["limits", "--store-dir", str(tmp_path), "--json"])
+    assert js.exit_code == 0
+    payload = json.loads(js.stdout)
+    clients = {entry["client"] for entry in payload["limits"]}
+    assert clients == {"codex", "claude-code"}
+
+    # client filter
+    only = CliRunner().invoke(app, ["limits", "--store-dir", str(tmp_path), "--client", "codex", "--json"])
+    payload2 = json.loads(only.stdout)
+    assert {e["client"] for e in payload2["limits"]} == {"codex"}
+
+
+def test_limits_command_client_all_and_invalid(tmp_path):
+    service = SentinelService(tmp_path)
+    service.record_event(rl.snapshot_to_event(_codex_snapshot(used=52.0)))
+    # --client all is a no-op filter (not a literal match) → shows data, never the
+    # false "no data" empty-state.
+    ok = CliRunner().invoke(app, ["limits", "--store-dir", str(tmp_path), "--client", "all", "--json"])
+    assert ok.exit_code == 0
+    assert {e["client"] for e in json.loads(ok.stdout)["limits"]} == {"codex"}
+    # an unknown client value errors instead of silently reporting no data
+    bad = CliRunner().invoke(app, ["limits", "--store-dir", str(tmp_path), "--client", "claude"])
+    assert bad.exit_code != 0


### PR DESCRIPTION
## What

A new foundation that records **provider-reported usage limits** and renders them with `agentacct limits`. For each client it shows the **5-hour** and **weekly (7-day)** windows with the provider's own used-percentage, reset countdown (when the provider reports one), plan, and credits.

Data is read **passively from local files — no credentials, no API calls, no CLI scraping, no statusline**:

- **Codex** — `rate_limits` on `token_count` events in `~/.codex/sessions/**/rollout-*.jsonl` (used %, window length, reset time, credits, plan).
- **Claude Code (desktop app)** — the 5h/7d utilization series in `~/Library/Application Support/Claude/plan-usage-history.json` (Pro/Max subscriptions only; no reset time is recorded there).

Snapshots are captured as a no-cost side effect of `agentacct usage import-local` and `agentacct usage watch`, and stored as a new `rate_limit_observed` event in the SQLite event log.

## Design

- **Transition-idempotent recording.** A snapshot is written only when its stream's state *changes* — including a decline or a window reset back to a previously-seen value — with a fresh observation time. An unchanged limit re-seen on every watch tick is a no-op. The volatile `credits.balance` is excluded from the state signature so a pay-as-you-go account doesn't mint an event every scan. This makes `limits` show the **current** reading rather than a high-water mark.
- **Isolation.** Machine-global reads (real `~/.codex` when no codex-home is given; the Claude desktop file) are gated so hermetic/custom scans never touch real files: an explicit `--codex-home` / `--claude-home`, the `CLAUDE_CONFIG_DIR` env, or `AGENTACCT_SCAN_GLOBAL_LIMITS=0` all suppress them. The test suite pins the global scan off.
- **Classification.** `rate_limit_observed` is registered as v1-retained; it is never classified as usage (so it can't pollute token/cost totals) and is never swept into the work feed.
- **Fail-soft.** Reading limits is best-effort and can never fail the usage import it rides along with; non-finite values and malformed lines are dropped rather than raised.

## Command

    agentacct limits [--client codex|claude-code|all] [--json] [--store-dir DIR]

## Testing

- `.venv/bin/pytest -q` (plain, CI-matching): **2933 passed, 1 skipped, 0 failed**.
- 22 new tests in `tests/test_rate_limits.py`: normalization, transition dedup (including a value that returns after a change), non-finite fail-soft, `CODEX_HOME` comma-separated roots, isolation gates, and the `limits` render + `--json` + client validation.
- Built via implement → 5-lens adversarial data-path review; all 8 confirmed findings fixed (high-water-mark display, credits-balance flooding, non-finite crash, `--client all` false-empty, `CLAUDE_CONFIG_DIR` leak, test isolation, `CODEX_HOME` multi-root, JSON NaN token).

## Notes / follow-ups

- Claude limits come from the **desktop app**'s file; terminal-CLI-only users don't have it (a statusline capture path is a possible future add). `agentacct now` is a separate follow-up.
- Known low/speculative (deferred): `read_codex_rate_limits_latest` reads the newest 8 rollout files by mtime; a pathological mtime pattern could momentarily surface a slightly stale codex snapshot (codex limits are account-wide, so the value is close regardless).
- No release or live-runtime change in this PR.
