### PR TITLE
feat(tui): estimate a session's share of the weekly Claude plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`agentacct tui` — "≈ X% of your weekly Claude plan" per session.** The home
+  **Recent sessions** panel (and the session detail) now estimate what fraction of
+  your weekly Claude subscription each task consumed — a `plan` column at a glance. The weekly meter is a per-week-reset cumulative, so a session's share is
+  its own weighted usage over the weekly capacity — and because models burn the plan
+  at very different rates per dollar, the estimate uses a **measured per-model weight
+  table** (shipped, so every user gets a reasonable number out of the box) scaled by a
+  **per-account factor** that self-calibrates from your own recorded 7-day usage
+  history (from any source — desktop plan-usage, Codex rollouts, or the Claude CLI
+  statusLine hook — so CLI-only users are covered). Always labeled a (rough) estimate,
+  it only claims a calibrated scale when the fit is trustworthy, and it sharpens as
+  more limit history accrues.
 - **`agentacct tui` — provider limits on the usage screen, client/model filters,
   and stale-account hiding.** The usage screen (press `u`) now also shows the
   provider plan-limit bars (5h / 7d used %, reset countdown), and `c` / `m` scope

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -1,0 +1,344 @@
+"""Estimate what fraction of a Claude subscription plan a session/task consumed.
+
+The weekly (7-day) plan meter is a **per-week-reset cumulative** counter — verified
+from the desktop plan-usage series, it climbs from a weekly reset then drops back to
+0 (unlike the 5-hour window, which rolls). So a session's contribution to the weekly
+plan is simply its own weighted usage divided by the weekly capacity — no rolling
+decay or concurrency confound to untangle.
+
+Raw token counts are the wrong unit and cost alone is not enough either: models burn
+the plan at very different rates *per dollar* (measured: Fable burns several times
+more of the weekly plan per dollar than Opus 4.8). So the estimate has two parts:
+
+* a **baseline per-model weight** — percent of the weekly plan per 1M tokens, at a
+  reference (Max-tier) scale. These ship with the product so every user gets a
+  reasonable estimate out of the box. They are *measured*, with Opus 4.8 solid (many
+  clean single-model intervals) and the rarer models approximate; a model absent from
+  the table falls back to a cost-scaled weight. This is the universal part.
+
+* a per-user **scale** — one number that maps the baseline onto *this* account's plan
+  (its tier sets the capacity, and the baseline can drift), learned by comparing the
+  baseline's predicted weekly-%% movement against the account's own recorded 7-day
+  usage-%% history. A single scalar is robust (no per-model collinearity) and updates
+  continuously as more limit history accrues — from any source that records it
+  (desktop plan-usage file import, Codex rollouts, or the Claude CLI statusLine hook),
+  so CLI-only users are covered too.
+
+Estimate = scale x Σ baseline_weight(model) x Mtokens(model). Always an ESTIMATE, and
+every result carries a ``confidence`` (``calibrated`` once fit from enough history,
+else ``baseline``). No credentials, no API calls — it reads the local event log.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+_SEVEN_DAY_MINUTES = 10080
+
+# Baseline per-model weekly-plan weights: percent of the weekly plan per 1M tokens,
+# at a reference (Max-tier) scale. Measured from a dense plan-usage series regressed
+# against per-model token volume (main + subagent turns). Opus 4.8 is well-determined
+# (dozens of clean single-model intervals); the rarer models are approximate — one
+# account rarely runs several models enough to separate them, so a per-user scale (and
+# eventually cross-user data) refines them. Values are intentionally conservative and
+# meant to be updated as more data accrues.
+BASELINE_MODEL_WEIGHTS: dict[str, float] = {
+    "claude-opus-4-8": 0.0127,             # solid: ~31 clean intervals
+    "claude-opus-5": 0.040,                # approximate (few clean intervals)
+    "claude-fable-5": 0.130,               # approximate: ~10x Opus 4.8; matches lived experience
+    "claude-haiku-4-5-20251001": 0.004,    # cost-scaled (cheap model)
+}
+# For a model not in the table, weight it from its own cost at Opus 4.8's measured
+# plan-percent-per-dollar, so a new/unknown model still gets a sensible baseline.
+_REF_PCT_PER_DOLLAR = 0.016
+# Below this many usable weekly-%% intervals we don't trust a scale fit — ship the
+# baseline as-is (scale 1.0) rather than chase a number from noise.
+_MIN_SCALE_INTERVALS = 3
+# Guard rails for what counts as a clean calibration interval. The window is kept
+# short so a weekly reset is unlikely to hide inside a net-positive interval.
+_MAX_INTERVAL_SECONDS = 12 * 3600.0
+_MAX_INTERVAL_PCT = 60.0
+# Only fit from recent history, so an old plan tier / stale baseline doesn't drag the
+# current scale.
+_CALIBRATION_WINDOW_DAYS = 21
+# Keep a raw fitted scale sane even if the sparse early data is noisy.
+_SCALE_CLAMP = (0.1, 10.0)
+# Only APPLY a fitted scale (and claim "calibrated") when it lands in this band. The
+# 7-day meter is account-wide but our tokens cover only tracked clients, so a scale
+# far from 1 means either heavy untracked Claude usage (desktop app / claude.ai) or a
+# very different plan tier — neither of which we can identify — so we keep the shipped
+# baseline rather than apply an unreliable (over- or under-stating) scale.
+_TRUSTED_SCALE_BAND = (0.5, 2.5)
+
+
+@dataclass(frozen=True)
+class PlanWeights:
+    """Effective per-model weekly-plan weights (percent per 1M tokens) for one account.
+
+    ``weights`` is the baseline times the fitted ``scale``. ``confidence`` is
+    ``calibrated`` when ``scale`` was fit from enough recorded 7-day history, else
+    ``baseline`` (the shipped table at scale 1.0). ``default_weight`` applies to a
+    model absent from ``weights``.
+    """
+
+    weights: Mapping[str, float]
+    default_weight: float
+    scale: float
+    confidence: str
+    basis: str
+    intervals_used: int
+    client: str
+
+    def weight_for(self, model: Any) -> float:
+        value = self.weights.get(str(model))
+        return float(value) if isinstance(value, (int, float)) else self.default_weight
+
+    def pct_for_tokens(self, tokens_by_model: Mapping[str, Any]) -> float:
+        """Estimated percent of the weekly plan for a per-model token map."""
+
+        total = 0.0
+        for model, tokens in tokens_by_model.items():
+            count = _finite(tokens)
+            if count is None or count <= 0:
+                continue
+            total += self.weight_for(model) * (count / 1_000_000.0)
+        return total
+
+
+def _finite(value: Any) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value)):
+        return float(value)
+    return None
+
+
+def baseline_weight(model: Any, cost_per_mtok: float | None = None) -> float:
+    """The shipped baseline weekly-plan weight for a model (%/Mtoken, reference scale).
+
+    Known models use the measured table; an unknown model is weighted from its own
+    cost at the reference plan-%%-per-dollar; with neither, it falls back to the Opus
+    4.8 anchor so the estimate is never zero for real usage.
+    """
+
+    name = str(model or "")
+    if name in BASELINE_MODEL_WEIGHTS:
+        return BASELINE_MODEL_WEIGHTS[name]
+    price = _finite(cost_per_mtok)
+    if price is not None and price > 0:
+        return price * _REF_PCT_PER_DOLLAR
+    return BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+
+
+def seven_day_series(events: Sequence[Mapping[str, Any]], *, client: str = "claude-code") -> list[tuple[float, float]]:
+    """``[(captured_at, used_percent_7d)]`` for one client, ascending by time, from the
+    recorded ``rate_limit_observed`` events' 7-day window."""
+
+    from .rate_limits import EVENT_TYPE
+
+    out: list[tuple[float, float]] = []
+    for event in events:
+        if event.get("event_type") != EVENT_TYPE:
+            continue
+        metadata = event.get("metadata") or {}
+        if client and str(metadata.get("client") or "") != client:
+            continue
+        captured = _finite(metadata.get("captured_at"))
+        if captured is None:
+            captured = _finite(event.get("created_at"))
+        if captured is None:
+            continue
+        for window in metadata.get("windows") or []:
+            if not isinstance(window, Mapping):
+                continue
+            if window.get("window_minutes") == _SEVEN_DAY_MINUTES or str(window.get("kind")) == "7d":
+                used = _finite(window.get("used_percent"))
+                if used is not None:
+                    out.append((captured, used))
+                    break
+    out.sort(key=lambda row: row[0])
+    return out
+
+
+def _cost_per_mtok(records: Sequence[Any]) -> dict[str, float]:
+    cost: dict[str, float] = {}
+    toks: dict[str, float] = {}
+    for record in records:
+        model = str(getattr(record, "model", "") or "")
+        if not model:
+            continue
+        toks[model] = toks.get(model, 0.0) + (_finite(getattr(record, "total_tokens_including_cached", None)) or 0.0)
+        price = _finite(getattr(record, "estimated_cost_usd", None))
+        if price is not None:
+            cost[model] = cost.get(model, 0.0) + price
+    return {m: cost[m] / (toks[m] / 1_000_000.0) for m in toks if toks[m] > 0 and m in cost}
+
+
+def _model_tokens_between(records: Sequence[Any], record_time, lo: float, hi: float) -> dict[str, float]:
+    tokens: dict[str, float] = {}
+    for record in records:
+        moment = record_time(record)
+        if not isinstance(moment, (int, float)) or isinstance(moment, bool):
+            continue
+        if not (lo < float(moment) <= hi):
+            continue
+        model = str(getattr(record, "model", "") or "")
+        if not model:
+            continue
+        total = _finite(getattr(record, "total_tokens_including_cached", None))
+        tokens[model] = tokens.get(model, 0.0) + (total or 0.0)
+    return tokens
+
+
+def calibrate_plan_weights(
+    events: list[dict[str, Any]],
+    *,
+    client: str = "claude-code",
+    records: list[Any] | None = None,
+    now: float | None = None,
+) -> PlanWeights:
+    """Baseline per-model weights scaled to this account's recorded plan history.
+
+    Fits ONE per-user scale = (observed weekly-%% moved) / (baseline-predicted %%)
+    over recent, clean, non-reset intervals — robust and collinearity-free. Only
+    intervals whose movement our tracked-client tokens can actually explain
+    (``predicted > 0``) contribute, and the fitted scale is applied only inside a
+    trusted band; otherwise the shipped baseline is kept. This guards the estimate's
+    known blind spot: the 7-day meter is ACCOUNT-WIDE (Claude desktop app, claude.ai,
+    other machines all move it) while our tokens cover only tracked clients, so
+    movement with no local tokens is untracked usage that must not inflate the scale.
+
+    ``records`` may be passed pre-built (the caller already ran the usage view) to
+    avoid rebuilding it. ``now`` bounds the recency window (injectable for tests).
+    ``events`` still supplies the 7-day series regardless.
+    """
+
+    from .api import _usage_record_time
+    import time as _time
+
+    now_epoch = now if now is not None else _time.time()
+    if records is None:
+        from .usage_snapshot import usage_records as _usage_records
+
+        records = _usage_records(events, client=client)
+
+    cost_per_mtok = _cost_per_mtok(records)
+    observed_models = {str(getattr(r, "model", "") or "") for r in records if getattr(r, "model", None)}
+    model_names = observed_models | set(BASELINE_MODEL_WEIGHTS)
+    base = {m: baseline_weight(m, cost_per_mtok.get(m)) for m in model_names if m}
+
+    series = seven_day_series(events, client=client)
+    window_start = now_epoch - _CALIBRATION_WINDOW_DAYS * 86400.0
+    observed = 0.0
+    predicted = 0.0
+    intervals = 0
+    for (t0, p0), (t1, p1) in zip(series, series[1:]):
+        if not (0 < t1 - t0 <= _MAX_INTERVAL_SECONDS):
+            continue
+        if t1 < window_start:  # only recent history reflects the current tier/mix
+            continue
+        delta = p1 - p0
+        if delta < 0 or delta > _MAX_INTERVAL_PCT:  # a drop is a weekly reset
+            continue
+        interval_tokens = _model_tokens_between(records, _usage_record_time, t0, t1)
+        pred = sum(base.get(m, 0.0) * (tok / 1_000_000.0) for m, tok in interval_tokens.items())
+        # Fit ONLY from movement our tokens can explain. An interval where the meter
+        # moved with no local tokens (pred == 0) is Claude usage outside the tracked
+        # clients (desktop app / web); counting it would inflate the scale and
+        # over-state every session, so skip it.
+        if pred <= 0:
+            continue
+        observed += delta
+        predicted += pred
+        intervals += 1
+
+    raw_scale = (observed / predicted) if predicted > 0 else 1.0
+    raw_scale = max(_SCALE_CLAMP[0], min(_SCALE_CLAMP[1], raw_scale))
+    trusted = _TRUSTED_SCALE_BAND[0] <= raw_scale <= _TRUSTED_SCALE_BAND[1]
+    if intervals >= _MIN_SCALE_INTERVALS and predicted > 0 and trusted:
+        scale = raw_scale
+        confidence = "calibrated"
+        basis = f"baseline scaled x{scale:.2f} to this account ({intervals} recent weekly-%% intervals)"
+    else:
+        # Too little clean history, or a fit outside the trusted band (heavy untracked
+        # Claude usage or a very different plan tier we can't identify) → keep the
+        # shipped baseline rather than apply an unreliable scale.
+        scale = 1.0
+        confidence = "baseline"
+        basis = "shipped baseline (record more 7-day limit history from tracked clients to calibrate)"
+
+    weights = {m: w * scale for m, w in base.items()}
+    default = BASELINE_MODEL_WEIGHTS["claude-opus-4-8"] * scale
+    return PlanWeights(
+        weights=weights,
+        default_weight=default,
+        scale=scale,
+        confidence=confidence,
+        basis=basis,
+        intervals_used=intervals,
+        client=client,
+    )
+
+
+def session_tokens_by_model(
+    events: list[dict[str, Any]] | None = None,
+    *,
+    client: str,
+    session_id: str,
+    records: list[Any] | None = None,
+) -> dict[str, float]:
+    """Per-model total tokens (incl. cache) for one session, from its usage records.
+
+    ``records`` may be passed pre-built to avoid rebuilding the usage view."""
+
+    if records is None:
+        from .usage_snapshot import usage_records as _usage_records
+
+        records = _usage_records(events or [], client=client)
+
+    tokens: dict[str, float] = {}
+    for record in records:
+        if str(getattr(record, "client", "") or "") != client:
+            continue
+        if str(getattr(record, "session_id", "") or "") != str(session_id):
+            continue
+        model = str(getattr(record, "model", "") or "")
+        if not model:
+            continue
+        total = _finite(getattr(record, "total_tokens_including_cached", None)) or 0.0
+        tokens[model] = tokens.get(model, 0.0) + total
+    return tokens
+
+
+def session_plan_pcts(
+    records: Sequence[Any], weights: PlanWeights, *, client: str = "claude-code"
+) -> dict[str, float]:
+    """``{session_id: estimated % of the weekly plan}`` for one client, in ONE pass.
+
+    Groups the pre-built usage records by (session, model) once, then applies
+    ``weights`` — so estimating many sessions (a list view) is cheap, not O(records)
+    per session."""
+
+    by_session: dict[str, dict[str, float]] = {}
+    for record in records:
+        if str(getattr(record, "client", "") or "") != client:
+            continue
+        session_id = str(getattr(record, "session_id", "") or "")
+        model = str(getattr(record, "model", "") or "")
+        if not session_id or not model:
+            continue
+        total = _finite(getattr(record, "total_tokens_including_cached", None)) or 0.0
+        bucket = by_session.setdefault(session_id, {})
+        bucket[model] = bucket.get(model, 0.0) + total
+    return {sid: weights.pct_for_tokens(tokens) for sid, tokens in by_session.items()}
+
+
+__all__ = [
+    "BASELINE_MODEL_WEIGHTS",
+    "PlanWeights",
+    "baseline_weight",
+    "seven_day_series",
+    "calibrate_plan_weights",
+    "session_tokens_by_model",
+    "session_plan_pcts",
+]

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -230,6 +230,20 @@ def _session_badge(entry: dict) -> str:
     return f"[{color}]{glyph} {label}[/]"
 
 
