### PR TITLE
fix(tui): freshen usage on launch/refresh; state record_section required args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`agentacct tui` freshens usage on launch and refresh.** The TUI now imports
+  usage from the client session logs in the background when it opens and on `r`
+  (the same scan the HTML dashboard did on Refresh), so the session you're in —
+  and a session you just started — show real token usage instead of zero. Runs
+  off the refresh timer, in a worker, and only when enabled (so it never scans on
+  every tick).
 - **`agentacct tui` sessions drill-down — folded subagents, roles, and a
   restructured detail.** The sessions list now shows only top-level sessions —
   child/subagent sessions are folded under their parent (a `⋔ sub` count column),
@@ -74,6 +80,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   single internal data layer (`agentacct.usage_snapshot`), so the three surfaces
   derive usage, cost, and rate-limit readings from one place and can never
   disagree. No change to `now` / `limits` output.
+
+### Fixed
+- **`agentacct_record_section` guidance now states its required arguments.** The
+  onboarding/instruction prose named `section_title` / `section_status` but not
+  that `source` and a stable `section_id` are also required, so some agents (e.g.
+  Codex) omitted them and the call failed. The shared instruction line — used by
+  the live MCP server instructions, the Claude Code SessionStart context, and the
+  on-disk `CLAUDE.md` / `AGENTS.md` — now lists all required args with a concrete
+  example.
 
 ## [0.6.0] - 2026-08-01
 

