### PR TITLE
feat(tui): fold subagent sessions, show their roles, restructure detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`agentacct tui` sessions drill-down — folded subagents, roles, and a
+  restructured detail.** The sessions list now shows only top-level sessions —
+  child/subagent sessions are folded under their parent (a `⋔ sub` count column),
+  so a run with dozens of subagents is one row instead of dozens. Opening a
+  session shows a **Subagents** section listing each child with its role and task,
+  read on the fly from the child's local transcript (`attributionAgent` +
+  the Task prompt) — no credentials, no re-import. The session detail is
+  restructured from a wall of text into a header panel plus one collapsible per
+  step (status + title collapsed; expand for the summary and colored check
+  results). Refresh feedback is clearer: the sessions rebuild shows a loading
+  indicator, and a manual `r` on the dashboard flashes the refreshed-stamp.
 - **`agentacct now` — a current usage & cost snapshot.** One glance at calendar
   windows (today / last 7 days / last 30 days / all time) with token totals,
   estimated cost, and session counts, plus a by-client and top-models breakdown

--- a/src/agentacct/subagent_roles.py
+++ b/src/agentacct/subagent_roles.py
@@ -1,0 +1,249 @@
+"""Read a Claude Code subagent's role + task from its local transcript.
+
+Decoupled, read-only, fail-soft — the same "read the local files the agent
+already wrote" pattern as :mod:`agentacct.rate_limits`. A child (subagent)
+session carries no role in agentacct's event log, but its transcript on disk
+does::
+
+    <claude>/projects/<project>/<parentSessionId>/subagents/agent-<agentId>.jsonl
+
+Each such file has an ``attributionAgent`` (the subagent type — e.g. ``Explore``,
+``general-purpose``, ``Plan``, ``workflow-subagent``) and its first user message
+is the Task prompt. The synthetic child session id agentacct assigns is
+``<parentSessionId>:agent-<agentId>``, so a child id maps straight to its file.
+
+Reads are bounded and never raise (a missing/renamed file simply yields no role).
+The machine-global scan is gated by ``AGENTACCT_SCAN_SUBAGENT_ROLES`` (pinned off
+in tests) unless an explicit ``projects_root`` is passed; the Claude projects root
+follows ``CLAUDE_CONFIG_DIR`` (else ``~/.claude``) and is overridable for tests via
+``AGENTACCT_CLAUDE_PROJECTS_ROOT``.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+SCAN_ENV = "AGENTACCT_SCAN_SUBAGENT_ROLES"
+ROOT_ENV = "AGENTACCT_CLAUDE_PROJECTS_ROOT"
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+# Role + task live in the first handful of lines; bound BOTH the line count and
+# the byte budget so a huge (or single-giant-line) transcript can never stall the
+# UI or blow up memory.
+_MAX_LINES = 400
+_MAX_BYTES = 512 * 1024
+
+
+@dataclass(frozen=True)
+class SubagentRole:
+    """A subagent's type (``attributionAgent``) and its Task prompt, if found."""
+
+    agent_type: str | None
+    task: str | None
+
+
+def scan_enabled() -> bool:
+    value = os.environ.get(SCAN_ENV)
+    if value is None:
+        return True
+    return value.strip().lower() not in _FALSE_VALUES
+
+
+def _claude_config_home() -> Path:
+    configured = os.environ.get("CLAUDE_CONFIG_DIR")
+    if configured:
+        parts = [p.strip() for p in configured.split(",") if p.strip()]
+        if parts:
+            return Path(parts[0]).expanduser()
+    return Path.home() / ".claude"
+
+
+def default_projects_root() -> Path:
+    override = os.environ.get(ROOT_ENV)
+    if override:
+        return Path(override).expanduser()
+    return _claude_config_home() / "projects"
+
+
+def _resolve_root(projects_root: Path | str | None) -> Path | None:
+    """The projects root to scan, or ``None`` when the global scan is disabled and
+    no explicit root was given (test isolation)."""
+
+    if projects_root is not None:
+        return Path(projects_root).expanduser()
+    if not scan_enabled():
+        return None
+    return default_projects_root()
+
+
+def _agent_id_from_child_session(client_session_id: str) -> tuple[str, str] | None:
+    """``<parent>:agent-<hex>`` → ``(parent, "agent-<hex>")``; else ``None``."""
+
+    if not isinstance(client_session_id, str) or ":" not in client_session_id:
+        return None
+    parent, _, agent = client_session_id.partition(":")
+    if not parent or not agent.startswith("agent-"):
+        return None
+    return parent, agent
+
+
+def _extract_role(path: Path) -> SubagentRole | None:
+    """Pull ``attributionAgent`` + the first user-text message from a transcript."""
+
+    agent_type: str | None = None
+    task: str | None = None
+    try:
+        # Bound BYTES (not just lines): read a fixed budget with errors="replace"
+        # so a corrupted/binary transcript — or a torn multi-byte char in one a
+        # subagent is still writing — can never raise UnicodeDecodeError or
+        # materialize an unbounded line. The module contract is "never raise".
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            data = handle.read(_MAX_BYTES)
+    except OSError:
+        return None
+    for line in data.splitlines()[:_MAX_LINES]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(obj, Mapping):
+            continue
+        if agent_type is None:
+            attribution = obj.get("attributionAgent")
+            if isinstance(attribution, str) and attribution.strip():
+                agent_type = attribution.strip()
+        if task is None:
+            message = obj.get("message")
+            is_user = obj.get("type") == "user" or (
+                isinstance(message, Mapping) and message.get("role") == "user"
+            )
+            if is_user and isinstance(message, Mapping):
+                task = _first_text(message.get("content"))
+        if agent_type is not None and task is not None:
+            break
+    if agent_type is None and task is None:
+        return None
+    return SubagentRole(agent_type=agent_type, task=task)
+
+
+def _first_text(content: object) -> str | None:
+    """The first human-readable text in a message ``content`` (str or block list).
+
+    Tool-result blocks (role user, but ``type != "text"``) are skipped, so the
+    Task prompt — not a tool echo — is what surfaces.
+    """
+
+    if isinstance(content, str):
+        text = content.strip()
+        return text or None
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, Mapping) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    return text.strip()
+    return None
+
+
+def subagent_files_for_parent(
+    parent_client_session_id: str, *, projects_root: Path | str | None = None
+) -> dict[str, Path]:
+    """One glob → ``{agent_id: transcript_path}`` for every subagent of a parent.
+
+    Batches the filesystem cost: a parent with many children needs a single
+    directory scan instead of one glob per child. Returns ``{}`` on any absence
+    or error.
+    """
+
+    root = _resolve_root(projects_root)
+    if root is None or not parent_client_session_id:
+        return {}
+    # The parent id is a single path segment. Reject anything that could escape
+    # the tree, and glob.escape so a metacharacter (e.g. "*") matches literally
+    # instead of every parent — a crafted id must never read outside the root.
+    if any(ch in parent_client_session_id for ch in ("/", os.sep, "\x00")) or ".." in parent_client_session_id:
+        return {}
+    pattern = str(root / "*" / glob.escape(parent_client_session_id) / "subagents" / "agent-*.jsonl")
+    try:
+        matches = glob.glob(pattern)
+    except OSError:
+        return {}
+    try:
+        root_resolved = root.resolve()
+    except OSError:
+        return {}
+    files: dict[str, Path] = {}
+    for match in matches:
+        path = Path(match)
+        try:
+            if not path.resolve().is_relative_to(root_resolved):  # containment guard
+                continue
+        except (OSError, ValueError):
+            continue
+        files.setdefault(path.stem, path)  # stem == "agent-<hex>"
+    return files
+
+
+def read_subagent_role(
+    client_session_id: str, *, projects_root: Path | str | None = None
+) -> SubagentRole | None:
+    """Role + task for one child session id, or ``None`` (not a child / no file)."""
+
+    parts = _agent_id_from_child_session(client_session_id)
+    if parts is None:
+        return None
+    parent, agent_id = parts
+    files = subagent_files_for_parent(parent, projects_root=projects_root)
+    path = files.get(agent_id)
+    if path is None:
+        return None
+    return _extract_role(path)
+
+
+def read_roles_for_children(
+    parent_client_session_id: str,
+    child_session_ids: list[str],
+    *,
+    projects_root: Path | str | None = None,
+) -> dict[str, SubagentRole]:
+    """Roles for a set of a parent's children, using a single directory scan.
+
+    Keyed by the full child session id. Children with no locatable/parseable
+    transcript are simply absent from the result (fail-soft).
+    """
+
+    files = subagent_files_for_parent(parent_client_session_id, projects_root=projects_root)
+    if not files:
+        return {}
+    roles: dict[str, SubagentRole] = {}
+    for child_id in child_session_ids:
+        parts = _agent_id_from_child_session(child_id)
+        if parts is None:
+            continue
+        path = files.get(parts[1])
+        if path is None:
+            continue
+        role = _extract_role(path)
+        if role is not None:
+            roles[child_id] = role
+    return roles
+
+
+__all__ = [
+    "SCAN_ENV",
+    "ROOT_ENV",
+    "SubagentRole",
+    "scan_enabled",
+    "default_projects_root",
+    "subagent_files_for_parent",
+    "read_subagent_role",
+    "read_roles_for_children",
+]

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -30,13 +30,15 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
-from textual.widgets import DataTable, Footer, Header, Static
+from textual.widgets import Collapsible, DataTable, Footer, Header, LoadingIndicator, Static
 
 from .service import SentinelService
