### PR TITLE
feat: agentacct tui — live terminal dashboard (Textual)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ build/
 .hermes/
 *.local.md
 .gstack/
+# Event-store runtime artifacts if a stray run creates a store at the repo root
+# (the real store lives in .agent-sentinel/ or the XDG state dir) — never commit.
+/events.sqlite3*
+/events.jsonl
+/events.jsonl.lock
+/events.authoritative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   now, `w` cycle the breakdown window, `q` quit. It polls the event log on an
   interval (`--refresh`, default 5s) and recomputes only when the log actually
   grew, while a one-second tick keeps the reset countdowns and freshness ticking.
+  The status line shows a `refreshed HH:MM:SS` stamp so a manual `r` is always
+  visible even when the numbers are unchanged.
   Supports `--window` and `--client`; requires an interactive terminal (for
   scripting, use the `--json` forms of `now` / `limits`). Adds `textual` as a
   dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,23 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   percentage, window, or credit value actually changes. `agentacct limits`
   supports `--json` and `--client`. Reading limits is best-effort and never fails
   a usage import.
+- **`agentacct tui` — a live terminal dashboard (Textual).** A full-screen,
+  auto-refreshing view over the same authoritative local event log as
+  `agentacct now` / `agentacct limits` (no credentials, no API calls): calendar-window
+  usage & cost (today / 7d / 30d / all), a by-client and top-models breakdown,
+  and provider rate-limit bars with a live reset countdown. Keys: `r` refresh
+  now, `w` cycle the breakdown window, `q` quit. It polls the event log on an
+  interval (`--refresh`, default 5s) and recomputes only when the log actually
+  grew, while a one-second tick keeps the reset countdowns and freshness ticking.
+  Supports `--window` and `--client`; requires an interactive terminal (for
+  scripting, use the `--json` forms of `now` / `limits`). Adds `textual` as a
+  dependency.
+
+### Changed
+- `agentacct now`, `agentacct limits`, and the new `agentacct tui` now share a
+  single internal data layer (`agentacct.usage_snapshot`), so the three surfaces
+  derive usage, cost, and rate-limit readings from one place and can never
+  disagree. No change to `now` / `limits` output.
 
 ## [0.6.0] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,12 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   interval (`--refresh`, default 5s) and recomputes only when the log actually
   grew, while a one-second tick keeps the reset countdowns and freshness ticking.
   The status line shows a `refreshed HH:MM:SS` stamp so a manual `r` is always
-  visible even when the numbers are unchanged.
+  visible even when the numbers are unchanged. Press `s` for a **sessions
+  drill-down**: a list of sessions (title, project, tokens, cost, step counts)
+  that you select into to see that session's work steps and their machine-check
+  results. The work ledger it reads is expensive, so it is built once on demand
+  in a background thread (never on the refresh timer) and cached until the log
+  changes.
   Supports `--window` and `--client`; requires an interactive terminal (for
   scripting, use the `--json` forms of `now` / `limits`). Adds `textual` as a
   dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "httpx>=0.27",
   "PyYAML>=6.0",
   "uvicorn>=0.30",
+  "textual>=0.60",
 ]
 
 [project.urls]

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -41,6 +41,19 @@ from . import autostart as autostart_mod
 from .autostart import AutostartError
 from .agent_capabilities import agent_capability_manifest
 from .api import UsageDiscoveryConfig, create_local_api_app