+def _plan_pct_cell(entry: dict, pcts: dict) -> str:
+    """A compact ``≈X%`` weekly-Claude-plan cell for a session row, or ``—``.
+
+    Claude-plan-specific (other clients show ``—``); the estimate comes from the
+    pre-computed per-session map so a list renders many rows cheaply."""
+
+    if str(entry.get("client") or "") != "claude-code":
+        return "—"
+    pct = (pcts or {}).get(str(entry.get("client_session_id")))
+    if not (isinstance(pct, (int, float)) and not isinstance(pct, bool) and pct > 0):
+        return "—"
+    return f"≈{pct:.1f}%" if pct >= 0.1 else "≈<0.1%"
+
+
 def _fold_sessions(sessions: list[dict]) -> tuple[list[dict], dict[str, list[dict]]]:
     """Fold every subagent DESCENDANT under its top-most root session.
 
@@ -356,6 +370,12 @@ class AgentAcctTUI(App):
         # non-coalescing lineages would let them stale-clobber / tear each other.
         self._recent_ledger: dict | None = None
         self._recent_ledger_fp: int | None = None
+        # Per-account weekly-plan estimate cache as a SINGLE tuple
+        # (fingerprint, weights, records, per-session pcts) so the recent-panel worker
+        # thread and the main-thread detail can never tear a multi-field write — one
+        # atomic assignment, keyed on the event-log content so it self-heals on change
+        # and never goes stale after an import.
+        self._plan_cache: Any = None
         # Folded child (subagent) sessions, keyed by the parent's session_key;
         # written ONLY by the sessions screen (its sole owner), read by the detail
         # screen. The home panel does not publish here (its table is non-interactive).
@@ -397,7 +417,9 @@ class AgentAcctTUI(App):
         self.query_one("#windows", DataTable).add_columns("window", "tokens", "est. cost", "sessions")
         self.query_one("#byclient", DataTable).add_columns("client", "tokens", "est. cost", "sessions")
         self.query_one("#bymodel", DataTable).add_columns("model", "client", "tokens", "est. cost")
-        self.query_one("#recent", DataTable).add_columns("session", "client", "status", "tokens", "activity")
+        self.query_one("#recent", DataTable).add_columns(
+            "session", "client", "status", "tokens", "plan", "activity"
+        )
         self.refresh_data(force=True)  # show the stored view instantly
         self._start_import()  # then freshen it from the client logs in the background
         self._start_recent()  # and fill the recent-sessions panel from the ledger
@@ -510,7 +532,36 @@ class AgentAcctTUI(App):
         # shared `_children_by_parent` would let a background home refresh disagree
         # with what SessionsScreen (its sole writer) is showing.
         top, _children = _fold_sessions(sessions)
-        self.call_from_thread(self._populate_recent, top)
+        # Estimate each session's share of the weekly plan (claude-code) — computed
+        # here on the worker thread (off the UI loop) and cached by fingerprint.
+        try:
+            _weights, _records, pcts = self._ensure_plan_cache(events)
+        except Exception:  # noqa: BLE001 - the plan column is best-effort.
+            pcts = {}
+        if worker.is_cancelled:
+            return
+        self.call_from_thread(self._populate_recent, top, pcts)
+
+    def _ensure_plan_cache(self, events: list) -> tuple:
+        """Compute + cache (weights, records, per-session plan %) keyed on the event
+        fingerprint. Shared by the recent panel and the session detail so the
+        expensive usage view + calibration run at most once per event change and a
+        stale scale can't survive an import. Stored as one tuple so a concurrent
+        writer (the recent worker vs a detail open) can never observe a torn pair;
+        the last writer wins and the tuple is always internally consistent."""
+
+        fingerprint = _events_fingerprint(events)
+        cache = self._plan_cache
+        if cache is None or cache[0] != fingerprint:
+            from .plan_cost import calibrate_plan_weights, session_plan_pcts
+            from .usage_snapshot import usage_records
+
+            records = usage_records(events, client="claude-code")
+            weights = calibrate_plan_weights(events, client="claude-code", records=records)
+            pcts = session_plan_pcts(records, weights, client="claude-code")
+            cache = (fingerprint, weights, records, pcts)
+            self._plan_cache = cache  # single atomic assignment
+        return cache[1], cache[2], cache[3]
 
     def _recent_error(self, message: str) -> None:
         self._recent_loading = False
@@ -522,8 +573,9 @@ class AgentAcctTUI(App):
         except Exception:  # noqa: BLE001 - last resort.
             pass
 
-    def _populate_recent(self, top: list[dict]) -> None:
+    def _populate_recent(self, top: list[dict], pcts: dict[str, float] | None = None) -> None:
         self._recent_loading = False
+        pcts = pcts or {}
         try:
             table = self.query_one("#recent", DataTable)
         except Exception:  # noqa: BLE001 - app tearing down.
@@ -542,6 +594,7 @@ class AgentAcctTUI(App):
                 _escape(str(entry.get("client") or "")),
                 _session_badge(entry),  # fixed-vocab colored badge (safe markup)
                 format_tokens(usage.get("total_tokens")),
+                _plan_pct_cell(entry, pcts),
                 _humanize_ago(entry.get("last_activity_at"), now),
             )
         note = f"{len(top)} sessions · press s for all" if top else "no sessions yet"
@@ -1021,8 +1074,37 @@ class SessionDetailScreen(Screen):
         if isinstance(last, (int, float)) and last:
             header += f" · {_humanize_ago(last, now)}"
         header += f" · {format_tokens(usage.get('total_tokens'))} tokens · {_session_cost_text(usage)}"
+        plan_line = self._plan_estimate(entry)
+        if plan_line:
+            header += f"\n[dim]{plan_line}[/]"
         self._header_text = header
         return header
+
+    def _plan_estimate(self, entry: dict) -> str | None:
+        """A one-line 'estimated % of the weekly Claude plan' for this session.
+
+        Claude-plan-specific (skipped for other clients). Fail-soft: any read/build
+        problem yields no line rather than crashing the detail. The per-account
+        weights are computed once and cached on the app; only the session's own
+        per-model tokens are gathered per open.
+        """
+
+        if str(entry.get("client") or "") != "claude-code":
+            return None
+        try:
+            app = self.app
+            events = SentinelService(app.store_dir, create=False).list_all_events()
+            # Shared, fingerprint-cached weights + per-session % (built once per event
+            # change, off the UI thread by the recent-panel worker when it ran first).
+            weights, _records, pcts = app._ensure_plan_cache(events)
+            pct = pcts.get(str(entry.get("client_session_id")))
+            if not (isinstance(pct, (int, float)) and pct > 0):
+                return None
+            shown = f"{pct:.1f}%" if pct >= 0.1 else "<0.1%"
+            note = "estimate" if getattr(weights, "confidence", "") == "calibrated" else "rough estimate"
+            return f"≈ {shown} of your weekly Claude plan · {note}"
+        except Exception:  # noqa: BLE001 - the estimate is best-effort; never crash the detail.
+            return None
 
     def _step_render(self, wi: dict, now: float) -> tuple[str, str]:
         status = str(wi.get("latest_status") or "?")

--- a/tests/test_plan_cost.py
+++ b/tests/test_plan_cost.py
@@ -1,0 +1,221 @@
+"""Tests for the weekly-plan cost estimator (`agentacct.plan_cost`)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentacct.client_usage import ClientUsageEvent
+from agentacct.service import SentinelService
+from agentacct import plan_cost as pc
+
+
+def _record_usage(service, *, client, model, session_id, tokens, updated_at, cost):
+    event = ClientUsageEvent(
+        client=client,
+        client_session_id=session_id,
+        source_path=Path(f"/tmp/{client}/{session_id}.jsonl"),
+        title=None,
+        cwd="/tmp/p",
+        model=model,
+        input_tokens=tokens,
+        output_tokens=0,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name=client,
+        started_at=updated_at,
+        updated_at=updated_at,
+        turn_count=1,
+        usage_row_lane=f"model:{model}",
+        source_namespace_fingerprint=f"sha256:{client}",
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=tokens,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    if cost is not None:
+        event["estimated_cost_usd"] = cost
+        event["cost_confidence"] = "estimated_from_tokens"
+    service.record_event(event, trusted_usage_import=True)
+
+
+def _record_7d(service, *, captured, pct, client="claude-code", index=0):
+    service.record_event({
+        "event_id": f"evt_rl_{client}_{index}",
+        "created_at": captured,
+        "source": client,
+        "event_type": "rate_limit_observed",
+        "metadata": {
+            "client": client,
+            "captured_at": captured,
+            "windows": [{"kind": "7d", "window_minutes": 10080, "used_percent": pct}],
+        },
+    })
+
+
+# ---------------------------------------------------------------------------
+# pure pieces
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_weight():
+    # a known model → the measured table value.
+    assert pc.baseline_weight("claude-opus-4-8") == pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    # an unknown model with a cost → cost-scaled at the reference plan-%/$.
+    assert pc.baseline_weight("brand-new", cost_per_mtok=2.0) == 2.0 * pc._REF_PCT_PER_DOLLAR
+    # unknown with no cost → the Opus anchor (never zero for real usage).
+    assert pc.baseline_weight("brand-new") == pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+
+
+def test_pct_for_tokens():
+    w = pc.PlanWeights(
+        weights={"claude-opus-4-8": 0.01, "claude-fable-5": 0.10},
+        default_weight=0.01, scale=1.0, confidence="baseline", basis="", intervals_used=0,
+        client="claude-code",
+    )
+    # 100M opus * 0.01 + 50M fable * 0.10 = 1.0 + 5.0 = 6.0%
+    assert abs(w.pct_for_tokens({"claude-opus-4-8": 100_000_000, "claude-fable-5": 50_000_000}) - 6.0) < 1e-9
+    # an unknown model uses default_weight; non-positive counts are ignored.
+    assert abs(w.pct_for_tokens({"other": 100_000_000, "x": 0, "y": -5}) - 1.0) < 1e-9
+
+
+def test_seven_day_series(tmp_path):
+    service = SentinelService(tmp_path)
+    _record_7d(service, captured=200.0, pct=5.0, index=1)
+    _record_7d(service, captured=100.0, pct=3.0, index=2)              # out of order on purpose
+    _record_7d(service, captured=150.0, pct=9.0, client="codex", index=3)  # other client filtered out
+    series = pc.seven_day_series(service.list_all_events(), client="claude-code")
+    assert series == [(100.0, 3.0), (200.0, 5.0)]  # ascending, claude only
+
+
+def test_session_tokens_by_model(tmp_path):
+    service = SentinelService(tmp_path)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s1",
+                  tokens=100, updated_at=1000, cost=0.1)
+    _record_usage(service, client="claude-code", model="claude-fable-5", session_id="s1",
+                  tokens=40, updated_at=1001, cost=0.1)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s2",
+                  tokens=999, updated_at=1002, cost=0.1)
+    tbm = pc.session_tokens_by_model(service.list_all_events(), client="claude-code", session_id="s1")
+    assert tbm == {"claude-opus-4-8": 100.0, "claude-fable-5": 40.0}  # only s1, grouped by model
+
+
+# ---------------------------------------------------------------------------
+# calibration
+# ---------------------------------------------------------------------------
+
+
+def test_calibrate_baseline_when_no_history(tmp_path):
+    service = SentinelService(tmp_path)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s1",
+                  tokens=1_000_000, updated_at=1000, cost=1.0)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code")
+    assert weights.confidence == "baseline"      # no 7d history → shipped baseline
+    assert weights.scale == 1.0
+    assert weights.weight_for("claude-opus-4-8") == pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+
+
+def test_calibrate_fits_scale_from_history(tmp_path):
+    # Construct history where the account's OWN weekly-% moves exactly 2x what the
+    # baseline predicts → the fitted per-user scale should be ~2.0 (calibrated).
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]  # %/Mtoken
+    # 100M Opus/hour → baseline predicts 100 * opus % per hour; make the real move 2x.
+    move = 2.0 * (100.0 * opus)
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(4):  # 4 intervals of 1 hour each (> _MIN_SCALE_INTERVALS)
+        mid = t0 + i * 3600 + 1800
+        _record_usage(service, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"s{i}", tokens=100_000_000, updated_at=mid, cost=1.0)
+        pct += move
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    # now= just after the synthetic history so the recency window includes it.
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + 5 * 3600))
+    assert weights.confidence == "calibrated"
+    assert weights.intervals_used >= pc._MIN_SCALE_INTERVALS
+    assert abs(weights.scale - 2.0) < 0.15                 # recovered the 2x scale (in the trusted band)
+    # the effective weight is the baseline times the fitted scale.
+    assert abs(weights.weight_for("claude-opus-4-8") - opus * weights.scale) < 1e-9
+
+
+def test_calibrate_ignores_weekly_reset(tmp_path):
+    # A drop in the 7d% (a weekly reset) must not be regressed as negative usage.
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    _record_7d(service, captured=float(t0), pct=50.0, index=0)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s1",
+                  tokens=10_000_000, updated_at=t0 + 1800, cost=1.0)
+    _record_7d(service, captured=float(t0 + 3600), pct=2.0, index=1)  # reset (50 → 2)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + 2 * 3600))
+    # the single reset interval is skipped → no usable intervals → baseline.
+    assert weights.confidence == "baseline"
+
+
+def test_calibrate_skips_untracked_movement(tmp_path):
+    # Regression (review): the 7-day meter is account-wide. If it moves but NO local
+    # usage records fall in those windows (Claude used on the desktop app / web), those
+    # intervals must NOT inflate the scale — with no locally-attributable tokens the
+    # fit has nothing, so it stays baseline instead of over-stating every session.
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(4):
+        pct += 5.0  # meter climbs, but no usage tokens are recorded
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + 5 * 3600))
+    assert weights.confidence == "baseline"
+    assert weights.intervals_used == 0
+
+
+def test_calibrate_untrusted_scale_falls_back_to_baseline(tmp_path):
+    # Regression (review): if the meter moved ~10x what local tokens predict (heavy
+    # untracked usage, or a very different tier we can't identify), the fitted scale is
+    # outside the trusted band → keep the baseline rather than a 10x over-estimate.
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    move = 10.0 * (100.0 * opus)  # 10x the baseline prediction
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(4):
+        mid = t0 + i * 3600 + 1800
+        _record_usage(service, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"s{i}", tokens=100_000_000, updated_at=mid, cost=1.0)
+        pct += move
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + 5 * 3600))
+    assert weights.confidence == "baseline"   # untrusted fit → baseline
+    assert weights.scale == 1.0
+    assert weights.weight_for("claude-opus-4-8") == opus
+
+
+def test_session_plan_pcts():
+    class _R:
+        def __init__(self, client, session_id, model, tok):
+            self.client = client; self.session_id = session_id
+            self.model = model; self.total_tokens_including_cached = tok
+
+    recs = [
+        _R("claude-code", "s1", "claude-opus-4-8", 100_000_000),
+        _R("claude-code", "s1", "claude-fable-5", 10_000_000),
+        _R("claude-code", "s2", "claude-opus-4-8", 50_000_000),
+        _R("codex", "s3", "gpt-5", 99_000_000),  # non-claude → excluded
+    ]
+    w = pc.PlanWeights(weights={"claude-opus-4-8": 0.01, "claude-fable-5": 0.10},
+                       default_weight=0.01, scale=1.0, confidence="baseline", basis="",
+                       intervals_used=0, client="claude-code")
+    pcts = pc.session_plan_pcts(recs, w, client="claude-code")
+    assert set(pcts) == {"s1", "s2"}                      # one pass, grouped, codex out
+    assert abs(pcts["s1"] - (100 * 0.01 + 10 * 0.10)) < 1e-9  # 1.0 + 1.0 = 2.0
+    assert abs(pcts["s2"] - 0.5) < 1e-9                       # 50M × 0.01

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1118,3 +1118,76 @@ def test_usage_screen_model_filter_dropped_when_absent_in_range(tmp_path):
             assert scr._model_filter is None  # dropped, not stranded on an empty page
 
     _run(scenario())