+from .subagent_roles import read_roles_for_children
 from .usage_snapshot import (
     LiveSnapshot,
     build_live_snapshot,
     cost_text,
+    finite,
     format_tokens,
     humanize_seconds,
     usage_bar,
@@ -121,6 +123,10 @@ class AgentAcctTUI(App):
     #byclient, #bymodel { height: auto; width: 1fr; }
     #bymodel { margin: 0 0 0 2; }
     #limits-body { padding: 0 0 1 0; }
+    #sessions-status { color: $text-muted; padding: 0 0 1 0; }
+    #sessions-loading { height: auto; }
+    #detail-header { padding: 0 1 1 1; }
+    #detail-scroll { padding: 0 1; }
     """
 
     BINDINGS = [
@@ -137,15 +143,23 @@ class AgentAcctTUI(App):
         client: str | None = None,
         window_token: str = "7d",
         refresh_seconds: float = 5.0,
+        subagent_projects_root: Path | str | None = None,
     ) -> None:
         super().__init__()
         self.store_dir = Path(store_dir)
         self.client = client
         self.window_token = window_token
         self.refresh_seconds = max(1.0, float(refresh_seconds))
+        # Where to read Claude subagent transcripts for child-session roles; None
+        # → the reader's default (~/.claude, gated by AGENTACCT_SCAN_SUBAGENT_ROLES).
+        # Tests point this at a tmp dir.
+        self.subagent_projects_root = subagent_projects_root
         self._snapshot: LiveSnapshot | None = None
         self._last_fingerprint: int | None = None
         self._last_refresh_at: float | None = None
+        # A manual `r` flashes the refreshed-stamp until this time, so a fast
+        # (often no-op) main-page refresh gives visible feedback.
+        self._flash_until: float = 0.0
         self._error: str | None = None
         # Work-ledger cache shared across the sessions/detail screens. The ledger
         # is EXPENSIVE (O(all events), no caching upstream — ~5s on ~8k events),
@@ -153,6 +167,9 @@ class AgentAcctTUI(App):
         # event log changes (fingerprint) or the user forces a refresh.
         self._work_ledger: dict | None = None
         self._work_ledger_fp: int | None = None
+        # Folded child (subagent) sessions, keyed by the parent's session_key;
+        # populated by the sessions screen, read by the detail screen.
+        self._children_by_parent: dict[str, list[dict]] = {}
         # Last composed text for each dynamic panel — a stable hook for headless
         # tests (avoids depending on Rich renderable internals).
         self._status_text: str = ""
@@ -261,7 +278,11 @@ class AgentAcctTUI(App):
             now = time.time()
             parts: list[str] = []
             if self._last_refresh_at is not None:
-                parts.append(f"refreshed {time.strftime('%H:%M:%S', time.localtime(self._last_refresh_at))}")
+                stamp = time.strftime("%H:%M:%S", time.localtime(self._last_refresh_at))
+                if now < self._flash_until:  # highlighted badge for ~1.2s after `r`
+                    parts.append(f"[black on green] ⟳ refreshed {stamp} [/]")
+                else:
+                    parts.append(f"refreshed {stamp}")
             if usage.as_of is not None:
                 parts.append(f"as of {humanize_seconds(now - usage.as_of)} ago")
             parts.append(f"{usage.usage_record_count} usage records")
@@ -385,6 +406,8 @@ class AgentAcctTUI(App):
     # -- actions ------------------------------------------------------------
 
     def action_refresh(self) -> None:
+        # Flash the refreshed-stamp so a fast (often unchanged) refresh is visible.
+        self._flash_until = time.time() + 1.2
         self.refresh_data(force=True)
 
     def action_cycle_window(self) -> None:
@@ -436,8 +459,24 @@ def _session_cost_text(usage: dict) -> str:
     )
 
 
+def _status_glyph(status: str) -> str:
+    if status in ("completed", "resolved", "handed_off"):
+        return "✓"
+    if status == "blocked":
+        return "⚠"
+    if status in ("started", "checkpoint"):
+        return "▶"
+    return "●"
+
+
+def _first_line(text: str, limit: int = 72) -> str:
+    line = str(text).strip().splitlines()[0] if str(text).strip() else ""
+    return line[:limit] + ("…" if len(line) > limit else "")
+
+
 class SessionsScreen(Screen):
-    """A list of sessions (from the work ledger); select one to drill in."""
+    """A list of TOP-LEVEL sessions (child/subagent sessions are folded into their
+    parent's detail); select one to drill in."""
 
     BINDINGS = [
         Binding("escape", "back", "Back"),
@@ -448,11 +487,13 @@ class SessionsScreen(Screen):
     def __init__(self) -> None:
         super().__init__()
         self._by_key: dict[str, dict] = {}
+        self._total_top = 0
         self._total_sessions = 0
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         yield Static("", id="sessions-status")
+        yield LoadingIndicator(id="sessions-loading")
         yield DataTable(id="sessions", cursor_type="row", zebra_stripes=True)
         yield Footer()
 
@@ -460,11 +501,17 @@ class SessionsScreen(Screen):
         self.title = "agentacct"
         self.sub_title = "sessions"
         table = self.query_one("#sessions", DataTable)
-        table.add_columns("session", "client", "project", "activity", "tokens", "est. cost", "steps")
-        self.query_one("#sessions-status", Static).update(
-            "Building the work ledger (one-time, a few seconds)…"
-        )
+        table.add_columns("session", "client", "project", "activity", "tokens", "est. cost", "steps", "⋔ sub")
+        self._set_loading(True, "Building the work ledger (one-time, a few seconds)…")
         self._load()
+
+    def _set_loading(self, loading: bool, message: str | None = None) -> None:
+        try:
+            self.query_one("#sessions-loading", LoadingIndicator).display = loading
+        except Exception:  # noqa: BLE001 - cosmetic only
+            pass
+        if message is not None:
+            self.query_one("#sessions-status", Static).update(message)
 
     @work(thread=True, exclusive=True)
     def _load(self, force: bool = False) -> None:
@@ -501,6 +548,7 @@ class SessionsScreen(Screen):
     def _show_error(self, message: str) -> None:
         if not self.is_mounted:  # a late callback must not touch a dismissed screen
             return
+        self._set_loading(False)
         self.query_one("#sessions-status", Static).update(
             f"[red]could not build the work ledger:[/] {_escape(message)}"
         )
@@ -509,10 +557,47 @@ class SessionsScreen(Screen):
         if not self.is_mounted:  # screen was dismissed before the build finished
             return
         sessions = list((ledger.get("session_rollup") or {}).get("sessions") or [])
-        # Most-recent first; unknown activity sorts last.
-        sessions.sort(key=lambda s: (s.get("last_activity_at") or 0.0), reverse=True)
         self._total_sessions = len(sessions)
-        shown = sessions[:_SESSIONS_LIMIT]
+
+        # Fold every subagent DESCENDANT under its top-most root session, so a run
+        # and all its (and its children's) subagents collapse to one row. Grouping
+        # follows the ledger's own rollup_group_key ("{client}::{parent}" for a
+        # child, else the session's own key), which already applies the parent
+        # source-namespace compatibility gate — the TUI never contradicts the
+        # ledger. The walk carries a visited-set: a parent cycle resolves to None
+        # so every session on it stays top-level (nothing can vanish), and an
+        # orphan chain (parent absent) stops at the top-most present ancestor.
+        by_session_key = {str(s.get("session_key")): s for s in sessions}
+
+        def _resolve_top(start: str) -> str | None:
+            seen: set[str] = set()
+            cur = start
+            while True:
+                node = by_session_key.get(cur)
+                if node is None:
+                    return cur
+                group = str(node.get("rollup_group_key") or cur)
+                if group == cur or group not in by_session_key:
+                    return cur  # a root, or the top-most present ancestor
+                if group in seen:
+                    return None  # cycle → keep this session top-level
+                seen.add(cur)
+                cur = group
+
+        children_by_parent: dict[str, list[dict]] = {}
+        top: list[dict] = []
+        for entry in sessions:
+            sk = str(entry.get("session_key"))
+            root = _resolve_top(sk)
+            if root is not None and root != sk:
+                children_by_parent.setdefault(root, []).append(entry)
+            else:
+                top.append(entry)
+        self.app._children_by_parent = children_by_parent
+
+        top.sort(key=lambda s: (s.get("last_activity_at") or 0.0), reverse=True)
+        self._total_top = len(top)
+        shown = top[:_SESSIONS_LIMIT]
 
         table = self.query_one("#sessions", DataTable)
         table.clear()
@@ -525,12 +610,11 @@ class SessionsScreen(Screen):
             counts = (entry.get("work") or {}).get("counts") or {}
             title = entry.get("client_session_title") or entry.get("client_session_id_short") or "(untitled)"
             steps = f"{counts.get('total', 0)}✓{counts.get('completed', 0)}"
-            active = counts.get("active", 0)
-            blocked = counts.get("blocked", 0)
-            if active:
-                steps += f" ▶{active}"
-            if blocked:
-                steps += f" ⚠{blocked}"
+            if counts.get("active", 0):
+                steps += f" ▶{counts.get('active', 0)}"
+            if counts.get("blocked", 0):
+                steps += f" ⚠{counts.get('blocked', 0)}"
+            n_children = len(children_by_parent.get(str(entry.get("session_key")), []))
             table.add_row(
                 _escape(str(title))[:48],
                 _escape(str(entry.get("client") or "")),
@@ -539,11 +623,15 @@ class SessionsScreen(Screen):
                 format_tokens(usage.get("total_tokens")),
                 _session_cost_text(usage),
                 steps,
+                str(n_children) if n_children else "",
                 key=key,
             )
-        cap = f" (showing most recent {_SESSIONS_LIMIT})" if self._total_sessions > _SESSIONS_LIMIT else ""
+        self._set_loading(False)
+        folded = self._total_sessions - self._total_top
+        cap = f" (showing most recent {_SESSIONS_LIMIT})" if self._total_top > _SESSIONS_LIMIT else ""
+        foldnote = f" · {folded} subagent sessions folded" if folded else ""
         self.query_one("#sessions-status", Static).update(
-            f"{self._total_sessions} sessions{cap} · Enter to open · r to rebuild · Esc back"
+            f"{self._total_top} sessions{cap}{foldnote} · Enter to open · r rebuild · Esc back"
         )
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
@@ -553,15 +641,19 @@ class SessionsScreen(Screen):
             self.app.push_screen(SessionDetailScreen(entry))
 
     def action_refresh(self) -> None:
-        self.query_one("#sessions-status", Static).update("Rebuilding the work ledger…")
+        self._set_loading(True, "Rebuilding the work ledger…")
         self._load(force=True)
 
     def action_back(self) -> None:
         self.app.pop_screen()
 
 
+# How many child sessions to render (with role lookups) in a parent's detail.
+_DETAIL_CHILDREN_LIMIT = 25
+
+
 class SessionDetailScreen(Screen):
-    """One session's steps (work items) and their machine-check results."""
+    """One session's steps (work items) + check results + its subagents."""
 
     BINDINGS = [
         Binding("escape", "back", "Back"),
@@ -572,80 +664,148 @@ class SessionDetailScreen(Screen):
     def __init__(self, entry: dict) -> None:
         super().__init__()
         self._entry = entry
-        # Composed text kept for headless tests (Rich renderable internals are
-        # not a stable assertion target).
+        # Composed text kept for headless tests (Rich renderable internals are not
+        # a stable assertion target).
         self._header_text = ""
         self._body_text = ""
+        self._subagents_text = ""
 
     def compose(self) -> ComposeResult:
+        entry = self._entry
+        now = time.time()
         yield Header(show_clock=True)
-        yield Static("", id="detail-header")
-        with VerticalScroll():
-            yield Static("", id="detail-body")
+        yield Static(self._render_header(entry, now), id="detail-header")
+        with VerticalScroll(id="detail-scroll"):
+            steps = self._steps()
+            if not steps:
+                yield Static(
+                    "[dim]No recorded work steps — steps come from MCP section/check "
+                    "events; a usage-only session has none.[/]",
+                    id="detail-nosteps",
+                )
+            for wi in steps:
+                title_line, content = self._step_render(wi, now)
+                self._body_text += title_line + "\n" + content + "\n"
+                yield Collapsible(Static(content), title=title_line, collapsed=True)
+            children = self._children()
+            if children:
+                subtitle, content = self._subagents_render(
+                    entry, children, now, getattr(self.app, "subagent_projects_root", None)
+                )
+                self._subagents_text = content
+                yield Collapsible(Static(content), title=subtitle, collapsed=True, id="subagents")
         yield Footer()
 
     def on_mount(self) -> None:
-        entry = self._entry
         self.title = "agentacct"
         self.sub_title = "session detail"
-        client = entry.get("client")
-        session_id = entry.get("client_session_id")
+
+    # -- data ---------------------------------------------------------------
+
+    def _steps(self) -> list[dict]:
+        ledger = getattr(self.app, "_work_ledger", None) or {}
+        client = self._entry.get("client")
+        sid = self._entry.get("client_session_id")
+        return [wi for wi in (ledger.get("work_items") or []) if _session_matches(wi, client, sid)]
+
+    def _children(self) -> list[dict]:
+        index = getattr(self.app, "_children_by_parent", {}) or {}
+        kids = list(index.get(str(self._entry.get("session_key")), []))
+        kids.sort(key=lambda s: ((s.get("usage") or {}).get("total_tokens") or 0), reverse=True)
+        return kids
+
+    # -- rendering ----------------------------------------------------------
+
+    def _render_header(self, entry: dict, now: float) -> str:
         title = entry.get("client_session_title") or entry.get("client_session_id_short") or "(untitled)"
         usage = entry.get("usage") or {}
-        now = time.time()
-
         header = f"[bold]{_escape(str(title))}[/]"
-        header += f"\n{_escape(str(client or ''))} · {_escape(str(entry.get('project') or '—'))}"
-        first, last = entry.get("first_activity_at"), entry.get("last_activity_at")
-        if isinstance(first, (int, float)) and isinstance(last, (int, float)) and first and last:
+        header += f"\n{_escape(str(entry.get('client') or ''))} · {_escape(str(entry.get('project') or '—'))}"
+        last = entry.get("last_activity_at")
+        if isinstance(last, (int, float)) and last:
             header += f" · {_humanize_ago(last, now)}"
-        header += (
-            f" · {format_tokens(usage.get('total_tokens'))} tokens"
-            f" · {_session_cost_text(usage)}"
-        )
+        header += f" · {format_tokens(usage.get('total_tokens'))} tokens · {_session_cost_text(usage)}"
         self._header_text = header
-        self.query_one("#detail-header", Static).update(header)
+        return header
 
-        ledger = getattr(self.app, "_work_ledger", None) or {}
-        work_items = [
-            wi for wi in (ledger.get("work_items") or []) if _session_matches(wi, client, session_id)
-        ]
-        self._body_text = self._render_steps(work_items, now)
-        self.query_one("#detail-body", Static).update(self._body_text)
+    def _step_render(self, wi: dict, now: float) -> tuple[str, str]:
+        status = str(wi.get("latest_status") or "?")
+        title = wi.get("title") or wi.get("section_id") or "(untitled step)"
+        kind = str(wi.get("kind") or "")
+        checks = [e for e in (wi.get("evidence_events") or []) if isinstance(e, dict)]
+        # Collapsible title is plain (escaped) — no color, so it can't break markup.
+        parts = [status, kind, _humanize_ago(wi.get("updated_at"), now)]
+        if checks:
+            parts.append(f"{len(checks)} checks")
+        title_line = f"{_status_glyph(status)} {_escape(str(title))}  — {_escape(' · '.join(p for p in parts if p))}"
 
-    def _render_steps(self, work_items: list[dict], now: float) -> str:
-        if not work_items:
-            return (
-                "No recorded work steps for this session.\n"
-                "[dim]Steps come from MCP section/check events; a usage-only session has none.[/]"
-            )
         lines: list[str] = []
-        for wi in work_items:
-            status = str(wi.get("latest_status") or "?")
-            color = _work_status_color(status)
-            title = wi.get("title") or wi.get("section_id") or "(untitled step)"
-            kind = str(wi.get("kind") or "")
-            meta = " · ".join(p for p in (_escape(kind) if kind else "", status, _humanize_ago(wi.get("updated_at"), now)) if p)
-            lines.append(f"[{color}]●[/] [bold]{_escape(str(title))}[/]  [dim]{meta}[/]")
-            summary = wi.get("summary")
-            if summary:
-                lines.append(f"    [dim]{_escape(str(summary))}[/]")
-            for ev in wi.get("evidence_events") or []:
-                if not isinstance(ev, dict):
-                    continue
-                mark, mcolor = _evidence_mark(str(ev.get("result") or ""))
-                etype = _escape(str(ev.get("evidence_type") or "check"))
-                summ = _escape(str(ev.get("summary") or ev.get("result") or ""))
-                cline = f"    [{mcolor}]{mark}[/] {etype}: {summ}"
-                exit_code = ev.get("exit_code")
-                if isinstance(exit_code, int):
-                    cline += f" [dim](exit {exit_code})[/]"
-                lines.append(cline)
-            blocker = wi.get("blocker")
-            if blocker:
-                lines.append(f"    [red]⚠ blocked:[/] {_escape(str(blocker))}")
-            lines.append("")
-        return "\n".join(lines).rstrip("\n")
+        summary = wi.get("summary")
+        if summary:
+            lines.append(f"[dim]{_escape(str(summary))}[/]")
+        for ev in checks:
+            mark, mcolor = _evidence_mark(str(ev.get("result") or ""))
+            etype = _escape(str(ev.get("evidence_type") or "check"))
+            summ = _escape(str(ev.get("summary") or ev.get("result") or ""))
+            cline = f"[{mcolor}]{mark}[/] {etype}: {summ}"
+            exit_code = ev.get("exit_code")
+            if isinstance(exit_code, int):
+                cline += f" [dim](exit {exit_code})[/]"
+            lines.append(cline)
+        blocker = wi.get("blocker")
+        if blocker:
+            lines.append(f"[red]⚠ blocked:[/] {_escape(str(blocker))}")
+        return title_line, ("\n".join(lines) if lines else "[dim](no summary or checks)[/]")
+
+    def _subagents_render(
+        self, entry: dict, children: list[dict], now: float, projects_root=None
+    ) -> tuple[str, str]:
+        # Aggregate over the folded set actually listed (all descendants), so the
+        # subtitle count and totals are self-consistent — the ledger's
+        # related.children_usage counts only DIRECT children and would disagree.
+        total = len(children)
+        agg_tokens = sum(int((c.get("usage") or {}).get("total_tokens") or 0) for c in children)
+        agg_cost = 0.0
+        any_cost = False
+        for c in children:
+            value = finite((c.get("usage") or {}).get("estimated_cost_usd"))
+            if value is not None:
+                agg_cost += value
+                any_cost = True
+        subtitle = f"⋔ Subagents ({total}) — {format_tokens(agg_tokens)} tok"
+        if any_cost:
+            subtitle += f" · ~${agg_cost:.2f}"
+
+        shown = children[:_DETAIL_CHILDREN_LIMIT]
+        child_ids = [str(c.get("client_session_id")) for c in shown]
+        roles = read_roles_for_children(
+            str(entry.get("client_session_id")), child_ids, projects_root=projects_root
+        )
+
+        lines: list[str] = []
+        for child in shown:
+            cid = str(child.get("client_session_id"))
+            usage = child.get("usage") or {}
+            counts = (child.get("work") or {}).get("counts") or {}
+            role = roles.get(cid)
+            role_type = (role.agent_type if role and role.agent_type else child.get("session_kind") or "subagent")
+            models = child.get("observed_models") or []
+            model = _escape(str(models[0])) if models else ""
+            head = f"[bold]{_escape(str(role_type))}[/]"
+            if role and role.task:
+                head += f" [dim]{_escape(_first_line(role.task))}[/]"
+            meta = " · ".join(
+                p for p in (
+                    f"{format_tokens(usage.get('total_tokens'))} tok",
+                    _session_cost_text(usage),
+                    model,
+                    (f"{counts.get('total', 0)} steps" if counts.get("total") else ""),
+                ) if p
+            )
+            lines.append(f"{head}\n    [dim]{meta}[/]")
+        if total > len(shown):
+            lines.append(f"[dim]… and {total - len(shown)} more (by token volume)[/]")
+        return subtitle, "\n".join(lines)
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,22 @@ def _disable_global_provider_limit_scan(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 @pytest.fixture(autouse=True)
+def _disable_global_subagent_role_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the machine-GLOBAL subagent-role transcript scan off for every test.
+
+    The TUI reads Claude subagent transcripts (``~/.claude/projects/.../subagents``)
+    to show a child session's role/task. Hermetic tests must never read the
+    developer's real machine, so ``AGENTACCT_SCAN_SUBAGENT_ROLES`` is pinned off
+    (a test that needs roles passes an explicit ``projects_root`` / sets
+    ``AGENTACCT_CLAUDE_PROJECTS_ROOT`` at a tmp dir). Also clear any real root
+    override that might leak in from the environment.
+    """
+
+    monkeypatch.setenv("AGENTACCT_SCAN_SUBAGENT_ROLES", "0")
+    monkeypatch.delenv("AGENTACCT_CLAUDE_PROJECTS_ROOT", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _allow_test_client_host(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep Starlette TestClient's default ``Host: testserver`` working.
 

--- a/tests/test_subagent_roles.py
+++ b/tests/test_subagent_roles.py
@@ -1,0 +1,113 @@
+"""Tests for the subagent role/task reader (Claude child transcripts)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agentacct import subagent_roles as sr
+
+
+def _write_transcript(root: Path, project: str, parent: str, agent_id: str, *, attribution, task_text, extra=None):
+    directory = root / project / parent / "subagents"
+    directory.mkdir(parents=True, exist_ok=True)
+    lines = [
+        {"type": "summary", "summary": "meta line, skipped"},
+        {"attributionAgent": attribution, "type": "assistant"} if attribution else {"type": "assistant"},
+        # a tool_result user message (role user, but not text) must be skipped
+        {"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "content": "echo"}]}},
+        {"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": task_text}]}},
+    ]
+    (directory / f"{agent_id}.jsonl").write_text(
+        "\n".join(json.dumps(line) for line in lines), encoding="utf-8"
+    )
+
+
+def test_read_subagent_role_from_transcript(tmp_path):
+    root = tmp_path / "projects"
+    parent, agent = "p-123", "agent-deadbeef"
+    _write_transcript(root, "proj-A", parent, agent, attribution="Explore", task_text="Investigate the thing")
+    role = sr.read_subagent_role(f"{parent}:{agent}", projects_root=root)
+    assert role is not None
+    assert role.agent_type == "Explore"
+    assert role.task == "Investigate the thing"  # first user TEXT (tool_result skipped)
+
+
+def test_read_subagent_role_non_child_and_missing(tmp_path):
+    root = tmp_path / "projects"
+    assert sr.read_subagent_role("plain-session-id", projects_root=root) is None  # no ':agent-'
+    assert sr.read_subagent_role("p1:agent-missing", projects_root=root) is None  # no file
+
+
+def test_subagent_role_scan_gate(tmp_path):
+    # conftest pins AGENTACCT_SCAN_SUBAGENT_ROLES off. An explicit root bypasses
+    # the gate; no root + scan off returns None (never reads the real machine).
+    root = tmp_path / "projects"
+    _write_transcript(root, "P", "par", "agent-x", attribution="Plan", task_text="t")
+    assert sr.read_subagent_role("par:agent-x", projects_root=root).agent_type == "Plan"
+    assert sr.read_subagent_role("par:agent-x") is None  # scan disabled, no explicit root
+
+
+def test_read_roles_for_children_single_scan(tmp_path):
+    root = tmp_path / "projects"
+    parent = "par"
+    _write_transcript(root, "P", parent, "agent-1", attribution="Explore", task_text="A")
+    _write_transcript(root, "P", parent, "agent-2", attribution="general-purpose", task_text="B")
+    children = [f"{parent}:agent-1", f"{parent}:agent-2", f"{parent}:agent-missing", "not-a-child"]
+    roles = sr.read_roles_for_children(parent, children, projects_root=root)
+    assert set(roles.keys()) == {f"{parent}:agent-1", f"{parent}:agent-2"}
+    assert roles[f"{parent}:agent-1"].agent_type == "Explore"
+    assert roles[f"{parent}:agent-2"].task == "B"
+
+
+def test_read_subagent_role_survives_malformed(tmp_path):
+    root = tmp_path / "projects"
+    directory = root / "P" / "par" / "subagents"
+    directory.mkdir(parents=True)
+    (directory / "agent-x.jsonl").write_text(
+        "not json\n"
+        "[1,2,3]\n"
+        '{"type":"user","message":{"role":"user","content":"hi there"}}\n',
+        encoding="utf-8",
+    )
+    role = sr.read_subagent_role("par:agent-x", projects_root=root)
+    assert role is not None
+    assert role.agent_type is None  # no attributionAgent present
+    assert role.task == "hi there"  # string content is accepted
+
+
+def test_read_subagent_role_survives_binary(tmp_path):
+    # A corrupted/binary transcript (or a torn multi-byte char in one still being
+    # written) must not raise UnicodeDecodeError — the read is byte-bounded and
+    # errors="replace". Valid lines before the garbage are still parsed.
+    root = tmp_path / "projects"
+    directory = root / "P" / "par" / "subagents"
+    directory.mkdir(parents=True)
+    (directory / "agent-x.jsonl").write_bytes(
+        json.dumps({"attributionAgent": "Explore"}).encode() + b"\n\xff\xfe bad bytes \x80\n"
+    )
+    role = sr.read_subagent_role("par:agent-x", projects_root=root)  # must not raise
+    assert role is not None and role.agent_type == "Explore"
+
+
+def test_subagent_files_for_parent_rejects_traversal_and_metachars(tmp_path):
+    root = tmp_path / "projects"
+    directory = root / "proj" / "par" / "subagents"
+    directory.mkdir(parents=True)
+    (directory / "agent-1.jsonl").write_text("{}", encoding="utf-8")
+    # a well-formed parent still resolves
+    assert set(sr.subagent_files_for_parent("par", projects_root=root).keys()) == {"agent-1"}
+    # '*' must NOT match every parent (glob.escape → literal)
+    assert sr.subagent_files_for_parent("*", projects_root=root) == {}
+    # traversal ids are rejected outright (never read outside the root)
+    assert sr.subagent_files_for_parent("../../etc", projects_root=root) == {}
+    assert sr.read_roles_for_children("../../x", ["../../x:agent-z"], projects_root=root) == {}
+
+
+def test_subagent_files_for_parent_batches(tmp_path):
+    root = tmp_path / "projects"
+    _write_transcript(root, "P", "par", "agent-1", attribution="Explore", task_text="A")
+    _write_transcript(root, "P", "par", "agent-2", attribution="Plan", task_text="B")
+    files = sr.subagent_files_for_parent("par", projects_root=root)
+    assert set(files.keys()) == {"agent-1", "agent-2"}
+    assert sr.subagent_files_for_parent("nope", projects_root=root) == {}

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -403,7 +403,7 @@ def test_tui_work_helpers():
     assert not _session_matches({"client": "codex", "client_session_id": "s2"}, "codex", "s1")
 
 
-def test_session_detail_render_steps_and_markup_safe():
+def test_session_detail_step_render_and_markup_safe():
     from rich.text import Text
 
     now = time.time()
@@ -413,8 +413,11 @@ def test_session_detail_render_steps_and_markup_safe():
         "evidence_events": [{"result": "passed", "evidence_type": "test", "summary": "all green", "exit_code": 0}],
     }
     screen = SessionDetailScreen({})
-    txt = screen._render_steps([good], now)
-    assert "Ship it" in txt and "✓" in txt and "exit 0" in txt
+    title_line, content = screen._step_render(good, now)
+    assert "Ship it" in title_line and "✓" in title_line  # status glyph in the collapsible title
+    assert "all green" in content and "exit 0" in content
+    Text.from_markup(title_line)  # valid markup
+    Text.from_markup(content)
 
     # markup injection in any data field must yield VALID markup (escaped), never crash.
     evil = {
@@ -422,11 +425,108 @@ def test_session_detail_render_steps_and_markup_safe():
         "summary": "[/]bad", "blocker": "[/]boom",
         "evidence_events": [{"result": "failed", "evidence_type": "y[/]", "summary": "[/]z", "exit_code": 1}],
     }
-    etxt = screen._render_steps([evil], now)
-    Text.from_markup(etxt)  # raises MarkupError if any field were left unescaped
-    assert "pwn" in etxt
+    t2, c2 = screen._step_render(evil, now)
+    Text.from_markup(t2)  # raises MarkupError if a field were left unescaped
+    Text.from_markup(c2)
+    assert "pwn" in t2 and "boom" in c2
 
-    assert "No recorded work steps" in screen._render_steps([], now)
+
+def test_sessions_screen_folds_children(tmp_path):
+    # Child sessions (related.parent present) must be folded out of the top-level
+    # list and indexed under their parent for the detail.
+    SentinelService(tmp_path)  # empty store so the worker builds an empty ledger fast
+
+    # Folding keys on the ledger's authoritative rollup_group_key (a child's ==
+    # "{client}::{parent}"; a root's == its own session_key).
+    fake_ledger = {"session_rollup": {"sessions": [
+        {"client": "cc", "client_session_id": "P", "session_key": "cc::P", "rollup_group_key": "cc::P",
+         "client_session_title": "Parent",
+         "usage": {"total_tokens": 100}, "work": {"counts": {"total": 1, "completed": 1}}},
+        {"client": "cc", "client_session_id": "P:agent-1", "session_key": "cc::P:agent-1", "rollup_group_key": "cc::P",
+         "session_kind": "child",
+         "usage": {"total_tokens": 9000}, "work": {"counts": {}}},
+    ]}}
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("s")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            scr = app.screen
+            scr._populate(fake_ledger)  # inject a parent+child ledger
+            table = scr.query_one("#sessions", DataTable)
+            assert table.row_count == 1  # only the parent is top-level
+            assert "cc::P" in app._children_by_parent  # keyed by parent session_key
+            assert len(app._children_by_parent["cc::P"]) == 1
+
+    _run(scenario())
+
+
+def test_sessions_screen_folding_multilevel_and_cycle_safe(tmp_path):
+    # Multi-level folding (grandchildren fold under their top-most root too) +
+    # cycle safety (a mutual parent cycle folds neither side, so nothing vanishes).
+    SentinelService(tmp_path)
+
+    def s(csid, group):
+        return {"client": "cc", "client_session_id": csid, "session_key": f"cc::{csid}",
+                "rollup_group_key": f"cc::{group}", "usage": {}, "work": {"counts": {}}}
+
+    fake = {"session_rollup": {"sessions": [
+        s("R", "R"),        # root
+        s("C", "R"),        # child of root R      → folds under R
+        s("G", "C"),        # grandchild (parent C) → also folds under R (top-most)
+        s("A", "B"),        # cycle A<->B
+        s("B", "A"),
+    ]}}
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("s")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            scr = app.screen
+            scr._populate(fake)
+            top = set(scr._by_key.keys())
+            assert scr.query_one("#sessions", DataTable).row_count == 3  # R, A, B
+            assert "cc::R" in top
+            assert "cc::C" not in top and "cc::G" not in top  # both fold under root R
+            assert "cc::A" in top and "cc::B" in top  # cycle: neither vanishes
+            assert {c["client_session_id"] for c in app._children_by_parent.get("cc::R", [])} == {"C", "G"}
+
+    _run(scenario())
+
+
+def test_subagents_render_reads_roles(tmp_path):
+    # 3b: the detail's Subagents section reads each child's role/task on the fly
+    # from its transcript on disk.
+    import json as _json
+
+    root = tmp_path / "projects"
+    directory = root / "proj" / "P" / "subagents"
+    directory.mkdir(parents=True)
+    (directory / "agent-1.jsonl").write_text(
+        _json.dumps({"attributionAgent": "Explore", "type": "assistant"}) + "\n"
+        + _json.dumps({"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": "Map the data layer"}]}}) + "\n",
+        encoding="utf-8",
+    )
+    entry = {"client": "cc", "client_session_id": "P",
+             "related": {"children_usage": {"total_tokens": 9000, "estimated_cost_usd": 2.0, "priced_rows": 1}}}
+    children = [{
+        "client_session_id": "P:agent-1", "session_kind": "child",
+        "usage": {"total_tokens": 9000, "estimated_cost_usd": 2.0, "priced_rows": 1},
+        "observed_models": ["claude-fable-5"], "work": {"counts": {"total": 0}},
+    }]
+    screen = SessionDetailScreen(entry)
+    subtitle, content = screen._subagents_render(entry, children, time.time(), projects_root=root)
+    assert "Subagents (1)" in subtitle
+    assert "9,000 tok" in subtitle  # aggregated child usage
+    assert "Explore" in content  # role type from the transcript
+    assert "Map the data layer" in content  # task from the transcript
+    assert "9,000 tok" in content
 
 
 def test_sessions_screen_worker_and_detail(tmp_path):


