### PR TITLE
feat(tui): plan limits + client/model filters on the usage screen; hide stale limit streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`agentacct tui` — provider limits on the usage screen, client/model filters,
+  and stale-account hiding.** The usage screen (press `u`) now also shows the
+  provider plan-limit bars (5h / 7d used %, reset countdown), and `c` / `m` scope
+  the whole page — time series, by-model table, and limits — to one client /
+  provider or one model. A signed-out or cancelled account, whose last plan reading
+  stays frozen forever, is now hidden once it has not updated in over a week (the
+  hidden count is disclosed) instead of lingering on the panel with a misleading
+  full bar.
 - **`agentacct tui` — session status badges, a dedicated usage screen, and a
   recent-sessions panel.** Every session now carries an at-a-glance status badge
   (`▶ in progress` / `⏸ handed off` / `✓ done` / `⚠ blocked`), derived from its

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -36,14 +36,17 @@ from textual.widgets import Collapsible, DataTable, Footer, Header, LoadingIndic
 from .service import SentinelService
 from .subagent_roles import read_roles_for_children
 from .usage_snapshot import (
+    ClientLimit,
     LiveSnapshot,
     UsagePage,
+    build_client_limits,
     build_live_snapshot,
     build_usage_page,
     cost_text,
     finite,
     format_tokens,
     humanize_seconds,
+    limit_is_stale,
     ratio_bar,
     usage_bar,
 )
@@ -119,6 +122,72 @@ def _limit_color(used_percent: float) -> str:
     if used_percent < 90:
         return "yellow"
     return "red"
+
+
+def _format_limit_lines(limits: list[ClientLimit], now: float) -> tuple[str, int]:
+    """(Rich-markup text, hidden-stale count) for a set of provider-limit readings.
+
+    Shared by the home Provider-limits panel and the usage screen so they render
+    identically. Stale streams (a signed-out / cancelled account frozen older than
+    its longest window) are dropped so the panel isn't cluttered with a meaningless
+    frozen bar — the count is returned so the hiding is disclosed, never silent.
+    Every provider-derived value is escaped: a stray ``[/]`` in e.g. ``plan_type``
+    would otherwise raise a MarkupError and take down the whole live view.
+    """
+
+    fresh = [limit for limit in limits if not limit_is_stale(limit, now)]
+    hidden = len(limits) - len(fresh)
+    lines: list[str] = []
+    for limit in fresh:
+        header = f"[bold]{_escape(limit.client)}[/]"
+        if limit.origin_label:
+            header += f" [dim]({_escape(limit.origin_label)})[/]"
+        if limit.plan_type:
+            header += f"  plan: {_escape(str(limit.plan_type))}"
+        if limit.org:
+            header += f"  org: {_escape(str(limit.org)[:8])}"
+        if limit.captured_at is not None:
+            header += f"  [dim](as of {humanize_seconds(now - limit.captured_at)} ago)[/]"
+        lines.append(header)
+        for window in limit.windows:
+            used = window.used_percent
+            bar_value = used if used is not None else 0.0
+            color = _limit_color(bar_value)
+            bar = f"[{color}]{usage_bar(bar_value)}[/]"
+            pct = f"{used:5.1f}%" if used is not None else "   — "
+            line = f"  {window.label:>7}  {bar}  {pct}"
+            resets_at = window.resets_at
+            if isinstance(resets_at, (int, float)) and not isinstance(resets_at, bool) and resets_at > 0:
+                delta = resets_at - now
+                line += f"  · resets in {humanize_seconds(delta)}" if delta > 0 else "  · resets now"
+            lines.append(line)
+        if isinstance(limit.credits, dict) and limit.credits.get("has_credits"):
+            lines.append(f"  credits: {_escape(str(limit.credits.get('balance')))}")
+        if limit.reached_type:
+            lines.append(f"  [red]⚠ limit reached: {_escape(str(limit.reached_type))}[/]")
+        lines.append("")
+    return "\n".join(lines).rstrip("\n"), hidden
+
+
+def _limits_panel_text(limits: list[ClientLimit], now: float) -> str:
+    """The full Provider-limits panel text (fresh readings + a disclosed stale
+    count), or an explicit empty/all-stale note. One implementation for the home
+    panel and the usage screen."""
+
+    if not limits:
+        return (
+            "No provider limit data recorded yet — use your agents, or run "
+            "`agentacct usage watch`."
+        )
+    text, hidden = _format_limit_lines(limits, now)
+    stale_note = (
+        f"[dim]{hidden} stale reading(s) hidden (e.g. a signed-out account).[/]"
+        if hidden
+        else ""
+    )
+    if not text:  # everything was stale
+        return f"[dim]No active provider limit readings.[/]  {stale_note}".rstrip()
+    return f"{text}\n\n{stale_note}" if stale_note else text
 
 
 def _session_status(entry: dict) -> tuple[str, str, str]:
@@ -229,6 +298,7 @@ class AgentAcctTUI(App):
     #recent { height: auto; }
     #usage-status { color: $text-muted; padding: 0 0 1 0; }
     #usage-scroll { padding: 0 1; }
+    #usage-limits { padding: 0 0 1 0; }
     #usage-periods, #usage-models { height: auto; }
     #sessions-status { color: $text-muted; padding: 0 0 1 0; }
     #sessions-loading { height: auto; }
@@ -625,50 +695,9 @@ class AgentAcctTUI(App):
             self._limits_text = ""
             body.update("")
             return
-        limits = self._snapshot.limits
-        if not limits:
-            self._limits_text = (
-                "No provider limit data recorded yet — use your agents, or run "
-                "`agentacct usage watch`."
-            )
-            body.update(self._limits_text)
-            return
-        now = time.time()
-        lines: list[str] = []
-        for limit in limits:
-            # Every value below is provider-derived and rendered as Rich markup,
-            # so escape it — a stray '[/]' in e.g. plan_type would otherwise raise
-            # a MarkupError and take down the whole live view.
-            header = f"[bold]{_escape(limit.client)}[/]"
-            if limit.origin_label:
-                header += f" [dim]({_escape(limit.origin_label)})[/]"
-            if limit.plan_type:
-                header += f"  plan: {_escape(str(limit.plan_type))}"
-            if limit.org:
-                header += f"  org: {_escape(str(limit.org)[:8])}"
-            if limit.captured_at is not None:
-                header += f"  [dim](as of {humanize_seconds(now - limit.captured_at)} ago)[/]"
-            lines.append(header)
-            for window in limit.windows:
-                used = window.used_percent
-                bar_value = used if used is not None else 0.0
-                color = _limit_color(bar_value)
-                bar = f"[{color}]{usage_bar(bar_value)}[/]"
-                pct = f"{used:5.1f}%" if used is not None else "   — "
-                line = f"  {window.label:>7}  {bar}  {pct}"
-                resets_at = window.resets_at
-                if isinstance(resets_at, (int, float)) and not isinstance(resets_at, bool) and resets_at > 0:
-                    delta = resets_at - now
-                    line += (
-                        f"  · resets in {humanize_seconds(delta)}" if delta > 0 else "  · resets now"
-                    )
-                lines.append(line)
-            if isinstance(limit.credits, dict) and limit.credits.get("has_credits"):
-                lines.append(f"  credits: {_escape(str(limit.credits.get('balance')))}")
-            if limit.reached_type:
-                lines.append(f"  [red]⚠ limit reached: {_escape(str(limit.reached_type))}[/]")
-            lines.append("")
-        self._limits_text = "\n".join(lines).rstrip("\n")
+        # Shared with the usage screen; hides stale (signed-out/cancelled) streams
+        # and discloses the count.
+        self._limits_text = _limits_panel_text(self._snapshot.limits, time.time())
         body.update(self._limits_text)
 
     def _tick_countdowns(self) -> None:
@@ -1098,6 +1127,8 @@ class UsageScreen(Screen):
         Binding("escape", "back", "Back"),
         Binding("backspace", "back", "Back"),
         Binding("d", "cycle_range", "Range"),
+        Binding("c", "cycle_client", "Client"),
+        Binding("m", "cycle_model", "Model"),
         Binding("r", "refresh", "Refresh"),
         Binding("q", "quit", "Quit"),
     ]
@@ -1106,14 +1137,24 @@ class UsageScreen(Screen):
         super().__init__()
         self._range_index = range_index % len(_USAGE_RANGE_CYCLE)
         self._page: UsagePage | None = None
+        # Filters (None = all). Client scopes the whole page + limits; model scopes
+        # the time series + by-model table. The cycle vocabularies are recomputed on
+        # each rebuild from the unfiltered / client-scoped views.
+        self._client_filter: str | None = None
+        self._model_filter: str | None = None
+        self._available_clients: list[str] = []
+        self._available_models: list[str] = []
         # Composed text kept for headless tests.
         self._status_text = ""
         self._periods_text = ""