+from .usage_snapshot import (
+    NOW_WINDOW_ALIASES,
+    ORIGIN_LABELS,
+    build_usage_snapshot,
+    cost_text,
+    format_tokens,
+    humanize_seconds,
+    latest_limit_events,
+    limit_json_entry,
+    limit_teaser_lines,
+    usage_bar,
+    window_label,
+)
 from .client_usage import (
     SUPPORTED_CLIENTS,
     apply_pricing_estimate_to_event,
@@ -7928,174 +7941,6 @@ def _select_serve_port(
     raise OSError(errno.EADDRINUSE, f"no free port in range {port}-{port + max_offset}")
 
 
-def _rl_bar(used_percent: float, width: int = 20) -> str:
-    pct = max(0.0, min(100.0, float(used_percent)))
-    filled = int(round(pct / 100.0 * width))
-    return "█" * filled + "░" * (width - filled)
-
-
-def _rl_humanize_seconds(seconds: float) -> str:
-    total = int(max(0, seconds))
-    days, rem = divmod(total, 86400)
-    hours, rem = divmod(rem, 3600)
-    minutes, _ = divmod(rem, 60)
-    if days:
-        return f"{days}d {hours}h"
-    if hours:
-        return f"{hours}h {minutes}m"
-    if minutes:
-        return f"{minutes}m"
-    return "<1m"
-
-
-def _rl_window_label(window: Mapping[str, Any]) -> str:
-    labels = {"5h": "5-hour", "7d": "7-day"}
-    kind = str(window.get("kind") or "")
-    if kind in labels:
-        return labels[kind]
-    minutes = window.get("window_minutes")
-    if isinstance(minutes, (int, float)):
-        return f"{int(minutes)}m"
-    return "window"
-
-
-def _rl_latest_snapshots(
-    service: "SentinelService",
-    *,
-    client: str | None,
-    events: list[dict[str, Any]] | None = None,
-) -> list[dict[str, Any]]:
-    """Latest rate_limit_observed event per (client, org, run_id).
-
-    Pass ``events`` to reuse an already-loaded event list (avoids a second full
-    ``list_all_events`` scan).
-    """
-
-    from .rate_limits import EVENT_TYPE as _RL_EVENT_TYPE
-
-    source_events = events if events is not None else service.list_all_events()
-    latest: dict[tuple[Any, Any, Any], tuple[float, dict[str, Any]]] = {}
-    for event in source_events:
-        if event.get("event_type") != _RL_EVENT_TYPE:
-            continue
-        metadata = event.get("metadata") or {}
-        event_client = metadata.get("client")
-        if client and event_client != client:
-            continue
-        key = (event_client, metadata.get("org"), event.get("run_id"))
-        captured = metadata.get("captured_at")
-        if not isinstance(captured, (int, float)) or isinstance(captured, bool):
-            created = event.get("created_at")
-            captured = float(created) if isinstance(created, (int, float)) else 0.0
-        ordering = float(captured)
-        current = latest.get(key)
-        if current is None or ordering >= current[0]:
-            latest[key] = (ordering, event)
-    return [
-        event
-        for _key, (_ordering, event) in sorted(
-            latest.items(), key=lambda item: (str(item[0][0]), str(item[0][1]))
-        )
-    ]
-
-
-_RL_ORIGIN_LABELS = {
-    "claude_plan_usage": "desktop app",
-    "claude_statusline": "CLI",
-}
-
-
-def _rl_json_entry(event: Mapping[str, Any]) -> dict[str, Any]:
-    metadata = event.get("metadata") or {}
-    return {
-        "client": metadata.get("client"),
-        "origin": metadata.get("origin"),
-        "plan_type": metadata.get("plan_type"),
-        "org": metadata.get("org"),
-        "captured_at": metadata.get("captured_at"),
-        "windows": metadata.get("windows") or [],
-        "credits": metadata.get("credits"),
-        "reached_type": metadata.get("reached_type"),
-        "source_file": metadata.get("source_file"),
-    }
-
-
-_NOW_WINDOWS: tuple[tuple[str, Optional[int]], ...] = (
-    ("today", 1),
-    ("last 7 days", 7),
-    ("last 30 days", 30),
-    ("all time", None),
-)
-# User --window tokens → the calendar window label above (matches the dashboard's
-# usage summary, which scopes by trailing calendar days).
-_NOW_WINDOW_ALIASES = {
-    "today": "today",
-    "24h": "today",
-    "7d": "last 7 days",
-    "30d": "last 30 days",
-    "all": "all time",
-}
-_NOW_WINDOW_DAYS = {label: days for label, days in _NOW_WINDOWS}
-
-
-def _now_fmt_int(value: Any) -> str:
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return f"{int(value):,}"
-    return "—"
-
-
-def _now_finite(value: Any) -> float | None:
-    if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value)):
-        return float(value)
-    return None
-
-
-def _now_cost_text(bucket: Mapping[str, Any]) -> str:
-    """A cost cell. The complete estimate (``$X.XX``) is shown ONLY when the cube
-    vouches for completeness via ``cost_complete`` (every additive row priced and
-    none held) — the mere presence of ``estimated_cost_usd`` does NOT imply
-    completeness, since it is a priced-rows-only sum that ignores unpriced additive
-    rows. Otherwise the priced subtotal is shown as partial (``~$``), or an
-    em-dash when nothing is priced. Non-finite values degrade to em-dash."""
-
-    if bucket.get("cost_complete"):
-        complete = _now_finite(bucket.get("estimated_cost_usd"))
-        if complete is not None:
-            return f"${complete:.2f}"
-    known = _now_finite(bucket.get("known_additive_cost_usd"))
-    if known is not None:
-        return f"~${known:.2f}"
-    return "—"
-
-
-def _now_limit_teaser(
-    service: "SentinelService",
-    *,
-    client: str | None,
-    events: list[dict[str, Any]] | None = None,
-) -> list[str]:
-    """Compact one-line-per-client latest provider limit readings (best-effort)."""
-    try:
-        snapshots = _rl_latest_snapshots(service, client=client, events=events)
-    except Exception:  # noqa: BLE001 - a teaser must never break `now`.
-        return []
-    lines: list[str] = []
-    for event in snapshots:
-        metadata = event.get("metadata") or {}
-        parts: list[str] = []
-        for window in metadata.get("windows") or []:
-            if not isinstance(window, Mapping):
-                continue
-            used = window.get("used_percent")
-            if not isinstance(used, (int, float)) or isinstance(used, bool):
-                continue
-            label = {"5h": "5h", "7d": "7d"}.get(str(window.get("kind") or ""), "win")
-            parts.append(f"{label} {float(used):.0f}%")
-        if parts:
-            lines.append(f"{metadata.get('client') or '?'}: " + " · ".join(parts))
-    return lines
-
-
 @app.command("now")
 def now(
     store_dir: Annotated[Optional[Path], typer.Option(help=_STORE_DIR_HELP)] = None,
@@ -8116,12 +7961,7 @@ def now(
     not fully priced shows a partial ``~$`` subtotal. See ``agentacct limits`` for
     provider rate-limit windows.
     """
-    from datetime import date
-
-    from .api import _build_usage_view, _usage_record_time
-    from .usage_cube import build_usage_cube
-
-    if window not in _NOW_WINDOW_ALIASES:
+    if window not in NOW_WINDOW_ALIASES:
         raise typer.BadParameter("--window must be one of: today, 7d, 30d, all")
     # 'all' / omitted → no client filter (matches `limits` and the dashboard).
     effective_client = None if client in (None, "all") else client
@@ -8129,63 +7969,33 @@ def now(
     resolved_store_dir = _resolve_cli_store_dir(store_dir).path
     service = SentinelService(resolved_store_dir, create=False)
     events = service.list_all_events()
-    # _build_usage_view maps events → usage records (model_usage only; session /
-    # diagnostic / work events are filtered out) exactly as the dashboard's usage
-    # summary does; saved+excluded mirrors that path so held rows are counted.
-    view = _build_usage_view([], events)
-    records = [*view.saved_records, *view.excluded_saved_records]
-    if effective_client is not None:
-        records = [r for r in records if getattr(r, "client", None) == effective_client]
 
-    now_epoch = time.time()
-    today = date.today()
-
-    # Delegate windowing to the vetted cube path: build_usage_cube(days=N) scopes
-    # the range to [today-(N-1) .. today] AND routes each row through
-    # usage_bucket_date, so future/absurd timestamps are excluded exactly as the
-    # dashboard's usage summary does (a hand-rolled `>= cutoff` filter would not).
-    def _cube_for_days(days: int | None) -> dict[str, Any]:
-        return build_usage_cube(records, record_time=_usage_record_time, days=days, today=today)
-
-    windows_out: list[dict[str, Any]] = []
-    for label, days in _NOW_WINDOWS:
-        windows_out.append({"window": label, "totals": _cube_for_days(days).get("totals") or {}})
-
-    primary_label = _NOW_WINDOW_ALIASES[window]
-    primary_cube = _cube_for_days(_NOW_WINDOW_DAYS[primary_label])
-
-    # Freshness: newest record with a real (finite, not-future) timestamp, so an
-    # unknown (0.0) or absurd future time can't fake a "<1m ago" / "56 years ago".
-    real_times = [
-        t
-        for r in records
-        if (t := _usage_record_time(r)) is not None
-        and isinstance(t, (int, float))
-        and math.isfinite(float(t))
-        and 0 < t <= now_epoch
-    ]
-    newest = max(real_times) if real_times else None
+    # The shared snapshot layer (usage_snapshot) maps events → usage records
+    # (model_usage only; session / diagnostic / work events excluded) and windows
+    # them via the cube's days=N path — the exact computation `agentacct now`, the
+    # dashboard's usage summary, and the TUI all share, so none can disagree.
+    snapshot = build_usage_snapshot(events, client=effective_client, breakdown_window=window)
 
     def _limits_payload() -> list[dict[str, Any]]:
         try:
             return [
-                _rl_json_entry(e)
-                for e in _rl_latest_snapshots(service, client=effective_client, events=events)
+                limit_json_entry(e)
+                for e in latest_limit_events(events, client=effective_client)
             ]
         except Exception:  # noqa: BLE001 - limits are best-effort; never break `now --json`.
             return []
 
     if json_output:
         payload = {
-            "as_of": newest,
-            "generated_at": now_epoch,
-            "event_count": len(events),
-            "usage_record_count": len(records),
-            "client_filter": effective_client,
-            "windows": windows_out,
-            "breakdown_window": primary_label,
-            "by_client": primary_cube.get("by_client") or [],
-            "by_model": primary_cube.get("by_model") or [],
+            "as_of": snapshot.as_of,
+            "generated_at": snapshot.generated_at,
+            "event_count": snapshot.event_count,
+            "usage_record_count": snapshot.usage_record_count,
+            "client_filter": snapshot.client_filter,
+            "windows": [{"window": w.label, "totals": w.totals} for w in snapshot.windows],
+            "breakdown_window": snapshot.breakdown_window,
+            "by_client": snapshot.by_client,
+            "by_model": snapshot.by_model,
             "limits": _limits_payload(),
         }
         print(json.dumps(payload, indent=2, sort_keys=True, allow_nan=False, default=str))
@@ -8194,16 +8004,17 @@ def now(
     console.print(
         "agentacct now — local event log; costs are token-based estimates, not billing."
     )
-    if newest is not None:
+    if snapshot.as_of is not None:
         console.print(
-            f"as of {_rl_humanize_seconds(now_epoch - newest)} ago · {len(records)} usage records\n"
+            f"as of {humanize_seconds(snapshot.generated_at - snapshot.as_of)} ago · "
+            f"{snapshot.usage_record_count} usage records\n"
         )
-    elif records:
-        console.print(f"{len(records)} usage records · newest timestamp unknown\n")
+    elif snapshot.usage_record_count:
+        console.print(f"{snapshot.usage_record_count} usage records · newest timestamp unknown\n")
     else:
         console.print("")
 
-    if not records:
+    if snapshot.usage_record_count == 0:
         if effective_client is not None:
             console.print(f"No usage recorded for client '{effective_client}'.")
         else:
@@ -8218,20 +8029,20 @@ def now(
     windows_table.add_column("tokens", justify="right")
     windows_table.add_column("est. cost", justify="right")
     windows_table.add_column("sessions", justify="right")
-    for entry in windows_out:
-        totals = entry["totals"]
+    for entry in snapshot.windows:
+        totals = entry.totals
         windows_table.add_row(
-            entry["window"],
-            _now_fmt_int(totals.get("total_tokens_including_cached")),
-            _now_cost_text(totals),
-            _now_fmt_int(totals.get("sessions")),
+            entry.label,
+            format_tokens(totals.get("total_tokens_including_cached")),
+            cost_text(totals),
+            format_tokens(totals.get("sessions")),
         )
     console.print(windows_table)
     console.print("[dim]~ cost = partial (some usage unpriced or held); costs are estimates, not billing.[/dim]")
 
-    by_client = primary_cube.get("by_client") or []
+    by_client = snapshot.by_client
     if by_client:
-        client_table = Table(title=f"by client · {primary_label}")
+        client_table = Table(title=f"by client · {snapshot.breakdown_window}")
         client_table.add_column("client")
         client_table.add_column("tokens", justify="right")
         client_table.add_column("est. cost", justify="right")
@@ -8239,15 +8050,15 @@ def now(
         for row in sorted(by_client, key=lambda r: -(r.get("total_tokens_including_cached") or 0)):
             client_table.add_row(
                 str(row.get("client")),
-                _now_fmt_int(row.get("total_tokens_including_cached")),
-                _now_cost_text(row),
-                _now_fmt_int(row.get("sessions")),
+                format_tokens(row.get("total_tokens_including_cached")),
+                cost_text(row),
+                format_tokens(row.get("sessions")),
             )
         console.print(client_table)
 
-    by_model = primary_cube.get("by_model") or []
+    by_model = snapshot.by_model
     if by_model:
-        model_table = Table(title=f"top models · {primary_label}")
+        model_table = Table(title=f"top models · {snapshot.breakdown_window}")
         model_table.add_column("model")
         model_table.add_column("client")
         model_table.add_column("tokens", justify="right")
@@ -8257,12 +8068,12 @@ def now(
             model_table.add_row(
                 str(row.get("model") or "—"),
                 str(row.get("client") or ""),
-                _now_fmt_int(row.get("total_tokens_including_cached")),
-                _now_cost_text(row),
+                format_tokens(row.get("total_tokens_including_cached")),
+                cost_text(row),
             )
         console.print(model_table)
 
-    teaser = _now_limit_teaser(service, client=effective_client, events=events)
+    teaser = limit_teaser_lines(events, client=effective_client)
     if teaser:
         console.print("\nlimits (provider-reported; run `agentacct limits` for detail):")
         for line in teaser:
@@ -8301,12 +8112,12 @@ def limits(
 
     resolved_store_dir = _resolve_cli_store_dir(store_dir).path
     service = SentinelService(resolved_store_dir, create=False)
-    snapshots = _rl_latest_snapshots(service, client=effective_client)
+    snapshots = latest_limit_events(service.list_all_events(), client=effective_client)
 
     if json_output:
         print(
             json.dumps(
-                {"limits": [_rl_json_entry(e) for e in snapshots]},
+                {"limits": [limit_json_entry(e) for e in snapshots]},
                 indent=2,
                 sort_keys=True,
                 allow_nan=False,
@@ -8334,7 +8145,7 @@ def limits(
         metadata = event.get("metadata") or {}
         event_client = metadata.get("client") or "?"
         header = str(event_client)
-        origin_label = _RL_ORIGIN_LABELS.get(str(metadata.get("origin") or ""))
+        origin_label = ORIGIN_LABELS.get(str(metadata.get("origin") or ""))
         if origin_label:
             header += f" ({origin_label})"
         plan = metadata.get("plan_type")
@@ -8348,7 +8159,7 @@ def limits(
             created = event.get("created_at")
             captured = created if isinstance(created, (int, float)) else None
         if isinstance(captured, (int, float)):
-            header += f"  (as of {_rl_humanize_seconds(now - captured)} ago)"
+            header += f"  (as of {humanize_seconds(now - captured)} ago)"
         console.print(header)
         windows = metadata.get("windows")
         for window in windows if isinstance(windows, list) else []:
@@ -8356,12 +8167,12 @@ def limits(
                 continue
             used = window.get("used_percent")
             used_value = float(used) if isinstance(used, (int, float)) and not isinstance(used, bool) else 0.0
-            line = f"  {_rl_window_label(window):>7}  {_rl_bar(used_value)}  {used_value:5.1f}%"
+            line = f"  {window_label(window):>7}  {usage_bar(used_value)}  {used_value:5.1f}%"
             resets_at = window.get("resets_at")
             if isinstance(resets_at, (int, float)) and not isinstance(resets_at, bool) and resets_at > 0:
                 delta = resets_at - now
                 line += (
-                    f"  · resets in {_rl_humanize_seconds(delta)}"
+                    f"  · resets in {humanize_seconds(delta)}"
                     if delta > 0
                     else "  · resets now"
                 )
@@ -8373,6 +8184,60 @@ def limits(
         if reached:
             console.print(f"  ⚠ limit reached: {reached}")
         console.print()
+
+
+@app.command("tui")
+def tui(
+    store_dir: Annotated[Optional[Path], typer.Option(help=_STORE_DIR_HELP)] = None,
+    window: Annotated[
+        str,
+        typer.Option(help="Initial breakdown window: today, 7d, 30d, or all (cycle with 'w')."),
+    ] = "7d",
+    client: Annotated[
+        Optional[str],
+        typer.Option(help="Filter to one client (e.g. codex, claude-code); 'all' or omit for every client."),
+    ] = None,
+    refresh: Annotated[
+        float,
+        typer.Option(help="Seconds between event-log polls (minimum 1)."),
+    ] = 5.0,
+) -> None:
+    """Live terminal dashboard — usage, cost, and provider rate limits, in place.
+
+    A full-screen view over the same authoritative local event log as
+    ``agentacct now`` / ``agentacct limits`` (no credentials, no API calls). Keys:
+    ``r`` refresh now, ``w`` cycle the breakdown window, ``q`` quit. Needs an
+    interactive terminal.
+    """
+    if window not in NOW_WINDOW_ALIASES:
+        raise typer.BadParameter("--window must be one of: today, 7d, 30d, all")
+    # A full-screen TUI needs a real terminal; in a pipe / CI / captured stdout
+    # there is nothing to drive it, so fail with a clear pointer instead of
+    # hanging or crashing.
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        console.print(
+            "agentacct tui needs an interactive terminal. For scripting, use "
+            "`agentacct now --json` or `agentacct limits --json`."
+        )
+        raise typer.Exit(1)
+    effective_client = None if client in (None, "all") else client
+    resolved_store_dir = _resolve_cli_store_dir(store_dir).path
+
+    try:
+        from .tui import AgentAcctTUI
+    except ImportError:
+        console.print(
+            "The TUI needs the optional 'textual' package. Install it with: "
+            "pip install textual"
+        )
+        raise typer.Exit(1)
+
+    AgentAcctTUI(
+        store_dir=resolved_store_dir,
+        client=effective_client,
+        window_token=window,
+        refresh_seconds=refresh,
+    ).run()
 
 
 @app.command("serve")

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8206,7 +8206,8 @@ def tui(
 
     A full-screen view over the same authoritative local event log as
     ``agentacct now`` / ``agentacct limits`` (no credentials, no API calls). Keys:
-    ``r`` refresh now, ``w`` cycle the breakdown window, ``q`` quit. Needs an
+    ``r`` refresh now, ``w`` cycle the breakdown window, ``s`` open the sessions
+    drill-down (a session's steps and their check results), ``q`` quit. Needs an
     interactive terminal.
     """
     if window not in NOW_WINDOW_ALIASES:

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -114,6 +114,7 @@ class AgentAcctTUI(App):
         self.refresh_seconds = max(1.0, float(refresh_seconds))
         self._snapshot: LiveSnapshot | None = None
         self._last_fingerprint: int | None = None
+        self._last_refresh_at: float | None = None
         self._error: str | None = None
         # Last composed text for each dynamic panel — a stable hook for headless
         # tests (avoids depending on Rich renderable internals).
@@ -189,6 +190,10 @@ class AgentAcctTUI(App):
         self._error = None
         self._last_fingerprint = fingerprint
         self._snapshot = snapshot
+        # Stamp the actual rebuild time so the status line gives visible feedback:
+        # `r` forces a rebuild, so the timestamp advances on every manual refresh
+        # even when the underlying numbers are unchanged.
+        self._last_refresh_at = time.time()
         self._render_all()
 
     # -- rendering ----------------------------------------------------------
@@ -218,6 +223,8 @@ class AgentAcctTUI(App):
             usage = self._snapshot.usage
             now = time.time()
             parts: list[str] = []
+            if self._last_refresh_at is not None:
+                parts.append(f"refreshed {time.strftime('%H:%M:%S', time.localtime(self._last_refresh_at))}")
             if usage.as_of is not None:
                 parts.append(f"as of {humanize_seconds(now - usage.as_of)} ago")
             parts.append(f"{usage.usage_record_count} usage records")

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -25,9 +25,11 @@ import time
 from pathlib import Path
 
 from rich.markup import escape as _escape
+from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Header, Static
 
 from .service import SentinelService
@@ -42,6 +44,34 @@ from .usage_snapshot import (
 
 # The window tokens the `w` key cycles through (same vocabulary as `now --window`).
 _WINDOW_CYCLE: tuple[str, ...] = ("today", "7d", "30d", "all")
+
+# The sessions drill-down shows the most-recent slice; the full count is always
+# reported so the cap is never silent.
+_SESSIONS_LIMIT = 500
+
+
+def _work_status_color(status: str) -> str:
+    """Green (done) / yellow (in-flight) / red (blocked) / dim (unknown)."""
+
+    if status in ("completed", "resolved", "handed_off"):
+        return "green"
+    if status in ("started", "checkpoint"):
+        return "yellow"
+    if status == "blocked":
+        return "red"
+    return "dim"
+
+
+def _evidence_mark(result: str) -> tuple[str, str]:
+    """(glyph, color) for a machine-check result."""
+
+    if result == "passed":
+        return "✓", "green"
+    if result in ("failed", "error"):
+        return "✗", "red"
+    if result == "skipped":
+        return "»", "yellow"
+    return "•", "dim"
 
 
 def _events_fingerprint(events: list) -> int:
@@ -97,6 +127,7 @@ class AgentAcctTUI(App):
         Binding("q", "quit", "Quit"),
         Binding("r", "refresh", "Refresh"),
         Binding("w", "cycle_window", "Cycle window"),
+        Binding("s", "open_sessions", "Sessions"),
     ]
 
     def __init__(
@@ -116,6 +147,12 @@ class AgentAcctTUI(App):
         self._last_fingerprint: int | None = None
         self._last_refresh_at: float | None = None
         self._error: str | None = None
+        # Work-ledger cache shared across the sessions/detail screens. The ledger
+        # is EXPENSIVE (O(all events), no caching upstream — ~5s on ~8k events),
+        # so it is built once on demand in a worker thread and reused until the
+        # event log changes (fingerprint) or the user forces a refresh.
+        self._work_ledger: dict | None = None
+        self._work_ledger_fp: int | None = None
         # Last composed text for each dynamic panel — a stable hook for headless
         # tests (avoids depending on Rich renderable internals).
         self._status_text: str = ""
@@ -358,5 +395,260 @@ class AgentAcctTUI(App):
         self.window_token = _WINDOW_CYCLE[(index + 1) % len(_WINDOW_CYCLE)]
         self.refresh_data(force=True)
 
+    def action_open_sessions(self) -> None:
+        # Only open the sessions drill-down from the base dashboard. The app-level
+        # `s` binding stays active while a (non-modal) sub-screen is on top, so
+        # without this guard a second `s` would stack a duplicate screen and spawn
+        # a second expensive ledger build.
+        if len(self.screen_stack) > 1:
+            return
+        self.push_screen(SessionsScreen())
 
-__all__ = ["AgentAcctTUI"]
+
+def _humanize_ago(ts: Any, now: float) -> str:
+    if isinstance(ts, (int, float)) and not isinstance(ts, bool) and ts > 0 and ts <= now:
+        return f"{humanize_seconds(now - ts)} ago"
+    return "—"
+
+
+def _session_matches(work_item: dict, client: Any, session_id: Any) -> bool:
+    return work_item.get("client") == client and work_item.get("client_session_id") == session_id
+
+
+def _session_cost_text(usage: dict) -> str:
+    """Cost cell for a session's usage summary, using the shared honesty rule.
+
+    The session summary carries no ``cost_complete`` flag (unlike the cube), so
+    derive it: complete only when some row is priced AND none is unpriced or held.
+    Otherwise :func:`cost_text` shows the priced subtotal as partial (``~$``) or
+    an em-dash. Equivalent to the cube's own completeness test in practice.
+    """
+
+    complete = bool(usage.get("priced_rows")) and not usage.get("unpriced_rows") and not usage.get(
+        "excluded_non_additive_rows"
+    )
+    return cost_text(
+        {
+            "cost_complete": complete,
+            "estimated_cost_usd": usage.get("estimated_cost_usd"),
+            "known_additive_cost_usd": usage.get("estimated_cost_usd"),
+        }
+    )
+
+
+class SessionsScreen(Screen):
+    """A list of sessions (from the work ledger); select one to drill in."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+        Binding("r", "refresh", "Rebuild"),
+        Binding("q", "quit", "Quit"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._by_key: dict[str, dict] = {}
+        self._total_sessions = 0
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static("", id="sessions-status")
+        yield DataTable(id="sessions", cursor_type="row", zebra_stripes=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = "agentacct"
+        self.sub_title = "sessions"
+        table = self.query_one("#sessions", DataTable)
+        table.add_columns("session", "client", "project", "activity", "tokens", "est. cost", "steps")
+        self.query_one("#sessions-status", Static).update(
+            "Building the work ledger (one-time, a few seconds)…"
+        )
+        self._load()
+
+    @work(thread=True, exclusive=True)
+    def _load(self, force: bool = False) -> None:
+        from textual.worker import get_current_worker
+
+        worker = get_current_worker()
+        app = self.app
+        try:
+            service = SentinelService(app.store_dir, create=False)
+            events = service.list_all_events()
+            fingerprint = _events_fingerprint(events)
+            if not force and app._work_ledger is not None and fingerprint == app._work_ledger_fp:
+                ledger = app._work_ledger
+            else:
+                from .work_ledger import build_work_ledger
+
+                ledger = build_work_ledger(events)
+                # A thread worker cancelled by `exclusive=True` (a newer `s`/`r`)
+                # cannot be interrupted mid-build, so bail before any side effect —
+                # otherwise this stale result would overwrite the fresher rebuild's
+                # cache and repaint the screen with older data.
+                if worker.is_cancelled:
+                    return
+                app._work_ledger = ledger
+                app._work_ledger_fp = fingerprint
+        except Exception as exc:  # noqa: BLE001 - surface, never crash the screen.
+            if not worker.is_cancelled:
+                app.call_from_thread(self._show_error, str(exc))
+            return
+        if worker.is_cancelled:
+            return
+        app.call_from_thread(self._populate, ledger)
+
+    def _show_error(self, message: str) -> None:
+        if not self.is_mounted:  # a late callback must not touch a dismissed screen
+            return
+        self.query_one("#sessions-status", Static).update(
+            f"[red]could not build the work ledger:[/] {_escape(message)}"
+        )
+
+    def _populate(self, ledger: dict) -> None:
+        if not self.is_mounted:  # screen was dismissed before the build finished
+            return
+        sessions = list((ledger.get("session_rollup") or {}).get("sessions") or [])
+        # Most-recent first; unknown activity sorts last.
+        sessions.sort(key=lambda s: (s.get("last_activity_at") or 0.0), reverse=True)
+        self._total_sessions = len(sessions)
+        shown = sessions[:_SESSIONS_LIMIT]
+
+        table = self.query_one("#sessions", DataTable)
+        table.clear()
+        self._by_key.clear()
+        now = time.time()
+        for index, entry in enumerate(shown):
+            key = str(entry.get("session_key") or index)
+            self._by_key[key] = entry
+            usage = entry.get("usage") or {}
+            counts = (entry.get("work") or {}).get("counts") or {}
+            title = entry.get("client_session_title") or entry.get("client_session_id_short") or "(untitled)"
+            steps = f"{counts.get('total', 0)}✓{counts.get('completed', 0)}"
+            active = counts.get("active", 0)
+            blocked = counts.get("blocked", 0)
+            if active:
+                steps += f" ▶{active}"
+            if blocked:
+                steps += f" ⚠{blocked}"
+            table.add_row(
+                _escape(str(title))[:48],
+                _escape(str(entry.get("client") or "")),
+                _escape(str(entry.get("project") or "—"))[:24],
+                _humanize_ago(entry.get("last_activity_at"), now),
+                format_tokens(usage.get("total_tokens")),
+                _session_cost_text(usage),
+                steps,
+                key=key,
+            )
+        cap = f" (showing most recent {_SESSIONS_LIMIT})" if self._total_sessions > _SESSIONS_LIMIT else ""
+        self.query_one("#sessions-status", Static).update(
+            f"{self._total_sessions} sessions{cap} · Enter to open · r to rebuild · Esc back"
+        )
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        key = event.row_key.value if event.row_key is not None else None
+        entry = self._by_key.get(str(key)) if key is not None else None
+        if entry is not None:
+            self.app.push_screen(SessionDetailScreen(entry))
+
+    def action_refresh(self) -> None:
+        self.query_one("#sessions-status", Static).update("Rebuilding the work ledger…")
+        self._load(force=True)
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+
+class SessionDetailScreen(Screen):
+    """One session's steps (work items) and their machine-check results."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+        Binding("backspace", "back", "Back"),
+        Binding("q", "quit", "Quit"),
+    ]
+
+    def __init__(self, entry: dict) -> None:
+        super().__init__()
+        self._entry = entry
+        # Composed text kept for headless tests (Rich renderable internals are
+        # not a stable assertion target).
+        self._header_text = ""
+        self._body_text = ""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static("", id="detail-header")
+        with VerticalScroll():
+            yield Static("", id="detail-body")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        entry = self._entry
+        self.title = "agentacct"
+        self.sub_title = "session detail"
+        client = entry.get("client")
+        session_id = entry.get("client_session_id")
+        title = entry.get("client_session_title") or entry.get("client_session_id_short") or "(untitled)"
+        usage = entry.get("usage") or {}
+        now = time.time()
+
+        header = f"[bold]{_escape(str(title))}[/]"
+        header += f"\n{_escape(str(client or ''))} · {_escape(str(entry.get('project') or '—'))}"
+        first, last = entry.get("first_activity_at"), entry.get("last_activity_at")
+        if isinstance(first, (int, float)) and isinstance(last, (int, float)) and first and last:
+            header += f" · {_humanize_ago(last, now)}"
+        header += (
+            f" · {format_tokens(usage.get('total_tokens'))} tokens"
+            f" · {_session_cost_text(usage)}"
+        )
+        self._header_text = header
+        self.query_one("#detail-header", Static).update(header)
+
+        ledger = getattr(self.app, "_work_ledger", None) or {}
+        work_items = [
+            wi for wi in (ledger.get("work_items") or []) if _session_matches(wi, client, session_id)
+        ]
+        self._body_text = self._render_steps(work_items, now)
+        self.query_one("#detail-body", Static).update(self._body_text)
+
+    def _render_steps(self, work_items: list[dict], now: float) -> str:
+        if not work_items:
+            return (
+                "No recorded work steps for this session.\n"
+                "[dim]Steps come from MCP section/check events; a usage-only session has none.[/]"
+            )
+        lines: list[str] = []
+        for wi in work_items:
+            status = str(wi.get("latest_status") or "?")
+            color = _work_status_color(status)
+            title = wi.get("title") or wi.get("section_id") or "(untitled step)"
+            kind = str(wi.get("kind") or "")
+            meta = " · ".join(p for p in (_escape(kind) if kind else "", status, _humanize_ago(wi.get("updated_at"), now)) if p)
+            lines.append(f"[{color}]●[/] [bold]{_escape(str(title))}[/]  [dim]{meta}[/]")
+            summary = wi.get("summary")
+            if summary:
+                lines.append(f"    [dim]{_escape(str(summary))}[/]")
+            for ev in wi.get("evidence_events") or []:
+                if not isinstance(ev, dict):
+                    continue
+                mark, mcolor = _evidence_mark(str(ev.get("result") or ""))
+                etype = _escape(str(ev.get("evidence_type") or "check"))
+                summ = _escape(str(ev.get("summary") or ev.get("result") or ""))
+                cline = f"    [{mcolor}]{mark}[/] {etype}: {summ}"
+                exit_code = ev.get("exit_code")
+                if isinstance(exit_code, int):
+                    cline += f" [dim](exit {exit_code})[/]"
+                lines.append(cline)
+            blocker = wi.get("blocker")
+            if blocker:
+                lines.append(f"    [red]⚠ blocked:[/] {_escape(str(blocker))}")
+            lines.append("")
+        return "\n".join(lines).rstrip("\n")
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+
+__all__ = ["AgentAcctTUI", "SessionsScreen", "SessionDetailScreen"]

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1,0 +1,355 @@
+"""The ``agentacct tui`` live terminal dashboard (Textual).
+
+A thin UI over :mod:`agentacct.usage_snapshot`: it polls the authoritative local
+event log and renders the same numbers ``agentacct now`` / ``agentacct limits``
+print — calendar-window usage & cost, a by-client / top-model breakdown, and
+provider rate-limit bars with a live reset countdown. No credentials, no API
+calls; the data path is identical to the CLI so the surfaces can never disagree.
+
+Refresh model (two timers):
+
+* every ``refresh_seconds`` — re-read the event log and, only when the event
+  count changed (the log is append-only, so count is a sound change key) or a
+  refresh was forced, rebuild the snapshot and repaint the tables. An unchanged
+  tick is cheap: no cube rebuild.
+* every second — recompute just the reset countdowns and the "as of" age from the
+  cached snapshot, so those tick smoothly without re-scanning the log.
+
+The whole thing is headless-testable with Textual's ``App.run_test()`` — see
+``tests/test_tui.py``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from rich.markup import escape as _escape
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.widgets import DataTable, Footer, Header, Static
+
+from .service import SentinelService
+from .usage_snapshot import (
+    LiveSnapshot,
+    build_live_snapshot,
+    cost_text,
+    format_tokens,
+    humanize_seconds,
+    usage_bar,
+)
+
+# The window tokens the `w` key cycles through (same vocabulary as `now --window`).
+_WINDOW_CYCLE: tuple[str, ...] = ("today", "7d", "30d", "all")
+
+
+def _events_fingerprint(events: list) -> int:
+    """A content-sensitive change key for the loaded event list.
+
+    The event COUNT is NOT a sound change key: the usage importer supersedes rows
+    IN PLACE (``service.replace_events`` drops a re-observed row and records a
+    fresh one), so a growing single-model session keeps the count fixed while its
+    tokens/cost change — the whole point of a live view. Hashing each event's
+    identity + observation time makes any append, removal, or in-place supersede
+    (which records a new event id) change the key and trigger a rebuild.
+
+    The values are stringified so the key is TOTAL: a corrupted/hand-injected
+    ledger row can round-trip ``event_id`` / ``created_at`` as a JSON list or
+    object (unhashable), and this function runs on the unguarded refresh path —
+    it must never raise, per refresh_data's fail-soft contract.
+    """
+
+    return hash(tuple((str(event.get("event_id")), str(event.get("created_at"))) for event in events))
+
+
+def _limit_color(used_percent: float) -> str:
+    """Green / amber / red by utilization — the at-a-glance headroom signal."""
+
+    if used_percent < 70:
+        return "green"
+    if used_percent < 90:
+        return "yellow"
+    return "red"
+
+
+class AgentAcctTUI(App):
+    """Live usage / cost / limits dashboard."""
+
+    CSS = """
+    .section-title {
+        text-style: bold;
+        color: $accent;
+        padding: 1 0 0 0;
+    }
+    #status {
+        color: $text-muted;
+        padding: 0 0 1 0;
+    }
+    #windows { height: auto; }
+    #breakdowns { height: auto; }
+    #byclient, #bymodel { height: auto; width: 1fr; }
+    #bymodel { margin: 0 0 0 2; }
+    #limits-body { padding: 0 0 1 0; }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("w", "cycle_window", "Cycle window"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        store_dir: Path,
+        client: str | None = None,
+        window_token: str = "7d",
+        refresh_seconds: float = 5.0,
+    ) -> None:
+        super().__init__()
+        self.store_dir = Path(store_dir)
+        self.client = client
+        self.window_token = window_token
+        self.refresh_seconds = max(1.0, float(refresh_seconds))
+        self._snapshot: LiveSnapshot | None = None
+        self._last_fingerprint: int | None = None
+        self._error: str | None = None
+        # Last composed text for each dynamic panel — a stable hook for headless
+        # tests (avoids depending on Rich renderable internals).
+        self._status_text: str = ""
+        self._limits_text: str = ""
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static("", id="status")
+        with Vertical(id="body"):
+            yield Static("Usage windows", classes="section-title")
+            yield DataTable(id="windows", cursor_type="none", zebra_stripes=True)
+            with Horizontal(id="breakdowns"):
+                with Vertical():
+                    yield Static("", id="byclient-title", classes="section-title")
+                    yield DataTable(id="byclient", cursor_type="none")
+                with Vertical():
+                    yield Static("", id="bymodel-title", classes="section-title")
+                    yield DataTable(id="bymodel", cursor_type="none")
+            yield Static("Provider limits", classes="section-title")
+            yield Static("", id="limits-body")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = "agentacct"
+        self.sub_title = "live usage · cost · limits"
+        self.query_one("#windows", DataTable).add_columns("window", "tokens", "est. cost", "sessions")
+        self.query_one("#byclient", DataTable).add_columns("client", "tokens", "est. cost", "sessions")
+        self.query_one("#bymodel", DataTable).add_columns("model", "client", "tokens", "est. cost")
+        self.refresh_data(force=True)
+        self.set_interval(self.refresh_seconds, self.refresh_data)
+        self.set_interval(1.0, self._tick_countdowns)
+
+    # -- data ---------------------------------------------------------------
+
+    def refresh_data(self, force: bool = False) -> None:
+        """Re-read the event log; rebuild the snapshot when it changed (or forced).
+
+        Fail-soft: a read or build error is shown in the status line and retried on
+        the next tick — it never crashes the UI and never poisons the change key
+        (the fingerprint is advanced only after a successful rebuild).
+        """
+
+        try:
+            service = SentinelService(self.store_dir, create=False)
+            events = service.list_all_events()
+        except Exception as exc:  # noqa: BLE001 - a live view must survive a bad read.
+            self._error = f"error reading store: {exc}"
+            self._render_status()
+            return
+
+        fingerprint = _events_fingerprint(events)
+        if (
+            not force
+            and self._snapshot is not None
+            and self._error is None
+            and fingerprint == self._last_fingerprint
+        ):
+            return  # content unchanged → skip the (expensive) cube rebuild.
+
+        try:
+            snapshot = build_live_snapshot(
+                events, client=self.client, breakdown_window=self.window_token
+            )
+        except Exception as exc:  # noqa: BLE001 - never let a build error kill the UI.
+            # Leave the fingerprint unadvanced so the next tick retries.
+            self._error = f"error building snapshot: {exc}"
+            self._render_status()
+            return
+
+        self._error = None
+        self._last_fingerprint = fingerprint
+        self._snapshot = snapshot
+        self._render_all()
+
+    # -- rendering ----------------------------------------------------------
+
+    def _render_all(self) -> None:
+        # Defense in depth: data-derived text is escaped before it reaches Rich
+        # markup (below), but a render helper must never be able to propagate an
+        # exception into Textual's event loop and kill the app.
+        try:
+            self._render_status()
+            self._render_windows()
+            self._render_breakdowns()
+            self._render_limits()
+        except Exception as exc:  # noqa: BLE001 - degrade to a plain note, never crash.
+            try:
+                self.query_one("#status", Static).update(f"render error: {_escape(str(exc))}")
+            except Exception:  # noqa: BLE001 - last resort; nothing more we can do.
+                pass
+
+    def _render_status(self) -> None:
+        store = _escape(str(self.store_dir))
+        if self._error is not None:
+            text = f"[red]{_escape(self._error)}[/]  ·  store: {store}"
+        elif self._snapshot is None:
+            text = f"loading…  ·  store: {store}"
+        else:
+            usage = self._snapshot.usage
+            now = time.time()
+            parts: list[str] = []
+            if usage.as_of is not None:
+                parts.append(f"as of {humanize_seconds(now - usage.as_of)} ago")
+            parts.append(f"{usage.usage_record_count} usage records")
+            parts.append(f"window: {usage.breakdown_window}")
+            if self.client:
+                parts.append(f"client: {_escape(self.client)}")
+            parts.append(f"store: {store}")
+            text = "  ·  ".join(parts)
+        self._status_text = text
+        self.query_one("#status", Static).update(text)
+
+    def _render_windows(self) -> None:
+        table = self.query_one("#windows", DataTable)
+        table.clear()
+        if self._snapshot is None:
+            return
+        for window in self._snapshot.usage.windows:
+            totals = window.totals
+            table.add_row(
+                window.label,
+                format_tokens(totals.get("total_tokens_including_cached")),
+                cost_text(totals),
+                format_tokens(totals.get("sessions")),
+            )
+
+    def _render_breakdowns(self) -> None:
+        if self._snapshot is None:
+            return
+        usage = self._snapshot.usage
+        self.query_one("#byclient-title", Static).update(f"by client · {usage.breakdown_window}")
+        self.query_one("#bymodel-title", Static).update(f"top models · {usage.breakdown_window}")
+
+        by_client = self.query_one("#byclient", DataTable)
+        by_client.clear()
+        for row in sorted(usage.by_client, key=lambda r: -(r.get("total_tokens_including_cached") or 0)):
+            by_client.add_row(
+                # Escape data-derived names: DataTable re-parses str cells as Rich
+                # markup, so an unescaped '[' pattern would raise mid-render.
+                _escape(str(row.get("client"))),
+                format_tokens(row.get("total_tokens_including_cached")),
+                cost_text(row),
+                format_tokens(row.get("sessions")),
+            )
+
+        by_model = self.query_one("#bymodel", DataTable)
+        by_model.clear()
+        top_models = sorted(
+            usage.by_model, key=lambda r: -(r.get("total_tokens_including_cached") or 0)
+        )[:8]
+        for row in top_models:
+            by_model.add_row(
+                _escape(str(row.get("model") or "—")),
+                _escape(str(row.get("client") or "")),
+                format_tokens(row.get("total_tokens_including_cached")),
+                cost_text(row),
+            )
+
+    def _render_limits(self) -> None:
+        body = self.query_one("#limits-body", Static)
+        if self._snapshot is None:
+            self._limits_text = ""
+            body.update("")
+            return
+        limits = self._snapshot.limits
+        if not limits:
+            self._limits_text = (
+                "No provider limit data recorded yet — use your agents, or run "
+                "`agentacct usage watch`."
+            )
+            body.update(self._limits_text)
+            return
+        now = time.time()
+        lines: list[str] = []
+        for limit in limits:
+            # Every value below is provider-derived and rendered as Rich markup,
+            # so escape it — a stray '[/]' in e.g. plan_type would otherwise raise
+            # a MarkupError and take down the whole live view.
+            header = f"[bold]{_escape(limit.client)}[/]"
+            if limit.origin_label:
+                header += f" [dim]({_escape(limit.origin_label)})[/]"
+            if limit.plan_type:
+                header += f"  plan: {_escape(str(limit.plan_type))}"
+            if limit.org:
+                header += f"  org: {_escape(str(limit.org)[:8])}"
+            if limit.captured_at is not None:
+                header += f"  [dim](as of {humanize_seconds(now - limit.captured_at)} ago)[/]"
+            lines.append(header)
+            for window in limit.windows:
+                used = window.used_percent
+                bar_value = used if used is not None else 0.0
+                color = _limit_color(bar_value)
+                bar = f"[{color}]{usage_bar(bar_value)}[/]"
+                pct = f"{used:5.1f}%" if used is not None else "   — "
+                line = f"  {window.label:>7}  {bar}  {pct}"
+                resets_at = window.resets_at
+                if isinstance(resets_at, (int, float)) and not isinstance(resets_at, bool) and resets_at > 0:
+                    delta = resets_at - now
+                    line += (
+                        f"  · resets in {humanize_seconds(delta)}" if delta > 0 else "  · resets now"
+                    )
+                lines.append(line)
+            if isinstance(limit.credits, dict) and limit.credits.get("has_credits"):
+                lines.append(f"  credits: {_escape(str(limit.credits.get('balance')))}")
+            if limit.reached_type:
+                lines.append(f"  [red]⚠ limit reached: {_escape(str(limit.reached_type))}[/]")
+            lines.append("")
+        self._limits_text = "\n".join(lines).rstrip("\n")
+        body.update(self._limits_text)
+
+    def _tick_countdowns(self) -> None:
+        """1-second tick: refresh only the time-derived text (countdowns + age)."""
+
+        if self._snapshot is None:
+            return
+        try:
+            self._render_status()
+            self._render_limits()
+        except Exception:  # noqa: BLE001 - a countdown repaint must never crash the app.
+            pass
+
+    # -- actions ------------------------------------------------------------
+
+    def action_refresh(self) -> None:
+        self.refresh_data(force=True)
+
+    def action_cycle_window(self) -> None:
+        try:
+            index = _WINDOW_CYCLE.index(self.window_token)
+        except ValueError:
+            index = _WINDOW_CYCLE.index("7d")
+        self.window_token = _WINDOW_CYCLE[(index + 1) % len(_WINDOW_CYCLE)]
+        self.refresh_data(force=True)
+
+
+__all__ = ["AgentAcctTUI"]