+
+
+def test_session_detail_shows_plan_estimate(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="cs1",
+                  input_tokens=100_000_000, output_tokens=0, updated_at=int(now - 3600), estimated_cost_usd=50.0)
+    entry = {"client": "claude-code", "client_session_id": "cs1", "client_session_title": "Big",
+             "usage": {"total_tokens": 100_000_000}, "work": {"items": []}}
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.push_screen(SessionDetailScreen(entry))
+            await pilot.pause()
+            det = app.screen
+            # 100M Opus 4.8 × baseline ≈ 1.3% → the estimate line renders.
+            assert "weekly Claude plan" in det._header_text
+            assert app._plan_cache is not None  # cached on the app for reuse
+
+    _run(scenario())
+
+
+def test_session_detail_no_plan_estimate_for_non_claude(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="codex", model="gpt-5", session_id="cx1",
+                  input_tokens=1_000_000, output_tokens=0, updated_at=int(now - 3600), estimated_cost_usd=1.0)
+    entry = {"client": "codex", "client_session_id": "cx1", "client_session_title": "Codex",
+             "usage": {"total_tokens": 1_000_000}, "work": {"items": []}}
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.push_screen(SessionDetailScreen(entry))
+            await pilot.pause()
+            det = app.screen
+            assert "weekly Claude plan" not in det._header_text  # claude-plan-specific
+
+    _run(scenario())
+
+
+def test_plan_pct_cell_helper():
+    from agentacct.tui import _plan_pct_cell
+    cc = {"client": "claude-code", "client_session_id": "s1"}
+    assert _plan_pct_cell(cc, {"s1": 2.5}) == "≈2.5%"
+    assert _plan_pct_cell(cc, {"s1": 0.04}) == "≈<0.1%"   # tiny but non-zero
+    assert _plan_pct_cell(cc, {"s1": 0.0}) == "—"          # zero → no estimate
+    assert _plan_pct_cell(cc, {}) == "—"                    # missing → no estimate
+    assert _plan_pct_cell({"client": "codex", "client_session_id": "s1"}, {"s1": 2.5}) == "—"  # non-claude
+
+
+def test_recent_panel_renders_plan_column(tmp_path):
+    SentinelService(tmp_path)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            claude = {"client": "claude-code", "client_session_id": "cs1",
+                      "client_session_title": "C", "usage": {"total_tokens": 100}, "work": {"items": []}}
+            codex = {"client": "codex", "client_session_id": "cx1",
+                     "client_session_title": "X", "usage": {"total_tokens": 100}, "work": {"items": []}}
+            app._populate_recent([claude, codex], {"cs1": 1.3})
+            recent = app.query_one("#recent", DataTable)
+            assert recent.row_count == 2
+            # columns: session, client, status, tokens, PLAN(4), activity
+            assert str(recent.get_row_at(0)[4]) == "≈1.3%"   # claude with an estimate
+            assert str(recent.get_row_at(1)[4]) == "—"        # codex → no plan estimate
+
+    _run(scenario())


