### PR TITLE
feat: agentacct now — current usage & cost snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`agentacct now` — a current usage & cost snapshot.** One glance at calendar
+  windows (today / last 7 days / last 30 days / all time) with token totals,
+  estimated cost, and session counts, plus a by-client and top-models breakdown
+  for a chosen window (`--window`, default 7d) and a compact provider-limit
+  teaser. Read from the authoritative local event log (no credentials, no API);
+  costs are agentacct's token-based estimates, not provider billing — a window
+  that isn't fully priced is shown as a partial `~$` subtotal rather than a
+  misleading exact figure. Supports `--json` and `--client`.
 - **`agentacct limits` — provider-reported usage limits, read from local files.**
   A new foundation records real rate-limit snapshots as `rate_limit_observed`
   events and renders them: for each client, the 5-hour and weekly (7-day) windows

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -7960,14 +7960,22 @@ def _rl_window_label(window: Mapping[str, Any]) -> str:
 
 
 def _rl_latest_snapshots(
-    service: "SentinelService", *, client: str | None
+    service: "SentinelService",
+    *,
+    client: str | None,
+    events: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Latest rate_limit_observed event per (client, org, run_id)."""
+    """Latest rate_limit_observed event per (client, org, run_id).
+
+    Pass ``events`` to reuse an already-loaded event list (avoids a second full
+    ``list_all_events`` scan).
+    """
 
     from .rate_limits import EVENT_TYPE as _RL_EVENT_TYPE
 
+    source_events = events if events is not None else service.list_all_events()
     latest: dict[tuple[Any, Any, Any], tuple[float, dict[str, Any]]] = {}
-    for event in service.list_all_events():
+    for event in source_events:
         if event.get("event_type") != _RL_EVENT_TYPE:
             continue
         metadata = event.get("metadata") or {}
@@ -8010,6 +8018,255 @@ def _rl_json_entry(event: Mapping[str, Any]) -> dict[str, Any]:
         "reached_type": metadata.get("reached_type"),
         "source_file": metadata.get("source_file"),
     }
+
+
+_NOW_WINDOWS: tuple[tuple[str, Optional[int]], ...] = (
+    ("today", 1),
+    ("last 7 days", 7),
+    ("last 30 days", 30),
+    ("all time", None),
+)
+# User --window tokens → the calendar window label above (matches the dashboard's
+# usage summary, which scopes by trailing calendar days).
+_NOW_WINDOW_ALIASES = {
+    "today": "today",
+    "24h": "today",
+    "7d": "last 7 days",
+    "30d": "last 30 days",
+    "all": "all time",
+}
+_NOW_WINDOW_DAYS = {label: days for label, days in _NOW_WINDOWS}
+
+
+def _now_fmt_int(value: Any) -> str:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"{int(value):,}"
+    return "—"
+
+
+def _now_finite(value: Any) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value)):
+        return float(value)
+    return None
+
+
+def _now_cost_text(bucket: Mapping[str, Any]) -> str:
+    """A cost cell. The complete estimate (``$X.XX``) is shown ONLY when the cube
+    vouches for completeness via ``cost_complete`` (every additive row priced and
+    none held) — the mere presence of ``estimated_cost_usd`` does NOT imply
+    completeness, since it is a priced-rows-only sum that ignores unpriced additive
+    rows. Otherwise the priced subtotal is shown as partial (``~$``), or an
+    em-dash when nothing is priced. Non-finite values degrade to em-dash."""
+
+    if bucket.get("cost_complete"):
+        complete = _now_finite(bucket.get("estimated_cost_usd"))
+        if complete is not None:
+            return f"${complete:.2f}"
+    known = _now_finite(bucket.get("known_additive_cost_usd"))
+    if known is not None:
+        return f"~${known:.2f}"
+    return "—"
+
+
+def _now_limit_teaser(
+    service: "SentinelService",
+    *,
+    client: str | None,
+    events: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    """Compact one-line-per-client latest provider limit readings (best-effort)."""
+    try:
+        snapshots = _rl_latest_snapshots(service, client=client, events=events)
+    except Exception:  # noqa: BLE001 - a teaser must never break `now`.
+        return []
+    lines: list[str] = []
+    for event in snapshots:
+        metadata = event.get("metadata") or {}
+        parts: list[str] = []
+        for window in metadata.get("windows") or []:
+            if not isinstance(window, Mapping):
+                continue
+            used = window.get("used_percent")
+            if not isinstance(used, (int, float)) or isinstance(used, bool):
+                continue
+            label = {"5h": "5h", "7d": "7d"}.get(str(window.get("kind") or ""), "win")
+            parts.append(f"{label} {float(used):.0f}%")
+        if parts:
+            lines.append(f"{metadata.get('client') or '?'}: " + " · ".join(parts))
+    return lines
+
+
+@app.command("now")
+def now(
+    store_dir: Annotated[Optional[Path], typer.Option(help=_STORE_DIR_HELP)] = None,
+    window: Annotated[
+        str,
+        typer.Option(help="Window for the by-client/by-model breakdown: today, 7d, 30d, or all."),
+    ] = "7d",
+    client: Annotated[
+        Optional[str],
+        typer.Option(help="Filter to one client (e.g. codex, claude-code); 'all' or omit for every client."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit machine-readable JSON.")] = False,
+) -> None:
+    """Current usage & cost snapshot — calendar-window tokens/cost, by client and model.
+
+    Reads the authoritative local event log (no credentials, no API calls). Costs
+    are agentacct's token-based ESTIMATES, not provider billing; a window that is
+    not fully priced shows a partial ``~$`` subtotal. See ``agentacct limits`` for
+    provider rate-limit windows.
+    """
+    from datetime import date
+
+    from .api import _build_usage_view, _usage_record_time
+    from .usage_cube import build_usage_cube
+
+    if window not in _NOW_WINDOW_ALIASES:
+        raise typer.BadParameter("--window must be one of: today, 7d, 30d, all")
+    # 'all' / omitted → no client filter (matches `limits` and the dashboard).
+    effective_client = None if client in (None, "all") else client
+
+    resolved_store_dir = _resolve_cli_store_dir(store_dir).path
+    service = SentinelService(resolved_store_dir, create=False)
+    events = service.list_all_events()
+    # _build_usage_view maps events → usage records (model_usage only; session /
+    # diagnostic / work events are filtered out) exactly as the dashboard's usage
+    # summary does; saved+excluded mirrors that path so held rows are counted.
+    view = _build_usage_view([], events)
+    records = [*view.saved_records, *view.excluded_saved_records]
+    if effective_client is not None:
+        records = [r for r in records if getattr(r, "client", None) == effective_client]
+
+    now_epoch = time.time()
+    today = date.today()
+
+    # Delegate windowing to the vetted cube path: build_usage_cube(days=N) scopes
+    # the range to [today-(N-1) .. today] AND routes each row through
+    # usage_bucket_date, so future/absurd timestamps are excluded exactly as the
+    # dashboard's usage summary does (a hand-rolled `>= cutoff` filter would not).
+    def _cube_for_days(days: int | None) -> dict[str, Any]:
+        return build_usage_cube(records, record_time=_usage_record_time, days=days, today=today)
+
+    windows_out: list[dict[str, Any]] = []
+    for label, days in _NOW_WINDOWS:
+        windows_out.append({"window": label, "totals": _cube_for_days(days).get("totals") or {}})
+
+    primary_label = _NOW_WINDOW_ALIASES[window]
+    primary_cube = _cube_for_days(_NOW_WINDOW_DAYS[primary_label])
+
+    # Freshness: newest record with a real (finite, not-future) timestamp, so an
+    # unknown (0.0) or absurd future time can't fake a "<1m ago" / "56 years ago".
+    real_times = [
+        t
+        for r in records
+        if (t := _usage_record_time(r)) is not None
+        and isinstance(t, (int, float))
+        and math.isfinite(float(t))
+        and 0 < t <= now_epoch
+    ]
+    newest = max(real_times) if real_times else None
+
+    def _limits_payload() -> list[dict[str, Any]]:
+        try:
+            return [
+                _rl_json_entry(e)
+                for e in _rl_latest_snapshots(service, client=effective_client, events=events)
+            ]
+        except Exception:  # noqa: BLE001 - limits are best-effort; never break `now --json`.
+            return []
+
+    if json_output:
+        payload = {
+            "as_of": newest,
+            "generated_at": now_epoch,
+            "event_count": len(events),
+            "usage_record_count": len(records),
+            "client_filter": effective_client,
+            "windows": windows_out,
+            "breakdown_window": primary_label,
+            "by_client": primary_cube.get("by_client") or [],
+            "by_model": primary_cube.get("by_model") or [],
+            "limits": _limits_payload(),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True, allow_nan=False, default=str))
+        return
+
+    console.print(
+        "agentacct now — local event log; costs are token-based estimates, not billing."
+    )
+    if newest is not None:
+        console.print(
+            f"as of {_rl_humanize_seconds(now_epoch - newest)} ago · {len(records)} usage records\n"
+        )
+    elif records:
+        console.print(f"{len(records)} usage records · newest timestamp unknown\n")
+    else:
+        console.print("")
+
+    if not records:
+        if effective_client is not None:
+            console.print(f"No usage recorded for client '{effective_client}'.")
+        else:
+            console.print("No usage recorded yet.")
+        console.print(
+            "  • Import local usage: `agentacct usage import-local` (or `agentacct usage watch`)."
+        )
+        return
+
+    windows_table = Table(title=None)
+    windows_table.add_column("window")
+    windows_table.add_column("tokens", justify="right")
+    windows_table.add_column("est. cost", justify="right")
+    windows_table.add_column("sessions", justify="right")
+    for entry in windows_out:
+        totals = entry["totals"]
+        windows_table.add_row(
+            entry["window"],
+            _now_fmt_int(totals.get("total_tokens_including_cached")),
+            _now_cost_text(totals),
+            _now_fmt_int(totals.get("sessions")),
+        )
+    console.print(windows_table)
+    console.print("[dim]~ cost = partial (some usage unpriced or held); costs are estimates, not billing.[/dim]")
+
+    by_client = primary_cube.get("by_client") or []
+    if by_client:
+        client_table = Table(title=f"by client · {primary_label}")
+        client_table.add_column("client")
+        client_table.add_column("tokens", justify="right")
+        client_table.add_column("est. cost", justify="right")
+        client_table.add_column("sessions", justify="right")
+        for row in sorted(by_client, key=lambda r: -(r.get("total_tokens_including_cached") or 0)):
+            client_table.add_row(
+                str(row.get("client")),
+                _now_fmt_int(row.get("total_tokens_including_cached")),
+                _now_cost_text(row),
+                _now_fmt_int(row.get("sessions")),
+            )
+        console.print(client_table)
+
+    by_model = primary_cube.get("by_model") or []
+    if by_model:
+        model_table = Table(title=f"top models · {primary_label}")
+        model_table.add_column("model")
+        model_table.add_column("client")
+        model_table.add_column("tokens", justify="right")
+        model_table.add_column("est. cost", justify="right")
+        top_models = sorted(by_model, key=lambda r: -(r.get("total_tokens_including_cached") or 0))[:8]
+        for row in top_models:
+            model_table.add_row(
+                str(row.get("model") or "—"),
+                str(row.get("client") or ""),
+                _now_fmt_int(row.get("total_tokens_including_cached")),
+                _now_cost_text(row),
+            )
+        console.print(model_table)
+
+    teaser = _now_limit_teaser(service, client=effective_client, events=events)
+    if teaser:
+        console.print("\nlimits (provider-reported; run `agentacct limits` for detail):")
+        for line in teaser:
+            console.print(f"  {line}")
 
 
 @app.command("limits")

--- a/tests/test_now_command.py
+++ b/tests/test_now_command.py
@@ -1,0 +1,170 @@
+"""Tests for `agentacct now` (current usage/cost snapshot on the event-log cube)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agentacct.cli import app
+from agentacct.client_usage import ClientUsageEvent
+from agentacct.service import SentinelService
+
+
+def _record_usage(
+    service: SentinelService,
+    *,
+    client: str,
+    model: str,
+    session_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    updated_at: int,
+    estimated_cost_usd: float | None,
+) -> None:
+    event = ClientUsageEvent(
+        client=client,
+        client_session_id=session_id,
+        source_path=Path(f"/tmp/{client}/{session_id}.jsonl"),
+        title=None,
+        cwd="/tmp/project",
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name=client,
+        started_at=updated_at,
+        updated_at=updated_at,
+        turn_count=1,
+        usage_row_lane=f"model:{model}",
+        source_namespace_fingerprint=f"sha256:{client}",
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=input_tokens + output_tokens,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    if estimated_cost_usd is not None:
+        event["estimated_cost_usd"] = estimated_cost_usd
+        event["cost_confidence"] = "estimated_from_tokens"
+    # trusted_usage_import=True stamps the usage-source markers the reader requires.
+    service.record_event(event, trusted_usage_import=True)
+
+
+def test_now_empty_store(tmp_path):
+    result = CliRunner().invoke(app, ["now", "--store-dir", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "No usage recorded yet" in result.stdout
+
+
+def test_now_windows_breakdown_and_cost(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    # ~2 days old → in 7d/30d/all, NOT in 24h
+    _record_usage(
+        service, client="claude-code", model="claude-opus-4-8", session_id="s-recent",
+        input_tokens=1000, output_tokens=200, updated_at=int(now - 2 * 86400), estimated_cost_usd=3.0,
+    )
+    # ~10 days old → in 30d/all, NOT in 7d/24h
+    _record_usage(
+        service, client="codex", model="gpt-5", session_id="s-old",
+        input_tokens=500, output_tokens=100, updated_at=int(now - 10 * 86400), estimated_cost_usd=1.0,
+    )
+
+    result = CliRunner().invoke(app, ["now", "--store-dir", str(tmp_path), "--window", "7d", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+
+    windows = {w["window"]: w["totals"] for w in payload["windows"]}
+    assert windows["today"].get("total_tokens_including_cached", 0) == 0
+    # last 7 days: only the recent (2-day-old) event
+    assert windows["last 7 days"]["total_tokens_including_cached"] == 1200
+    assert windows["last 7 days"]["estimated_cost_usd"] == 3.0
+    assert windows["last 7 days"]["cost_complete"] is True
+    # last 30 days + all: both events
+    assert windows["last 30 days"]["total_tokens_including_cached"] == 1800
+    assert windows["all time"]["total_tokens_including_cached"] == 1800
+
+    # breakdown window is 7d → only claude-code present
+    clients = {row["client"] for row in payload["by_client"]}
+    assert clients == {"claude-code"}
+
+
+def test_now_client_filter(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(
+        service, client="claude-code", model="claude-opus-4-8", session_id="c1",
+        input_tokens=100, output_tokens=50, updated_at=int(now - 3600), estimated_cost_usd=0.5,
+    )
+    _record_usage(
+        service, client="codex", model="gpt-5", session_id="x1",
+        input_tokens=80, output_tokens=20, updated_at=int(now - 3600), estimated_cost_usd=0.2,
+    )
+    result = CliRunner().invoke(
+        app, ["now", "--store-dir", str(tmp_path), "--window", "7d", "--client", "codex", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["client_filter"] == "codex"
+    assert {row["client"] for row in payload["by_client"]} == {"codex"}
+    assert payload["windows"][1]["totals"]["total_tokens_including_cached"] == 100  # last 7d, codex only
+
+
+def test_now_human_render_smoke(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(
+        service, client="claude-code", model="claude-opus-4-8", session_id="h1",
+        input_tokens=1000, output_tokens=500, updated_at=int(now - 3600), estimated_cost_usd=2.5,
+    )
+    result = CliRunner().invoke(app, ["now", "--store-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    out = result.stdout
+    assert "agentacct now" in out
+    assert "last 7 days" in out and "all time" in out
+    assert "by client" in out
+    assert "claude-opus-4-8" in out  # top models
+
+
+def test_now_cost_text_uses_cost_complete():
+    from agentacct.cli import _now_cost_text
+
+    # complete → plain $; the presence of estimated_cost_usd alone is NOT enough.
+    assert _now_cost_text({"cost_complete": True, "estimated_cost_usd": 4.0, "known_additive_cost_usd": 4.0}) == "$4.00"
+    # priced subtotal present but NOT complete (unpriced rows) → partial with ~.
+    assert _now_cost_text({"cost_complete": False, "estimated_cost_usd": 4.0, "known_additive_cost_usd": 4.0}) == "~$4.00"
+    # nothing priced → em-dash
+    assert _now_cost_text({"cost_complete": False, "estimated_cost_usd": None, "known_additive_cost_usd": None}) == "—"
+    # non-finite degrades to em-dash (no $nan)
+    assert _now_cost_text({"cost_complete": True, "estimated_cost_usd": float("nan"), "known_additive_cost_usd": float("inf")}) == "—"
+
+
+def test_now_client_all_is_no_filter(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(
+        service, client="claude-code", model="claude-opus-4-8", session_id="a1",
+        input_tokens=100, output_tokens=50, updated_at=int(now - 3600), estimated_cost_usd=0.5,
+    )
+    _record_usage(
+        service, client="codex", model="gpt-5", session_id="b1",
+        input_tokens=80, output_tokens=20, updated_at=int(now - 3600), estimated_cost_usd=0.2,
+    )
+    result = CliRunner().invoke(app, ["now", "--store-dir", str(tmp_path), "--client", "all", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["client_filter"] is None  # 'all' normalized to no filter
+    assert {row["client"] for row in payload["by_client"]} == {"claude-code", "codex"}
+
+
+def test_now_invalid_window(tmp_path):
+    result = CliRunner().invoke(app, ["now", "--store-dir", str(tmp_path), "--window", "5m"])
+    assert result.exit_code != 0


### PR DESCRIPTION
## What

`agentacct now` — a current usage & cost snapshot, the other half of CLI phase B (alongside `agentacct limits`). One glance:

    agentacct now — local event log; costs are token-based estimates, not billing.
    as of 1d 5h ago · 2586 usage records

    window         tokens          est. cost    sessions
    today          0               —            0
    last 7 days    1,465,430,979   $1160.53     158
    last 30 days   23,220,825,360  ~$19667.55   2,215
    all time       27,157,893,548  ~$24737.17   2,572
    ~ cost = partial (some usage unpriced or held); costs are estimates, not billing.

    by client · last 7 days       →  claude-code $1160, codex $5, …
    top models · last 7 days      →  claude-opus-4-8 $915, claude-opus-5 $329, …
    limits (provider-reported)    →  codex: 7d 0% · claude-code: 5h 12% · 7d 26%

## How

- Reads the **authoritative local event log** (no credentials, no API): `list_all_events()` → `_build_usage_view` → `build_usage_cube`, the exact path the dashboard's usage summary uses. No `rm_usage_day` dependency (that projection is absent/unmaintained and cost-dormant). `_build_usage_view` already filters to real `model_usage` rows, so session/diagnostic/work events are excluded.
- **Calendar windows** (today / 7d / 30d / all) are delegated to `build_usage_cube(days=N)` — the vetted path bounds the range to trailing calendar days *and* routes each row through `usage_bucket_date`, so future/absurd timestamps are excluded exactly as the dashboard does (a hand-rolled `>= cutoff` filter would not).
- **Honest cost.** Costs are agentacct's token-based estimates, not billing. A window is shown as a complete `$X.XX` **only** when the cube's `cost_complete` signal is true (every additive row priced, none held); otherwise the priced-rows-only subtotal is shown as partial `~$` (or `—` when nothing is priced). This is gated on `cost_complete`, not the mere presence of an estimate — so a mix of priced and unpriced models is never presented as complete.
- `--window` (today/7d/30d/all, default 7d) drives the by-client + top-models breakdown; `--client` filters (with `all`/omitted meaning every client, matching `limits`); `--json` for machine consumption. The event log is read once and reused for the limits teaser; the teaser is best-effort and never breaks `now`.

## Testing

- `.venv/bin/pytest -q` (plain, CI-matching): **2940 passed, 1 skipped, 0 failed**.
- 7 tests in `tests/test_now_command.py`: empty store, window/breakdown/cost math, `--client` filter, `--client all` = no-filter, `_now_cost_text` completeness gating (incl. non-finite → `—`), invalid `--window`, human-render smoke.
- Built via implement → 3-lens adversarial review; all confirmed findings fixed — headlined by a **HIGH honesty bug** (the cost cell used the presence of `estimated_cost_usd`, which the cube leaves non-None even when unpriced additive rows exist, so a partial cost was shown as complete and spend was understated). Also fixed: unbounded/absurd-timestamp windowing, `--client all` treated literally, `newest` faked by a zero/absurd timestamp, an unguarded `now --json` limits scan, and a redundant second event-log read.

## Notes

- Verified on the live store: 0.44s, 2586 usage records, real per-client / per-model costs.
- Independent of PR #41 (statusline); branches off #40. No release or live-runtime change.
