### PR TITLE
feat: re-sync client integrations after an agentacct upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Client integrations re-sync themselves after an upgrade (`agentacct sync`).**
+  Onboarding wrote a client's MCP config, hooks, and instructions once; a later
+  agentacct upgrade left them stale (the source of the outdated-`record_section`
+  guidance). The activation record now stamps the agentacct version that wrote the
+  integration, and `agentacct start` re-syncs the recorded clients when that stamp
+  is behind the installed version — re-running the same idempotent onboard writers,
+  so it never clobbers your own settings (a custom statusLine is left alone). A new
+  `agentacct sync` forces the refresh on demand. This keeps a machine's MCP /
+  instructions / hooks current with the installed version instead of drifting.
 - **`agentacct tui` freshens usage on launch and refresh.** The TUI now imports
   usage from the client session logs in the background when it opens and on `r`
   (the same scan the HTML dashboard did on Refresh), so the session you're in —

--- a/src/agentacct/activation.py
+++ b/src/agentacct/activation.py
@@ -271,12 +271,18 @@ class ActivationStateStore:
         project_dir: Path | str,
         clients: Sequence[str],
         configured_at: float | None = None,
+        agentacct_version: str | None = None,
     ) -> dict[str, Any]:
         """Record that agentacct finished configuring ``clients`` for ``project_dir``.
 
         Safe to call repeatedly: if the same project is already recorded, the
         new clients are merged into the existing list with no duplicates.
         Requires at least one client.  Returns the resulting activation record.
+
+        ``agentacct_version`` stamps the agentacct version that wrote the
+        integration, so a later run can detect a stale install and re-sync the
+        client configs. A version change is NOT a no-op even when the clients are
+        unchanged — it rewrites the record so the stamp advances.
         """
         normalized_clients = sorted(
             {
@@ -293,6 +299,7 @@ class ActivationStateStore:
             "configured_at": float(time.time() if configured_at is None else configured_at),
             "project_dir": resolved_project,
             "clients": normalized_clients,
+            "agentacct_version": agentacct_version,
         }
         try:
             with self._locked():
@@ -302,6 +309,7 @@ class ActivationStateStore:
                     and not current.get("issue")
                     and current.get("project_dir") == resolved_project
                     and set(normalized_clients).issubset(set(current.get("clients") or ()))
+                    and current.get("agentacct_version") == agentacct_version
                 ):
                     return dict(current)
                 if (
@@ -342,11 +350,15 @@ class ActivationStateStore:
                 raise ValueError("activation state fields are invalid")
             if any(not isinstance(client, str) or not client for client in clients):
                 raise ValueError("activation clients are invalid")
+            raw_version = value.get("agentacct_version")
             return {
                 "schema_version": ACTIVATION_INSTALL_SCHEMA_VERSION,
                 "configured_at": configured_at,
                 "project_dir": project_dir,
                 "clients": list(clients),
+                # The agentacct version that wrote this integration (None for
+                # records written before version stamping). Drives the re-sync.
+                "agentacct_version": raw_version if isinstance(raw_version, str) else None,
             }
         except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError, OverflowError) as exc:
             return {

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -187,18 +187,28 @@ app = typer.Typer(
 )
 
 
-def _version_callback(value: bool) -> None:
-    """Print the installed agentacct version and exit (eager --version option)."""
-    if not value:
-        return
+def _package_version() -> str:
+    """The installed agentacct version, or ``0.0.0+source`` for a bare checkout.
+
+    An editable install freezes this at install time, so a version bump is
+    observable only after ``uv tool install --force``/reinstall — which is exactly
+    when the integration re-sync should refresh the client configs.
+    """
+
     from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version as _dist_version
 
     try:
-        resolved = _dist_version("agentacct")
+        return _dist_version("agentacct")
     except PackageNotFoundError:  # source checkout without installed dist metadata
-        resolved = "0.0.0+source"
-    print(f"agentacct {resolved}")
+        return "0.0.0+source"
+
+
+def _version_callback(value: bool) -> None:
+    """Print the installed agentacct version and exit (eager --version option)."""
+    if not value:
+        return
+    print(f"agentacct {_package_version()}")
     raise typer.Exit()
 
 
@@ -1468,6 +1478,103 @@ def _warn_global_store_mismatches(store_dir: Path, command: str) -> None:
         pass
 
 
+def _resync_integration(
+    store_dir: Path, clients, command: str, *, assume_yes: bool = True
+) -> tuple[list[str], list[str]]:
+    """Re-run the idempotent onboard writers for already-configured clients so their
+    MCP config / hooks / instructions match the installed agentacct version.
+
+    Reuses the exact per-client onboard helpers (which preserve user customizations
+    — the settings merge is gated by ``assume_yes``, the MCP write is a
+    key-preserving upsert, instructions replace only the managed block, and a user's
+    own statusLine is never touched). Best-effort per client: a failure for one
+    never aborts the caller (e.g. ``start``).
+
+    Returns ``(resynced, errored)``. A writer that RAISES (a real, possibly
+    transient failure — locked/corrupt config, disk, permissions) lands in
+    ``errored`` so the caller can leave the version stamp stale and retry next
+    start. A writer that merely returns ``False`` (a steady-state SKIP, e.g. a
+    user's custom pre-rename block agentacct refuses to touch) is neither resynced
+    nor errored, so the stamp still advances and we don't loop forever.
+    """
+
+    client_set = {str(c).strip().lower() for c in clients}
+    resynced: list[str] = []
+    errored: list[str] = []
+    if "claude-code" in client_set:
+        try:
+            if _onboard_global_claude(store_dir, command, assume_yes=assume_yes):
+                resynced.append("claude-code")
+        except Exception:  # noqa: BLE001 - re-sync must never break the caller.
+            errored.append("claude-code")
+    if "codex" in client_set:
+        try:
+            if _onboard_global_codex(store_dir, command):
+                resynced.append("codex")
+        except Exception:  # noqa: BLE001
+            errored.append("codex")
+    return resynced, errored
+
+
+def _resync_integration_if_stale(store_dir: Path, *, force: bool = False) -> dict[str, Any]:
+    """Re-sync client integrations when the install version changed (or ``force``).
+
+    Reads the activation record; if its stamped agentacct version differs from the
+    installed one (or ``force``), re-runs the idempotent writers for the recorded
+    clients and re-stamps. A cheap no-op when already current — safe to call on
+    every ``start`` so a client's MCP/instructions/hooks never drift behind an
+    agentacct upgrade. Never raises: a re-sync problem must not stop the runtime."""
+
+    try:
+        store = ActivationStateStore(store_dir)
+        snap = store.snapshot()
+    except Exception:  # noqa: BLE001
+        return {"status": "unavailable"}
+    if not isinstance(snap, Mapping) or snap.get("issue"):
+        return {"status": "no-activation"}
+    clients = [str(c) for c in (snap.get("clients") or []) if str(c).strip()]
+    if not clients:
+        return {"status": "no-clients"}
+    # Only global installs are re-synced here: `_onboard_global_*` write USER-scope
+    # config (~/.claude, ~/.codex), which is correct only when the record is the
+    # global one (project_dir == home, as _onboard_global stamps it). Re-running
+    # them for a project-scoped install would write the wrong (user) scope, so skip.
+    try:
+        is_global = str(Path(snap.get("project_dir") or "").expanduser().resolve()) == str(
+            Path.home().resolve()
+        )
+    except Exception:  # noqa: BLE001
+        is_global = False
+    if not is_global:
+        return {"status": "project-scope-skipped"}
+    current = _package_version()
+    stamped = snap.get("agentacct_version")
+    if not force and stamped == current:
+        return {"status": "current", "version": current}
+    try:
+        command = _resolve_absolute_mcp_command()
+    except Exception:  # noqa: BLE001
+        return {"status": "unavailable"}
+    resynced, errored = _resync_integration(store_dir, clients, command, assume_yes=True)
+    # Advance the version stamp ONLY when no client's writer raised. A raised
+    # writer stays stale so the next start retries it (fixing a transient failure);
+    # a client that merely returned False (steady-state skip) is not "errored", so
+    # a legitimately-unwritable install still advances and never loops every start.
+    if not errored:
+        try:
+            project_dir = snap.get("project_dir") or str(Path.home())
+            store.mark_configured(project_dir=project_dir, clients=clients, agentacct_version=current)
+        except Exception:  # noqa: BLE001 - writers ran; a stamp failure just retries next start.
+            pass
+    return {
+        "status": "partial" if errored else "resynced",
+        "from": stamped,
+        "to": current,
+        "clients": resynced,
+        "errored": errored,
+    }
+
+
 def _onboard_global(*, agent: str, port: int, start_runtime: bool, mcp: bool, assume_yes: bool) -> None:
     """Install agentacct ONCE, machine-wide: user-scope MCP + hooks + instructions
     against one global store, writing ZERO files into any repo."""
@@ -1539,7 +1646,8 @@ def _onboard_global(*, agent: str, port: int, start_runtime: bool, mcp: bool, as
     if recording_clients:
         try:
             ActivationStateStore(store_dir).mark_configured(
-                project_dir=Path.home(), clients=recording_clients
+                project_dir=Path.home(), clients=recording_clients,
+                agentacct_version=_package_version(),
             )
         except ActivationStateError as exc:
             console.print(f"Onboarding stopped safely: {exc}")
@@ -1782,6 +1890,7 @@ def onboard(
             ActivationStateStore(store_dir).mark_configured(
                 project_dir=project_dir,
                 clients=recording_clients,
+                agentacct_version=_package_version(),
             )
         except ActivationStateError as exc:
             console.print(f"Onboarding stopped safely: {exc}")
@@ -1898,6 +2007,66 @@ def _supervise_foreground(
     return ticks
 
 
+def _resync_client_integration_on_start(store_dir: Path) -> None:
+    """Version-gated integration re-sync invoked from `start` — quiet unless it
+    actually refreshed something, and never fatal to the runtime."""
+
+    try:
+        result = _resync_integration_if_stale(store_dir)
+    except Exception:  # noqa: BLE001
+        return
+    resynced = result.get("clients") or []
+    errored = result.get("errored") or []
+    if resynced:
+        console.print(
+            f"Re-synced client integration for agentacct {result.get('to')} "
+            f"(installed version changed): {', '.join(resynced)}"
+        )
+    if errored:
+        console.print(
+            f"Could not re-sync {', '.join(errored)} for agentacct {result.get('to')} "
+            "— will retry on next start; run `agentacct sync` or check that client's config."
+        )
+
+
+@app.command("sync")
+def sync_integration(
+    store_dir: Annotated[Optional[Path], typer.Option(help=_DASHBOARD_STORE_DIR_HELP)] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit machine-readable JSON.")] = False,
+) -> None:
+    """Re-sync client integrations (MCP config, hooks, instructions) to the installed
+    agentacct version.
+
+    Runs automatically on `start` when the version changes; run it yourself to force
+    a refresh (e.g. after an upgrade). Idempotent and non-clobbering: it re-writes
+    only agentacct's own config/instructions/hooks and never touches your own
+    settings (a custom statusLine is left alone).
+    """
+
+    resolved = _resolve_dashboard_cli_store_dir(store_dir).path
+    result = _resync_integration_if_stale(resolved, force=True)
+    if json_output:
+        print(json.dumps(result, indent=2, sort_keys=True, default=str))
+        return
+    status = result.get("status")
+    if status == "no-activation":
+        console.print("No activation record found — run `agentacct onboard` first.")
+    elif status == "no-clients":
+        console.print("No configured clients to re-sync.")
+    elif status == "project-scope-skipped":
+        console.print("Project-scoped install — re-sync only runs for global installs. Re-run `agentacct onboard` in the project instead.")
+    elif status == "unavailable":
+        console.print("Could not read the activation record; nothing re-synced.")
+    elif status in ("resynced", "partial"):
+        clients = ", ".join(result.get("clients") or []) or "(none)"
+        console.print(f"Re-synced client integration to agentacct {result.get('to')}: {clients}")
+        errored = result.get("errored") or []
+        if errored:
+            console.print(f"Could not re-sync: {', '.join(errored)} — check that client's config and retry.")
+    else:
+        console.print(f"Integration re-sync: {status}")
+
+
 @app.command("start")
 def runtime_start(
     store_dir: Annotated[Optional[Path], typer.Option(help=_DASHBOARD_STORE_DIR_HELP)] = None,
@@ -1922,6 +2091,7 @@ def runtime_start(
         _runtime_start_foreground(store_dir, host=host, port=port, json_output=json_output)
         return
     resolved = _resolve_dashboard_cli_store_dir(store_dir).path
+    _resync_client_integration_on_start(resolved)
     _health, external_watcher_running = _runtime_ingestion_health(resolved)
     try:
         payload = _managed_runtime(resolved, host=host, port=port).start(
@@ -1947,6 +2117,7 @@ def _runtime_start_foreground(
     """Ensure the runtime is up, then supervise it in the foreground."""
 
     resolved = _resolve_dashboard_cli_store_dir(store_dir).path
+    _resync_client_integration_on_start(resolved)
     manager = _managed_runtime(resolved, host=host, port=port)
 
     def _ensure() -> dict[str, Any]:

--- a/tests/test_integration_resync.py
+++ b/tests/test_integration_resync.py
@@ -1,0 +1,144 @@
+"""Tests for version-stamped client-integration re-sync (#2b).
+
+The re-sync keeps a user's installed MCP config / hooks / instructions current
+after an agentacct upgrade. These tests pin the version-gate + scope logic; the
+actual writers (which touch ~/.claude, ~/.codex) are already covered by the
+onboard tests and are stubbed here so the gate is exercised hermetically.
+
+Global installs stamp ``project_dir == home`` (that is what ``_onboard_global``
+records), so the "global" cases below use ``Path.home()`` — the re-sync only runs
+for global installs, since it re-runs the USER-scope onboard writers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import agentacct.cli as cli
+from agentacct.activation import ActivationStateStore
+from agentacct.cli import app
+from agentacct.service import SentinelService
+
+_HOME = str(Path.home())
+
+
+def test_mark_configured_stamps_and_reads_version(tmp_path):
+    store = ActivationStateStore(tmp_path / "state")
+    record = store.mark_configured(project_dir=tmp_path, clients=["codex"], agentacct_version="1.2.3")
+    assert record["agentacct_version"] == "1.2.3"
+    assert store.snapshot()["agentacct_version"] == "1.2.3"
+    # An unstamped record reads back as None (pre-stamping installs).
+    other = ActivationStateStore(tmp_path / "state2")
+    other.mark_configured(project_dir=tmp_path, clients=["codex"])
+    assert other.snapshot()["agentacct_version"] is None
+
+
+def _stub_resync(monkeypatch, calls, *, errored=()):
+    errored = list(errored)
+
+    def _fake(store_dir, clients, command, **kwargs):
+        calls.append(list(clients))
+        ok = [c for c in clients if c not in errored]
+        return ok, list(errored)
+
+    monkeypatch.setattr(cli, "_resync_integration", _fake)
+    monkeypatch.setattr(cli, "_resolve_absolute_mcp_command", lambda: "agentacct")
+
+
+def test_resync_gate_fires_on_version_change_and_restamps(tmp_path, monkeypatch):
+    calls: list = []
+    _stub_resync(monkeypatch, calls)
+    monkeypatch.setattr(cli, "_package_version", lambda: "9.9.9")
+    store_dir = tmp_path / "state"
+    store = ActivationStateStore(store_dir)
+
+    # No activation record → nothing to re-sync.
+    assert cli._resync_integration_if_stale(store_dir)["status"] == "no-activation"
+
+    # An OLD stamped version on a GLOBAL install → re-sync fires and re-stamps.
+    store.mark_configured(project_dir=_HOME, clients=["codex", "claude-code"], agentacct_version="0.0.1")
+    result = cli._resync_integration_if_stale(store_dir)
+    assert result["status"] == "resynced" and result["from"] == "0.0.1" and result["to"] == "9.9.9"
+    assert calls and set(calls[-1]) == {"codex", "claude-code"}
+    assert store.snapshot()["agentacct_version"] == "9.9.9"  # re-stamped
+    assert set(store.snapshot()["clients"]) == {"codex", "claude-code"}
+
+
+def test_resync_gate_is_noop_when_current(tmp_path, monkeypatch):
+    calls: list = []
+    _stub_resync(monkeypatch, calls)
+    monkeypatch.setattr(cli, "_package_version", lambda: "9.9.9")
+    store_dir = tmp_path / "state"
+    ActivationStateStore(store_dir).mark_configured(
+        project_dir=_HOME, clients=["codex"], agentacct_version="9.9.9"
+    )
+    assert cli._resync_integration_if_stale(store_dir)["status"] == "current"
+    assert calls == []  # no writers run when the version is unchanged
+    # force overrides the gate.
+    assert cli._resync_integration_if_stale(store_dir, force=True)["status"] == "resynced"
+    assert calls  # ran under force
+
+
+def test_resync_gate_fires_on_unstamped_record(tmp_path, monkeypatch):
+    calls: list = []
+    _stub_resync(monkeypatch, calls)
+    monkeypatch.setattr(cli, "_package_version", lambda: "9.9.9")
+    store_dir = tmp_path / "state"
+    ActivationStateStore(store_dir).mark_configured(project_dir=_HOME, clients=["codex"])  # no version
+    result = cli._resync_integration_if_stale(store_dir)
+    assert result["status"] == "resynced" and result["from"] is None
+    assert calls
+
+
+def test_resync_skips_project_scope(tmp_path, monkeypatch):
+    # A project-scoped install (project_dir != home) must NOT run the USER-scope
+    # global writers — that would write config for the wrong scope.
+    calls: list = []
+    _stub_resync(monkeypatch, calls)
+    monkeypatch.setattr(cli, "_package_version", lambda: "9.9.9")
+    store_dir = tmp_path / "state"
+    ActivationStateStore(store_dir).mark_configured(
+        project_dir=tmp_path, clients=["codex"], agentacct_version="0.0.1"  # stale, but project scope
+    )
+    result = cli._resync_integration_if_stale(store_dir, force=True)
+    assert result["status"] == "project-scope-skipped"
+    assert calls == []  # writers never run for a project-scoped record
+
+
+def test_resync_partial_failure_keeps_stamp_stale_and_retries(tmp_path, monkeypatch):
+    # A client whose writer RAISES must NOT advance the version stamp — so the next
+    # start retries it (fixing a transient failure) instead of silently skipping it
+    # until the next upgrade.
+    calls: list = []
+    _stub_resync(monkeypatch, calls, errored=["claude-code"])
+    monkeypatch.setattr(cli, "_package_version", lambda: "9.9.9")
+    store_dir = tmp_path / "state"
+    store = ActivationStateStore(store_dir)
+    store.mark_configured(project_dir=_HOME, clients=["codex", "claude-code"], agentacct_version="0.0.1")
+
+    r1 = cli._resync_integration_if_stale(store_dir)
+    assert r1["status"] == "partial" and r1["errored"] == ["claude-code"] and r1["clients"] == ["codex"]
+    assert store.snapshot()["agentacct_version"] == "0.0.1"  # stamp NOT advanced
+
+    calls.clear()
+    r2 = cli._resync_integration_if_stale(store_dir)
+    assert r2["status"] == "partial"  # retried, not silently "current"
+    assert calls  # the writers ran again
+
+
+def test_sync_command_forces_resync(tmp_path, monkeypatch):
+    calls: list = []
+    _stub_resync(monkeypatch, calls)
+    monkeypatch.setattr(cli, "_package_version", lambda: "9.9.9")
+    SentinelService(tmp_path)  # make tmp_path a store the CLI resolver accepts
+    ActivationStateStore(tmp_path).mark_configured(
+        project_dir=_HOME, clients=["codex"], agentacct_version="9.9.9"  # already current + global
+    )
+    result = CliRunner().invoke(app, ["sync", "--store-dir", str(tmp_path), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "resynced"  # sync forces even when version matches
+    assert calls  # the writers ran


### PR DESCRIPTION
## Summary

Keeps a machine's agentacct client integrations current after an upgrade — the
systemic fix behind the stale-`record_section`-guidance issue (#2 from the TUI
feedback).

**The problem:** `agentacct onboard` writes each client's MCP config, hooks, and
instructions **once**. When agentacct is later upgraded, those on-disk artifacts
don't move with it, so a client can keep following an older version's guidance
(exactly why a Codex session followed outdated `record_section` args). Nothing
detected or re-synced the drift.

**The fix:**
- The activation record now **stamps the agentacct version** that wrote the
  integration (`mark_configured` records it, `snapshot()` reads it back).
- `agentacct start` **re-syncs** the recorded clients when that stamp is behind the
  installed version — re-running the same idempotent onboard writers. Cheap no-op
  when already current, so it's safe on every start.
- New **`agentacct sync`** forces the refresh on demand (e.g. right after an
  upgrade).

**Safety (the whole point of reusing the existing writers):**
- Non-clobbering: the settings merge is dedup + a user's own statusLine is never
  touched; the MCP entry is a key-preserving upsert; instructions replace only the
  managed marker block. Never prompts on a daemon start (`assume_yes`).
- **Global-scope only**: the re-sync runs the user-scope global writers, so it only
  acts on a global install (`project_dir == home`); a project-scoped record is
  skipped rather than getting user-scope config written for it.
- Best-effort — a re-sync problem can never break `start`.

## Adversarial review

One issue confirmed (filed twice, same root cause), fixed:

- **MEDIUM** — the version stamp advanced *unconditionally* after the re-sync, so a
  client whose writer **raised** (a transient FS/permission/lock error) was
  silently never retried until the next version bump, and `start` even printed
  "Re-synced" when zero clients actually did. Fixed: only advance the stamp when no
  client's writer raised (a client that merely *returns False* — a steady-state
  skip, e.g. a user's custom pre-rename block — still advances, so a legitimately
  unwritable install doesn't loop every start). `start` now reports what actually
  re-synced and what failed. Regression test included.
  (The review's own "never-advance would loop every start" counter-case is handled
  by the raised-vs-returns-False distinction.)

## Tests

`.venv/bin/pytest -q`: **3012 passed, 1 skipped**. New `tests/test_integration_resync.py`:
version stamping + round-trip, the version gate (fires on change / no-op when
current / fires on unstamped / force), project-scope skip, the partial-failure
stamp-stays-stale retry, and the `sync` command.

## Not included (owner-gated)

No release, no deploy.