+        self._limits_text = ""
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         yield Static("", id="usage-status")
         with VerticalScroll(id="usage-scroll"):
+            yield Static("Plan limits", classes="section-title")
+            yield Static("", id="usage-limits")
             yield Static("Usage over time", classes="section-title")
             yield DataTable(id="usage-periods", cursor_type="none", zebra_stripes=True)
             yield Static("By model", classes="section-title")
@@ -1123,6 +1164,8 @@ class UsageScreen(Screen):
     def on_mount(self) -> None:
         self.title = "agentacct"
         self.sub_title = "usage"
+        # Inherit the app-level --client filter as the starting scope.
+        self._client_filter = getattr(self.app, "client", None)
         self.query_one("#usage-periods", DataTable).add_columns(
             "period", "tokens", "est. cost", "sessions", ""
         )
@@ -1133,10 +1176,30 @@ class UsageScreen(Screen):
 
     def _rebuild(self) -> None:
         days, label = _USAGE_RANGE_CYCLE[self._range_index]
+        cf, mf = self._client_filter, self._model_filter
         try:
-            service = SentinelService(self.app.store_dir, create=False)
-            events = service.list_all_events()
-            page = build_usage_page(events, client=getattr(self.app, "client", None), days=days)
+            events = SentinelService(self.app.store_dir, create=False).list_all_events()
+            # Client vocabulary from the unfiltered view; model vocabulary from the
+            # current client scope (model-unfiltered) — so cycling never collapses
+            # the option list to the single value currently selected. Reuse builds
+            # where the filters make them identical (the screen is on-demand, not on
+            # a timer, so a couple of cube builds are fine).
+            unfiltered = build_usage_page(events, days=days)
+            self._available_clients = sorted(
+                {str(m.get("client")) for m in unfiltered.by_model if m.get("client")}
+            )
+            scoped = unfiltered if cf is None else build_usage_page(events, client=cf, days=days)
+            self._available_models = sorted(
+                {str(m.get("model")) for m in scoped.by_model if m.get("model")}
+            )
+            # A range (or client) change can strand the model filter on a model with
+            # no usage in the new scope; drop it so the view never renders an empty
+            # page while the status line still claims a now-absent model filter.
+            if mf is not None and mf not in self._available_models:
+                mf = None
+                self._model_filter = None
+            page = scoped if mf is None else build_usage_page(events, client=cf, model=mf, days=days)
+            limits = build_client_limits(events, client=cf)
         except Exception as exc:  # noqa: BLE001 - surface, never crash the screen.
             self._status_text = f"error: {exc}"
             try:
@@ -1148,24 +1211,29 @@ class UsageScreen(Screen):
             return
         self._page = page
         try:
-            self._render_page(page, label)
+            self._render_page(page, label, limits)
         except Exception as exc:  # noqa: BLE001 - a render error degrades to a note.
             try:
                 self.query_one("#usage-status", Static).update(f"render error: {_escape(str(exc))}")
             except Exception:  # noqa: BLE001
                 pass
 
-    def _render_page(self, page: UsagePage, label: str) -> None:
+    def _render_page(self, page: UsagePage, label: str, limits: list[ClientLimit]) -> None:
         now = time.time()
         parts = [f"range: {label}", f"{page.granularity}"]
         if page.as_of is not None and page.as_of <= now:
             parts.append(f"as of {humanize_seconds(now - page.as_of)} ago")
         parts.append(f"{page.usage_record_count} usage records")
-        if page.client_filter:
-            parts.append(f"client: {_escape(str(page.client_filter))}")
-        parts.append("d range · r refresh · Esc back")
+        parts.append(f"client: {_escape(str(page.client_filter)) if page.client_filter else 'all'}")
+        if page.model_filter:
+            parts.append(f"model: {_escape(str(page.model_filter))}")
+        parts.append("c client · m model · d range · r · Esc")
         self._status_text = "  ·  ".join(parts)
         self.query_one("#usage-status", Static).update(self._status_text)
+
+        # Plan limits (shared renderer with the home panel; stale streams hidden).
+        self._limits_text = _limits_panel_text(limits, now)
+        self.query_one("#usage-limits", Static).update(self._limits_text)
 
         # Periods newest-first for a monitor (latest on top, no scroll needed); the
         # "unknown" bucket (bad-timestamp rows, all-time only) always sorts last so