--- a/src/agentacct/usage_snapshot.py
+++ b/src/agentacct/usage_snapshot.py
@@ -1,0 +1,505 @@
+"""Shared usage & rate-limit snapshot layer.
+
+Pure functions and typed dataclasses computed over an already-loaded event list.
+``agentacct now``, ``agentacct limits`` and the Textual TUI all consume this one
+module so the three surfaces derive identical numbers from a single place — the
+authoritative local event log, with no credentials or API calls.
+
+Data paths (factored out of the CLI commands verbatim, so behavior is unchanged):
+
+* **usage/cost** — ``_build_usage_view([], events)`` (:mod:`agentacct.api`) maps
+  events to usage records (``model_usage`` only; session / diagnostic / work
+  events are excluded), then :func:`agentacct.usage_cube.build_usage_cube` with
+  ``days=N`` scopes each calendar window. Expressing a window as ``days=N``
+  routes every row through ``usage_bucket_date``, so future / absurd timestamps
+  are excluded exactly as the dashboard's usage summary does (a hand-rolled
+  ``>= cutoff`` filter would not). Cost completeness is read from the cube's own
+  ``cost_complete`` flag — never inferred from the mere presence of an estimate
+  (``estimated_cost_usd`` stays non-``None`` even when additive rows are unpriced,
+  so presence would over-claim completeness).
+
+* **limits** — the latest ``rate_limit_observed`` event per ``(client, org,
+  run_id)`` stream from the same event list (see :mod:`agentacct.rate_limits`).
+  The provider-reported windows carry ``used_percent`` + ``resets_at`` and drive
+  the live bars and reset countdown.
+
+The heavy imports (:mod:`agentacct.api`, :mod:`agentacct.usage_cube`,
+:mod:`agentacct.rate_limits`) are deferred into the functions that need them so
+importing this module stays cheap for the CLI's cold start.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Mapping, Optional
+
+
+# ---------------------------------------------------------------------------
+# window vocabulary (shared by `now` and the TUI)
+# ---------------------------------------------------------------------------
+
+# Calendar windows shown in the overview, newest-first. ``None`` days = all time.
+NOW_WINDOWS: tuple[tuple[str, Optional[int]], ...] = (
+    ("today", 1),
+    ("last 7 days", 7),
+    ("last 30 days", 30),
+    ("all time", None),
+)
+# User ``--window`` tokens → the calendar window label above. Mirrors the
+# dashboard's usage summary, which scopes by trailing calendar days.
+NOW_WINDOW_ALIASES: dict[str, str] = {
+    "today": "today",
+    "24h": "today",
+    "7d": "last 7 days",
+    "30d": "last 30 days",
+    "all": "all time",
+}
+NOW_WINDOW_DAYS: dict[str, Optional[int]] = {label: days for label, days in NOW_WINDOWS}
+
+# Origin → a short human label distinguishing the Claude feeds.
+ORIGIN_LABELS: dict[str, str] = {
+    "claude_plan_usage": "desktop app",
+    "claude_statusline": "CLI",
+}
+
+# Short labels for the two canonical rate-limit windows.
+WINDOW_KIND_LABELS: dict[str, str] = {"5h": "5h", "7d": "7d"}
+
+
+# ---------------------------------------------------------------------------
+# pure formatters (reused by the CLI renderers and the TUI)
+# ---------------------------------------------------------------------------
+
+
+def finite(value: Any) -> float | None:
+    """The value as a finite float, or ``None`` (rejects bool, inf, nan)."""
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value)):
+        return float(value)
+    return None
+
+
+def format_tokens(value: Any) -> str:
+    """A thousands-separated integer, or an em-dash when not a real number."""
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"{int(value):,}"
+    return "—"
+
+
+def cost_text(bucket: Mapping[str, Any]) -> str:
+    """A cost cell for a cube bucket.
+
+    The complete estimate (``$X.XX``) is shown ONLY when the cube vouches for
+    completeness via ``cost_complete`` (every additive row priced, none held) —
+    the mere presence of ``estimated_cost_usd`` does NOT imply completeness, since
+    it is a priced-rows-only sum that ignores unpriced additive rows. Otherwise
+    the priced subtotal is shown as partial (``~$``), or an em-dash when nothing
+    is priced. Non-finite values degrade to an em-dash.
+    """
+
+    if bucket.get("cost_complete"):
+        complete = finite(bucket.get("estimated_cost_usd"))
+        if complete is not None:
+            return f"${complete:.2f}"
+    known = finite(bucket.get("known_additive_cost_usd"))
+    if known is not None:
+        return f"~${known:.2f}"
+    return "—"
+
+
+def usage_bar(used_percent: float, width: int = 20) -> str:
+    """A unicode fill bar for a 0..100 percentage (clamped)."""
+
+    pct = max(0.0, min(100.0, float(used_percent)))
+    filled = int(round(pct / 100.0 * width))
+    return "█" * filled + "░" * (width - filled)
+
+
+def humanize_seconds(seconds: float) -> str:
+    """A compact ``2d 3h`` / ``4h 5m`` / ``6m`` / ``<1m`` duration string."""
+
+    total = int(max(0, seconds))
+    days, rem = divmod(total, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, _ = divmod(rem, 60)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m"
+    return "<1m"
+
+
+def window_label(window: Mapping[str, Any]) -> str:
+    """A human label for a rate-limit window (``5-hour`` / ``7-day`` / ``Nm``)."""
+
+    labels = {"5h": "5-hour", "7d": "7-day"}
+    kind = str(window.get("kind") or "")
+    if kind in labels:
+        return labels[kind]
+    minutes = finite(window.get("window_minutes"))
+    if minutes is not None:
+        return f"{int(minutes)}m"
+    return "window"
+
+
+# ---------------------------------------------------------------------------
+# rate-limit selection (pure over events)
+# ---------------------------------------------------------------------------
+
+
+def latest_limit_events(
+    events: list[dict[str, Any]], *, client: str | None = None
+) -> list[dict[str, Any]]:
+    """Latest ``rate_limit_observed`` event per ``(client, org, run_id)`` stream.
+
+    Ordered by the provider observation time (``metadata.captured_at``, falling
+    back to ``created_at``). Sorted deterministically by ``(client, org)`` for a
+    stable render. ``client`` filters to one client when given.
+    """
+
+    from .rate_limits import EVENT_TYPE
+
+    latest: dict[tuple[Any, Any, Any], tuple[float, dict[str, Any]]] = {}
+    for event in events:
+        if event.get("event_type") != EVENT_TYPE:
+            continue
+        metadata = event.get("metadata") or {}
+        event_client = metadata.get("client")
+        if client and event_client != client:
+            continue
+        key = (event_client, metadata.get("org"), event.get("run_id"))
+        captured = metadata.get("captured_at")
+        if not isinstance(captured, (int, float)) or isinstance(captured, bool):
+            created = event.get("created_at")
+            captured = float(created) if isinstance(created, (int, float)) else 0.0
+        ordering = float(captured)
+        current = latest.get(key)
+        if current is None or ordering >= current[0]:
+            latest[key] = (ordering, event)
+    return [
+        event
+        for _key, (_ordering, event) in sorted(
+            latest.items(), key=lambda item: (str(item[0][0]), str(item[0][1]))
+        )
+    ]
+
+
+def limit_json_entry(event: Mapping[str, Any]) -> dict[str, Any]:
+    """The public JSON shape for one latest-limit event.
+
+    Passes the raw window dicts through verbatim so ``now --json`` and
+    ``limits --json`` stay byte-for-byte stable.
+    """
+
+    metadata = event.get("metadata") or {}
+    return {
+        "client": metadata.get("client"),
+        "origin": metadata.get("origin"),
+        "plan_type": metadata.get("plan_type"),
+        "org": metadata.get("org"),
+        "captured_at": metadata.get("captured_at"),
+        "windows": metadata.get("windows") or [],
+        "credits": metadata.get("credits"),
+        "reached_type": metadata.get("reached_type"),
+        "source_file": metadata.get("source_file"),
+    }
+
+
+def limit_teaser_lines(
+    events: list[dict[str, Any]], *, client: str | None = None
+) -> list[str]:
+    """Compact one-line-per-client limit readings (``codex: 5h 12% · 7d 26%``).
+
+    Best-effort: never raises (a teaser must not be able to break ``now``).
+    """
+
+    try:
+        snapshots = latest_limit_events(events, client=client)
+    except Exception:  # noqa: BLE001 - a teaser must never break its caller.
+        return []
+    lines: list[str] = []
+    for event in snapshots:
+        metadata = event.get("metadata") or {}
+        parts: list[str] = []
+        for window in metadata.get("windows") or []:
+            if not isinstance(window, Mapping):
+                continue
+            used = window.get("used_percent")
+            if not isinstance(used, (int, float)) or isinstance(used, bool):
+                continue
+            label = WINDOW_KIND_LABELS.get(str(window.get("kind") or ""), "win")
+            parts.append(f"{label} {float(used):.0f}%")
+        if parts:
+            lines.append(f"{metadata.get('client') or '?'}: " + " · ".join(parts))
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# typed snapshots (the TUI's data model)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UsageWindow:
+    """One calendar window's totals bucket (from the cube)."""
+
+    label: str
+    days: Optional[int]
+    totals: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class UsageSnapshot:
+    """The usage/cost half of a live snapshot.
+
+    ``windows`` holds the four calendar overviews; ``by_client`` / ``by_model``
+    are the cube breakdown for the selected ``breakdown_window``.
+    """
+
+    as_of: Optional[float]
+    generated_at: float
+    event_count: int
+    usage_record_count: int
+    client_filter: Optional[str]
+    windows: list[UsageWindow]
+    breakdown_window: str
+    by_client: list[dict[str, Any]]
+    by_model: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class LimitWindow:
+    """One provider rate-limit window, normalized for display."""
+
+    kind: str
+    label: str
+    used_percent: Optional[float]
+    window_minutes: Optional[int]
+    resets_at: Optional[int]
+
+
+@dataclass(frozen=True)
+class ClientLimit:
+    """The latest provider-limit reading for one client stream."""
+
+    client: str
+    origin: Optional[str]
+    origin_label: Optional[str]
+    plan_type: Optional[str]
+    org: Optional[str]
+    captured_at: Optional[float]
+    windows: list[LimitWindow]
+    credits: Optional[Mapping[str, Any]]
+    reached_type: Optional[str]
+    source_file: Optional[str]
+    raw_event: Mapping[str, Any] = field(repr=False, default_factory=dict)
+
+    def to_json_entry(self) -> dict[str, Any]:
+        """The byte-stable public JSON shape (raw windows passed through)."""
+
+        return limit_json_entry(self.raw_event)
+
+
+@dataclass(frozen=True)
+class LiveSnapshot:
+    """Everything the TUI renders in one refresh tick."""
+
+    usage: UsageSnapshot
+    limits: list[ClientLimit]
+
+
+# ---------------------------------------------------------------------------
+# builders
+# ---------------------------------------------------------------------------
+
+
+def usage_records(events: list[dict[str, Any]], *, client: str | None = None) -> list[Any]:
+    """Map events to dashboard usage records (optionally filtered to one client).
+
+    Includes both additive and held (excluded) rows — exactly the set the cube
+    needs so held usage is still counted toward availability.
+    """
+
+    from .api import _build_usage_view
+
+    view = _build_usage_view([], events)
+    records = [*view.saved_records, *view.excluded_saved_records]
+    if client is not None:
+        records = [r for r in records if getattr(r, "client", None) == client]
+    return records
+
+
+def _captured_at(event: Mapping[str, Any]) -> float | None:
+    metadata = event.get("metadata") or {}
+    captured = metadata.get("captured_at")
+    if isinstance(captured, (int, float)) and not isinstance(captured, bool):
+        return float(captured)
+    created = event.get("created_at")
+    if isinstance(created, (int, float)) and not isinstance(created, bool):
+        return float(created)
+    return None
+
+
+def build_usage_snapshot(
+    events: list[dict[str, Any]],
+    *,
+    client: str | None = None,
+    breakdown_window: str = "7d",
+    now: float | None = None,
+    today: date | None = None,
+) -> UsageSnapshot:
+    """Build the usage/cost snapshot: four calendar windows plus the selected
+    window's by-client / by-model breakdown.
+
+    ``breakdown_window`` is a ``--window`` token (``today`` / ``24h`` / ``7d`` /
+    ``30d`` / ``all``). Raises ``ValueError`` for an unknown token so callers can
+    surface a clear error. ``now`` / ``today`` are injectable for tests.
+    """
+
+    from .api import _usage_record_time
+    from .usage_cube import build_usage_cube
+
+    if breakdown_window not in NOW_WINDOW_ALIASES:
+        raise ValueError("breakdown_window must be one of: today, 24h, 7d, 30d, all")
+
+    records = usage_records(events, client=client)
+    now_epoch = now if now is not None else time.time()
+    day = today or date.today()
+
+    def _cube_for_days(days: int | None) -> dict[str, Any]:
+        return build_usage_cube(records, record_time=_usage_record_time, days=days, today=day)
+
+    windows = [
+        UsageWindow(label=label, days=days, totals=_cube_for_days(days).get("totals") or {})
+        for label, days in NOW_WINDOWS
+    ]
+
+    primary_label = NOW_WINDOW_ALIASES[breakdown_window]
+    primary_cube = _cube_for_days(NOW_WINDOW_DAYS[primary_label])
+
+    # Freshness: newest record with a real (finite, not-future) timestamp, so an
+    # unknown (0.0) or absurd future time can't fake a "<1m ago".
+    real_times = [
+        t
+        for r in records
+        if (t := _usage_record_time(r)) is not None
+        and isinstance(t, (int, float))
+        and math.isfinite(float(t))
+        and 0 < t <= now_epoch
+    ]
+    as_of = max(real_times) if real_times else None
+
+    return UsageSnapshot(
+        as_of=as_of,
+        generated_at=now_epoch,
+        event_count=len(events),
+        usage_record_count=len(records),
+        client_filter=client,
+        windows=windows,
+        breakdown_window=primary_label,
+        by_client=primary_cube.get("by_client") or [],
+        by_model=primary_cube.get("by_model") or [],
+    )
+
+
+def build_client_limits(
+    events: list[dict[str, Any]], *, client: str | None = None
+) -> list[ClientLimit]:
+    """Parse the latest provider-limit events into typed :class:`ClientLimit`
+    objects for display (the TUI). JSON parity is served separately via
+    :func:`limit_json_entry` / :meth:`ClientLimit.to_json_entry`."""
+
+    results: list[ClientLimit] = []
+    for event in latest_limit_events(events, client=client):
+        metadata = event.get("metadata") or {}
+        windows: list[LimitWindow] = []
+        for window in metadata.get("windows") or []:
+            if not isinstance(window, Mapping):
+                continue
+            # Guard window_minutes / resets_at through finite() before int() — a
+            # bare int() on a non-finite float raises (int(inf) -> OverflowError,
+            # int(nan) -> ValueError) and would abort the whole build. The
+            # recording path already drops non-finite values, but events are read
+            # via json.loads, which accepts bare Infinity/NaN, so a corrupted or
+            # hand-injected event must not be able to crash the display layer.
+            minutes = finite(window.get("window_minutes"))
+            resets = finite(window.get("resets_at"))
+            windows.append(
+                LimitWindow(
+                    kind=str(window.get("kind") or ""),
+                    label=window_label(window),
+                    used_percent=finite(window.get("used_percent")),
+                    window_minutes=int(minutes) if minutes is not None else None,
+                    resets_at=int(resets) if resets is not None else None,
+                )
+            )
+        origin = metadata.get("origin")
+        credits = metadata.get("credits")
+        results.append(
+            ClientLimit(
+                client=str(metadata.get("client") or "?"),
+                origin=origin,
+                origin_label=ORIGIN_LABELS.get(str(origin or "")),
+                plan_type=metadata.get("plan_type"),
+                org=metadata.get("org"),
+                captured_at=_captured_at(event),
+                windows=windows,
+                credits=credits if isinstance(credits, Mapping) else None,
+                reached_type=metadata.get("reached_type"),
+                source_file=metadata.get("source_file"),
+                raw_event=event,
+            )
+        )
+    return results
+
+
+def build_live_snapshot(
+    events: list[dict[str, Any]],
+    *,
+    client: str | None = None,
+    breakdown_window: str = "7d",
+    now: float | None = None,
+    today: date | None = None,
+) -> LiveSnapshot:
+    """The full snapshot the TUI renders each tick: usage + limits from one
+    already-loaded event list (one scan, both halves)."""
+
+    return LiveSnapshot(
+        usage=build_usage_snapshot(
+            events, client=client, breakdown_window=breakdown_window, now=now, today=today
+        ),
+        limits=build_client_limits(events, client=client),
+    )
+
+
+__all__ = [
+    "NOW_WINDOWS",
+    "NOW_WINDOW_ALIASES",
+    "NOW_WINDOW_DAYS",
+    "ORIGIN_LABELS",
+    "WINDOW_KIND_LABELS",
+    "finite",
+    "format_tokens",
+    "cost_text",
+    "usage_bar",
+    "humanize_seconds",
+    "window_label",
+    "latest_limit_events",
+    "limit_json_entry",
+    "limit_teaser_lines",
+    "UsageWindow",
+    "UsageSnapshot",
+    "LimitWindow",
+    "ClientLimit",
+    "LiveSnapshot",
+    "usage_records",
+    "build_usage_snapshot",
+    "build_client_limits",
+    "build_live_snapshot",
+]