### PR DESCRIPTION
## What

Estimate what fraction of a Claude subscription's **weekly plan** a session/task
consumed, and show it on the session-detail screen as
`≈ X% of your weekly Claude plan · <rough> estimate`.

The weekly (7-day) plan meter is a **per-week-reset cumulative** counter (verified
from the desktop plan-usage series: it climbs from a weekly reset, then drops to 0 —
unlike the 5-hour window, which rolls). So a session's share is just its own weighted
usage over the weekly capacity — no rolling decay or concurrency to untangle.

Raw tokens are the wrong unit, and **cost alone is not enough** either: models burn
the plan at very different rates *per dollar* (measured on real data: Fable burns
several × more of the weekly plan per dollar than Opus 4.8). So:

```
estimate = scale × Σ baseline_weight(model) × Mtokens(model)
```

- **`baseline_weight`** — a shipped, **measured** per-model weight table (% of the
  weekly plan per 1M tokens). Opus 4.8 is well-determined (dozens of clean
  single-model intervals); the rarer models are approximate and an unknown model is
  cost-scaled. This is the **universal** part — every user gets a reasonable estimate
  out of the box.
- **`scale`** — one **per-account** number, self-calibrated by comparing the
  baseline's predicted weekly-% movement against the account's own recorded 7-day
  usage-% history (a single scalar — robust, no per-model collinearity). It **keeps
  updating** as more limit history accrues, from **any** source that records it
  (desktop plan-usage import, Codex rollouts, or the Claude CLI statusLine hook), so
  **CLI-only users are covered** — no dependency on the desktop app.