### PR DESCRIPTION
## Summary

Follow-up polish to the `agentacct tui` sessions drill-down, from live feedback on
#43. Four things:

1. **Refresh progress feedback.** The sessions rebuild (the one slow, ~5s
   `build_work_ledger` call) now shows a loading indicator; a manual `r` on the
   dashboard flashes the refreshed-stamp so a fast, unchanged refresh is visible.
   (The ledger build has no sub-progress, so the sessions indicator is
   indeterminate — an honest spinner, not a fake percentage.)
2. **Child/subagent sessions are folded.** The sessions list showed every session
   flat — a run with dozens of subagents was dozens of rows. Now child sessions
   fold under their top-most root session (following the ledger's own
   `rollup_group_key` grouping, **multi-level and cycle-safe**), with a `⋔ sub`
   count column. On the real store this drops the top-level list from **2638 → 174**.
3. **Subagents are meaningful.** Opening a session shows a **Subagents** section
   listing each child with its **role and task** — read on the fly from the child's
   local transcript (`attributionAgent` + the Task prompt), e.g. `Explore ·
   "Read-only investigation of the agentacct repo…" · 1.7M tok · $1.70`. This is
   the same "read the local files the agent already wrote" pattern as `limits`: no
   credentials, no API, no re-import (agentacct doesn't record subagent roles, but
   the transcripts on disk have them).