--- a/tests/test_now_command.py
+++ b/tests/test_now_command.py
@@ -135,16 +135,18 @@ def test_now_human_render_smoke(tmp_path):
 
 
 def test_now_cost_text_uses_cost_complete():
-    from agentacct.cli import _now_cost_text
+    # The cost cell logic now lives in the shared snapshot layer that `now`,
+    # `limits`, and the TUI all consume.
+    from agentacct.usage_snapshot import cost_text
 
     # complete → plain $; the presence of estimated_cost_usd alone is NOT enough.
-    assert _now_cost_text({"cost_complete": True, "estimated_cost_usd": 4.0, "known_additive_cost_usd": 4.0}) == "$4.00"
+    assert cost_text({"cost_complete": True, "estimated_cost_usd": 4.0, "known_additive_cost_usd": 4.0}) == "$4.00"
     # priced subtotal present but NOT complete (unpriced rows) → partial with ~.
-    assert _now_cost_text({"cost_complete": False, "estimated_cost_usd": 4.0, "known_additive_cost_usd": 4.0}) == "~$4.00"
+    assert cost_text({"cost_complete": False, "estimated_cost_usd": 4.0, "known_additive_cost_usd": 4.0}) == "~$4.00"
     # nothing priced → em-dash
-    assert _now_cost_text({"cost_complete": False, "estimated_cost_usd": None, "known_additive_cost_usd": None}) == "—"
+    assert cost_text({"cost_complete": False, "estimated_cost_usd": None, "known_additive_cost_usd": None}) == "—"
     # non-finite degrades to em-dash (no $nan)