Every result carries a `confidence`: `calibrated` once the scale is fit from enough
history, else `baseline` (the shipped table). The estimate is deliberately honest —
labeled a *rough* estimate until an account is calibrated, and it sharpens over time.

## Why this shape

Derived from a local analysis of dense real data: a per-model linear model fits the
weekly-% movement well (R²≈0.9), but a **single account can't separate the models**
(people run one main model at a time → collinearity), so the *universal* per-model
weights ship as a measured baseline (refined as cross-user data accrues) while the
easy *per-account* scale self-calibrates. Fast-mode is deliberately not a factor yet:
it was verified to be <1% of real usage and the server serves `standard` regardless of
the UI toggle in the observed data.

## Surface

Shown **at a glance on the home Recent-sessions panel** (a `plan` column) and on the
`SessionDetailScreen` header — claude-code sessions only (others show `—`),
**fail-soft** (any read/build problem → no estimate, never crashes). Weights, the
usage records they were fit from, and every session's estimated % are computed once
per event change (off the UI thread by the recent-panel worker) and cached on the app
as **one tuple keyed by the event-log fingerprint** — cheap reopens, never stale after
an import, and torn-proof across the worker/detail callers.

## Known blind spot (and how it's guarded)

The 7-day meter is **account-wide** — the Claude desktop app, claude.ai, and other
machines all move it — while agentacct's tokens cover only tracked clients. So the
scale fit could be inflated by movement it can't attribute. Guards: the scale is fit
**only from intervals whose movement local tokens can explain** (an interval where the
meter moved with no local tokens is skipped), **only over recent history**, and a
fitted scale is **applied (and labeled "calibrated") only inside a trusted band** —
otherwise the shipped baseline is kept. This bounds any over-estimate; the residual
(a single interval mixing tracked + untracked usage) is capped and honestly labeled.