@@ -1206,6 +1274,26 @@ class UsageScreen(Screen):
 
     def action_cycle_range(self) -> None:
         self._range_index = (self._range_index + 1) % len(_USAGE_RANGE_CYCLE)
+        self._rebuild()
+
+    def action_cycle_client(self) -> None:
+        options: list[str | None] = [None, *self._available_clients]
+        try:
+            index = options.index(self._client_filter)
+        except ValueError:
+            index = 0
+        self._client_filter = options[(index + 1) % len(options)]
+        # Models are client-scoped, so a client change invalidates the model filter.
+        self._model_filter = None
+        self._rebuild()
+
+    def action_cycle_model(self) -> None:
+        options: list[str | None] = [None, *self._available_models]
+        try:
+            index = options.index(self._model_filter)
+        except ValueError:
+            index = 0
+        self._model_filter = options[(index + 1) % len(options)]
         self._rebuild()
 
     def action_refresh(self) -> None:

--- a/src/agentacct/usage_snapshot.py
+++ b/src/agentacct/usage_snapshot.py
@@ -303,6 +303,7 @@ class UsagePage:
     generated_at: float
     usage_record_count: int
     client_filter: Optional[str]
+    model_filter: Optional[str]
     totals: dict[str, Any]
     by_period: list[dict[str, Any]]
     by_model: list[dict[str, Any]]
