### PR TITLE
feat(tui): session status badges, a usage screen, and recent sessions on home (#4/#5/#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`agentacct tui` — session status badges, a dedicated usage screen, and a
+  recent-sessions panel.** Every session now carries an at-a-glance status badge
+  (`▶ in progress` / `⏸ handed off` / `✓ done` / `⚠ blocked`), derived from its
+  recorded steps so a cleanly handed-off run reads as handed-off rather than
+  still-active — shown in the sessions list, the session-detail header, and a new
+  **Recent sessions** panel on the home screen (the five most-recently-active
+  sessions, filled in the background so the usage/limits view still paints
+  instantly). A new usage screen (press `u`) shows a per-day (or per-week for long
+  ranges) token & cost time series with in-terminal bars plus a by-model
+  breakdown; `d` cycles the range (7d / 30d / 90d / all). All from the same
+  authoritative local event log the rest of the TUI reads — no credentials, no
+  API calls.
 - **Client integrations re-sync themselves after an upgrade (`agentacct sync`).**
   Onboarding wrote a client's MCP config, hooks, and instructions once; a later
   agentacct upgrade left them stale (the source of the outdated-`record_section`

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8378,8 +8378,9 @@ def tui(
     A full-screen view over the same authoritative local event log as
     ``agentacct now`` / ``agentacct limits`` (no credentials, no API calls). Keys:
     ``r`` refresh now, ``w`` cycle the breakdown window, ``s`` open the sessions
-    drill-down (a session's steps and their check results), ``q`` quit. Needs an
-    interactive terminal.
+    drill-down (a session's steps and their check results), ``u`` open the usage
+    screen (a per-day/-week token & cost time series with by-model detail), ``q``
+    quit. Needs an interactive terminal.
     """
     if window not in NOW_WINDOW_ALIASES:
         raise typer.BadParameter("--window must be one of: today, 7d, 30d, all")

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -128,9 +128,16 @@ def _session_status(entry: dict) -> tuple[str, str, str]:
     ``work['counts']``, because that bucket folds ``handed_off`` (and
     ``started`` / ``checkpoint``) into ``active`` (see work_ledger
     ``_session_work_summary``), so a cleanly handed-off session would otherwise
-    misread as still in progress. Precedence: any blocked step dominates, then any
-    open step (in progress), then a clean hand-off, then done; a usage-only
-    session with no recorded steps shows no badge.
+    misread as still in progress.
+
+    Precedence: blocked > handed-off > in-progress > done. A hand-off is a
+    *session-level* clean stop (the agent handed the work to another session), so
+    it deliberately outranks a still-open step: a real session commonly leaves one
+    stray section ``started`` that was never closed, and that must not make an
+    already-handed-off run read as "in progress". (The rollup's work items carry
+    no timestamps, so we can't order by "latest step"; this precedence encodes the
+    same intent — a hand-off closes the in-progress gap.) A usage-only session
+    with no recorded steps shows no badge.
     """
 
     work = entry.get("work") or {}
@@ -138,10 +145,10 @@ def _session_status(entry: dict) -> tuple[str, str, str]:
     statuses = [str(item.get("latest_status") or "") for item in items if isinstance(item, dict)]
     if any(s == "blocked" for s in statuses):
         return ("⚠", "blocked", "red")
-    if any(s in ("started", "checkpoint") for s in statuses):
-        return ("▶", "in progress", "yellow")
     if any(s == "handed_off" for s in statuses):
         return ("⏸", "handed off", "cyan")
+    if any(s in ("started", "checkpoint") for s in statuses):
+        return ("▶", "in progress", "yellow")
     if any(s in ("completed", "resolved") for s in statuses):
         return ("✓", "done", "green")
     return ("·", "—", "dim")
@@ -210,8 +217,11 @@ class AgentAcctTUI(App):
         color: $text-muted;
         padding: 0 0 1 0;
     }
+    /* The home body scrolls: on a short terminal the limits + recent-sessions
+       panels below the fold would otherwise be clipped and unreachable. */
+    #body { height: 1fr; }
     #windows { height: auto; }
-    #breakdowns { height: auto; }
+    #breakdowns { height: auto; padding: 1 0 0 0; }
     #byclient, #bymodel { height: auto; width: 1fr; }
     #bymodel { margin: 0 0 0 2; }
     #limits-body { padding: 0 0 1 0; }
@@ -291,9 +301,17 @@ class AgentAcctTUI(App):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         yield Static("", id="status")
-        with Vertical(id="body"):
+        # Scrollable so nothing below the fold is unreachable; the two panels the
+        # user most wants at a glance — provider limits ("how much left") and the
+        # recent sessions — sit above the by-client / by-model detail breakdown.
+        with VerticalScroll(id="body"):
             yield Static("Usage windows", classes="section-title")
             yield DataTable(id="windows", cursor_type="none", zebra_stripes=True)
+            yield Static("Provider limits", classes="section-title")
+            yield Static("", id="limits-body")
+            yield Static("Recent sessions", classes="section-title")
+            yield Static("", id="recent-status")
+            yield DataTable(id="recent", cursor_type="none")
             with Horizontal(id="breakdowns"):
                 with Vertical():
                     yield Static("", id="byclient-title", classes="section-title")
@@ -301,11 +319,6 @@ class AgentAcctTUI(App):
                 with Vertical():
                     yield Static("", id="bymodel-title", classes="section-title")
                     yield DataTable(id="bymodel", cursor_type="none")
-            yield Static("Provider limits", classes="section-title")
-            yield Static("", id="limits-body")
-            yield Static("Recent sessions", classes="section-title")
-            yield Static("", id="recent-status")
-            yield DataTable(id="recent", cursor_type="none")
         yield Footer()
 
     def on_mount(self) -> None:

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -37,11 +37,14 @@ from .service import SentinelService
 from .subagent_roles import read_roles_for_children
 from .usage_snapshot import (
     LiveSnapshot,
+    UsagePage,
     build_live_snapshot,
+    build_usage_page,
     cost_text,
     finite,
     format_tokens,
     humanize_seconds,
+    ratio_bar,
     usage_bar,
 )
 
@@ -118,6 +121,82 @@ def _limit_color(used_percent: float) -> str:
     return "red"
 
 
+def _session_status(entry: dict) -> tuple[str, str, str]:
+    """(glyph, label, color) for a session's overall state.
+
+    Derived from the session's work items' ``latest_status`` — NOT
+    ``work['counts']``, because that bucket folds ``handed_off`` (and
+    ``started`` / ``checkpoint``) into ``active`` (see work_ledger
+    ``_session_work_summary``), so a cleanly handed-off session would otherwise
+    misread as still in progress. Precedence: any blocked step dominates, then any
+    open step (in progress), then a clean hand-off, then done; a usage-only
+    session with no recorded steps shows no badge.
+    """
+
+    work = entry.get("work") or {}
+    items = work.get("items") or []
+    statuses = [str(item.get("latest_status") or "") for item in items if isinstance(item, dict)]
+    if any(s == "blocked" for s in statuses):
+        return ("⚠", "blocked", "red")
+    if any(s in ("started", "checkpoint") for s in statuses):
+        return ("▶", "in progress", "yellow")
+    if any(s == "handed_off" for s in statuses):
+        return ("⏸", "handed off", "cyan")
+    if any(s in ("completed", "resolved") for s in statuses):
+        return ("✓", "done", "green")
+    return ("·", "—", "dim")
+
+
+def _session_badge(entry: dict) -> str:
+    """A short colored status badge cell for a session (safe fixed-vocab markup)."""
+
+    glyph, label, color = _session_status(entry)
+    return f"[{color}]{glyph} {label}[/]"
+
+
+def _fold_sessions(sessions: list[dict]) -> tuple[list[dict], dict[str, list[dict]]]:
+    """Fold every subagent DESCENDANT under its top-most root session.
+
+    Returns ``(top_level_sessions_newest_first, children_by_parent_session_key)``.
+    A run and all its (and its children's) subagents collapse to one top-level
+    row. Grouping follows the ledger's own ``rollup_group_key`` ("{client}::{parent}"
+    for a child, else the session's own key), which already applies the parent
+    source-namespace compatibility gate — the TUI never contradicts the ledger.
+    The walk carries a visited-set so a parent cycle resolves to ``None`` (every
+    session on it stays top-level, nothing can vanish) and an orphan chain (parent
+    absent) stops at the top-most present ancestor.
+    """
+
+    by_session_key = {str(s.get("session_key")): s for s in sessions}
+
+    def _resolve_top(start: str) -> str | None:
+        seen: set[str] = set()
+        cur = start
+        while True:
+            node = by_session_key.get(cur)
+            if node is None:
+                return cur
+            group = str(node.get("rollup_group_key") or cur)
+            if group == cur or group not in by_session_key:
+                return cur  # a root, or the top-most present ancestor
+            if group in seen:
+                return None  # cycle → keep this session top-level
+            seen.add(cur)
+            cur = group
+
+    children_by_parent: dict[str, list[dict]] = {}
+    top: list[dict] = []
+    for entry in sessions:
+        sk = str(entry.get("session_key"))
+        root = _resolve_top(sk)
+        if root is not None and root != sk:
+            children_by_parent.setdefault(root, []).append(entry)
+        else:
+            top.append(entry)
+    top.sort(key=lambda s: (s.get("last_activity_at") or 0.0), reverse=True)
+    return top, children_by_parent
+
+
 class AgentAcctTUI(App):
     """Live usage / cost / limits dashboard."""
 
@@ -136,6 +215,11 @@ class AgentAcctTUI(App):
     #byclient, #bymodel { height: auto; width: 1fr; }
     #bymodel { margin: 0 0 0 2; }
     #limits-body { padding: 0 0 1 0; }
+    #recent-status { color: $text-muted; padding: 0 0 1 0; }
+    #recent { height: auto; }
+    #usage-status { color: $text-muted; padding: 0 0 1 0; }
+    #usage-scroll { padding: 0 1; }
+    #usage-periods, #usage-models { height: auto; }
     #sessions-status { color: $text-muted; padding: 0 0 1 0; }
     #sessions-loading { height: auto; }
     #detail-header { padding: 0 1 1 1; }
@@ -147,6 +231,7 @@ class AgentAcctTUI(App):
         Binding("r", "refresh", "Refresh"),
         Binding("w", "cycle_window", "Cycle window"),
         Binding("s", "open_sessions", "Sessions"),
+        Binding("u", "open_usage", "Usage"),
     ]
 
     def __init__(
@@ -174,6 +259,10 @@ class AgentAcctTUI(App):
         # (often no-op) main-page refresh gives visible feedback.
         self._flash_until: float = 0.0
         self._importing: bool = False
+        # Recent-sessions panel (home) build guard — mutated on the main thread
+        # only (kicker + populate/error callbacks), so it needs no lock. Prevents
+        # re-kicking the home ledger build while one is already in flight.
+        self._recent_loading: bool = False
         self._error: str | None = None
         # Work-ledger cache shared across the sessions/detail screens. The ledger
         # is EXPENSIVE (O(all events), no caching upstream — ~5s on ~8k events),
@@ -181,13 +270,21 @@ class AgentAcctTUI(App):
         # event log changes (fingerprint) or the user forces a refresh.
         self._work_ledger: dict | None = None
         self._work_ledger_fp: int | None = None
+        # The home recent-sessions panel keeps its OWN ledger cache (see
+        # _load_recent), deliberately separate from _work_ledger above: its worker
+        # runs on a different node+group, so sharing one cache across the two
+        # non-coalescing lineages would let them stale-clobber / tear each other.
+        self._recent_ledger: dict | None = None
+        self._recent_ledger_fp: int | None = None
         # Folded child (subagent) sessions, keyed by the parent's session_key;
-        # populated by the sessions screen, read by the detail screen.
+        # written ONLY by the sessions screen (its sole owner), read by the detail
+        # screen. The home panel does not publish here (its table is non-interactive).
         self._children_by_parent: dict[str, list[dict]] = {}
         # Last composed text for each dynamic panel — a stable hook for headless
         # tests (avoids depending on Rich renderable internals).
         self._status_text: str = ""
         self._limits_text: str = ""
+        self._recent_text: str = ""
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -206,6 +303,9 @@ class AgentAcctTUI(App):
                     yield DataTable(id="bymodel", cursor_type="none")
             yield Static("Provider limits", classes="section-title")
             yield Static("", id="limits-body")
+            yield Static("Recent sessions", classes="section-title")
+            yield Static("", id="recent-status")
+            yield DataTable(id="recent", cursor_type="none")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -214,8 +314,10 @@ class AgentAcctTUI(App):
         self.query_one("#windows", DataTable).add_columns("window", "tokens", "est. cost", "sessions")
         self.query_one("#byclient", DataTable).add_columns("client", "tokens", "est. cost", "sessions")
         self.query_one("#bymodel", DataTable).add_columns("model", "client", "tokens", "est. cost")
+        self.query_one("#recent", DataTable).add_columns("session", "client", "status", "tokens", "activity")
         self.refresh_data(force=True)  # show the stored view instantly
         self._start_import()  # then freshen it from the client logs in the background
+        self._start_recent()  # and fill the recent-sessions panel from the ledger
         self.set_interval(self.refresh_seconds, self.refresh_data)
         self.set_interval(1.0, self._tick_countdowns)
 
@@ -260,6 +362,111 @@ class AgentAcctTUI(App):
     def _on_import_done(self) -> None:
         self._importing = False
         self.refresh_data(force=True)
+        # Fresh usage just landed → rebuild the recent-sessions panel from it
+        # (force supersedes any still-running pre-import build via the recent
+        # lineage's exclusive group; the cancelled build's is_cancelled guard
+        # drops it before it can write the panel's private cache).
+        self._start_recent(force=True)
+
+    # -- recent sessions (home panel) ---------------------------------------
+
+    def _start_recent(self, force: bool = False) -> None:
+        """Kick the background ledger build that fills the home recent-sessions
+        panel. Coalesced: no second build starts while one is in flight unless
+        ``force`` supersedes it (a manual refresh or fresh post-import usage)."""
+
+        if self._recent_loading and not force:
+            return
+        self._recent_loading = True
+        try:
+            self.query_one("#recent-status", Static).update("loading recent sessions…")
+        except Exception:  # noqa: BLE001 - cosmetic only.
+            pass
+        self._load_recent(force=force)
+
+    @work(thread=True, exclusive=True, group="recent")
+    def _load_recent(self, force: bool = False) -> None:
+        from textual.worker import get_current_worker
+
+        worker = get_current_worker()
+        try:
+            service = SentinelService(self.store_dir, create=False)
+            events = service.list_all_events()
+            fingerprint = _events_fingerprint(events)
+            # The home panel keeps its OWN ledger cache, deliberately separate from
+            # the SessionsScreen `_work_ledger` shared cache. That screen's worker
+            # runs on a different node+group, so `exclusive=` cannot coalesce or
+            # cancel across the two — sharing one cache would let this lineage
+            # stale-clobber the other's (and tear the two-field pair). Decoupling
+            # keeps SessionsScreen the SOLE writer of the shared cache (its prior,
+            # reviewed design); the only cost is building the ledger once for the
+            # panel and again if the user opens `s` (both off the refresh timer).
+            if not force and self._recent_ledger is not None and fingerprint == self._recent_ledger_fp:
+                ledger = self._recent_ledger
+            else:
+                from .work_ledger import build_work_ledger
+
+                ledger = build_work_ledger(events)
+                # A build cancelled by a newer `r`/import can't be interrupted
+                # mid-flight; bail before any side effect so a stale result never
+                # overwrites the fresher rebuild's cache. Only this (exclusive)
+                # lineage writes these fields, so at most one writer is ever live.
+                if worker.is_cancelled:
+                    return
+                self._recent_ledger = ledger
+                self._recent_ledger_fp = fingerprint
+        except Exception as exc:  # noqa: BLE001 - the panel degrades, never crashes the app.
+            if not worker.is_cancelled:
+                self.call_from_thread(self._recent_error, str(exc))
+            return
+        if worker.is_cancelled:
+            return
+        sessions = list((ledger.get("session_rollup") or {}).get("sessions") or [])
+        # Only the top-level list is needed here; the fold's children index is NOT
+        # published — the recent table is non-interactive, and overwriting the
+        # shared `_children_by_parent` would let a background home refresh disagree
+        # with what SessionsScreen (its sole writer) is showing.
+        top, _children = _fold_sessions(sessions)
+        self.call_from_thread(self._populate_recent, top)
+
+    def _recent_error(self, message: str) -> None:
+        self._recent_loading = False
+        self._recent_text = f"could not load sessions: {message}"
+        try:
+            self.query_one("#recent-status", Static).update(
+                f"[red]could not load sessions:[/] {_escape(message)}"
+            )
+        except Exception:  # noqa: BLE001 - last resort.
+            pass
+
+    def _populate_recent(self, top: list[dict]) -> None:
+        self._recent_loading = False
+        try:
+            table = self.query_one("#recent", DataTable)
+        except Exception:  # noqa: BLE001 - app tearing down.
+            return
+        table.clear()
+        now = time.time()
+        for entry in top[:5]:
+            usage = entry.get("usage") or {}
+            title = (
+                entry.get("client_session_title")
+                or entry.get("client_session_id_short")
+                or "(untitled)"
+            )
+            table.add_row(
+                _escape(str(title))[:40],
+                _escape(str(entry.get("client") or "")),
+                _session_badge(entry),  # fixed-vocab colored badge (safe markup)
+                format_tokens(usage.get("total_tokens")),
+                _humanize_ago(entry.get("last_activity_at"), now),
+            )
+        note = f"{len(top)} sessions · press s for all" if top else "no sessions yet"
+        self._recent_text = note
+        try:
+            self.query_one("#recent-status", Static).update(note)
+        except Exception:  # noqa: BLE001 - cosmetic only.
+            pass
 
     # -- data ---------------------------------------------------------------
 
@@ -469,6 +676,11 @@ class AgentAcctTUI(App):
         self._flash_until = time.time() + 1.2
         self.refresh_data(force=True)
         self._start_import()  # also re-scan the client logs for fresh usage
+        # Rebuild the recent panel now. When an import is enabled it also rebuilds
+        # on completion (fresh usage), so only force a build here when there is no
+        # import to trigger it — avoids a redundant double build on every `r`.
+        if not _auto_import_enabled():
+            self._start_recent(force=True)
 
     def action_cycle_window(self) -> None:
         try:
@@ -486,6 +698,14 @@ class AgentAcctTUI(App):
         if len(self.screen_stack) > 1:
             return
         self.push_screen(SessionsScreen())
+
+    def action_open_usage(self) -> None:
+        # Same guard as the sessions drill-down: the app-level `u` binding stays
+        # active while a (non-modal) sub-screen is on top, so without this a second
+        # `u` would stack a duplicate usage screen.
+        if len(self.screen_stack) > 1:
+            return
+        self.push_screen(UsageScreen())
 
 
 def _humanize_ago(ts: Any, now: float) -> str:
@@ -561,7 +781,9 @@ class SessionsScreen(Screen):
         self.title = "agentacct"
         self.sub_title = "sessions"
         table = self.query_one("#sessions", DataTable)
-        table.add_columns("session", "client", "project", "activity", "tokens", "est. cost", "steps", "⋔ sub")
+        table.add_columns(
+            "session", "client", "project", "activity", "status", "tokens", "est. cost", "steps", "⋔ sub"
+        )
         self._set_loading(True, "Building the work ledger (one-time, a few seconds)…")
         self._load()
 
@@ -620,42 +842,10 @@ class SessionsScreen(Screen):
         self._total_sessions = len(sessions)
 
         # Fold every subagent DESCENDANT under its top-most root session, so a run
-        # and all its (and its children's) subagents collapse to one row. Grouping
-        # follows the ledger's own rollup_group_key ("{client}::{parent}" for a
-        # child, else the session's own key), which already applies the parent
-        # source-namespace compatibility gate — the TUI never contradicts the
-        # ledger. The walk carries a visited-set: a parent cycle resolves to None
-        # so every session on it stays top-level (nothing can vanish), and an
-        # orphan chain (parent absent) stops at the top-most present ancestor.
-        by_session_key = {str(s.get("session_key")): s for s in sessions}
-
-        def _resolve_top(start: str) -> str | None:
-            seen: set[str] = set()
-            cur = start
-            while True:
-                node = by_session_key.get(cur)
-                if node is None:
-                    return cur
-                group = str(node.get("rollup_group_key") or cur)
-                if group == cur or group not in by_session_key:
-                    return cur  # a root, or the top-most present ancestor
-                if group in seen:
-                    return None  # cycle → keep this session top-level
-                seen.add(cur)
-                cur = group
-
-        children_by_parent: dict[str, list[dict]] = {}
-        top: list[dict] = []
-        for entry in sessions:
-            sk = str(entry.get("session_key"))
-            root = _resolve_top(sk)
-            if root is not None and root != sk:
-                children_by_parent.setdefault(root, []).append(entry)
-            else:
-                top.append(entry)
+        # and all its (and its children's) subagents collapse to one row (shared
+        # with the home recent-sessions panel via _fold_sessions).
+        top, children_by_parent = _fold_sessions(sessions)
         self.app._children_by_parent = children_by_parent
-
-        top.sort(key=lambda s: (s.get("last_activity_at") or 0.0), reverse=True)
         self._total_top = len(top)
         shown = top[:_SESSIONS_LIMIT]
 
@@ -680,6 +870,7 @@ class SessionsScreen(Screen):
                 _escape(str(entry.get("client") or "")),
                 _escape(str(entry.get("project") or "—"))[:24],
                 _humanize_ago(entry.get("last_activity_at"), now),
+                _session_badge(entry),
                 format_tokens(usage.get("total_tokens")),
                 _session_cost_text(usage),
                 steps,
@@ -780,6 +971,9 @@ class SessionDetailScreen(Screen):
         title = entry.get("client_session_title") or entry.get("client_session_id_short") or "(untitled)"
         usage = entry.get("usage") or {}
         header = f"[bold]{_escape(str(title))}[/]"
+        glyph, label, color = _session_status(entry)
+        if label != "—":  # a usage-only session (no recorded steps) shows no badge
+            header += f"  [{color}]{glyph} {label}[/]"
         header += f"\n{_escape(str(entry.get('client') or ''))} · {_escape(str(entry.get('project') or '—'))}"
         last = entry.get("last_activity_at")
         if isinstance(last, (int, float)) and last:
@@ -871,4 +1065,141 @@ class SessionDetailScreen(Screen):
         self.app.pop_screen()
 
 
-__all__ = ["AgentAcctTUI", "SessionsScreen", "SessionDetailScreen"]
+# The trailing ranges the usage screen's `d` key cycles: (days, label). None =
+# all time. Granularity is auto (daily for short ranges, weekly for 90/all).
+_USAGE_RANGE_CYCLE: tuple[tuple[int | None, str], ...] = (
+    (7, "7d"),
+    (30, "30d"),
+    (90, "90d"),
+    (None, "all"),
+)
+# How many (client, model) rows the by-model detail lists.
+_USAGE_MODELS_LIMIT = 20
+
+
+class UsageScreen(Screen):
+    """A dedicated usage view: a per-period token/cost time series (with text
+    bars) plus a by-model detail table, over the same cube the overview uses."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+        Binding("backspace", "back", "Back"),
+        Binding("d", "cycle_range", "Range"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("q", "quit", "Quit"),
+    ]
+
+    def __init__(self, *, range_index: int = 1) -> None:  # default → 30d
+        super().__init__()
+        self._range_index = range_index % len(_USAGE_RANGE_CYCLE)
+        self._page: UsagePage | None = None
+        # Composed text kept for headless tests.
+        self._status_text = ""
+        self._periods_text = ""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static("", id="usage-status")
+        with VerticalScroll(id="usage-scroll"):
+            yield Static("Usage over time", classes="section-title")
+            yield DataTable(id="usage-periods", cursor_type="none", zebra_stripes=True)
+            yield Static("By model", classes="section-title")
+            yield DataTable(id="usage-models", cursor_type="none")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = "agentacct"
+        self.sub_title = "usage"
+        self.query_one("#usage-periods", DataTable).add_columns(
+            "period", "tokens", "est. cost", "sessions", ""
+        )
+        self.query_one("#usage-models", DataTable).add_columns(
+            "model", "client", "tokens", "est. cost", "sessions"
+        )
+        self._rebuild()
+
+    def _rebuild(self) -> None:
+        days, label = _USAGE_RANGE_CYCLE[self._range_index]
+        try:
+            service = SentinelService(self.app.store_dir, create=False)
+            events = service.list_all_events()
+            page = build_usage_page(events, client=getattr(self.app, "client", None), days=days)
+        except Exception as exc:  # noqa: BLE001 - surface, never crash the screen.
+            self._status_text = f"error: {exc}"
+            try:
+                self.query_one("#usage-status", Static).update(
+                    f"[red]could not build usage:[/] {_escape(str(exc))}"
+                )
+            except Exception:  # noqa: BLE001 - last resort.
+                pass
+            return
+        self._page = page
+        try:
+            self._render_page(page, label)
+        except Exception as exc:  # noqa: BLE001 - a render error degrades to a note.
+            try:
+                self.query_one("#usage-status", Static).update(f"render error: {_escape(str(exc))}")
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _render_page(self, page: UsagePage, label: str) -> None:
+        now = time.time()
+        parts = [f"range: {label}", f"{page.granularity}"]
+        if page.as_of is not None and page.as_of <= now:
+            parts.append(f"as of {humanize_seconds(now - page.as_of)} ago")
+        parts.append(f"{page.usage_record_count} usage records")
+        if page.client_filter:
+            parts.append(f"client: {_escape(str(page.client_filter))}")
+        parts.append("d range · r refresh · Esc back")
+        self._status_text = "  ·  ".join(parts)
+        self.query_one("#usage-status", Static).update(self._status_text)
+
+        # Periods newest-first for a monitor (latest on top, no scroll needed); the
+        # "unknown" bucket (bad-timestamp rows, all-time only) always sorts last so
+        # it never masquerades as the most recent period. Bars scale to the busiest
+        # period in view — the share-of-peak signal a TUI can draw without a chart.
+        periods = list(page.by_period)
+        dated = [p for p in periods if p.get("period") != "unknown"]
+        unknown = [p for p in periods if p.get("period") == "unknown"]
+        ordered = list(reversed(dated)) + unknown
+        peak = max((int(p.get("total_tokens_including_cached") or 0) for p in ordered), default=0)
+
+        table = self.query_one("#usage-periods", DataTable)
+        table.clear()
+        text_rows: list[str] = []
+        for period in ordered:
+            tokens = int(period.get("total_tokens_including_cached") or 0)
+            bar = ratio_bar(tokens, peak)
+            table.add_row(
+                _escape(str(period.get("period"))),
+                format_tokens(tokens),
+                cost_text(period),
+                format_tokens(period.get("sessions")),
+                bar,
+            )
+            text_rows.append(f"{period.get('period')} {tokens} {bar}")
+        self._periods_text = "\n".join(text_rows)
+
+        models = self.query_one("#usage-models", DataTable)
+        models.clear()
+        for model in page.by_model[:_USAGE_MODELS_LIMIT]:
+            models.add_row(
+                _escape(str(model.get("model") or "—")),
+                _escape(str(model.get("client") or "")),
+                format_tokens(model.get("total_tokens_including_cached")),
+                cost_text(model),
+                format_tokens(model.get("sessions")),
+            )
+
+    def action_cycle_range(self) -> None:
+        self._range_index = (self._range_index + 1) % len(_USAGE_RANGE_CYCLE)
+        self._rebuild()
+
+    def action_refresh(self) -> None:
+        self._rebuild()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+
+__all__ = ["AgentAcctTUI", "SessionsScreen", "SessionDetailScreen", "UsageScreen"]

--- a/src/agentacct/usage_snapshot.py
+++ b/src/agentacct/usage_snapshot.py
@@ -119,6 +119,19 @@ def usage_bar(used_percent: float, width: int = 20) -> str:
     return "█" * filled + "░" * (width - filled)
 
 
+def ratio_bar(value: Any, max_value: Any, width: int = 20) -> str:
+    """A unicode fill bar for ``value`` scaled to ``max_value`` (the row's share
+    of the busiest bucket). An empty / non-positive max yields an all-empty bar so
+    a zero-usage window never draws a full bar. Non-finite inputs degrade to 0."""
+
+    numerator = finite(value) or 0.0
+    denominator = finite(max_value) or 0.0
+    if denominator <= 0.0 or numerator <= 0.0:
+        return "░" * width
+    filled = int(round(max(0.0, min(1.0, numerator / denominator)) * width))
+    return "█" * filled + "░" * (width - filled)
+
+
 def humanize_seconds(seconds: float) -> str:
     """A compact ``2d 3h`` / ``4h 5m`` / ``6m`` / ``<1m`` duration string."""
 
@@ -274,6 +287,28 @@ class UsageSnapshot:
 
 
 @dataclass(frozen=True)
+class UsagePage:
+    """The dedicated usage screen's data: a period time series + model detail.
+
+    ``by_period`` / ``by_model`` / ``totals`` are the raw cube buckets for the
+    selected trailing-``range_days`` range (``None`` = all time), at the resolved
+    ``granularity`` (daily for short ranges, weekly for long ones). Kept as plain
+    dicts — the same shape the HTML dashboard's Theme A cluster rendered — so the
+    screen renders straight from the cube with no re-derivation.
+    """
+
+    range_days: Optional[int]
+    granularity: str
+    as_of: Optional[float]
+    generated_at: float
+    usage_record_count: int
+    client_filter: Optional[str]
+    totals: dict[str, Any]
+    by_period: list[dict[str, Any]]
+    by_model: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
 class LimitWindow:
     """One provider rate-limit window, normalized for display."""
 
@@ -408,6 +443,64 @@ def build_usage_snapshot(
     )
 
 
+def build_usage_page(
+    events: list[dict[str, Any]],
+    *,
+    client: str | None = None,
+    days: int | None = 30,
+    granularity: str | None = None,
+    now: float | None = None,
+    today: date | None = None,
+) -> UsagePage:
+    """Build the dedicated usage screen's data for a trailing ``days`` range.
+
+    ``days=None`` = all time. ``granularity`` defaults to the cube's own rule
+    (daily for 7/30-day ranges, weekly for 90/all) via ``resolve_granularity`` so
+    a long range collapses to readable weekly buckets instead of hundreds of days.
+    Reuses the exact ``now`` data path (``usage_records`` → ``build_usage_cube``)
+    so the page can never disagree with the overview. ``now`` / ``today`` are
+    injectable for tests.
+    """
+
+    from .api import _usage_record_time
+    from .usage_cube import build_usage_cube, resolve_granularity
+
+    records = usage_records(events, client=client)
+    now_epoch = now if now is not None else time.time()
+    day = today or date.today()
+    days_choice = "all" if days is None else str(days)
+    gran = granularity or resolve_granularity(days_choice, "auto")
+
+    cube = build_usage_cube(
+        records, record_time=_usage_record_time, days=days, granularity=gran, today=day
+    )
+
+    # Freshness: newest record with a real (finite, not-future) timestamp — the
+    # same honest "as of" rule the overview uses (an unknown 0.0 or an absurd
+    # future time can't fake a "<1m ago").
+    real_times = [
+        t
+        for r in records
+        if (t := _usage_record_time(r)) is not None
+        and isinstance(t, (int, float))
+        and math.isfinite(float(t))
+        and 0 < t <= now_epoch
+    ]
+    as_of = max(real_times) if real_times else None
+
+    return UsagePage(
+        range_days=days,
+        granularity=gran,
+        as_of=as_of,
+        generated_at=now_epoch,
+        usage_record_count=len(records),
+        client_filter=client,
+        totals=cube.get("totals") or {},
+        by_period=cube.get("by_period") or [],
+        by_model=cube.get("by_model") or [],
+    )
+
+
 def build_client_limits(
     events: list[dict[str, Any]], *, client: str | None = None
 ) -> list[ClientLimit]:
@@ -488,6 +581,7 @@ __all__ = [
     "format_tokens",
     "cost_text",
     "usage_bar",
+    "ratio_bar",
     "humanize_seconds",
     "window_label",
     "latest_limit_events",
@@ -495,11 +589,13 @@ __all__ = [
     "limit_teaser_lines",
     "UsageWindow",
     "UsageSnapshot",
+    "UsagePage",
     "LimitWindow",
     "ClientLimit",
     "LiveSnapshot",
     "usage_records",
     "build_usage_snapshot",
+    "build_usage_page",
     "build_client_limits",
     "build_live_snapshot",
 ]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -722,18 +722,34 @@ def test_session_status_and_badge_helpers():
     # No recorded steps → no badge (usage-only session).
     assert _session_status({}) == ("·", "—", "dim")
     assert _session_status({"work": {"items": []}}) == ("·", "—", "dim")
-    # Precedence: blocked > in-progress > handed-off > done.
+    # Precedence: blocked > handed-off > in-progress > done.
     assert _session_status({"work": {"items": [{"latest_status": "resolved"}]}})[1] == "done"
     assert _session_status({"work": {"items": [{"latest_status": "completed"}]}})[1] == "done"
     assert _session_status(
         {"work": {"items": [{"latest_status": "handed_off"}, {"latest_status": "completed"}]}}
     )[1] == "handed off"
+    # A hand-off outranks a stray still-open step: a real handed-off session often
+    # leaves one section `started` that was never closed, and must still read
+    # "handed off", not "in progress".
     assert _session_status(
         {"work": {"items": [{"latest_status": "started"}, {"latest_status": "handed_off"}]}}
-    )[1] == "in progress"
+    )[1] == "handed off"
+    # Regression for the exact live shape (one stray `started` amid handed_off +
+    # completed) that used to misread as "in progress".
     assert _session_status(
-        {"work": {"items": [{"latest_status": "blocked"}, {"latest_status": "started"}]}}
+        {"work": {"items": [
+            {"latest_status": "handed_off"}, {"latest_status": "completed"},
+            {"latest_status": "started"}, {"latest_status": "completed"},
+        ]}}
+    )[1] == "handed off"
+    # blocked still dominates everything (an alarm worth surfacing).
+    assert _session_status(
+        {"work": {"items": [{"latest_status": "blocked"}, {"latest_status": "handed_off"}]}}
     )[1] == "blocked"
+    # a genuinely active session (open step, no hand-off) still reads in progress.
+    assert _session_status(
+        {"work": {"items": [{"latest_status": "started"}, {"latest_status": "completed"}]}}
+    )[1] == "in progress"
     # The badge is valid Rich markup for every state (fixed vocab, never data).
     for st in ("blocked", "started", "handed_off", "completed"):
         Text.from_markup(_session_badge({"work": {"items": [{"latest_status": st}]}}))
@@ -943,5 +959,25 @@ def test_recent_panel_uses_private_cache_not_shared(tmp_path):
             assert app._work_ledger is None
             assert app._work_ledger_fp is None
             assert app._children_by_parent == {}
+
+    _run(scenario())
+
+
+def test_home_body_is_scrollable(tmp_path):
+    # Regression: the home body must be a VerticalScroll so the provider-limits and
+    # recent-sessions panels below the fold are reachable on a short terminal
+    # (they were clipped when #body was a plain, non-scrolling Vertical).
+    from textual.containers import VerticalScroll
+
+    SentinelService(tmp_path)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert isinstance(app.query_one("#body"), VerticalScroll)
+            # the limits + recent panels are inside it and mounted.
+            assert app.query_one("#limits-body") is not None
+            assert app.query_one("#recent") is not None
 
     _run(scenario())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -708,3 +708,240 @@ def test_tui_command_requires_tty(tmp_path):
 def test_tui_command_invalid_window(tmp_path):
     result = CliRunner().invoke(cli_app, ["tui", "--store-dir", str(tmp_path), "--window", "5m"])
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# #4 session status badge + shared folding helper
+# ---------------------------------------------------------------------------
+
+
+def test_session_status_and_badge_helpers():
+    from agentacct.tui import _session_status, _session_badge
+    from rich.text import Text
+
+    # No recorded steps → no badge (usage-only session).
+    assert _session_status({}) == ("·", "—", "dim")
+    assert _session_status({"work": {"items": []}}) == ("·", "—", "dim")
+    # Precedence: blocked > in-progress > handed-off > done.
+    assert _session_status({"work": {"items": [{"latest_status": "resolved"}]}})[1] == "done"
+    assert _session_status({"work": {"items": [{"latest_status": "completed"}]}})[1] == "done"
+    assert _session_status(
+        {"work": {"items": [{"latest_status": "handed_off"}, {"latest_status": "completed"}]}}
+    )[1] == "handed off"
+    assert _session_status(
+        {"work": {"items": [{"latest_status": "started"}, {"latest_status": "handed_off"}]}}
+    )[1] == "in progress"
+    assert _session_status(
+        {"work": {"items": [{"latest_status": "blocked"}, {"latest_status": "started"}]}}
+    )[1] == "blocked"
+    # The badge is valid Rich markup for every state (fixed vocab, never data).
+    for st in ("blocked", "started", "handed_off", "completed"):
+        Text.from_markup(_session_badge({"work": {"items": [{"latest_status": st}]}}))
+    Text.from_markup(_session_badge({}))
+
+
+def test_fold_sessions_helper_multilevel_and_cycle_safe():
+    from agentacct.tui import _fold_sessions
+
+    def s(csid, group, last=0.0):
+        return {
+            "client": "cc", "client_session_id": csid, "session_key": f"cc::{csid}",
+            "rollup_group_key": f"cc::{group}", "last_activity_at": last,
+        }
+
+    # R root, C child of R, G grandchild (parent C) → both fold under R (top-most);
+    # A<->B is a mutual cycle → neither folds, so nothing vanishes.
+    sessions = [s("R", "R", 3), s("C", "R", 2), s("G", "C", 1), s("A", "B"), s("B", "A")]
+    top, children = _fold_sessions(sessions)
+    top_keys = {t["session_key"] for t in top}
+    assert "cc::R" in top_keys and "cc::A" in top_keys and "cc::B" in top_keys
+    assert "cc::C" not in top_keys and "cc::G" not in top_keys
+    assert {c["client_session_id"] for c in children["cc::R"]} == {"C", "G"}
+    assert top[0]["session_key"] == "cc::R"  # sorted newest-first
+
+
+def test_sessions_screen_status_column(tmp_path):
+    SentinelService(tmp_path)  # empty store → the worker builds an empty ledger fast
+    fake = {"session_rollup": {"sessions": [
+        {"client": "cc", "client_session_id": "P", "session_key": "cc::P", "rollup_group_key": "cc::P",
+         "client_session_title": "Parent", "usage": {"total_tokens": 100},
+         "work": {"items": [{"latest_status": "blocked"}], "counts": {"total": 1, "blocked": 1}}},
+    ]}}
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("s")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            scr = app.screen
+            scr._populate(fake)
+            table = scr.query_one("#sessions", DataTable)
+            assert table.row_count == 1
+            # status is the 5th column (session, client, project, activity, STATUS, …).
+            assert "blocked" in str(table.get_row_at(0)[4])
+
+    _run(scenario())
+
+
+def test_session_detail_header_shows_status_badge():
+    from rich.text import Text
+
+    now = time.time()
+    entry = {
+        "client_session_title": "Big task", "client": "codex", "project": "/p",
+        "last_activity_at": now - 60, "usage": {"total_tokens": 1234},
+        "work": {"items": [{"latest_status": "handed_off"}]},
+    }
+    header = SessionDetailScreen(entry)._render_header(entry, now)
+    assert "handed off" in header
+    Text.from_markup(header)  # valid markup
+
+    # A usage-only session (no steps) shows no badge on the title line.
+    entry2 = {"client_session_title": "solo", "client": "codex", "usage": {}, "work": {"items": []}}
+    header2 = SessionDetailScreen(entry2)._render_header(entry2, now)
+    assert "—" not in header2.split("\n")[0]
+    Text.from_markup(header2)
+
+
+# ---------------------------------------------------------------------------
+# #5 usage screen
+# ---------------------------------------------------------------------------
+
+
+def test_usage_screen_renders_and_cycles_range(tmp_path):
+    from agentacct.tui import UsageScreen
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt-5", session_id="s1",
+                  input_tokens=1000, output_tokens=200, updated_at=int(now - 3600), estimated_cost_usd=1.0)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s2",
+                  input_tokens=500, output_tokens=50, updated_at=int(now - 2 * 86400), estimated_cost_usd=0.5)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("u")
+            await pilot.pause()
+            scr = app.screen
+            assert isinstance(scr, UsageScreen)
+            assert scr.query_one("#usage-periods", DataTable).row_count > 0
+            assert scr.query_one("#usage-models", DataTable).row_count >= 2
+            assert "range: 30d" in scr._status_text and "daily" in scr._status_text
+            # `d` cycles 30d → 90d, which flips the granularity to weekly.
+            await pilot.press("d")
+            await pilot.pause()
+            assert "range: 90d" in scr._status_text and "weekly" in scr._status_text
+
+    _run(scenario())
+
+
+def test_usage_screen_empty_store(tmp_path):
+    from agentacct.tui import UsageScreen
+
+    SentinelService(tmp_path)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.push_screen(UsageScreen())
+            await pilot.pause()
+            scr = app.screen
+            assert isinstance(scr, UsageScreen)
+            assert scr.query_one("#usage-periods", DataTable).row_count == 0
+            assert scr.query_one("#usage-models", DataTable).row_count == 0
+
+    _run(scenario())
+
+
+def test_usage_screen_repeat_u_does_not_stack(tmp_path):
+    from agentacct.tui import UsageScreen
+
+    SentinelService(tmp_path)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("u")
+            await pilot.pause()
+            await pilot.press("u")  # app-level `u` stays active under the sub-screen
+            await pilot.pause()
+            assert sum(1 for s in app.screen_stack if isinstance(s, UsageScreen)) == 1
+
+    _run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# #6 recent-sessions panel on home
+# ---------------------------------------------------------------------------
+
+
+def test_recent_panel_populates_on_home(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_section(service, section_id="sec1", title="Ship the thing", status="started",
+                    client="codex", session_id="s1", created_at=now - 200, summary="wip")
+    _record_section(service, section_id="sec1", title="Ship the thing", status="handed_off",
+                    client="codex", session_id="s1", created_at=now - 100, summary="handed off")
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.workers.wait_for_complete()  # the recent-sessions ledger worker
+            await pilot.pause()
+            recent = app.query_one("#recent", DataTable)
+            assert recent.row_count >= 1
+            # the status column (index 2) reflects the handed-off section.
+            assert "handed off" in str(recent.get_row_at(0)[2])
+            assert "press s for all" in app._recent_text
+
+    _run(scenario())
+
+
+def test_recent_panel_empty_store(tmp_path):
+    SentinelService(tmp_path)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert app.query_one("#recent", DataTable).row_count == 0
+            assert app._recent_text == "no sessions yet"
+
+    _run(scenario())
+
+
+def test_recent_panel_uses_private_cache_not_shared(tmp_path):
+    # Regression (adversarial review): the home recent panel must NOT write the
+    # SessionsScreen shared cache. Its build lineage (group="recent", App node) and
+    # SessionsScreen._load (default group, Screen node) cannot coalesce via
+    # exclusive=, so sharing _work_ledger / _children_by_parent would let the two
+    # stale-clobber / tear each other. The panel keeps a private _recent_ledger.
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_section(service, section_id="sec1", title="t", status="completed",
+                    client="codex", session_id="s1", created_at=now - 100)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert app.query_one("#recent", DataTable).row_count >= 1
+            # the panel populated its PRIVATE cache…
+            assert app._recent_ledger is not None
+            # …and left the SessionsScreen shared cache untouched (sole-writer).
+            assert app._work_ledger is None
+            assert app._work_ledger_fp is None
+            assert app._children_by_parent == {}
+
+    _run(scenario())

--- a/tests/test_usage_snapshot.py
+++ b/tests/test_usage_snapshot.py
@@ -413,3 +413,73 @@ def test_build_live_snapshot_bundles_usage_and_limits(tmp_path):
     assert live.usage.usage_record_count == 1
     assert [c.client for c in live.limits] == ["codex"]
     assert live.limits[0].windows[0].used_percent == 52.0
+
+
+# ---------------------------------------------------------------------------
+# ratio_bar + build_usage_page (the dedicated usage screen's data path)
+# ---------------------------------------------------------------------------
+
+
+def test_ratio_bar():
+    assert us.ratio_bar(0, 0) == "░" * 20  # zero max → empty, never a full bar
+    assert us.ratio_bar(10, 10) == "█" * 20
+    assert us.ratio_bar(5, 10, width=10) == "█" * 5 + "░" * 5
+    assert us.ratio_bar(-3, 10) == "░" * 20  # non-positive value → empty
+    assert us.ratio_bar(10, 0) == "░" * 20  # zero denominator → empty
+    assert us.ratio_bar(20, 10) == "█" * 20  # value > max clamps to full
+    # non-finite inputs must never reach the arithmetic (would raise/overflow).
+    assert us.ratio_bar(float("inf"), 10) == "░" * 20
+    assert us.ratio_bar(5, float("nan")) == "░" * 20
+
+
+def test_build_usage_page_periods_models_and_granularity(tmp_path):
+    service = SentinelService(tmp_path)
+    _seed_windows_store(service)  # today / 3d / 20d / 200d / future rows
+    events = service.list_all_events()
+
+    page = us.build_usage_page(events, days=30, now=_NOW, today=_TODAY)
+    assert page.range_days == 30
+    assert page.granularity == "daily"
+    # 30 daily buckets, gap-filled (a gap is information), newest day present.
+    assert len(page.by_period) == 30
+    periods = {p["period"]: p for p in page.by_period}
+    assert _TODAY.isoformat() in periods
+    assert int(periods[_TODAY.isoformat()]["total_tokens_including_cached"]) > 0
+    # by_model has the two in-range models (claude-opus within 7d, gpt-5 at 20d).
+    models = {m["model"] for m in page.by_model}
+    assert {"claude-opus-4-8", "gpt-5"} <= models
+    assert int(page.totals["total_tokens_including_cached"]) > 0
+    # freshness: newest real (not-future) row → finite, not the future row.
+    assert page.as_of is not None and page.as_of <= _NOW
+    assert page.usage_record_count == 5
+
+
+def test_build_usage_page_weekly_for_long_ranges(tmp_path):
+    service = SentinelService(tmp_path)
+    _seed_windows_store(service)
+    events = service.list_all_events()
+    assert us.build_usage_page(events, days=7, now=_NOW, today=_TODAY).granularity == "daily"
+    assert us.build_usage_page(events, days=90, now=_NOW, today=_TODAY).granularity == "weekly"
+    # all time (days=None) also collapses to weekly buckets.
+    assert us.build_usage_page(events, days=None, now=_NOW, today=_TODAY).granularity == "weekly"
+
+
+def test_build_usage_page_client_filter(tmp_path):
+    service = SentinelService(tmp_path)
+    _seed_windows_store(service)
+    events = service.list_all_events()
+    page = us.build_usage_page(events, client="codex", days=None, now=_NOW, today=_TODAY)
+    assert page.client_filter == "codex"
+    # only codex rows counted → no claude model in the detail.
+    assert all(m["client"] == "codex" for m in page.by_model)
+
+
+def test_build_usage_page_empty_store(tmp_path):
+    service = SentinelService(tmp_path)
+    page = us.build_usage_page(service.list_all_events(), days=30, now=_NOW, today=_TODAY)
+    # a truly empty result stays empty (the screen renders an explicit empty
+    # state instead of a wall of zero rows).
+    assert page.by_period == []
+    assert page.by_model == []
+    assert page.usage_record_count == 0
+    assert page.as_of is None


### PR DESCRIPTION
## What

Three `agentacct tui` follow-ups (#4/#5/#6), one PR, all on the same
authoritative local event log the rest of the TUI reads (no credentials, no API):

- **#4 — session status badge.** Every session shows an at-a-glance state:
  `▶ in progress` / `⏸ handed off` / `✓ done` / `⚠ blocked` / `—` (usage-only).
  Derived from the session's recorded steps (`work["items"][].latest_status`),
  **not** `work["counts"]` — counts folds `handed_off` (and `started`/`checkpoint`)
  into `active`, so a cleanly handed-off run would otherwise misread as still
  in-progress. Shown in the sessions list (new `status` column), the session
  detail header, and the #6 home panel.
- **#5 — dedicated usage screen (press `u`).** A per-period token & cost time
  series with in-terminal bars (scaled to the busiest period) plus a by-model
  detail table. `d` cycles the trailing range 7d / 30d / 90d / all, with auto
  granularity (daily for short ranges, weekly for long ones). Built on a new
  `usage_snapshot.build_usage_page()` that reuses the exact `now` data path
  (`usage_records` → `build_usage_cube`), so it can never disagree with the
  overview.
- **#6 — recent sessions on the home screen.** A read-only panel of the five
  most-recently-active top-level sessions (with the #4 badge), filled by a
  background ledger build so the usage/limits view still paints instantly.

## Safety / honesty

- `now --json` / `limits --json` are untouched (byte-stable) — `build_usage_page` /
  `UsagePage` / `ratio_bar` are additive and share no state with them.
- Fixed-vocabulary badges are safe Rich markup; all provider/user-derived cells
  stay `_escape()`d. `ratio_bar` degrades non-finite / zero-max inputs to an empty
  bar. The usage build and the recent-panel worker fail soft (a bad read/build
  shows a note, never crashes the app).
- `_fold_sessions` was extracted from `SessionsScreen._populate` (behavior-identical)
  and is now shared with the home panel.

## Adversarial review (found + fixed a real defect)

A 5-lens read-only review + verify pass ran on the diff. The crash/markup, #4, and
#5 lenses came back clean; the threading lens **confirmed** a race I introduced in
#6: the recent-panel ledger worker (`group="recent"`, App node) and
`SessionsScreen._load` (default group, Screen node) are in different `exclusive=`
scopes, so they could not coalesce and both wrote the **shared** `_work_ledger` /
`_children_by_parent` cache — enabling a torn pair and a stale-clobber observable at
the untagged `SessionDetailScreen._steps` read.

Fix: the home panel now keeps a **private** `_recent_ledger` cache and no longer
touches the shared cache or publishes `_children_by_parent`, so `SessionsScreen`
is again the sole writer of both (its prior, reviewed invariant). A follow-up
fix-audit confirmed the race is fully removed with no new defect, and a regression
test (`test_recent_panel_uses_private_cache_not_shared`) pins the invariant.

## Tests

`.venv/bin/pytest -q` → **3027 passed, 1 skipped** (+15 new tests: `build_usage_page`
/ `ratio_bar` semantics, `_session_status` precedence incl. the counts-vs-items
distinction, `_fold_sessions` multilevel + cycle safety, the usage screen render +
range cycling + no-stack guard, and the recent-panel populate / empty / private-cache
cases). Also verified headless against the real store (read-only, auto-import off):
renders 175 top-level sessions with correct badges (handed-off runs read as
handed-off), the usage screen's 30 daily buckets + by-model detail, and `d` → weekly.