## Adversarial review

A 3-lens read-only review + verify pass ran on the diff. It confirmed and I fixed:
**2 MEDIUM** — (1) the scale fit conflated the account-wide meter with CLI-only tokens
(untracked-usage intervals inflated it and it was mislabeled "calibrated") → the
`pred>0`-only fit + trusted-band gate + recency window above; (2) the detail open did a
full-store read and two usage-view rebuilds synchronously on the render thread → now
reads once, threads pre-built `records` into both functions (one build), and caches
weights + records on the app keyed by the event-log fingerprint (cheap reopens, never
stale). Plus LOW cache-staleness (same fingerprint key) and reset-hidden-in-interval
(tighter 12h interval). A follow-up fix-audit returned FIX-COMPLETE.

## Safety

- `now --json` / `limits --json` and every existing surface are unaffected — `plan_cost`
  is a new, additive module.
- The header line interpolates only a formatted float and a fixed-vocabulary confidence
  word (no unescaped provider/user data); fail-soft (any error → no line).

## Tests

`.venv/bin/pytest -q` → **3048 passed, 1 skipped** (+14: `baseline_weight`,
`pct_for_tokens`, `seven_day_series` filter/order, `session_tokens_by_model`, the
baseline fallback, scale recovery from synthetic history, weekly-reset skipping,
**untracked-movement skipping**, **untrusted-scale → baseline**, and the detail-header
estimate showing for claude / absent for codex; plus `session_plan_pcts`,
`_plan_pct_cell`, and the home Recent-panel `plan` column). Verified on the real store:
the home panel shows `≈ 2.5%` for a 196M-token Opus session and `—` for a codex one
(Opus 4.8 ≈ 0.0127 %/Mtoken ≈ a full week at ~7.9B tokens, matching the offline
analysis). The home-panel addition passed a second read-only review (CLEAN): the
single-tuple cache is torn-proof across the worker/detail callers and the session-id
join is validated.