@@ -447,6 +448,7 @@ def build_usage_page(
     events: list[dict[str, Any]],
     *,
     client: str | None = None,
+    model: str | None = None,
     days: int | None = 30,
     granularity: str | None = None,
     now: float | None = None,
@@ -454,12 +456,13 @@ def build_usage_page(
 ) -> UsagePage:
     """Build the dedicated usage screen's data for a trailing ``days`` range.
 
-    ``days=None`` = all time. ``granularity`` defaults to the cube's own rule
-    (daily for 7/30-day ranges, weekly for 90/all) via ``resolve_granularity`` so
-    a long range collapses to readable weekly buckets instead of hundreds of days.
-    Reuses the exact ``now`` data path (``usage_records`` → ``build_usage_cube``)
-    so the page can never disagree with the overview. ``now`` / ``today`` are
-    injectable for tests.
+    ``days=None`` = all time. ``client`` / ``model`` scope the whole page to one
+    platform / one model (``None`` = every one). ``granularity`` defaults to the
+    cube's own rule (daily for 7/30-day ranges, weekly for 90/all) via
+    ``resolve_granularity`` so a long range collapses to readable weekly buckets
+    instead of hundreds of days. Reuses the exact ``now`` data path
+    (``usage_records`` → ``build_usage_cube``) so the page can never disagree with
+    the overview. ``now`` / ``today`` are injectable for tests.
     """
 
     from .api import _usage_record_time
@@ -472,7 +475,7 @@ def build_usage_page(
     gran = granularity or resolve_granularity(days_choice, "auto")
 
     cube = build_usage_cube(
-        records, record_time=_usage_record_time, days=days, granularity=gran, today=day
+        records, record_time=_usage_record_time, model=model, days=days, granularity=gran, today=day
     )
 
     # Freshness: newest record with a real (finite, not-future) timestamp — the
@@ -495,6 +498,7 @@ def build_usage_page(
         generated_at=now_epoch,
         usage_record_count=len(records),
         client_filter=client,
+        model_filter=model,
         totals=cube.get("totals") or {},
         by_period=cube.get("by_period") or [],
         by_model=cube.get("by_model") or [],
@@ -552,6 +556,41 @@ def build_client_limits(
     return results
 
 
+#: A limit stream is only hidden once it has not updated in over this long — a
+#: genuinely abandoned account, not one that is merely idle. Floors the staleness
+#: horizon so a stream reporting only a short (e.g. 5-hour) window is not dropped
+#: after a few hours of inactivity.
+STALE_HORIZON_SECONDS = 7 * 86400.0
+
+
+def limit_is_stale(limit: "ClientLimit", now: float) -> bool:
+    """Whether a provider-limit stream is stale — abandoned rather than merely idle.
+
+    A signed-out or cancelled account keeps a frozen last reading forever (the
+    desktop plan-usage file retains its old samples and the event log never expires
+    a ``rate_limit_observed``), so its bar would misleadingly claim e.g. "5h 100%"
+    weeks later. The TUI hides a stream once its newest reading is older than the
+    longest window it reports — but never below a one-week floor
+    (:data:`STALE_HORIZON_SECONDS`). The floor matters: a stream can legitimately
+    carry only a short window (a 5-hour-only Codex/statusline reading, or a Claude
+    sample missing its 7-day field), and a live-but-idle account must NOT be hidden
+    (and implied signed-out) after a few hours past that window. The desktop app
+    keeps sampling every few minutes while an account is signed in, so only a truly
+    abandoned stream — no update in over a week — ages past the floor. An unknown
+    capture time (``captured_at`` None) is treated as fresh; hiding on missing data
+    would drop a live account."""
+
+    if limit.captured_at is None:
+        return False
+    longest = 0.0
+    for window in limit.windows:
+        minutes = window.window_minutes
+        if isinstance(minutes, (int, float)) and not isinstance(minutes, bool) and minutes > 0:
+            longest = max(longest, float(minutes) * 60.0)
+    threshold = max(longest, STALE_HORIZON_SECONDS)
+    return (now - limit.captured_at) > threshold
+
+
 def build_live_snapshot(
     events: list[dict[str, Any]],
     *,
@@ -597,5 +636,6 @@ __all__ = [
     "build_usage_snapshot",
     "build_usage_page",
     "build_client_limits",
+    "limit_is_stale",
     "build_live_snapshot",
 ]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -981,3 +981,140 @@ def test_home_body_is_scrollable(tmp_path):
             assert app.query_one("#recent") is not None
 
     _run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# provider-limit staleness + usage-screen limits & filters
+# ---------------------------------------------------------------------------
+
+
+def _claude_limit(org, captured_age, used=40.0):
+    from agentacct.usage_snapshot import ClientLimit, LimitWindow
+    return ClientLimit(
+        client="claude-code", origin="claude_plan_usage", origin_label="desktop app",
+        plan_type=None, org=org, captured_at=time.time() - captured_age,
+        windows=[LimitWindow(kind="7d", label="7-day", used_percent=used, window_minutes=10080, resets_at=None)],
+        credits=None, reached_type=None, source_file=None, raw_event={},
+    )
+
+
+def test_format_limit_lines_and_panel_text():
+    from agentacct.tui import _format_limit_lines, _limits_panel_text
+    from rich.text import Text
+
+    now = time.time()
+    dead = _claude_limit("deadorg", 8 * 86400, used=100.0)  # 8d old → stale
+    live = _claude_limit("liveorg", 600, used=35.0)          # 10m old → fresh
+
+    text, hidden = _format_limit_lines([dead, live], now)
+    assert hidden == 1
+    assert "liveorg" in text and "deadorg" not in text  # the dead account is dropped
+    Text.from_markup(text)  # valid markup
+
+    panel = _limits_panel_text([dead, live], now)
+    assert "1 stale reading(s) hidden" in panel  # hiding is disclosed, never silent
+    # all-stale → explicit note, still valid markup.
+    all_stale = _limits_panel_text([dead], now)
+    assert "No active provider limit readings" in all_stale
+    Text.from_markup(all_stale)
+    # no data at all → the record-data hint.
+    assert "No provider limit data recorded yet" in _limits_panel_text([], now)
+
+
+def test_home_render_limits_hides_stale(tmp_path):
+    SentinelService(tmp_path)
+    from agentacct.usage_snapshot import UsageSnapshot, LiveSnapshot
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            now = time.time()
+            app._snapshot = LiveSnapshot(
+                usage=UsageSnapshot(
+                    as_of=None, generated_at=now, event_count=0, usage_record_count=0,
+                    client_filter=None, windows=[], breakdown_window="last 7 days",
+                    by_client=[], by_model=[],
+                ),
+                limits=[_claude_limit("deadorg", 8 * 86400, used=100.0),
+                        _claude_limit("liveorg", 600, used=35.0)],
+            )
+            app._render_limits()
+            assert "liveorg" in app._limits_text and "deadorg" not in app._limits_text
+            assert "1 stale reading(s) hidden" in app._limits_text
+
+    _run(scenario())
+
+
+def test_usage_screen_limits_and_filters(tmp_path):
+    from agentacct.tui import UsageScreen
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt-5", session_id="c1",
+                  input_tokens=1000, output_tokens=100, updated_at=int(now - 3600), estimated_cost_usd=1.0)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="a1",
+                  input_tokens=500, output_tokens=50, updated_at=int(now - 3600), estimated_cost_usd=0.5)
+    _record_usage(service, client="claude-code", model="claude-fable-5", session_id="a2",
+                  input_tokens=300, output_tokens=30, updated_at=int(now - 3600), estimated_cost_usd=0.4)
+    _seed_codex_limit(service, used=52.0, resets_at=int(now + 7200), captured=now - 60)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("u")
+            await pilot.pause()
+            scr = app.screen
+            assert isinstance(scr, UsageScreen)
+            # the fresh codex limit renders in the usage-screen Plan limits section.
+            assert "codex" in scr._limits_text
+            assert set(scr._available_clients) >= {"claude-code", "codex"}
+            assert "client: all" in scr._status_text
+            # `c` scopes to a client; `m` then scopes to one of that client's models.
+            await pilot.press("c")
+            await pilot.pause()
+            assert scr._client_filter in ("claude-code", "codex")
+            await pilot.press("m")
+            await pilot.pause()
+            assert scr._model_filter is not None
+            assert scr.query_one("#usage-models", DataTable).row_count == 1
+
+    _run(scenario())
+
+
+def test_usage_screen_model_filter_dropped_when_absent_in_range(tmp_path):
+    # Regression (review): cycling the range must not strand the model filter on a
+    # model with no usage in the new range (empty page + stale "model: X" status).
+    from agentacct.tui import UsageScreen
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    # fable only 40d ago (present in 90d/all, absent in 7d/30d); opus is recent.
+    _record_usage(service, client="claude-code", model="claude-fable-5", session_id="f1",
+                  input_tokens=100, output_tokens=10, updated_at=int(now - 40 * 86400), estimated_cost_usd=0.5)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="o1",
+                  input_tokens=100, output_tokens=10, updated_at=int(now - 3600), estimated_cost_usd=0.5)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.push_screen(UsageScreen(range_index=2))  # 90d, where fable exists
+            await pilot.pause()
+            scr = app.screen
+            scr._client_filter = "claude-code"
+            scr._model_filter = "claude-fable-5"
+            scr._rebuild()
+            await pilot.pause()
+            assert scr._model_filter == "claude-fable-5"
+            assert "claude-fable-5" in scr._available_models
+            # 90d → all (fable still present) → 7d (fable absent → filter dropped).
+            scr.action_cycle_range()  # all
+            await pilot.pause()
+            scr.action_cycle_range()  # 7d
+            await pilot.pause()
+            assert "claude-fable-5" not in scr._available_models
+            assert scr._model_filter is None  # dropped, not stranded on an empty page
+
+    _run(scenario())

--- a/tests/test_usage_snapshot.py
+++ b/tests/test_usage_snapshot.py
@@ -483,3 +483,46 @@ def test_build_usage_page_empty_store(tmp_path):
     assert page.by_model == []
     assert page.usage_record_count == 0
     assert page.as_of is None
+
+
+# ---------------------------------------------------------------------------
+# limit_is_stale + build_usage_page model filter
+# ---------------------------------------------------------------------------
+
+
+def _limit(captured_age_days, windows_minutes, now):
+    wins = [us.LimitWindow(kind="w", label="w", used_percent=50.0, window_minutes=m, resets_at=None)
+            for m in windows_minutes]
+    captured = None if captured_age_days is None else now - captured_age_days * 86400
+    return us.ClientLimit(client="c", origin=None, origin_label=None, plan_type=None, org=None,
+                          captured_at=captured, windows=wins, credits=None, reached_type=None,
+                          source_file=None, raw_event={})
+
+
+def test_limit_is_stale():
+    now = 1_000_000.0
+    # older than the (7d) horizon → stale (e.g. a signed-out account).
+    assert us.limit_is_stale(_limit(8, [300, 10080], now), now) is True
+    # within the week → fresh.
+    assert us.limit_is_stale(_limit(2, [10080], now), now) is False
+    # a 5h-ONLY stream read 6h ago must NOT be hidden: the one-week floor keeps a
+    # live-but-idle account visible rather than implying it signed out.
+    assert us.limit_is_stale(_limit(0.25, [300], now), now) is False
+    # …but a 5h-only stream abandoned for over a week IS stale.
+    assert us.limit_is_stale(_limit(9, [300], now), now) is True
+    # unknown capture time → never stale (can't judge; don't drop a live account).
+    assert us.limit_is_stale(_limit(None, [300], now), now) is False
+    # no usable window length → the week floor: 3d fresh, 9d stale.
+    assert us.limit_is_stale(_limit(3, [], now), now) is False
+    assert us.limit_is_stale(_limit(9, [], now), now) is True
+
+
+def test_build_usage_page_model_filter(tmp_path):
+    service = SentinelService(tmp_path)
+    _record_usage(service, client="codex", model="gpt-5", session_id="a",
+                  input_tokens=100, output_tokens=10, updated_at=int(_NOW - 3600), estimated_cost_usd=1.0)
+    _record_usage(service, client="codex", model="gpt-4", session_id="b",
+                  input_tokens=200, output_tokens=20, updated_at=int(_NOW - 3600), estimated_cost_usd=2.0)
+    page = us.build_usage_page(service.list_all_events(), model="gpt-5", days=30, now=_NOW, today=_TODAY)
+    assert page.model_filter == "gpt-5"
+    assert {m["model"] for m in page.by_model} == {"gpt-5"}  # scoped to the one model


### PR DESCRIPTION
## What

Usage-page detail + a fix for the lingering "dead account" — all on the same
authoritative local event log, no credentials.

- **Auto-hide stale provider-limit streams.** A signed-out / cancelled account
  keeps a frozen last reading forever (the desktop plan-usage file retains its old
  samples, and the event log never expires a `rate_limit_observed`), so it lingered
  on the home Provider-limits panel misleadingly claiming e.g. "5h 100%" weeks
  later. `usage_snapshot.limit_is_stale(limit, now)` — stale once its newest reading
  is older than the longest window it reports — and the shared renderer drops stale
  streams, **disclosing the hidden count** rather than silently. (Real store: the
  owner's cancelled Claude org, ~13 days old at 5h 100% / 7d 40%, is now hidden with
  "1 stale reading(s) hidden".)
- **Plan limits on the usage screen.** The provider-limit panel (5h/7d bars + reset
  countdown) renders on the usage screen too, via a shared `_limits_panel_text` so
  the home panel and the usage screen agree exactly.
- **Client + model filters on the usage screen.** `c` cycles the client/provider
  scope (all + each observed client), `m` cycles the model scope (within the current
  client); the time series, the by-model table, and the limits panel all follow.
  `build_usage_page` gained a `model=` passthrough to the cube; `UsagePage` gained a
  `model_filter` field.

## Why the "how much plan is left" is now honest

The stale-hide is the visible half of a broader finding while prototyping the
per-task plan-cost feature (separate work): the two Claude readings on the home
panel were two accounts (two orgs), one of them cancelled and frozen. Hiding the
dead stream leaves the panel showing only live subscriptions.

## Safety

- `now --json` / `limits --json` are untouched (byte-stable): the stale-hide and
  the render refactor are TUI-only; the CLI still emits via `limit_json_entry` and
  the cube. `limit_is_stale` never hides a stream with an unknown capture time.
- The stale threshold is floored at **one week**, so a stream that reports only a
  short (5h) window is never dropped after a few hours of idleness — only a
  genuinely abandoned account (no update in over a week) is hidden. The desktop app
  keeps sampling every few minutes while signed in, so a live account stays fresh.
- All provider/user-derived values stay `_escape()`d in the shared renderer.
- The usage screen fails soft (a bad read/build shows a note, never crashes).

## Adversarial review

A 4-lens read-only review + verify pass ran on the diff. Parity/crash came back
clean. **1 confirmed defect, fixed**: `action_cycle_range` didn't reset the model
filter, so cycling the range onto a window where that model had no usage stranded
the view on an empty page — now the filter is dropped when absent from the new
scope. **1 correctness hardening**: three lenses flagged that the original
"longest reported window" stale threshold would hide a live-but-idle account whose
only window is short (5h) — fixed with the one-week floor above (and a
fix-audit confirmed both changes are complete with no new defect).

## Tests

`.venv/bin/pytest -q` → **3034 passed, 1 skipped** (+6: `limit_is_stale` incl. the
short-window floor, `build_usage_page` model filter, `_format_limit_lines` /
`_limits_panel_text` hide-and-disclose states, the home stale-hide, the usage-screen
limits + `c`/`m` filters, and the model-filter-dropped-on-range-change regression).
Verified headless on the real store: the cancelled org is hidden, the usage screen
scopes to one client's models.