-    assert _now_cost_text({"cost_complete": True, "estimated_cost_usd": float("nan"), "known_additive_cost_usd": float("inf")}) == "—"
+    assert cost_text({"cost_complete": True, "estimated_cost_usd": float("nan"), "known_additive_cost_usd": float("inf")}) == "—"
 
 
 def test_now_client_all_is_no_filter(tmp_path):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -302,6 +302,28 @@ def test_tui_survives_markup_in_model_name(tmp_path):
     _run(scenario())
 
 
+def test_tui_refresh_updates_visible_timestamp(tmp_path):
+    # Pressing `r` gives visible feedback even when the data is unchanged: the
+    # status line's "refreshed HH:MM:SS" advances because `r` forces a rebuild.
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt-5", session_id="s1",
+                  input_tokens=100, output_tokens=10, updated_at=int(now - 3600), estimated_cost_usd=0.5)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._last_refresh_at is not None
+            assert "refreshed" in app._status_text
+            before = app._last_refresh_at
+            await pilot.press("r")  # force a rebuild even though nothing changed
+            await pilot.pause()
+            assert app._last_refresh_at >= before
+
+    _run(scenario())
+
+
 def test_events_fingerprint_is_total_and_change_sensitive():
     # Regression: the fingerprint runs on refresh_data's unguarded path, so it must
     # never raise — a corrupted/hand-injected ledger row can round-trip event_id /

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,334 @@
+"""Headless tests for the `agentacct tui` Textual app.
+
+Driven with Textual's ``App.run_test()`` (no real terminal). The suite has no
+pytest-asyncio, so each scenario is a coroutine run via ``asyncio.run``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agentacct.cli import app as cli_app
+from agentacct.client_usage import ClientUsageEvent
+from agentacct.service import SentinelService
+import agentacct.rate_limits as rl
+from agentacct.tui import AgentAcctTUI
+from agentacct.usage_snapshot import (
+    ClientLimit,
+    LimitWindow,
+    LiveSnapshot,
+    UsageSnapshot,
+)
+
+from textual.widgets import DataTable
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def _record_usage(
+    service: SentinelService,
+    *,
+    client: str,
+    model: str,
+    session_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    updated_at: int,
+    estimated_cost_usd: float | None,
+) -> None:
+    event = ClientUsageEvent(
+        client=client,
+        client_session_id=session_id,
+        source_path=Path(f"/tmp/{client}/{session_id}.jsonl"),
+        title=None,
+        cwd="/tmp/project",
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name=client,
+        started_at=updated_at,
+        updated_at=updated_at,
+        turn_count=1,
+        usage_row_lane=f"model:{model}",
+        source_namespace_fingerprint=f"sha256:{client}",
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=input_tokens + output_tokens,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    if estimated_cost_usd is not None:
+        event["estimated_cost_usd"] = estimated_cost_usd
+        event["cost_confidence"] = "estimated_from_tokens"
+    service.record_event(event, trusted_usage_import=True)
+
+
+def _seed_codex_limit(service: SentinelService, *, used: float, resets_at: int, captured: float) -> None:
+    service.record_event(
+        rl.snapshot_to_event(
+            rl.normalize_codex_rate_limits(
+                {"primary": {"used_percent": used, "window_minutes": 10080, "resets_at": resets_at}, "plan_type": "pro"},
+                captured_at=captured,
+            )
+        )
+    )
+
+
+def test_tui_mounts_and_populates(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s1",
+                  input_tokens=1000, output_tokens=200, updated_at=int(now - 3600), estimated_cost_usd=3.0)
+    _record_usage(service, client="codex", model="gpt-5", session_id="s2",
+                  input_tokens=500, output_tokens=100, updated_at=int(now - 2 * 3600), estimated_cost_usd=1.0)
+    _seed_codex_limit(service, used=52.0, resets_at=int(now + 7200), captured=now - 60)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._snapshot is not None
+            # four calendar windows are always present.
+            assert app.query_one("#windows", DataTable).row_count == 4
+            # both clients seeded → by-client rows.
+            assert app.query_one("#byclient", DataTable).row_count >= 2
+            assert app.query_one("#bymodel", DataTable).row_count >= 2
+            # limits panel shows the codex reading with a live reset countdown.
+            assert "codex" in app._limits_text
+            assert "resets in" in app._limits_text
+            assert "usage records" in app._status_text
+
+    _run(scenario())
+
+
+def test_tui_empty_store(tmp_path):
+    SentinelService(tmp_path)  # create an empty store
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._snapshot is not None
+            assert app._snapshot.usage.usage_record_count == 0
+            # windows still render (all zero), by-client/by-model empty.
+            assert app.query_one("#windows", DataTable).row_count == 4
+            assert app.query_one("#byclient", DataTable).row_count == 0
+            assert "No provider limit data" in app._limits_text
+            assert "0 usage records" in app._status_text
+
+    _run(scenario())
+
+
+def test_tui_refresh_picks_up_new_events(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt-5", session_id="s1",
+                  input_tokens=100, output_tokens=10, updated_at=int(now - 3600), estimated_cost_usd=0.5)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._snapshot.usage.usage_record_count == 1
+            # a new session appears in the store, then the user hits `r`.
+            _record_usage(service, client="codex", model="gpt-5", session_id="s2",
+                          input_tokens=200, output_tokens=20, updated_at=int(now - 1800), estimated_cost_usd=0.7)
+            await pilot.press("r")
+            await pilot.pause()
+            assert app._snapshot.usage.usage_record_count == 2
+
+    _run(scenario())
+
+
+def test_tui_cycle_window(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt-5", session_id="s1",
+                  input_tokens=100, output_tokens=10, updated_at=int(now - 3600), estimated_cost_usd=0.5)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, window_token="7d", refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._snapshot.usage.breakdown_window == "last 7 days"
+            await pilot.press("w")  # 7d → 30d
+            await pilot.pause()
+            assert app.window_token == "30d"
+            assert app._snapshot.usage.breakdown_window == "last 30 days"
+
+    _run(scenario())
+
+
+def test_tui_renders_none_percent_limit_without_crashing(tmp_path):
+    SentinelService(tmp_path)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # A limit window with an unparseable percentage (used_percent=None) must
+            # render as an em-dash, never raise.
+            app._snapshot = LiveSnapshot(
+                usage=UsageSnapshot(
+                    as_of=None, generated_at=time.time(), event_count=0, usage_record_count=0,
+                    client_filter=None, windows=[], breakdown_window="last 7 days",
+                    by_client=[], by_model=[],
+                ),
+                limits=[
+                    ClientLimit(
+                        client="codex", origin=None, origin_label=None, plan_type=None, org=None,
+                        captured_at=None,
+                        windows=[LimitWindow(kind="7d", label="7-day", used_percent=None, window_minutes=10080, resets_at=None)],
+                        credits=None, reached_type=None, source_file=None, raw_event={},
+                    )
+                ],
+            )
+            app._render_limits()
+            assert "codex" in app._limits_text
+            assert "—" in app._limits_text  # None percent → em-dash, no crash
+
+    _run(scenario())
+
+
+def test_tui_refresh_picks_up_in_place_supersede(tmp_path):
+    # Regression: the usage importer supersedes a growing session IN PLACE
+    # (replace_events), so the event COUNT stays fixed while tokens change. A
+    # count-keyed cache would freeze the live view; the fingerprint key must catch
+    # it on a normal (non-forced) poll tick.
+    from agentacct.client_usage import is_local_usage_import_event, local_usage_event_key
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt-5", session_id="s1",
+                  input_tokens=1000, output_tokens=200, updated_at=int(now - 3600), estimated_cost_usd=1.0)
+
+    def _tokens(app):
+        by_label = {w.label: w for w in app._snapshot.usage.windows}
+        return int(by_label["all time"].totals.get("total_tokens_including_cached") or 0)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._snapshot.usage.usage_record_count == 1
+            before = _tokens(app)
+
+            # Supersede s1 in place with a higher-token reading — count stays 1.
+            grown = ClientUsageEvent(
+                client="codex", client_session_id="s1", source_path=Path("/tmp/codex/s1.jsonl"),
+                title=None, cwd="/tmp/project", model="gpt-5",
+                input_tokens=5000, output_tokens=1000, cached_input_tokens=0,
+                cache_creation_input_tokens=0, cache_read_input_tokens=0,
+                cache_creation_tokens_reported=True, cache_read_tokens_reported=True,
+                reasoning_output_tokens=0, provider_name="codex",
+                started_at=int(now - 3600), updated_at=int(now - 1800), turn_count=2,
+                usage_row_lane="model:gpt-5", source_namespace_fingerprint="sha256:codex",
+                input_tokens_reported=True, output_tokens_reported=True,
+                reasoning_output_tokens_reported=True, total_tokens=6000, total_tokens_reported=True,
+            ).to_sentinel_event()
+            grown["estimated_cost_usd"] = 6.0
+            grown["cost_confidence"] = "estimated_from_tokens"
+            service.replace_events(
+                lambda e: is_local_usage_import_event(e) and local_usage_event_key(e) == ("codex", "s1"),
+                [grown],
+                trusted_usage_import=True,
+            )
+            assert len(service.list_all_events()) == 1  # count unchanged
+
+            # The exact non-forced call the auto-refresh timer makes.
+            app.refresh_data()
+            await pilot.pause()
+            assert app._snapshot.usage.usage_record_count == 1
+            assert _tokens(app) > before  # picked up the in-place growth, not stale
+
+    _run(scenario())
+
+
+def test_tui_survives_markup_in_provider_limit_data(tmp_path):
+    # A provider field containing a Rich-markup closing tag (e.g. plan_type='pro[/]')
+    # must not crash the live view (it is escaped before rendering).
+    service = SentinelService(tmp_path)
+    now = time.time()
+    service.record_event({
+        "source": "t", "event_type": "rate_limit_observed", "run_id": "r1",
+        "provider": None, "model": None, "estimated_input_tokens": None,
+        "estimated_output_tokens": None, "estimated_cost_usd": None,
+        "usage_confidence": None, "cost_confidence": None,
+        "metadata": {
+            "client": "codex", "origin": None, "captured_at": now - 60,
+            "windows": [{"kind": "7d", "used_percent": 52.0, "window_minutes": 10080, "resets_at": int(now + 7200)}],
+            "plan_type": "pro[/]", "credits": {"has_credits": True, "balance": "9[/]"},
+            "reached_type": "usage[/]", "org": "[/]abcdef", "source_file": None,
+        },
+    })
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._snapshot is not None  # did not crash on mount
+            assert "codex" in app._limits_text
+
+    _run(scenario())
+
+
+def test_tui_survives_markup_in_model_name(tmp_path):
+    # A model name with a dangling closing tag would crash Textual's DataTable
+    # cell formatter unless escaped.
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt[/]5", session_id="s1",
+                  input_tokens=100, output_tokens=10, updated_at=int(now - 3600), estimated_cost_usd=0.5)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # by_model row present and the app is alive (no MarkupError from add_row).
+            assert app.query_one("#bymodel", DataTable).row_count == 1
+
+    _run(scenario())
+
+
+def test_events_fingerprint_is_total_and_change_sensitive():
+    # Regression: the fingerprint runs on refresh_data's unguarded path, so it must
+    # never raise — a corrupted/hand-injected ledger row can round-trip event_id /
+    # created_at as an (unhashable) JSON list/object.
+    from agentacct.tui import _events_fingerprint
+
+    events = [
+        {"event_id": "e1", "created_at": 1.0},
+        {"event_id": "e2", "created_at": [1, 2]},   # unhashable created_at
+        {"event_id": ["x"], "created_at": 3.0},     # unhashable event_id
+        {},                                          # missing keys
+    ]
+    fp = _events_fingerprint(events)  # must not raise
+    assert isinstance(fp, int)
+    # still change-sensitive: any value change flips the key.
+    changed = [{"event_id": "e1", "created_at": 2.0}, *events[1:]]
+    assert _events_fingerprint(changed) != fp
+
+
+def test_tui_command_requires_tty(tmp_path):
+    # Under CliRunner stdout is not a TTY, so the command must fail fast with a
+    # clear pointer instead of launching a blocking full-screen app.
+    result = CliRunner().invoke(cli_app, ["tui", "--store-dir", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "interactive terminal" in result.output
+
+
+def test_tui_command_invalid_window(tmp_path):
+    result = CliRunner().invoke(cli_app, ["tui", "--store-dir", str(tmp_path), "--window", "5m"])
+    assert result.exit_code != 0

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -16,7 +16,7 @@ from agentacct.cli import app as cli_app
 from agentacct.client_usage import ClientUsageEvent
 from agentacct.service import SentinelService
 import agentacct.rate_limits as rl
-from agentacct.tui import AgentAcctTUI
+from agentacct.tui import AgentAcctTUI, SessionsScreen, SessionDetailScreen
 from agentacct.usage_snapshot import (
     ClientLimit,
     LimitWindow,
@@ -341,6 +341,175 @@ def test_events_fingerprint_is_total_and_change_sensitive():
     # still change-sensitive: any value change flips the key.
     changed = [{"event_id": "e1", "created_at": 2.0}, *events[1:]]
     assert _events_fingerprint(changed) != fp
+
+
+def _record_section(service, *, section_id, title, status, client, session_id, created_at, summary=None):
+    service.record_event({
+        "event_id": f"evt_sec_{section_id}_{status}",
+        "created_at": created_at,
+        "source": client,
+        "event_type": f"section_{status}",
+        "run_id": None,
+        "metadata": {
+            "sentinel_semantic_kind": "section",
+            "client": client,
+            "client_session_id": session_id,
+            "client_context_keys_authored": ["client_session_id"],
+            "project_dir": "/tmp/project",
+            "section_id": section_id,
+            "section_status": status,
+            "section_title": title,
+            "summary": summary or "",
+            "kind": "implementation",
+        },
+    })
+
+
+def _record_check(service, *, section_id, client, result, created_at):
+    service.record_event({
+        "event_id": f"evt_chk_{section_id}_{result}",
+        "created_at": created_at,
+        "source": client,
+        "event_type": "machine_check",
+        "metadata": {
+            "sentinel_semantic_kind": "evidence",
+            "section_id": section_id,
+            "evidence_type": "test",
+            "result": result,
+            "summary": "Tests passed.",
+            "command": "pytest",
+            "exit_code": 0,
+            "client": client,
+        },
+    })
+
+
+def test_tui_work_helpers():
+    from agentacct.tui import _work_status_color, _evidence_mark, _humanize_ago, _session_matches
+
+    assert _work_status_color("completed") == "green"
+    assert _work_status_color("handed_off") == "green"
+    assert _work_status_color("started") == "yellow"
+    assert _work_status_color("blocked") == "red"
+    assert _work_status_color("weird") == "dim"
+    assert _evidence_mark("passed")[0] == "✓"
+    assert _evidence_mark("failed")[0] == "✗"
+    assert _evidence_mark("skipped")[0] == "»"
+    now = 1000.0
+    assert _humanize_ago(now - 60, now).endswith("ago")
+    assert _humanize_ago(None, now) == "—"
+    assert _humanize_ago(now + 100, now) == "—"  # future never shows a bogus age
+    assert _session_matches({"client": "codex", "client_session_id": "s1"}, "codex", "s1")
+    assert not _session_matches({"client": "codex", "client_session_id": "s2"}, "codex", "s1")
+
+
+def test_session_detail_render_steps_and_markup_safe():
+    from rich.text import Text
+
+    now = time.time()
+    good = {
+        "title": "Ship it", "latest_status": "completed", "kind": "testing",
+        "updated_at": now - 120, "summary": "done",
+        "evidence_events": [{"result": "passed", "evidence_type": "test", "summary": "all green", "exit_code": 0}],
+    }
+    screen = SessionDetailScreen({})
+    txt = screen._render_steps([good], now)
+    assert "Ship it" in txt and "✓" in txt and "exit 0" in txt
+
+    # markup injection in any data field must yield VALID markup (escaped), never crash.
+    evil = {
+        "title": "pwn[/]", "latest_status": "blocked", "kind": "x[/]", "updated_at": now,
+        "summary": "[/]bad", "blocker": "[/]boom",
+        "evidence_events": [{"result": "failed", "evidence_type": "y[/]", "summary": "[/]z", "exit_code": 1}],
+    }
+    etxt = screen._render_steps([evil], now)
+    Text.from_markup(etxt)  # raises MarkupError if any field were left unescaped
+    assert "pwn" in etxt
+
+    assert "No recorded work steps" in screen._render_steps([], now)
+
+
+def test_sessions_screen_worker_and_detail(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt-5", session_id="sess-1",
+                  input_tokens=1000, output_tokens=200, updated_at=int(now - 600), estimated_cost_usd=2.0)
+    _record_section(service, section_id="sec1", title="Do the work", status="started",
+                    client="codex", session_id="sess-1", created_at=now - 600)
+    _record_section(service, section_id="sec1", title="Do the work", status="completed",
+                    client="codex", session_id="sess-1", created_at=now - 300, summary="finished")
+    _record_check(service, section_id="sec1", client="codex", result="passed", created_at=now - 290)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("s")  # open the sessions drill-down
+            await app.workers.wait_for_complete()  # let the ledger worker finish
+            await pilot.pause()
+            scr = app.screen
+            assert isinstance(scr, SessionsScreen)
+            table = scr.query_one("#sessions", DataTable)
+            assert table.row_count >= 1
+            entry = next((e for e in scr._by_key.values() if e.get("client_session_id") == "sess-1"), None)
+            assert entry is not None, "seeded session should appear in the rollup"
+
+            app.push_screen(SessionDetailScreen(entry))
+            await pilot.pause()
+            det = app.screen
+            assert isinstance(det, SessionDetailScreen)
+            assert "Do the work" in det._body_text  # the step
+            assert "✓" in det._body_text  # its passing check
+
+    _run(scenario())
+
+
+def test_tui_repeat_s_does_not_stack_sessions(tmp_path):
+    # Regression: the app-level `s` binding stays active on the (non-modal)
+    # sessions screen, so a second `s` must NOT stack a duplicate screen or spawn
+    # a second expensive build worker.
+    SentinelService(tmp_path)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("s")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            await pilot.press("s")  # `s` again while already on the sessions screen
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert sum(1 for s in app.screen_stack if isinstance(s, SessionsScreen)) == 1
+
+    _run(scenario())
+
+
+def test_sessions_screen_callbacks_guard_unmounted():
+    # Regression: a build worker that finishes after its screen is dismissed calls
+    # _populate/_show_error on an unmounted screen — these must no-op, not raise
+    # NoMatches on query_one.
+    screen = SessionsScreen()  # constructed, never mounted → is_mounted is False
+    assert not screen.is_mounted
+    screen._populate({"session_rollup": {"sessions": []}})  # must not raise
+    screen._show_error("boom")  # must not raise
+
+
+def test_sessions_screen_empty_store(tmp_path):
+    SentinelService(tmp_path)  # empty store → empty (but non-crashing) sessions list
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("s")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            scr = app.screen
+            assert isinstance(scr, SessionsScreen)
+            assert scr.query_one("#sessions", DataTable).row_count == 0
+
+    _run(scenario())
 
 
 def test_tui_command_requires_tty(tmp_path):

--- a/tests/test_usage_snapshot.py
+++ b/tests/test_usage_snapshot.py
@@ -1,0 +1,415 @@
+"""Tests for the shared usage/limit snapshot layer (`agentacct.usage_snapshot`).
+
+This module is the single data path `agentacct now`, `agentacct limits`, and the
+Textual TUI all consume, so it is where the cube-windowing, cost-completeness,
+and rate-limit-selection semantics are pinned.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, datetime, time as dtime
+from pathlib import Path
+
+from agentacct.client_usage import ClientUsageEvent
+from agentacct.service import SentinelService
+from agentacct import usage_snapshot as us
+
+
+# ---------------------------------------------------------------------------
+# seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _record_usage(
+    service: SentinelService,
+    *,
+    client: str,
+    model: str,
+    session_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    updated_at: int,
+    estimated_cost_usd: float | None,
+) -> None:
+    event = ClientUsageEvent(
+        client=client,
+        client_session_id=session_id,
+        source_path=Path(f"/tmp/{client}/{session_id}.jsonl"),
+        title=None,
+        cwd="/tmp/project",
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name=client,
+        started_at=updated_at,
+        updated_at=updated_at,
+        turn_count=1,
+        usage_row_lane=f"model:{model}",
+        source_namespace_fingerprint=f"sha256:{client}",
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=input_tokens + output_tokens,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    if estimated_cost_usd is not None:
+        event["estimated_cost_usd"] = estimated_cost_usd
+        event["cost_confidence"] = "estimated_from_tokens"
+    service.record_event(event, trusted_usage_import=True)
+
+
+def _rl_event(
+    *,
+    client: str,
+    run_id: str,
+    captured_at: float,
+    windows: list,
+    org: str | None = None,
+    origin: str | None = None,
+    created_at: float = 0.0,
+    plan_type: str | None = None,
+    credits: dict | None = None,
+    reached_type: str | None = None,
+    source_file: str | None = None,
+) -> dict:
+    """A hand-built ``rate_limit_observed`` event (the selection/parsing layer is
+    pure over such dicts, so limit tests need no store)."""
+
+    return {
+        "event_type": "rate_limit_observed",
+        "source": "test",
+        "run_id": run_id,
+        "created_at": created_at,
+        "metadata": {
+            "client": client,
+            "org": org,
+            "origin": origin,
+            "captured_at": captured_at,
+            "windows": windows,
+            "plan_type": plan_type,
+            "credits": credits,
+            "reached_type": reached_type,
+            "source_file": source_file,
+        },
+    }
+
+
+# a fixed local-noon "now" so trailing-day windows never straddle midnight.
+_TODAY = date(2026, 6, 15)
+_NOW = datetime.combine(_TODAY, dtime(12, 0, 0)).timestamp()
+
+
+# ---------------------------------------------------------------------------
+# pure formatters
+# ---------------------------------------------------------------------------
+
+
+def test_finite():
+    assert us.finite(3) == 3.0
+    assert us.finite(2.5) == 2.5
+    assert us.finite(True) is None  # bool is not a number here
+    assert us.finite(float("nan")) is None
+    assert us.finite(float("inf")) is None
+    assert us.finite(None) is None
+    assert us.finite("4") is None
+
+
+def test_format_tokens():
+    assert us.format_tokens(1234567) == "1,234,567"
+    assert us.format_tokens(0) == "0"
+    assert us.format_tokens(None) == "—"
+    assert us.format_tokens(True) == "—"
+
+
+def test_cost_text_honours_cost_complete():
+    # complete → plain $; presence of estimated_cost_usd alone is NOT enough.
+    assert us.cost_text({"cost_complete": True, "estimated_cost_usd": 4.0, "known_additive_cost_usd": 4.0}) == "$4.00"
+    # priced subtotal present but not complete → partial with ~.
+    assert us.cost_text({"cost_complete": False, "estimated_cost_usd": 4.0, "known_additive_cost_usd": 4.0}) == "~$4.00"
+    # nothing priced → em-dash.
+    assert us.cost_text({"cost_complete": False, "estimated_cost_usd": None, "known_additive_cost_usd": None}) == "—"
+    # non-finite degrades to em-dash (never $nan).
+    assert us.cost_text({"cost_complete": True, "estimated_cost_usd": float("nan"), "known_additive_cost_usd": float("inf")}) == "—"
+
+
+def test_usage_bar_clamps_and_sizes():
+    assert us.usage_bar(0) == "░" * 20
+    assert us.usage_bar(100) == "█" * 20
+    assert us.usage_bar(50, width=10) == "█" * 5 + "░" * 5
+    # out-of-range clamps rather than overflows/underflows.
+    assert us.usage_bar(150) == "█" * 20
+    assert us.usage_bar(-10) == "░" * 20
+
+
+def test_humanize_seconds():
+    assert us.humanize_seconds(0) == "<1m"
+    assert us.humanize_seconds(59) == "<1m"
+    assert us.humanize_seconds(90) == "1m"
+    assert us.humanize_seconds(3660) == "1h 1m"
+    assert us.humanize_seconds(2 * 86400 + 3 * 3600) == "2d 3h"
+    assert us.humanize_seconds(-100) == "<1m"  # negative floors to 0
+
+
+def test_window_label():
+    assert us.window_label({"kind": "5h"}) == "5-hour"
+    assert us.window_label({"kind": "7d"}) == "7-day"
+    assert us.window_label({"kind": "other", "window_minutes": 120}) == "120m"
+    assert us.window_label({"kind": "other"}) == "window"
+    # non-finite window_minutes must not reach int() (would raise) → "window".
+    assert us.window_label({"kind": "other", "window_minutes": float("inf")}) == "window"
+    assert us.window_label({"kind": "other", "window_minutes": float("nan")}) == "window"
+
+
+# ---------------------------------------------------------------------------
+# build_usage_snapshot — windows, cost honesty, freshness, filters
+# ---------------------------------------------------------------------------
+
+
+def _seed_windows_store(service: SentinelService) -> None:
+    # today, 3d, 20d, 200d, and a FUTURE row — one distinct session each.
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s-today",
+                  input_tokens=100, output_tokens=10, updated_at=int(_NOW - 3600), estimated_cost_usd=1.0)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s-3d",
+                  input_tokens=200, output_tokens=20, updated_at=int(_NOW - 3 * 86400), estimated_cost_usd=2.0)
+    _record_usage(service, client="codex", model="gpt-5", session_id="s-20d",
+                  input_tokens=300, output_tokens=30, updated_at=int(_NOW - 20 * 86400), estimated_cost_usd=3.0)
+    _record_usage(service, client="codex", model="gpt-5", session_id="s-200d",
+                  input_tokens=400, output_tokens=40, updated_at=int(_NOW - 200 * 86400), estimated_cost_usd=4.0)
+    _record_usage(service, client="codex", model="gpt-5", session_id="s-future",
+                  input_tokens=500, output_tokens=50, updated_at=int(_NOW + 5 * 86400), estimated_cost_usd=5.0)
+
+
+def _sessions(window: us.UsageWindow) -> int:
+    return int(window.totals.get("sessions") or 0)
+
+
+def test_usage_snapshot_calendar_windows(tmp_path):
+    service = SentinelService(tmp_path)
+    _seed_windows_store(service)
+    snap = us.build_usage_snapshot(service.list_all_events(), now=_NOW, today=_TODAY)
+
+    by_label = {w.label: w for w in snap.windows}
+    # today: only the today row. 7d: today + 3d. 30d: + 20d.
+    assert _sessions(by_label["today"]) == 1
+    assert _sessions(by_label["last 7 days"]) == 2
+    assert _sessions(by_label["last 30 days"]) == 3
+    # all time keeps every valid-dated row INCLUDING the future one (a bounded
+    # window would drop future; all-time has no upper bound) → all 5 sessions.
+    assert _sessions(by_label["all time"]) == 5
+
+    # token totals are monotonic across the trailing windows.
+    tok = lambda w: int(by_label[w].totals.get("total_tokens_including_cached") or 0)
+    assert tok("today") < tok("last 7 days") < tok("last 30 days")
+
+    assert snap.event_count == 5
+    assert snap.usage_record_count == 5
+
+
+def test_usage_snapshot_as_of_excludes_future(tmp_path):
+    service = SentinelService(tmp_path)
+    _seed_windows_store(service)
+    snap = us.build_usage_snapshot(service.list_all_events(), now=_NOW, today=_TODAY)
+    # freshness = newest real (<= now) row; the future row must not win.
+    assert snap.as_of is not None
+    assert snap.as_of <= _NOW
+    assert snap.as_of == float(int(_NOW - 3600))
+
+
+def test_usage_snapshot_client_filter(tmp_path):
+    service = SentinelService(tmp_path)
+    _seed_windows_store(service)
+    snap = us.build_usage_snapshot(service.list_all_events(), client="codex", now=_NOW, today=_TODAY)
+    assert snap.client_filter == "codex"
+    # only codex rows counted (20d + 200d + future = 3 in all-time; 0 in 7d).
+    by_label = {w.label: w for w in snap.windows}
+    assert _sessions(by_label["all time"]) == 3
+    assert _sessions(by_label["last 7 days"]) == 0
+    assert all(row["client"] == "codex" for row in snap.by_client)
+
+
+def test_usage_snapshot_cost_complete_vs_partial(tmp_path):
+    service = SentinelService(tmp_path)
+    # one priced + one UNPRICED row on the same day → the day's cost is not complete.
+    _record_usage(service, client="codex", model="gpt-5", session_id="priced",
+                  input_tokens=100, output_tokens=10, updated_at=int(_NOW - 3600), estimated_cost_usd=1.5)
+    _record_usage(service, client="codex", model="gpt-5", session_id="unpriced",
+                  input_tokens=100, output_tokens=10, updated_at=int(_NOW - 3600), estimated_cost_usd=None)
+    snap = us.build_usage_snapshot(service.list_all_events(), now=_NOW, today=_TODAY)
+    today = {w.label: w for w in snap.windows}["today"].totals
+    assert today["cost_complete"] is False
+    assert us.cost_text(today) == "~$1.50"  # partial: only the priced subtotal
+
+
+def test_usage_snapshot_all_priced_is_complete(tmp_path):
+    service = SentinelService(tmp_path)
+    _record_usage(service, client="codex", model="gpt-5", session_id="p1",
+                  input_tokens=100, output_tokens=10, updated_at=int(_NOW - 3600), estimated_cost_usd=1.5)
+    _record_usage(service, client="codex", model="gpt-5", session_id="p2",
+                  input_tokens=100, output_tokens=10, updated_at=int(_NOW - 3600), estimated_cost_usd=2.5)
+    snap = us.build_usage_snapshot(service.list_all_events(), now=_NOW, today=_TODAY)
+    today = {w.label: w for w in snap.windows}["today"].totals
+    assert today["cost_complete"] is True
+    assert us.cost_text(today) == "$4.00"
+
+
+def test_usage_snapshot_empty_store(tmp_path):
+    service = SentinelService(tmp_path)
+    snap = us.build_usage_snapshot(service.list_all_events(), now=_NOW, today=_TODAY)
+    assert snap.usage_record_count == 0
+    assert snap.as_of is None
+    assert [w.label for w in snap.windows] == ["today", "last 7 days", "last 30 days", "all time"]
+    assert snap.by_client == []
+    assert snap.by_model == []
+
+
+def test_usage_snapshot_breakdown_window_alias(tmp_path):
+    service = SentinelService(tmp_path)
+    _seed_windows_store(service)
+    events = service.list_all_events()
+    assert us.build_usage_snapshot(events, breakdown_window="24h", now=_NOW, today=_TODAY).breakdown_window == "today"
+    assert us.build_usage_snapshot(events, breakdown_window="7d", now=_NOW, today=_TODAY).breakdown_window == "last 7 days"
+    assert us.build_usage_snapshot(events, breakdown_window="all", now=_NOW, today=_TODAY).breakdown_window == "all time"
+
+
+def test_usage_snapshot_bad_breakdown_window_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        us.build_usage_snapshot([], breakdown_window="5m")
+
+
+# ---------------------------------------------------------------------------
+# rate-limit selection & parsing
+# ---------------------------------------------------------------------------
+
+
+def _codex_7d(used: float, *, captured: float, resets_at=42):
+    return _rl_event(
+        client="codex", run_id="codex_rate_limit", captured_at=captured, plan_type="pro",
+        windows=[{"kind": "7d", "used_percent": used, "window_minutes": 10080, "resets_at": resets_at}],
+    )
+
+
+def _claude_desktop(*, org: str, fh: float, sd: float, captured: float):
+    return _rl_event(
+        client="claude-code", org=org, run_id=f"claude_plan_usage_{org}",
+        origin="claude_plan_usage", captured_at=captured,
+        windows=[
+            {"kind": "5h", "used_percent": fh, "window_minutes": 300, "resets_at": None},
+            {"kind": "7d", "used_percent": sd, "window_minutes": 10080, "resets_at": None},
+        ],
+    )
+
+
+def test_latest_limit_events_picks_newest_per_stream():
+    events = [_codex_7d(40.0, captured=1000.0), _codex_7d(55.0, captured=2000.0)]
+    latest = us.latest_limit_events(events)
+    assert len(latest) == 1  # one codex stream
+    assert latest[0]["metadata"]["captured_at"] == 2000.0  # the newer reading wins
+
+
+def test_latest_limit_events_client_filter():
+    events = [_codex_7d(55.0, captured=2000.0), _claude_desktop(org="abc", fh=10.0, sd=20.0, captured=1500.0)]
+    assert {e["metadata"]["client"] for e in us.latest_limit_events(events)} == {"codex", "claude-code"}
+    assert {e["metadata"]["client"] for e in us.latest_limit_events(events, client="codex")} == {"codex"}
+    assert {e["metadata"]["client"] for e in us.latest_limit_events(events, client="claude-code")} == {"claude-code"}
+
+
+def test_build_client_limits_parses_windows():
+    events = [_codex_7d(55.0, captured=2000.0), _claude_desktop(org="abc", fh=10.0, sd=20.0, captured=1500.0)]
+    by_client = {c.client: c for c in us.build_client_limits(events)}
+
+    codex = by_client["codex"]
+    assert codex.plan_type == "pro"
+    assert len(codex.windows) == 1
+    assert codex.windows[0].kind == "7d"
+    assert codex.windows[0].label == "7-day"
+    assert codex.windows[0].used_percent == 55.0
+    assert codex.windows[0].resets_at == 42
+
+    claude = by_client["claude-code"]
+    assert claude.origin == "claude_plan_usage"
+    assert claude.origin_label == "desktop app"
+    assert [w.kind for w in claude.windows] == ["5h", "7d"]
+    assert claude.windows[0].used_percent == 10.0
+    assert claude.windows[0].resets_at is None
+
+
+def test_build_client_limits_survives_malformed_windows():
+    ev = _rl_event(
+        client="codex", run_id="codex_rate_limit", captured_at=3000.0,
+        windows=[
+            "not-a-mapping",
+            # non-finite used_percent AND window_minutes on one window.
+            {"kind": "5h", "used_percent": "bad", "window_minutes": float("inf")},
+            # non-finite resets_at (would crash a bare int()); finite window_minutes kept.
+            {"kind": "7d", "used_percent": float("inf"), "window_minutes": 10080, "resets_at": float("nan")},
+        ],
+    )
+    limits = us.build_client_limits([ev])
+    assert len(limits) == 1
+    windows = limits[0].windows
+    assert len(windows) == 2  # the non-mapping entry is skipped
+    assert all(w.used_percent is None for w in windows)  # bad + inf → None, no crash
+    # non-finite window_minutes / resets_at degrade to None instead of crashing int().
+    assert windows[0].window_minutes is None  # inf
+    assert windows[1].window_minutes == 10080
+    assert windows[1].resets_at is None  # nan
+
+
+def test_limit_json_entry_and_parity():
+    ev = _codex_7d(40.0, captured=1000.0)
+    entry = us.limit_json_entry(ev)
+    assert entry == {
+        "client": "codex",
+        "origin": None,
+        "plan_type": "pro",
+        "org": None,
+        "captured_at": 1000.0,
+        "windows": [{"kind": "7d", "used_percent": 40.0, "window_minutes": 10080, "resets_at": 42}],
+        "credits": None,
+        "reached_type": None,
+        "source_file": None,
+    }
+    # the typed object serializes back to the byte-stable JSON shape.
+    assert us.build_client_limits([ev])[0].to_json_entry() == entry
+
+
+def test_limit_teaser_lines():
+    events = [_codex_7d(52.4, captured=2000.0), _claude_desktop(org="abc", fh=12.0, sd=26.0, captured=1500.0)]
+    lines = us.limit_teaser_lines(events)
+    assert "codex: 7d 52%" in lines
+    assert "claude-code: 5h 12% · 7d 26%" in lines
+
+
+# ---------------------------------------------------------------------------
+# build_live_snapshot — the TUI's one-scan bundle
+# ---------------------------------------------------------------------------
+
+
+def test_build_live_snapshot_bundles_usage_and_limits(tmp_path):
+    import agentacct.rate_limits as rl
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, client="codex", model="gpt-5", session_id="s1",
+                  input_tokens=100, output_tokens=10, updated_at=int(_NOW - 3600), estimated_cost_usd=1.0)
+    service.record_event(
+        rl.snapshot_to_event(
+            rl.normalize_codex_rate_limits(
+                {"primary": {"used_percent": 52.0, "window_minutes": 10080, "resets_at": 42}, "plan_type": "pro"},
+                captured_at=_NOW - 100,
+            )
+        )
+    )
+    live = us.build_live_snapshot(service.list_all_events(), now=_NOW, today=_TODAY)
+    assert isinstance(live, us.LiveSnapshot)
+    assert live.usage.usage_record_count == 1
+    assert [c.client for c in live.limits] == ["codex"]
+    assert live.limits[0].windows[0].used_percent == 52.0

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "textual" },
     { name = "typer" },
     { name = "uvicorn" },
 ]
