### PR TITLE
feat: Claude terminal-CLI rate limits via a lightweight statusLine hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     `token_count` events: used percent, window length, reset time, credits, plan).
   - **Claude Code (desktop app)** from `~/Library/Application Support/Claude/plan-usage-history.json`
     (the desktop app's rolling 5-hour / 7-day utilization series; Pro/Max only).
+  - **Claude Code (terminal CLI)** via a lightweight `statusLine` command
+    (`python -m agentacct.statusline_hook`) that Claude Code feeds its live
+    5-hour / 7-day utilization — the only local surface for CLI-only users, who
+    have no desktop plan-usage file. The hook is tiny and fail-open (it never
+    slows or breaks the status bar); it writes the reading to a spool the usage
+    import ingests, and also prints a compact status bar (model · context% ·
+    5h/7d · cost). `agentacct onboard` installs it into `~/.claude/settings.json`
+    without ever overwriting a status line you already configured.
   Snapshots are captured as a no-cost side effect of `agentacct usage import-local`
   and `agentacct usage watch`, and recorded idempotently — an unchanged limit
   re-observed on every scan is a no-op, so a new event is written only when a

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -591,6 +591,19 @@ def _merge_claude_settings_from_example(example_path: Path, target: Path) -> tup
         if key not in env:
             changed = True
         env[key] = value
+    # statusLine is an OPTIONAL, cosmetic add-on (the terminal-CLI rate-limit bar),
+    # NOT part of the required record-your-work recipe. So — unlike env/hooks — a
+    # conflict must NEVER be fatal: a user who already runs their own statusLine
+    # (ccusage, powerline, a custom script) keeps it, and env + hooks still merge.
+    # We only install ours when the user has none.
+    desired_statusline = generated.get("statusLine")
+    if isinstance(desired_statusline, dict):
+        current_statusline = current.get("statusLine")
+        if current_statusline is None:
+            current["statusLine"] = desired_statusline
+            changed = True
+        # else: absent-vs-ours already handled; a user's own different statusLine
+        # is left untouched (they can adopt agentacct's manually).
     desired_hooks = generated.get("hooks") if isinstance(generated.get("hooks"), dict) else {}
     for event_name, rows in desired_hooks.items():
         if not isinstance(rows, list):
@@ -6145,11 +6158,13 @@ def _local_usage_import_payload(
                         existing_event_ids.add(str(recorded_observation["event_id"]))
         # Provider rate-limit snapshots (CLI phase B foundation): passively read
         # the provider-reported usage-limit windows Codex writes to its session
-        # rollout files and the Claude desktop app writes to its plan-usage
-        # history, and record them as rate_limit_observed events. Best-effort and
-        # content-idempotent (record_event dedups an unchanged snapshot via its
-        # idempotency_key), so it is safe on every watch tick and can never fail
-        # the usage import it rides along with.
+        # rollout files, the Claude desktop app writes to its plan-usage history,
+        # and the terminal-CLI statusLine hook writes to its spool — and record
+        # them as rate_limit_observed events. Dedup is TRANSITION-based
+        # (record_snapshots_transitionally against each stream's last recorded
+        # snapshot; snapshots carry no idempotency_key), so an unchanged limit is
+        # a no-op but a change/decline/reset is recorded with a fresh time. The
+        # whole block is best-effort and can never fail the usage import.
         rate_limit_snapshots_recorded = 0
         if not dry_run:
             from . import rate_limits as _rate_limits
@@ -6178,6 +6193,18 @@ def _local_usage_import_payload(
                     and _global_scan
                 ):
                     _rl_snapshots.extend(_rate_limits.read_claude_plan_usage_latest())
+                # Terminal-CLI users have no desktop plan-usage file; their limits
+                # arrive via the statusLine spool. Its path follows the Claude
+                # config home (CLAUDE_CONFIG_DIR / ~/.claude), so it stays isolated
+                # under a relocated home — gate only on claude_home + global scan.
+                if (
+                    client in ("all", "claude-code")
+                    and claude_home is None
+                    and _global_scan
+                ):
+                    _statusline_rl = _rate_limits.read_claude_statusline_latest()
+                    if _statusline_rl is not None:
+                        _rl_snapshots.append(_statusline_rl)
             except Exception:  # noqa: BLE001 - a limits read must never break the usage import.
                 _rl_snapshots = []
             if _rl_snapshots:
@@ -7964,10 +7991,17 @@ def _rl_latest_snapshots(
     ]
 
 
+_RL_ORIGIN_LABELS = {
+    "claude_plan_usage": "desktop app",
+    "claude_statusline": "CLI",
+}
+
+
 def _rl_json_entry(event: Mapping[str, Any]) -> dict[str, Any]:
     metadata = event.get("metadata") or {}
     return {
         "client": metadata.get("client"),
+        "origin": metadata.get("origin"),
         "plan_type": metadata.get("plan_type"),
         "org": metadata.get("org"),
         "captured_at": metadata.get("captured_at"),
@@ -7991,10 +8025,11 @@ def limits(
 
     Read passively from local files — no credentials, no API calls. Codex limits
     come from ~/.codex session files; Claude limits from the Claude desktop app's
-    local plan-usage history (Pro/Max subscriptions only). Populate them by using
-    your agents, or by running ``agentacct usage watch``. Percentages are the
-    provider's own reported utilization; reset times are shown when the provider
-    records them (Codex).
+    plan-usage history, or — for terminal-CLI users — a statusLine hook
+    (``agentacct onboard`` installs it). Claude limits are Pro/Max only. Populate
+    them by using your agents, or by running ``agentacct usage watch``. Percentages
+    are the provider's own reported utilization; reset times are shown when the
+    provider records them (Codex and the Claude statusLine).
     """
 
     # Normalize/validate the client selector the same way the rest of the CLI
@@ -8028,6 +8063,10 @@ def limits(
         console.print(
             "  • Claude (desktop app, Pro/Max): use Claude, or `agentacct usage watch`."
         )
+        console.print(
+            "  • Claude (terminal CLI, Pro/Max): `agentacct onboard` installs a "
+            "statusLine that captures limits while you code."
+        )
         return
 
     now = time.time()
@@ -8038,6 +8077,9 @@ def limits(
         metadata = event.get("metadata") or {}
         event_client = metadata.get("client") or "?"
         header = str(event_client)
+        origin_label = _RL_ORIGIN_LABELS.get(str(metadata.get("origin") or ""))
+        if origin_label:
+            header += f" ({origin_label})"
         plan = metadata.get("plan_type")
         if plan:
             header += f"  plan: {plan}"

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -966,8 +966,20 @@ def claude_code_settings_example(python_executable: str | None = None, *, hook_p
     # demonstrably record nothing even with the directive delivered. The
     # merge-never-clobber rule applies to "env" exactly as to "hooks": whoever
     # merges this example must preserve the env keys the user already has.
+    # The statusLine is a lightweight, always-fast command (imports only
+    # agentacct.rate_limits) that captures Claude's rate-limit reading for
+    # terminal-CLI users — where the desktop plan-usage file does not exist — and
+    # prints a compact status bar. It runs as a direct command (NOT the hook
+    # wrapper, which dispatches on hook_event_name), so it is `python -m` and the
+    # same string works for project and user-level installs.
+    statusline_command = f"{shlex.quote(python_command)} -m agentacct.statusline_hook"
     return {
         "env": {"ENABLE_TOOL_SEARCH": "auto"},
+        "statusLine": {
+            "type": "command",
+            "command": statusline_command,
+            "padding": 0,
+        },
         "hooks": {
             "PreToolUse": [
                 {

--- a/src/agentacct/rate_limits.py
+++ b/src/agentacct/rate_limits.py
@@ -50,8 +50,22 @@ EVENT_TYPE = "rate_limit_observed"
 
 CODEX_SOURCE = "codex-local-rate-limit"
 CLAUDE_SOURCE = "claude-desktop-plan-usage"
+CLAUDE_STATUSLINE_SOURCE = "claude-code-statusline"
 
 CODEX_RUN_ID = "codex_rate_limit"
+CLAUDE_STATUSLINE_RUN_ID = "claude_statusline"
+
+# Snapshot origins (drive source + run_id so the feeds stay distinct streams).
+ORIGIN_CODEX_SESSION = "codex_session"
+ORIGIN_CLAUDE_PLAN_USAGE = "claude_plan_usage"
+ORIGIN_CLAUDE_STATUSLINE = "claude_statusline"
+
+# The terminal-CLI statusLine spool: a lightweight statusLine command
+# (`python -m agentacct.statusline_hook`) writes the latest Claude rate-limit
+# reading here, and the usage import reads it. Path follows the Claude config
+# home (CLAUDE_CONFIG_DIR, else ~/.claude) so it is naturally isolated when that
+# home is relocated; overridable via env for tests/custom setups.
+STATUSLINE_SPOOL_ENV = "AGENTACCT_STATUSLINE_SPOOL"
 
 # Canonical rolling-window lengths (minutes) used to label windows.
 FIVE_HOUR_MINUTES = 300
@@ -97,10 +111,18 @@ class RateLimitWindow:
 
 @dataclass(frozen=True)
 class RateLimitSnapshot:
-    """A single provider-reported limit observation for one client."""
+    """A single provider-reported limit observation for one client.
+
+    ``origin`` identifies which local source produced it — ``codex_session``,
+    ``claude_plan_usage`` (the Claude desktop app's history file), or
+    ``claude_statusline`` (the terminal-CLI statusLine spool). It drives the
+    recorded event's ``source`` and per-stream ``run_id`` so the three feeds stay
+    distinct streams that never collide.
+    """
 
     client: str  # "codex" | "claude-code"
     windows: tuple[RateLimitWindow, ...]
+    origin: str = "unknown"
     captured_at: float | None = None  # provider sample/event time, epoch seconds
     plan_type: str | None = None
     credits: Mapping[str, Any] | None = None
@@ -225,6 +247,7 @@ def normalize_codex_rate_limits(
     return RateLimitSnapshot(
         client="codex",
         windows=tuple(windows),
+        origin=ORIGIN_CODEX_SESSION,
         captured_at=_epoch_seconds(captured_at),
         plan_type=_str_or_none(rate_limits.get("plan_type")),
         credits=credits,
@@ -281,8 +304,57 @@ def normalize_claude_plan_usage_sample(
     return RateLimitSnapshot(
         client="claude-code",
         windows=tuple(windows),
+        origin=ORIGIN_CLAUDE_PLAN_USAGE,
         captured_at=captured_at,
         org=_str_or_none(sample.get("org")),
+        source_file=source_file,
+    )
+
+
+def normalize_claude_statusline(
+    payload: Any,
+    *,
+    captured_at: float | None = None,
+    source_file: str | None = None,
+) -> RateLimitSnapshot | None:
+    """Turn a Claude Code statusLine payload into a snapshot, or ``None``.
+
+    The statusLine JSON carries ``rate_limits.five_hour`` / ``.seven_day`` with
+    ``used_percentage`` + ``resets_at`` (Pro/Max subscriptions only; absent for
+    API-key auth). Unlike the desktop plan-usage file, this feed HAS reset times.
+    """
+
+    if not isinstance(payload, Mapping):
+        return None
+    rate_limits = payload.get("rate_limits")
+    if not isinstance(rate_limits, Mapping):
+        return None
+    windows: list[RateLimitWindow] = []
+    for key, kind, minutes in (
+        ("five_hour", "5h", FIVE_HOUR_MINUTES),
+        ("seven_day", "7d", SEVEN_DAY_MINUTES),
+    ):
+        window = rate_limits.get(key)
+        if not isinstance(window, Mapping):
+            continue
+        used = _float_or_none(window.get("used_percentage"))
+        if used is None:
+            continue
+        windows.append(
+            RateLimitWindow(
+                kind=kind,
+                used_percent=used,
+                window_minutes=minutes,
+                resets_at=_int_or_none(window.get("resets_at")),
+            )
+        )
+    if not windows:
+        return None
+    return RateLimitSnapshot(
+        client="claude-code",
+        windows=tuple(windows),
+        origin=ORIGIN_CLAUDE_STATUSLINE,
+        captured_at=_epoch_seconds(captured_at),
         source_file=source_file,
     )
 
@@ -295,19 +367,26 @@ def normalize_claude_plan_usage_sample(
 def snapshot_run_id(snapshot: RateLimitSnapshot) -> str:
     """A stable per-stream run_id.
 
-    Codex limits are account-wide, so all codex snapshots share one run_id;
-    Claude's series is per-org. Both are stable across scans so consecutive
-    unchanged snapshots collapse to one recorded event.
+    Codex limits are account-wide, so all codex snapshots share one run_id; the
+    Claude desktop plan-usage series is per-org; the terminal-CLI statusLine feed
+    is its own stream. All are stable across scans so consecutive unchanged
+    snapshots collapse to one recorded event.
     """
 
-    if snapshot.client == "codex":
+    if snapshot.origin == ORIGIN_CODEX_SESSION or snapshot.client == "codex":
         return CODEX_RUN_ID
+    if snapshot.origin == ORIGIN_CLAUDE_STATUSLINE:
+        return CLAUDE_STATUSLINE_RUN_ID
     org = snapshot.org or "unknown"
     return f"claude_plan_usage_{org}"
 
 
-def _snapshot_source(client: str) -> str:
-    return CODEX_SOURCE if client == "codex" else CLAUDE_SOURCE
+def _snapshot_source(snapshot: RateLimitSnapshot) -> str:
+    if snapshot.origin == ORIGIN_CODEX_SESSION or snapshot.client == "codex":
+        return CODEX_SOURCE
+    if snapshot.origin == ORIGIN_CLAUDE_STATUSLINE:
+        return CLAUDE_STATUSLINE_SOURCE
+    return CLAUDE_SOURCE
 
 
 def snapshot_state_signature(snapshot: RateLimitSnapshot) -> str:
@@ -352,6 +431,7 @@ def snapshot_to_event(snapshot: RateLimitSnapshot) -> dict[str, Any]:
 
     metadata: dict[str, Any] = {
         "client": snapshot.client,
+        "origin": snapshot.origin,
         "captured_at": snapshot.captured_at,
         "windows": [w.to_dict() for w in snapshot.windows],
         "plan_type": snapshot.plan_type,
@@ -363,7 +443,7 @@ def snapshot_to_event(snapshot: RateLimitSnapshot) -> dict[str, Any]:
         "state_signature": snapshot_state_signature(snapshot),
     }
     return {
-        "source": _snapshot_source(snapshot.client),
+        "source": _snapshot_source(snapshot),
         "event_type": EVENT_TYPE,
         "run_id": snapshot_run_id(snapshot),
         "provider": None,
@@ -462,6 +542,91 @@ def default_claude_plan_usage_path() -> Path:
         / "Application Support"
         / "Claude"
         / "plan-usage-history.json"
+    )
+
+
+def _claude_config_home() -> Path:
+    """The Claude Code config home: the first CLAUDE_CONFIG_DIR entry, else ~/.claude.
+
+    CLAUDE_CONFIG_DIR is comma-separated for the rest of agentacct (see
+    source_paths), so we split the same way — NOT on os.pathsep — to stay
+    consistent with the home the usage import actually scans.
+    """
+
+    configured = os.environ.get("CLAUDE_CONFIG_DIR")
+    if configured:
+        parts = [p.strip() for p in configured.split(",") if p.strip()]
+        if parts:
+            return Path(parts[0]).expanduser()
+    return Path.home() / ".claude"
+
+
+def default_claude_statusline_spool_path() -> Path:
+    """Where the statusLine hook writes, and the import reads, the latest Claude
+    CLI rate-limit reading. Follows the Claude config home (CLAUDE_CONFIG_DIR else
+    ~/.claude). Writer (the hook, run by Claude with its env) and reader (the
+    usage import) agree only when they see the SAME CLAUDE_CONFIG_DIR; if a user
+    relocates the home for `claude` but not for `agentacct watch`, the CLI feed is
+    simply absent (fails soft), not wrong. Override with AGENTACCT_STATUSLINE_SPOOL."""
+
+    override = os.environ.get(STATUSLINE_SPOOL_ENV)
+    if override:
+        return Path(override).expanduser()
+    return _claude_config_home() / "agentacct" / "statusline-latest.json"
+
+
+def write_claude_statusline_spool(
+    rate_limits: Any,
+    *,
+    captured_at: float,
+    path: Path | str | None = None,
+) -> bool:
+    """Atomically write the latest statusLine rate-limit reading to the spool.
+
+    Best-effort: returns False on any failure (the statusLine command must never
+    fail). Overwrites — the spool holds only the latest reading, ingested by the
+    usage import.
+    """
+
+    target = Path(path).expanduser() if path is not None else default_claude_statusline_spool_path()
+    document = {"v": 1, "captured_at": captured_at, "rate_limits": rate_limits}
+    # A UNIQUE temp name per writer: several Claude Code sessions write this one
+    # spool at ~300ms cadence, so a fixed temp name would let concurrent writers
+    # clobber each other's temp and defeat the os.replace atomicity.
+    tmp = target.with_name(f".{target.name}.tmp-{os.getpid()}-{os.urandom(4).hex()}")
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(document), encoding="utf-8")
+        os.replace(tmp, target)
+        return True
+    except (OSError, TypeError, ValueError):
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return False
+
+
+def read_claude_statusline_latest(
+    path: Path | str | None = None,
+) -> RateLimitSnapshot | None:
+    """Read the statusLine spool into a snapshot, or ``None`` if absent/malformed."""
+
+    target = Path(path).expanduser() if path is not None else default_claude_statusline_spool_path()
+    try:
+        raw = target.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        document = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(document, Mapping):
+        return None
+    return normalize_claude_statusline(
+        {"rate_limits": document.get("rate_limits")},
+        captured_at=document.get("captured_at"),
+        source_file=str(target),
     )
 
 
@@ -607,23 +772,33 @@ def read_claude_plan_usage_latest(
 
 __all__ = [
     "CLAUDE_SOURCE",
+    "CLAUDE_STATUSLINE_RUN_ID",
+    "CLAUDE_STATUSLINE_SOURCE",
     "CODEX_RUN_ID",
     "CODEX_SOURCE",
     "EVENT_TYPE",
     "FIVE_HOUR_MINUTES",
     "GLOBAL_LIMIT_SCAN_ENV",
+    "ORIGIN_CLAUDE_PLAN_USAGE",
+    "ORIGIN_CLAUDE_STATUSLINE",
+    "ORIGIN_CODEX_SESSION",
     "SEVEN_DAY_MINUTES",
+    "STATUSLINE_SPOOL_ENV",
     "RateLimitSnapshot",
     "RateLimitWindow",
     "default_claude_plan_usage_path",
+    "default_claude_statusline_spool_path",
     "default_codex_sessions_root",
     "global_limit_scan_enabled",
     "normalize_claude_plan_usage_sample",
+    "normalize_claude_statusline",
     "normalize_codex_rate_limits",
     "read_claude_plan_usage_latest",
+    "read_claude_statusline_latest",
     "read_codex_rate_limits_latest",
     "record_snapshots_transitionally",
     "snapshot_run_id",
     "snapshot_state_signature",
     "snapshot_to_event",
+    "write_claude_statusline_spool",
 ]

--- a/src/agentacct/statusline_hook.py
+++ b/src/agentacct/statusline_hook.py
@@ -1,0 +1,105 @@
+"""Lightweight Claude Code statusLine hook for agentacct (terminal-CLI users).
+
+Installed as the Claude Code ``statusLine`` command via
+``python -m agentacct.statusline_hook``. Claude invokes it (at most ~every 300ms)
+with the session JSON on stdin. This module is deliberately tiny — it imports
+only the stdlib and (lazily) ``agentacct.rate_limits``; agentacct's package
+``__init__`` is empty, so it starts in tens of milliseconds rather than the ~0.4s
+of the full CLI. That matters: a heavy process on every status render would lag
+the bar and burn CPU.
+
+It does two things and never fails:
+
+1. Persist the latest provider rate-limit reading to a spool file that
+   ``agentacct usage import-local`` / ``watch`` ingest into ``rate_limit_observed``
+   events — the heavy recording stays OUT of this hot path.
+2. Print a one-line status string (model · context% · 5h/7d limits · cost).
+
+Any error is swallowed and a minimal line is printed, so a slow or broken hook
+can never break or delay Claude Code's status bar.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Any, Mapping
+
+
+def _limit_pct(window: Any) -> str:
+    if isinstance(window, Mapping):
+        used = window.get("used_percentage")
+        if isinstance(used, (int, float)) and not isinstance(used, bool):
+            return f"{int(round(used))}%"
+    return "—"
+
+
+def render_status_line(payload: Mapping[str, Any]) -> str:
+    """Compact one-line status: model · ctx% · 5h/7d · $cost (fields present only)."""
+
+    parts: list[str] = []
+    model = payload.get("model")
+    if isinstance(model, Mapping):
+        name = model.get("display_name") or model.get("id")
+        if name:
+            parts.append(str(name))
+    ctx = payload.get("context_window")
+    if isinstance(ctx, Mapping):
+        used = ctx.get("used_percentage")
+        if isinstance(used, (int, float)) and not isinstance(used, bool):
+            parts.append(f"ctx {int(round(used))}%")
+    rate_limits = payload.get("rate_limits")
+    if isinstance(rate_limits, Mapping):
+        parts.append(f"5h {_limit_pct(rate_limits.get('five_hour'))}")
+        parts.append(f"7d {_limit_pct(rate_limits.get('seven_day'))}")
+    cost = payload.get("cost")
+    if isinstance(cost, Mapping):
+        total = cost.get("total_cost_usd")
+        if isinstance(total, (int, float)) and not isinstance(total, bool):
+            parts.append(f"${float(total):.2f}")
+    return "  ".join(parts)
+
+
+def _safe_print(text: str) -> None:
+    # Even stdout can fail (e.g. BrokenPipe if Claude closed the pipe); swallow it
+    # so nothing escapes main() and the process still exits 0.
+    try:
+        print(text)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+    except Exception:  # noqa: BLE001 - never let a read error break the status bar.
+        _safe_print("")
+        return 0
+
+    payload: Any = {}
+    try:
+        payload = json.loads(raw) if raw and raw.strip() else {}
+    except Exception:  # noqa: BLE001 - malformed stdin → empty payload, still print.
+        payload = {}
+
+    # Persist the latest reading for agentacct to ingest (best-effort, off the
+    # hot path's critical output).
+    if isinstance(payload, Mapping) and isinstance(payload.get("rate_limits"), Mapping):
+        try:
+            from agentacct import rate_limits as rl
+
+            rl.write_claude_statusline_spool(payload["rate_limits"], captured_at=time.time())
+        except Exception:  # noqa: BLE001 - spooling must never break the bar.
+            pass
+
+    try:
+        line = render_status_line(payload) if isinstance(payload, Mapping) else ""
+    except Exception:  # noqa: BLE001 - rendering must never break the bar.
+        line = ""
+    _safe_print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_statusline_hook.py
+++ b/tests/test_statusline_hook.py
@@ -1,0 +1,214 @@
+"""Tests for the terminal-CLI Claude statusLine rate-limit path."""
+
+from __future__ import annotations
+
+import io
+import json
+
+from typer.testing import CliRunner
+
+from agentacct import rate_limits as rl
+from agentacct import statusline_hook
+from agentacct.cli import app
+from agentacct.service import SentinelService
+
+
+def _statusline_payload(five=18, seven=63):
+    return {
+        "model": {"display_name": "Opus 4.8", "id": "claude-opus-4-8"},
+        "context_window": {"used_percentage": 42},
+        "cost": {"total_cost_usd": 1.27},
+        "rate_limits": {
+            "five_hour": {"used_percentage": five, "resets_at": 1785600000},
+            "seven_day": {"used_percentage": seven, "resets_at": 1785900000},
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# normalization + stream identity
+# --------------------------------------------------------------------------- #
+
+
+def test_normalize_statusline_has_windows_resets_and_origin():
+    snap = rl.normalize_claude_statusline(_statusline_payload(), captured_at=1000.0)
+    assert snap is not None
+    assert snap.client == "claude-code"
+    assert snap.origin == rl.ORIGIN_CLAUDE_STATUSLINE
+    windows = {w.kind: w for w in snap.windows}
+    assert windows["5h"].used_percent == 18.0 and windows["5h"].resets_at == 1785600000
+    assert windows["7d"].used_percent == 63.0 and windows["7d"].resets_at == 1785900000
+
+
+def test_normalize_statusline_rejects_missing_and_empty():
+    assert rl.normalize_claude_statusline(None) is None
+    assert rl.normalize_claude_statusline({}) is None  # no rate_limits
+    assert rl.normalize_claude_statusline({"rate_limits": {}}) is None  # no windows
+    # A window missing used_percentage is skipped, keeping the other.
+    snap = rl.normalize_claude_statusline(
+        {"rate_limits": {"five_hour": {"resets_at": 1}, "seven_day": {"used_percentage": 5}}}
+    )
+    assert [w.kind for w in snap.windows] == ["7d"]
+
+
+def test_statusline_is_a_distinct_stream_from_plan_usage():
+    sl = rl.normalize_claude_statusline(_statusline_payload())
+    pu = rl.normalize_claude_plan_usage_sample({"t": 1, "org": "o", "u": {"fh": 1, "sd": 2}})
+    sl_event = rl.snapshot_to_event(sl)
+    pu_event = rl.snapshot_to_event(pu)
+    assert sl_event["source"] == rl.CLAUDE_STATUSLINE_SOURCE
+    assert sl_event["run_id"] == rl.CLAUDE_STATUSLINE_RUN_ID
+    assert sl_event["metadata"]["origin"] == rl.ORIGIN_CLAUDE_STATUSLINE
+    # distinct stream keys so a hybrid user's two feeds never collide
+    assert (sl_event["source"], sl_event["run_id"]) != (pu_event["source"], pu_event["run_id"])
+
+
+# --------------------------------------------------------------------------- #
+# spool round-trip + path resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_spool_write_read_roundtrip(tmp_path):
+    spool = tmp_path / "statusline-latest.json"
+    ok = rl.write_claude_statusline_spool(
+        _statusline_payload()["rate_limits"], captured_at=1234.5, path=spool
+    )
+    assert ok and spool.exists()
+    snap = rl.read_claude_statusline_latest(spool)
+    assert snap is not None and snap.captured_at == 1234.5
+    assert {w.kind for w in snap.windows} == {"5h", "7d"}
+    # missing / malformed → None
+    assert rl.read_claude_statusline_latest(tmp_path / "nope.json") is None
+    (tmp_path / "bad.json").write_text("{not json", encoding="utf-8")
+    assert rl.read_claude_statusline_latest(tmp_path / "bad.json") is None
+
+
+def test_spool_path_follows_env_and_claude_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv(rl.STATUSLINE_SPOOL_ENV, str(tmp_path / "explicit.json"))
+    assert rl.default_claude_statusline_spool_path() == tmp_path / "explicit.json"
+    monkeypatch.delenv(rl.STATUSLINE_SPOOL_ENV, raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    assert rl.default_claude_statusline_spool_path() == tmp_path / "cfg" / "agentacct" / "statusline-latest.json"
+
+
+# --------------------------------------------------------------------------- #
+# the hook itself: fast, fail-open, spools + prints
+# --------------------------------------------------------------------------- #
+
+
+def test_hook_writes_spool_and_prints(tmp_path, monkeypatch, capsys):
+    spool = tmp_path / "sl.json"
+    monkeypatch.setenv(rl.STATUSLINE_SPOOL_ENV, str(spool))
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(_statusline_payload())))
+    rc = statusline_hook.main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "5h 18%" in out and "7d 63%" in out and "Opus 4.8" in out
+    assert spool.exists()
+    snap = rl.read_claude_statusline_latest(spool)
+    assert snap is not None
+
+
+def test_hook_is_fail_open_on_bad_stdin(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv(rl.STATUSLINE_SPOOL_ENV, str(tmp_path / "sl.json"))
+    monkeypatch.setattr("sys.stdin", io.StringIO("{ this is not json"))
+    rc = statusline_hook.main()
+    assert rc == 0  # never breaks the status bar
+    capsys.readouterr()  # a line was printed (possibly empty); no exception
+
+
+def test_hook_without_rate_limits_still_prints_no_spool(tmp_path, monkeypatch, capsys):
+    spool = tmp_path / "sl.json"
+    monkeypatch.setenv(rl.STATUSLINE_SPOOL_ENV, str(spool))
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"model": {"display_name": "X"}})))
+    assert statusline_hook.main() == 0
+    assert "X" in capsys.readouterr().out
+    assert not spool.exists()  # nothing to spool when the payload has no rate_limits
+
+
+# --------------------------------------------------------------------------- #
+# import ingests the spool (gated); install merges statusLine (never clobbers)
+# --------------------------------------------------------------------------- #
+
+
+def test_import_ingests_statusline_spool(tmp_path, monkeypatch):
+    from agentacct.cli import _local_usage_import_payload
+
+    spool = tmp_path / "sl.json"
+    rl.write_claude_statusline_spool(_statusline_payload()["rate_limits"], captured_at=5000.0, path=spool)
+    monkeypatch.setenv(rl.STATUSLINE_SPOOL_ENV, str(spool))
+    monkeypatch.setenv("AGENTACCT_SCAN_GLOBAL_LIMITS", "1")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))  # hermetic usage discovery
+    store_dir = tmp_path / "state"
+
+    _local_usage_import_payload(store_dir=store_dir, client="claude-code", claude_home=None)
+    events = [
+        e
+        for e in SentinelService(store_dir).list_all_events()
+        if e.get("event_type") == "rate_limit_observed"
+    ]
+    assert len(events) == 1
+    assert events[0]["source"] == rl.CLAUDE_STATUSLINE_SOURCE
+
+
+def test_import_does_not_ingest_spool_when_global_scan_off(tmp_path, monkeypatch):
+    from agentacct.cli import _local_usage_import_payload
+
+    spool = tmp_path / "sl.json"
+    rl.write_claude_statusline_spool(_statusline_payload()["rate_limits"], captured_at=5000.0, path=spool)
+    monkeypatch.setenv(rl.STATUSLINE_SPOOL_ENV, str(spool))
+    # conftest already pins AGENTACCT_SCAN_GLOBAL_LIMITS off; be explicit.
+    monkeypatch.setenv("AGENTACCT_SCAN_GLOBAL_LIMITS", "0")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    store_dir = tmp_path / "state"
+
+    _local_usage_import_payload(store_dir=store_dir, client="claude-code", claude_home=None)
+    events = [
+        e
+        for e in SentinelService(store_dir).list_all_events()
+        if e.get("event_type") == "rate_limit_observed"
+    ]
+    assert events == []
+
+
+def test_install_example_includes_statusline_and_never_blocks_core_merge(tmp_path):
+    from agentacct.hooks import claude_code_settings_example
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    example = claude_code_settings_example(python_executable="/usr/bin/python3")
+    assert "statusLine" in example
+    assert "agentacct.statusline_hook" in example["statusLine"]["command"]
+
+    example_path = tmp_path / "example.json"
+    example_path.write_text(json.dumps(example), encoding="utf-8")
+
+    # fresh target → statusLine + env + hooks all installed
+    target = tmp_path / "settings.json"
+    _merge_claude_settings_from_example(example_path, target)
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    assert merged["statusLine"]["command"] == example["statusLine"]["command"]
+    assert merged["env"]["ENABLE_TOOL_SEARCH"] == "auto"
+    assert "PreToolUse" in merged["hooks"]
+
+
+def test_user_statusline_is_preserved_and_never_blocks_core_recording(tmp_path):
+    """The regression the adversarial review caught: a user's own statusLine must
+    be left untouched AND must NOT abort the essential env+hooks merge."""
+    from agentacct.hooks import claude_code_settings_example
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    example_path = tmp_path / "example.json"
+    example_path.write_text(
+        json.dumps(claude_code_settings_example(python_executable="/usr/bin/python3")),
+        encoding="utf-8",
+    )
+    target = tmp_path / "settings.json"
+    target.write_text(
+        json.dumps({"statusLine": {"type": "command", "command": "my-own-bar"}}),
+        encoding="utf-8",
+    )
+    _merge_claude_settings_from_example(example_path, target)  # must NOT raise
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    assert merged["statusLine"]["command"] == "my-own-bar"  # theirs kept
+    assert merged["env"]["ENABLE_TOOL_SEARCH"] == "auto"  # core env still merged
+    assert "PreToolUse" in merged["hooks"]  # core recording hooks still merged


### PR DESCRIPTION
## What

Extends the limits foundation ([#40](https://github.com/mikehasa/agentacct/pull/40)) to **terminal-CLI Claude Code users**. #40 read Claude limits only from the desktop app's `plan-usage-history.json`; a pure terminal-CLI user (never opens the desktop app) has no such file. Their only local rate-limit surface is the **statusLine stdin** Claude Code feeds a status command (Pro/Max, ≥2.1.x), so this PR captures it.

**Codex is unaffected** — it already writes `rate_limits` into its own CLI session files (`~/.codex/sessions`), so Codex CLI users were covered by #40. This gap was Claude-specific.

## How

- **`src/agentacct/statusline_hook.py`** — a deliberately tiny hook run as the Claude Code `statusLine` command via `python -m agentacct.statusline_hook`. It imports only the stdlib and `agentacct.rate_limits` (measured ~50 ms cold start, vs ~0.4 s for the full CLI — a heavy process on every ~300 ms render would lag the bar). It reads the session JSON on stdin, writes the latest `rate_limits` to a spool file, and prints a compact bar (`model · ctx% · 5h · 7d · $cost`). **Fail-open**: every path (stdin read, JSON parse, spool write, render, even stdout) is guarded, so it can never crash, slow, or block Claude Code's status bar.
- **Spool, not direct recording.** The hook only writes a spool; `agentacct usage import-local` / `watch` ingest it and record `rate_limit_observed` via the existing **transition-based dedup**. The heavy recording stays out of the 300 ms hot path.
- **`rate_limits.py`** — `normalize_claude_statusline` (5h/7d windows *with* reset times, which the desktop plan-usage file lacks); an atomic spool writer (unique temp per writer) + reader that follow the Claude config home (`CLAUDE_CONFIG_DIR` else `~/.claude`); and an `origin` field so the three feeds — codex session, Claude desktop plan-usage, Claude CLI statusline — stay distinct streams that never collide.
- **Install.** `agentacct onboard` adds the `statusLine` to `~/.claude/settings.json`. A user's existing statusLine is **never overwritten**, and — critically — a statusLine conflict **never blocks** the essential env + hooks recording merge.

## Command / output

The hook produces, for example:

    Opus 4.8  ctx 42%  5h 18%  7d 63%  $1.27

and `agentacct limits` then renders the captured windows with reset countdowns. A hybrid (desktop + CLI) user sees both streams, labelled `claude-code (desktop app)` and `claude-code (CLI)`.

## Testing

- `.venv/bin/pytest -q` (plain, CI-matching): **2945 passed, 1 skipped, 0 failed**.
- 12 new tests in `tests/test_statusline_hook.py`: normalize, spool round-trip + path resolution, the hook (fast, fail-open on bad stdin, spools + prints), import ingestion + global-scan isolation, and the install merge (statusLine installed on a fresh target; a user's own statusLine preserved AND core env+hooks still merge).
- Built via implement → 5-lens adversarial review; all confirmed findings fixed, headlined by a **HIGH**: the initial never-clobber guard *raised* on a statusLine conflict, which aborted the whole env+hooks merge and silently disabled recording for anyone with a custom statusLine — now non-fatal. Also fixed: concurrent-spool temp-name atomicity, unguarded stdout, `CLAUDE_CONFIG_DIR` comma split, hybrid two-row labelling, and help/empty-state text.

## Notes / follow-ups (low)

- The statusLine command bakes an absolute interpreter path; a moved/reinstalled venv needs `agentacct onboard` again to refresh it. A `doctor` check for the statusLine command (it currently only inspects `hooks`) is a possible follow-up.
- The CLI statusline feed is a single stream (the statusLine JSON carries no org); a user switching Anthropic accounts on one machine would see them share that stream. Documented; account splitting can come later if the payload exposes an org.
- Writer (the hook, in Claude's env) and reader (the import) agree on the spool path only when they share `CLAUDE_CONFIG_DIR`; a mismatch fails soft (feed simply absent), never wrong.
- No release or live-runtime change in this PR.