4. **Detail restructured.** The session detail was a wall of text; it's now a
   header panel plus one **collapsible per step** (status + title collapsed; expand
   for the summary and colored check results), then the Subagents section.

## What's in here

- `src/agentacct/subagent_roles.py` — new decoupled reader for a child's role/task.
  Fail-soft, byte-bounded, UTF-8-tolerant, path-contained; env-gated
  (`AGENTACCT_SCAN_SUBAGENT_ROLES`, pinned off in tests).
- `src/agentacct/tui.py` — folding, the Subagents section, the collapsible detail,
  and the progress indicators.
- `tests/test_subagent_roles.py`, `tests/test_tui.py`, `tests/conftest.py` (scan pin).

## Adversarial review

Multi-lens review (find → independently verify), all confirmed issues fixed:

- **HIGH** — a binary/invalid-UTF-8 transcript (e.g. a torn multi-byte char in a
  subagent that is still writing) raised `UnicodeDecodeError` past the reader's
  `except OSError` and crashed the detail on the UI thread → the read is now
  byte-bounded with `errors="replace"`.
- **MEDIUM ×2** — folding re-derived parent links and ignored the ledger's
  namespace-compatibility refusal, hiding sessions the ledger treats as top-level
  → folding now keys on the ledger's own `rollup_group_key`.
- **LOW ×3** — glob path-traversal / metachar (`glob.escape` + containment check),
  an unbounded single-line read (byte cap), and a folding cycle that could hide
  both sides (visited-set guard). All fixed + regression-tested.
- The "blocking filesystem I/O in compose" concern was investigated and **rejected**
  — the single-glob + 25-child cap keeps it well under a frame.

## Tests

- `.venv/bin/pytest -q` (plain, CI-matching): **3002 passed, 1 skipped**.
- New coverage: reader (role/task extraction, binary/malformed tolerance, glob
  containment, batch), folding (multi-level, cycle-safe, ledger-key grouping),
  the Subagents section reading roles, and the progress/flash behavior.

## Not included (owner-gated)

No release and no deploy. Note: on the live runtime the provider-limit and
subagent-role data only fully populate once the phase-B code is deployed and
`usage watch` has run; against the current store, usage/cost/folding/roles all
work (roles read straight from `~/.claude` transcripts).