@@ -25,6 +26,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13" },
+    { name = "textual", specifier = ">=0.60" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
@@ -153,6 +155,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +178,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
 [[package]]
 name = "mdurl"
 version = "0.1.2"
@@ -171,6 +202,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -418,6 +458,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -451,6 +508,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **`agentacct tui`**, a live full-screen terminal dashboard (Textual) over the
same authoritative local event log as `agentacct now` / `agentacct limits` — no
credentials, no API calls. It shows calendar-window usage & cost (today / 7d / 30d
/ all), a by-client and top-models breakdown, and provider rate-limit bars with a
live reset countdown.

Per the plan, this **first factors a shared data layer** — `agentacct.usage_snapshot`
— that `now`, `limits`, and the TUI all consume, so the three surfaces derive usage,
cost, and rate-limit readings from one place and can never disagree.

## What's in here

- `src/agentacct/usage_snapshot.py` — new pure module (dataclasses + builders +
  formatters) over an already-loaded event list. Reuses the existing
  `_build_usage_view` → `build_usage_cube(days=N)` path and the latest-per-stream
  `rate_limit_observed` selection; nothing about the computation changes.
- `src/agentacct/tui.py` — the `AgentAcctTUI` Textual app.
- `src/agentacct/cli.py` — `now` / `limits` rewired to the shared layer (thin
  shells now); new `tui` command (lazy-imports textual, guards non-TTY).
- `pyproject.toml` — adds `textual>=0.60`.
- `tests/test_usage_snapshot.py`, `tests/test_tui.py` — new; `tests/test_now_command.py`
  points its cost-cell test at the shared layer.

## `now` / `limits` parity

The refactor **relocates** logic without changing behavior: `now --json` and
`limits --json` stay byte-for-byte identical (limit JSON still passes the raw
window dicts through verbatim; usage windows/breakdown are the same cube output).
Cost completeness still comes from the cube's `cost_complete` flag — never inferred
from `estimated_cost_usd` presence (the prior HIGH bug). The existing now/limits/
rate_limits suites pass unchanged.

## TUI behavior

- Refresh: polls the event log every `--refresh` seconds (default 5) and rebuilds
  only when the append-only log grew; a 1-second tick refreshes just the reset
  countdowns + freshness. Keys: `r` refresh, `w` cycle window, `q` quit.
- Fail-soft: empty store, missing limits, malformed / `None` percentages, and
  store-read errors render gracefully (no crash); non-TTY invocation exits with a
  clear pointer to the `--json` forms instead of hanging.

## Adversarial review

Two rounds of multi-lens adversarial review (find → independently verify each
finding), all confirmed issues fixed:

- **Round 1** — parity and usage/cost lenses found nothing; 4 confirmed and fixed:
  - **HIGH** — the TUI's auto-refresh keyed on event *count*, but the usage importer
    supersedes a growing session **in place** (`replace_events`), so a live single-model
    session's tokens/cost would freeze. Fixed: refresh keys on a content fingerprint.
  - **MEDIUM/LOW** — Rich-markup in provider data (`plan_type`/`org`/… and model/client
    cells) could crash the app; now escaped, with the render path guarded.
  - **LOW** — non-finite `window_minutes`/`resets_at` hit a bare `int()`; now guarded.
- **Round 2** (audit of the fixes) — one fix-induced regression: the new fingerprint
  could `TypeError` on a corrupted ledger row (unhashable `created_at`). Fixed by making
  the key total; regression-tested.

## Tests

- `.venv/bin/pytest -q` (plain, CI-matching): **2984 passed, 1 skipped**.
- New: `usage_snapshot` tests (windows, cost honesty, future-timestamp handling, limit
  selection/parsing, non-finite guards, JSON parity) + TUI tests (mount/populate, empty
  store, refresh picks up in-place supersede, window cycle, markup-injection safety,
  total fingerprint, non-TTY guard).

## Not included (owner-gated)

No release and no deploy — `textual` is added to dependencies but the live runtime
is not touched.