--- a/src/agentacct/install_guide.py
+++ b/src/agentacct/install_guide.py
@@ -262,7 +262,7 @@ _RECORDING_CONTRACT_LINES = (
     # outright ("unexpected argument(s): title"), so the instruction shipped a
     # call that could not succeed. mcp.py now also accepts `title` as an alias,
     # which is what keeps already-rendered CLAUDE.md/AGENTS.md files working.
-    "- Open a section with `agentacct_record_section` (`section_status=started`) BEFORE your first other tool call, and again before each meaningful task; set `section_title` to a short human goal (e.g. \"add rate-limit to login\"). Complete it (`section_status=completed`) or block it (`blocked`) when done.",
+    "- Open a section with `agentacct_record_section` BEFORE your first other tool call, and again before each meaningful task. REQUIRED args: `source` (your client name, e.g. \"codex\" or \"claude-code\"), a stable `section_id` (reuse the SAME id across this section's started/checkpoint/completed calls), and `section_status`; also set `section_title` to a short human goal. Start with `section_status=started`; finish with `completed` (or `blocked`). Example: agentacct_record_section(source=\"codex\", section_id=\"add-rate-limit\", section_status=\"started\", section_title=\"add rate-limit to login\").",
     "- For a long task, send `section_status=checkpoint` updates rather than one giant section.",
     "- When the user hands the work off or says they are continuing in a new session, record the section as `section_status=handed_off` (a clean stop) — do not leave it `started`/`checkpoint`.",
     "- After running tests or a build, record the objective result with `agentacct_record_machine_check`.",

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -21,6 +21,7 @@ The whole thing is headless-testable with Textual's ``App.run_test()`` — see
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 
@@ -46,6 +47,18 @@ from .usage_snapshot import (
 
 # The window tokens the `w` key cycles through (same vocabulary as `now --window`).
 _WINDOW_CYCLE: tuple[str, ...] = ("today", "7d", "30d", "all")
+
+# The TUI freshens the store from the client session files on launch/refresh (like
+# the HTML dashboard's Refresh) so the in-flight session shows real usage. Pinned
+# off in tests so they never scan the developer's real ~/.claude / ~/.codex.
+_AUTO_IMPORT_ENV = "AGENTACCT_TUI_AUTO_IMPORT"
+
+
+def _auto_import_enabled() -> bool:
+    value = os.environ.get(_AUTO_IMPORT_ENV)
+    if value is None:
+        return True
+    return value.strip().lower() not in ("0", "false", "no", "off")
 
 # The sessions drill-down shows the most-recent slice; the full count is always
 # reported so the cap is never silent.
@@ -160,6 +173,7 @@ class AgentAcctTUI(App):
         # A manual `r` flashes the refreshed-stamp until this time, so a fast
         # (often no-op) main-page refresh gives visible feedback.
         self._flash_until: float = 0.0
+        self._importing: bool = False
         self._error: str | None = None
         # Work-ledger cache shared across the sessions/detail screens. The ledger
         # is EXPENSIVE (O(all events), no caching upstream — ~5s on ~8k events),
@@ -200,9 +214,52 @@ class AgentAcctTUI(App):
         self.query_one("#windows", DataTable).add_columns("window", "tokens", "est. cost", "sessions")
         self.query_one("#byclient", DataTable).add_columns("client", "tokens", "est. cost", "sessions")
         self.query_one("#bymodel", DataTable).add_columns("model", "client", "tokens", "est. cost")
-        self.refresh_data(force=True)
+        self.refresh_data(force=True)  # show the stored view instantly
+        self._start_import()  # then freshen it from the client logs in the background
         self.set_interval(self.refresh_seconds, self.refresh_data)
         self.set_interval(1.0, self._tick_countdowns)
+
+    # -- usage import (store freshness) -------------------------------------
+
+    def _start_import(self) -> None:
+        """Kick a background usage import so the in-flight session shows real usage.
+
+        Off (env-gated) → no-op, so the auto-refresh timer never triggers a scan
+        and tests never read the developer's real client logs.
+
+        Never launches a second import while one is in flight: the importer mutates
+        a PROCESS-GLOBAL pricing catalog (env + cache) and restores it on exit, so
+        two overlapping imports would corrupt each other's pricing and persist
+        mis-priced rows. `exclusive=True` on the worker cannot prevent this (a
+        running thread can't be cancelled mid-call), so we gate here. ``_importing``
+        is only ever mutated on the main thread (here and in ``_on_import_done``),
+        so the guard is race-free without a lock.
+        """
+
+        if self._importing or not _auto_import_enabled():
+            return
+        self._importing = True
+        self._render_status()
+        self._import_usage()
+
+    @work(thread=True, exclusive=True, group="import")
+    def _import_usage(self) -> None:
+        from textual.worker import get_current_worker
+
+        worker = get_current_worker()
+        try:
+            from .cli import _local_usage_import_payload
+
+            _local_usage_import_payload(store_dir=self.store_dir, client="all", estimate_costs=True)
+        except Exception:  # noqa: BLE001 - freshness is best-effort; never crash the UI.
+            pass
+        if worker.is_cancelled:
+            return
+        self.call_from_thread(self._on_import_done)
+
+    def _on_import_done(self) -> None:
+        self._importing = False
+        self.refresh_data(force=True)
 
     # -- data ---------------------------------------------------------------
 
@@ -290,6 +347,8 @@ class AgentAcctTUI(App):
             if self.client:
                 parts.append(f"client: {_escape(self.client)}")
             parts.append(f"store: {store}")
+            if self._importing:
+                parts.append("[yellow]⟳ importing usage…[/]")
             text = "  ·  ".join(parts)
         self._status_text = text
         self.query_one("#status", Static).update(text)
@@ -409,6 +468,7 @@ class AgentAcctTUI(App):
         # Flash the refreshed-stamp so a fast (often unchanged) refresh is visible.
         self._flash_until = time.time() + 1.2
         self.refresh_data(force=True)
+        self._start_import()  # also re-scan the client logs for fresh usage
 
     def action_cycle_window(self) -> None:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,20 @@ def _disable_global_subagent_role_scan(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _disable_tui_auto_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the TUI's launch/refresh usage import off for every test.
+
+    The TUI freshens the store from the client session files (~/.claude, ~/.codex,
+    …) on launch/`r` — a hermetic test must never scan the developer's real logs.
+    A test exercising the import opts in with
+    ``monkeypatch.setenv("AGENTACCT_TUI_AUTO_IMPORT", "1")`` and monkeypatches the
+    importer so it writes only to its tmp store.
+    """
+
+    monkeypatch.setenv("AGENTACCT_TUI_AUTO_IMPORT", "0")
+
+
+@pytest.fixture(autouse=True)
 def _allow_test_client_host(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep Starlette TestClient's default ``Host: testserver`` working.
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -612,6 +612,91 @@ def test_sessions_screen_empty_store(tmp_path):
     _run(scenario())
 
 
+def test_tui_auto_imports_usage_on_launch(tmp_path, monkeypatch):
+    # #1/#3: the TUI freshens the store from the client logs on launch, so the
+    # in-flight session's usage shows even if it wasn't imported yet. Stub the
+    # importer so it writes into the tmp store (no real client-log scan).
+    import agentacct.cli as cli_mod
+
+    monkeypatch.setenv("AGENTACCT_TUI_AUTO_IMPORT", "1")  # opt in (conftest pins off)
+    SentinelService(tmp_path)  # empty store initially
+    now = time.time()
+
+    def fake_import(*, store_dir, client, estimate_costs=False, **kwargs):
+        _record_usage(SentinelService(store_dir), client="claude-code", model="claude-opus-4-8",
+                      session_id="live-1", input_tokens=1000, output_tokens=200,
+                      updated_at=int(now - 60), estimated_cost_usd=3.0)
+        return {}
+
+    monkeypatch.setattr(cli_mod, "_local_usage_import_payload", fake_import)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.workers.wait_for_complete()  # let the import worker finish
+            await pilot.pause()
+            assert app._snapshot is not None
+            assert app._snapshot.usage.usage_record_count >= 1  # imported usage now shows
+
+    _run(scenario())
+
+
+def test_tui_serializes_concurrent_imports(tmp_path, monkeypatch):
+    # Regression: pressing r during the launch import must NOT start a second,
+    # overlapping import — overlapping imports corrupt the process-global pricing
+    # catalog (env + cache restored on exit) and persist mis-priced rows.
+    import threading
+    import agentacct.cli as cli_mod
+
+    monkeypatch.setenv("AGENTACCT_TUI_AUTO_IMPORT", "1")
+    SentinelService(tmp_path)
+    gate = threading.Event()
+    calls = {"n": 0}
+
+    def blocking_import(*, store_dir, client, estimate_costs=False, **kwargs):
+        calls["n"] += 1
+        gate.wait(timeout=5)  # hold this import "in flight"
+        return {}
+
+    monkeypatch.setattr(cli_mod, "_local_usage_import_payload", blocking_import)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()  # on_mount launches import #1 (blocks in the worker)
+            for _ in range(3):
+                await pilot.press("r")  # must be skipped while import #1 is in flight
+                await pilot.pause()
+            assert app._importing is True  # still in flight
+            assert calls["n"] <= 1  # no second (overlapping) import launched
+            gate.set()  # release import #1
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert calls["n"] == 1  # exactly the launch import ran
+
+    _run(scenario())
+
+
+def test_tui_auto_import_gated_off_by_default(tmp_path, monkeypatch):
+    # With the gate off (the conftest default), launch must NOT call the importer
+    # (so tests never scan real client logs).
+    import agentacct.cli as cli_mod
+
+    called = {"n": 0}
+    monkeypatch.setattr(cli_mod, "_local_usage_import_payload", lambda **kw: called.__setitem__("n", called["n"] + 1))
+    SentinelService(tmp_path)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+    _run(scenario())
+    assert called["n"] == 0
+
+
 def test_tui_command_requires_tty(tmp_path):
     # Under CliRunner stdout is not a TTY, so the command must fail fast with a
     # clear pointer instead of launching a blocking full-screen app.


### PR DESCRIPTION
## Summary

Two accuracy fixes from live feedback on the TUI.

### 1. The TUI now shows the current session's real usage (#1/#3)

The TUI read only the **stored** events, and usage lands in the store only after
`usage import` / `usage watch` runs — so the session you're in showed **0 tokens**
(and a just-started Codex session didn't appear at all) until the next import. The
old HTML dashboard avoided this by doing a live re-scan on Refresh.

The TUI now does the same: on launch and on `r` it imports usage from the client
session logs in a background worker, then rebuilds. Off the refresh timer,
env-gated (`AGENTACCT_TUI_AUTO_IMPORT`, pinned off in tests), and **serialized** —
only one import runs at a time. (Verified: after the import, this session's rollup
shows ~117.7M tokens instead of 0.)

Note on #3 (Codex): Codex sessions were never actually gone — there are dozens in
the store, but the newest was ~6 days old and sorted below the recent Claude
sessions. A *just-started* Codex session shows once its usage imports; its MCP
*section* still can't attach to a session because Codex doesn't expose a session id
to MCP (a Codex-side limitation, surfaced as a warning at record time).

### 2. `agentacct_record_section` guidance states its required args (#2)

The instruction prose named `section_title` / `section_status` but never said
`source` and a stable `section_id` are also required, so some agents (Codex) omitted
them and the call failed twice before succeeding. The shared instruction line now
lists all required args with a concrete example. Because that line feeds the **live**
MCP server instructions and the Claude Code SessionStart context (the on-disk hook
delegates to the live binary), the fix takes effect on upgrade; only the static
`CLAUDE.md` / `AGENTS.md` block needs a re-run to refresh.

> Follow-up (separate PR, by owner's call): a systemic **integration re-sync** —
> version-stamp the installed integration and re-sync it (idempotently, without
> clobbering user config) on update/restart, so client MCP/instructions/hooks never
> drift from the installed version. Investigated here; design captured for its own PR.

## Adversarial review

Focused review; one confirmed issue, fixed:

- **MEDIUM** — `@work(exclusive=True)` can't cancel a *running* thread, so `on_mount`
  + rapid `r` launched **concurrent** imports, and `_local_usage_import_payload`
  mutates a process-global pricing catalog (env + cache, restored in `finally`) — one
  import's cleanup mid-flight flipped another's pricing and persisted **mis-priced
  rows**. Fixed by serializing: `_start_import` no-ops while an import is in flight
  (the `_importing` flag is main-thread-only, so the guard is race-free). Regression
  test included.

## Tests

`.venv/bin/pytest -q`: **3005 passed, 1 skipped**. New: import-on-launch wiring,
gated-off-by-default, and the serialization regression; the reworded instruction line
still satisfies every asserted phrase.

## Not included (owner-gated)

No release, no deploy.
