### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-04
+
 ### Added
 - **`agentacct tui` — "≈ X% of your weekly Claude plan" per session.** The home
   **Recent sessions** panel (and the session detail) now estimate what fraction of
@@ -401,7 +403,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `agentacct-claude`, and `agentacct-codex` console scripts. Local-first,
   observe-only, no telemetry, no provider API keys. Python ≥ 3.11 on macOS / Linux.
 
-[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/mikehasa/agentacct/releases/tag/v0.7.0
+[0.6.0]: https://github.com/mikehasa/agentacct/releases/tag/v0.6.0
+[0.5.3]: https://github.com/mikehasa/agentacct/releases/tag/v0.5.3
 [0.5.2]: https://github.com/mikehasa/agentacct/releases/tag/v0.5.2
 [0.5.1]: https://github.com/mikehasa/agentacct/releases/tag/v0.5.1
 [0.5.0]: https://github.com/mikehasa/agentacct/releases/tag/v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentacct"
-version = "0.6.0"
+version = "0.7.0"
 description = "Local-first Agent Work Intelligence for coding agents: usage truth, recorded work, and honest joins"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cut **0.7.0**. Bumps `pyproject.toml` (0.6.0 → 0.7.0) and dates the CHANGELOG
`[Unreleased]` section as `[0.7.0] - 2026-08-04`.

Highlights since 0.6.0:

- **`agentacct tui`** — a live terminal dashboard: usage windows, provider rate-limit
  bars with reset countdowns, recent sessions with status badges, a usage screen
  (`u`), and a sessions drill-down (`s`) with per-step work ledgers + check evidence.
- **`agentacct limits` / `agentacct now`** — provider rate-limit windows read passively
  from local files, and a current usage/cost snapshot.
- **Weekly-plan-cost estimate (beta)** — "≈ X% of your weekly Claude plan" per session,
  self-calibrated from recorded limit history.
- README now leads with the TUI + screenshots.

After merge: cut the GitHub Release `v0.7.0` (fires the PyPI publish).
