### PR TITLE
fix(import): one unreadable Claude transcript no longer zeroes the whole import

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -6465,6 +6465,16 @@ def _local_usage_import_payload(
             )
         )
         plan = plan_local_usage_import(candidates, service.list_all_events())
+        # issue #53: sessions whose usage DID parse but were withheld from import
+        # as incomplete (a selected transcript could not be fully read this scan).
+        # Captured here — before any later plan reassignment — so the CLI can fail
+        # loudly instead of reporting a silent $0 for a measurement gap.
+        withheld_incomplete_session_count = len(
+            {
+                (candidate.client, candidate.client_session_id)
+                for candidate in plan.incomplete_source_candidates
+            }
+        )
         refresh_candidates_before_reprice = list(plan.refresh_candidates)
         refreshed_candidate_count = len(plan.refresh_candidates)
         # Unknown→priced reprice (refresh + estimate-costs only): stored rows
@@ -6744,6 +6754,7 @@ def _local_usage_import_payload(
             },
             "source_diagnostics": import_diagnostics,
             "importable_sessions": len(import_candidates),
+            "withheld_incomplete_sessions": withheld_incomplete_session_count,
             "imported_events": len(recorded),
             "refreshed_events": (
                 refreshed_candidate_count if dry_run and refresh else actual_refresh_count if refresh else 0
@@ -7020,9 +7031,28 @@ def usage_import_local(
         refresh=refresh,
     )
     if json_output:
+        # Machine consumers detect a measurement gap via the payload's
+        # withheld_incomplete_sessions field; keep stdout clean + exit 0.
         print(json.dumps(payload, indent=2, sort_keys=True))
         return
     _print_usage_import_payload(payload, store_dir=resolved_store_dir, estimate_costs=estimate_costs)
+    # issue #53: a Claude-side pipeline failure used to report a silent $0 with
+    # exit 0. If usage parsed but was withheld as incomplete, say so loudly on
+    # stderr and exit non-zero so the gap is never read as "nothing was spent".
+    # Human CLI surface only; --json returns above, and the watch daemon, TUI,
+    # onboard, and dashboard callers use the payload directly and are unaffected.
+    withheld = int(payload.get("withheld_incomplete_sessions", 0) or 0)
+    if withheld:
+        print(
+            f"WARNING: {withheld} session(s) had usage that could not be fully read "
+            "this scan and was withheld from this import — a measurement gap, not $0 "
+            "spent (any session imported on an earlier scan keeps its prior totals). "
+            "Re-run the import; if it persists, please report it at "
+            "https://github.com/mikehasa/agentacct/issues.",
+            file=sys.stderr,
+            flush=True,
+        )
+        raise typer.Exit(3)
 
 
 @usage_app.command("watch")

--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -2021,7 +2021,6 @@ def _discover_claude_code_usage_from_home(
 
     path_entries: list[tuple[Path, float]] = []
     fingerprints: dict[Path, _ClaudeFileFingerprint] = {}
-    source_identity_complete = True
     for path in transcript_paths:
         try:
             mtime, fingerprint = _claude_transcript_stat(
@@ -2039,10 +2038,8 @@ def _discover_claude_code_usage_from_home(
             path_entries.append((path, mtime))
             fingerprints[path] = fingerprint
         except _ClaudeTranscriptUnsafePathError:
-            source_identity_complete = False
             record_error("claude_transcript_unsafe_path")
         except OSError:
-            source_identity_complete = False
             record_error("claude_transcript_stat_failed")
 
     identity_entries: list[tuple[Path, float, str, int, bool]] = []
@@ -2055,17 +2052,14 @@ def _discover_claude_code_usage_from_home(
                 expected_fingerprint=fingerprints[path],
             )
         except _ClaudeTranscriptUnsafePathError:
-            source_identity_complete = False
             record_error("claude_transcript_unsafe_path")
             identity_entries.append((path, mtime, f"unsafe:{path}", 0, False))
             continue
         except _ClaudeTranscriptChangedDuringScanError:
-            source_identity_complete = False
             record_error("claude_transcript_changed_during_scan")
             identity_entries.append((path, mtime, f"changed:{path}", 0, False))
             continue
         except OSError:
-            source_identity_complete = False
             record_error("claude_transcript_read_failed")
             # An unreadable identity cannot safely enter selection: its real
             # root could otherwise be split from a selected parent/child
@@ -2073,7 +2067,6 @@ def _discover_claude_code_usage_from_home(
             identity_entries.append((path, mtime, f"unreadable:{path}", 0, False))
             continue
         if not identity_scan_complete:
-            source_identity_complete = False
             record_error("claude_transcript_identity_scan_truncated")
             # Never fall back to ``path.stem`` for a budget-unresolved file.
             # A late child identity would become a fake root, rotate through
@@ -2099,7 +2092,15 @@ def _discover_claude_code_usage_from_home(
     observations: list[ClientSessionObservation] = []
     seen_usage_outputs: dict[str, int] = {}
     parsed_transcript_files = 0
-    selected_cohort_complete = source_identity_complete
+    # issue #53: the identity failures above (stat/read/unsafe/scan-truncated)
+    # are on files that are EXCLUDED from selection and are already reported via
+    # diagnostics (error_count, error_codes, unresolved_identity_files). They must
+    # NOT retroactively withhold the cleanly-parsed rows of unrelated SELECTED
+    # sessions — otherwise one stray unreadable/non-transcript file (e.g. an
+    # unrecognized workflow journal, or a transient stat failure) silently zeroes
+    # the whole source's import. Cohort completeness reflects only the selected
+    # files actually parsed below.
+    selected_cohort_complete = True
     _claude_total_files = len(entries)
     for _claude_index, (path, mtime, _root_session_id, _parent_sort_key, identity_readable) in enumerate(entries):
         if _claude_index % _PROGRESS_EMIT_STRIDE == 0 or _claude_index + 1 == _claude_total_files:

--- a/tests/test_client_usage.py
+++ b/tests/test_client_usage.py
@@ -3031,10 +3031,12 @@ def test_claude_non_regular_jsonl_is_rejected_without_blocking(tmp_path):
         limit_sessions=10,
     )
 
+    # issue #53: the FIFO is still rejected (unsafe path, surfaced in
+    # error_codes) but no longer blocks the readable sibling's usage.
     assert [event.client_session_id for event in result.events] == [
         "claude-session"
     ]
-    assert result.events[0].source_parse_complete is False
+    assert result.events[0].source_parse_complete is True
     assert result.diagnostics["claude-code"]["error_codes"] == [
         "claude_transcript_unsafe_path"
     ]
@@ -3070,18 +3072,21 @@ def test_unknown_truncated_claude_identity_is_non_writable_and_does_not_consume_
         limit_sessions=1,
     )
 
+    # issue #53: the truncated file is still excluded (non-writable, does not
+    # consume the limit slot) and surfaced in error_codes, but the readable
+    # session now imports instead of being withheld along with it.
     assert [event.client_session_id for event in result.events] == ["claude-session"]
-    assert result.events[0].source_parse_complete is False
+    assert result.events[0].source_parse_complete is True
     diagnostic = result.diagnostics["claude-code"]
     assert diagnostic["selected_root_groups"] == 1
     assert diagnostic["error_codes"] == [
         "claude_transcript_identity_scan_truncated"
     ]
     plan = plan_local_usage_import(result.events, [])
-    assert plan.new_candidates == []
+    assert plan.new_candidates == result.events
     assert plan.refresh_candidates == []
     assert plan.migration_candidates == []
-    assert plan.incomplete_source_candidates == result.events
+    assert plan.incomplete_source_candidates == []
 
 
 def test_claude_descendant_file_symlink_is_rejected_without_importing_foreign_data(
@@ -3114,8 +3119,10 @@ def test_claude_descendant_file_symlink_is_rejected_without_importing_foreign_da
         limit_sessions=10,
     )
 
+    # issue #53: the symlinked foreign file is still excluded (unsafe path) and
+    # its data never enters an event; the readable sibling now imports normally.
     assert [event.client_session_id for event in result.events] == ["claude-session"]
-    assert result.events[0].source_parse_complete is False
+    assert result.events[0].source_parse_complete is True
     assert result.diagnostics["claude-code"]["error_codes"] == [
         "claude_transcript_unsafe_path"
     ]
@@ -3125,7 +3132,7 @@ def test_claude_descendant_file_symlink_is_rejected_without_importing_foreign_da
     )
     assert "FOREIGN PRIVATE TITLE" not in serialized
     assert "/foreign/private/project" not in serialized
-    assert plan_local_usage_import(result.events, []).new_candidates == []
+    assert plan_local_usage_import(result.events, []).new_candidates == result.events
 
 
 def test_claude_transcript_replacement_between_identity_and_usage_reads_fails_closed(
@@ -3366,7 +3373,10 @@ def test_discover_client_usage_with_diagnostics_isolates_unreadable_claude_trans
     assert diagnostic["returned_rows"] == 1
     assert diagnostic["error_count"] == 1
     assert diagnostic["error_codes"] == ["claude_transcript_read_failed"]
-    assert result.events[0].source_parse_complete is False
+    # issue #53: the readable transcript's usage is retained (see this test's
+    # own contract above: a bad sibling is visible in diagnostics WITHOUT
+    # discarding the readable transcript's usage).
+    assert result.events[0].source_parse_complete is True
     assert str(tmp_path) not in json.dumps(diagnostic)
 
 

--- a/tests/test_ingestion_health_integration.py
+++ b/tests/test_ingestion_health_integration.py
@@ -23,7 +23,6 @@ from agentacct.ingestion_health import (
     IngestionHealthStore,
 )
 from agentacct.service import SentinelService
-from agentacct.usage_truth import is_local_session_observation_event
 from refresh_flash import refresh_flash_qs, run_dashboard_refresh
 
 
@@ -344,11 +343,12 @@ def test_claude_structural_recovery_is_source_specific_and_retries_fail_closed(
             for event in current_ledger
             if event not in ledger_before_failure
         ]
-        assert len(added) == 1
-        assert is_local_session_observation_event(added[0])
-        assert added[0]["metadata"]["client_session_id"] == "claude-session"
-        assert "estimated_input_tokens" not in added[0]
-        assert "estimated_output_tokens" not in added[0]
+        # issue #53: the unresolved late-child no longer withholds the readable
+        # session's usage, so that usage stays imported from the clean scan
+        # (unchanged here) and no fallback usage-unavailable observation is
+        # written. The structural failure is still surfaced via degraded health
+        # (asserted above); nothing new is written and late-child never imports.
+        assert added == []
         assert all(
             event.get("metadata", {}).get("client_session_id") != "late-child"
             for event in current_ledger

--- a/tests/test_issue53_import_fail_closed.py
+++ b/tests/test_issue53_import_fail_closed.py
@@ -1,0 +1,210 @@
+"""Regression tests for issue #53.
+
+At real-world volume the Claude importer reported ``0 sessions / $0.00`` with
+exit 0 while its own diagnostics showed the parser had extracted usage. The
+cause was a source-global fail-closed: a single file that could not be
+identity-resolved (an unrecognized non-transcript bookkeeping file, or a
+transient stat failure) marked *every* parsed usage row incomplete, so the
+planner withheld all of them.
+
+These tests pin the fixed behavior:
+  * an unresolvable, EXCLUDED file no longer withholds unrelated clean sessions,
+  * a genuinely malformed SELECTED file is still withheld (safety preserved),
+  * the CLI now fails loudly (non-zero exit) instead of a silent $0 when usage
+    parsed but was withheld, and exposes ``withheld_incomplete_sessions``.
+"""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agentacct.cli import app
+from agentacct.client_usage import (
+    discover_client_usage_with_diagnostics,
+    plan_local_usage_import,
+    select_usage_import_candidates,
+)
+
+
+def _write_good(project: Path, session_id: str, *, output_tokens: int = 200) -> Path:
+    path = project / f"{session_id}.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "sessionId": session_id,
+                "cwd": "/work/project",
+                "timestamp": "2026-08-01T00:00:00Z",
+                "message": {
+                    "model": "claude-opus-4-8",
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": output_tokens,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _make_home_with_good_sessions(
+    root: Path, *, n_dirs: int = 4, per_dir: int = 2
+) -> tuple[Path, set[str]]:
+    claude_home = root / "claude-home"
+    projects = claude_home / "projects"
+    projects.mkdir(parents=True)
+    sessions: set[str] = set()
+    for d in range(n_dirs):
+        project = projects / f"-work-proj{d}"
+        project.mkdir()
+        for s in range(per_dir):
+            sid = f"sess-{d}-{s}"
+            _write_good(project, sid)
+            sessions.add(sid)
+    return claude_home, sessions
+
+
+def _write_identity_unresolvable(project: Path, name: str, *, nlines: int = 300) -> Path:
+    # >256 lines, none carrying a sessionId -> the bounded identity peek gives up
+    # and records ``claude_transcript_identity_scan_truncated`` for this file.
+    path = project / f"{name}.jsonl"
+    path.write_text(
+        "\n".join(json.dumps({"type": "summary", "idx": i}) for i in range(nlines)) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _overwrite_malformed(project: Path, session_id: str) -> Path:
+    # A valid usage row followed by a malformed line -> the file parses a usage
+    # event but flags malformed_transcript_lines, which legitimately withholds.
+    path = project / f"{session_id}.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "sessionId": session_id,
+                "timestamp": "2026-08-01T00:00:00Z",
+                "message": {
+                    "model": "claude-opus-4-8",
+                    "usage": {"input_tokens": 1, "output_tokens": 2},
+                },
+            }
+        )
+        + "\n{ this is not json }\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_unresolvable_excluded_file_does_not_withhold_clean_sessions(tmp_path):
+    claude_home, sessions = _make_home_with_good_sessions(tmp_path, n_dirs=4, per_dir=2)
+    _write_identity_unresolvable(
+        claude_home / "projects" / "-work-proj0", "journal-like"
+    )
+
+    result = discover_client_usage_with_diagnostics(
+        client="claude-code",
+        claude_home=claude_home,
+        limit_sessions=200,
+    )
+
+    # Every cleanly-parsed session stays complete despite the one bad file.
+    assert result.events
+    assert all(event.source_parse_complete for event in result.events)
+
+    imported = {
+        candidate.client_session_id
+        for candidate in select_usage_import_candidates(
+            plan_local_usage_import(result.events, []),
+            include_refresh=False,
+        )
+    }
+    assert imported == sessions  # was empty before the fix
+
+    # The failure is still surfaced, so ingestion health / reconciliation
+    # authority stay conservative (they gate on these diagnostics, not on the
+    # usage rows' completeness).
+    diag = result.diagnostics["claude-code"]
+    assert "claude_transcript_identity_scan_truncated" in diag["error_codes"]
+    assert diag["error_count"] >= 1
+
+
+def test_malformed_selected_file_is_still_withheld(tmp_path):
+    claude_home, _ = _make_home_with_good_sessions(tmp_path, n_dirs=1, per_dir=2)
+    _overwrite_malformed(claude_home / "projects" / "-work-proj0", "sess-0-0")
+
+    result = discover_client_usage_with_diagnostics(
+        client="claude-code",
+        claude_home=claude_home,
+        limit_sessions=200,
+    )
+    plan = plan_local_usage_import(result.events, [])
+    withheld = {
+        candidate.client_session_id
+        for candidate in plan.incomplete_source_candidates
+    }
+    assert "sess-0-0" in withheld
+
+
+def test_cli_import_exits_nonzero_when_usage_is_withheld(tmp_path):
+    claude_home, _ = _make_home_with_good_sessions(tmp_path, n_dirs=1, per_dir=1)
+    _overwrite_malformed(claude_home / "projects" / "-work-proj0", "sess-0-0")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "usage", "import-local",
+            "--client", "claude-code",
+            "--claude-home", str(claude_home),
+            "--store-dir", str(tmp_path / "store"),
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 3
+    assert "withheld" in result.output.lower()
+
+
+def test_cli_import_exit_zero_when_only_excluded_file_unresolvable(tmp_path):
+    claude_home, _ = _make_home_with_good_sessions(tmp_path, n_dirs=2, per_dir=2)
+    _write_identity_unresolvable(
+        claude_home / "projects" / "-work-proj0", "journal-like"
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "usage", "import-local",
+            "--client", "claude-code",
+            "--claude-home", str(claude_home),
+            "--store-dir", str(tmp_path / "store"),
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def test_cli_import_json_exposes_withheld_field(tmp_path):
+    claude_home, sessions = _make_home_with_good_sessions(tmp_path, n_dirs=2, per_dir=2)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "usage", "import-local",
+            "--client", "claude-code",
+            "--claude-home", str(claude_home),
+            "--store-dir", str(tmp_path / "store"),
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["withheld_incomplete_sessions"] == 0
+    assert payload["importable_sessions"] == len(sessions)


### PR DESCRIPTION
## What

At real-world volume the Claude importer reported `0 sessions / $0.00` with exit 0 while its own `--json` diagnostics showed the parser had extracted usage — a silent parse-then-discard. Root cause: the completeness check was source-global. Any single file that could not be identity-resolved — an unreadable/stat-failed file, or a non-transcript bookkeeping file (e.g. a workflow journal) whose first 256 lines / 256 KiB carried no `sessionId` — flipped one source-wide flag that marked every parsed usage row incomplete, so `plan_local_usage_import` withheld all of them. Larger real trees are far likelier to contain one such file, which is why it was shape/volume-dependent.

## Fix

1. Cohort completeness now reflects only the selected files that were actually parsed. An unresolvable or excluded file is still left out of selection and still reported through diagnostics (`error_count`, `unresolved_identity_files`); it no longer withholds the cleanly-parsed rows of unrelated sessions. Reconciliation and deletion authority are unchanged — they gate on the diagnostics, not on usage-row completeness — and unsafe/symlinked/changed files are still excluded from parsing, so no foreign content can leak in.
2. Surface parse-then-discard instead of a silent $0. The import payload gains `withheld_incomplete_sessions`, and `usage import-local` prints a warning and exits non-zero (human path only) when usage parsed but was withheld. `--json` stays clean and exits 0 with the field present; the watch daemon, onboard, TUI, and dashboard callers use the payload directly and are unaffected.

## Tests

New regression tests cover the excluded-file case (clean sessions still import), a genuinely malformed selected file (still withheld — safety preserved), and the CLI exit/`--json` paths. Six existing tests that asserted the old whole-source withhold were updated to the new behavior, keeping every security and diagnostics invariant. Full suite: 3064 passed, 1 skipped.

## Known limitations (candidate follow-up)

- A malformed or mid-write (`changed_during_scan`) *selected* transcript still withholds its whole cohort, so the non-zero exit above can fire transiently on a manual run that overlaps an active Claude session (the watch daemon is unaffected, since it never takes the CLI exit path). Making only the skip-type cases non-poisoning is a safe follow-up; the malformed case is left deliberately conservative because Claude's replay dedup is content-keyed across files, so partial-parse rows cannot be dropped from one file without risking a double-count in its siblings.
- Identity-*excluded* files never become usage events, so that narrow class is not covered by `withheld_incomplete_sessions`. In practice these are non-transcript bookkeeping files with no real usage.

Fixes #53. Reported by @Evaack.
