### PR TITLE
fix(import): a workflow journal written mid-scan no longer withholds real sessions

### DIFF
--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -2277,7 +2277,9 @@ def _discover_claude_code_usage_from_home(
             record_error("claude_transcript_read_failed")
             continue
         if observed_fingerprint != expected_fingerprint:
-            selected_cohort_complete = False
+            # Same transient mid-scan race, on a workflow journal. Journals carry
+            # no usage rows, so a changed journal never justified withholding the
+            # real sessions around it (issue #53 follow-up).
             record_error("claude_transcript_changed_during_scan")
     if not selected_cohort_complete:
         events = [replace(event, source_parse_complete=False) for event in events]

--- a/tests/test_client_usage.py
+++ b/tests/test_client_usage.py
@@ -2932,11 +2932,14 @@ def test_claude_workflow_journal_mutation_after_validation_fails_closed(
     assert [event.client_session_id for event in result.events] == [
         "claude-session"
     ]
-    assert result.events[0].source_parse_complete is False
+    # issue #53 follow-up: the journal change is still detected and flagged
+    # (error_codes below), but a changed workflow journal — which carries no
+    # usage — no longer withholds the real session's usage.
+    assert result.events[0].source_parse_complete is True
     assert result.diagnostics["claude-code"]["error_codes"] == [
         "claude_transcript_changed_during_scan"
     ]
-    assert plan_local_usage_import(result.events, []).new_candidates == []
+    assert plan_local_usage_import(result.events, []).new_candidates == result.events
 
 
 def test_claude_projects_root_symlink_is_rejected_as_unsafe(tmp_path):


### PR DESCRIPTION
## What

Follow-up to #54. A recognized Claude workflow journal (`.../subagents/workflows/wf_*/journal.jsonl`) that is appended-to between the tree inventory and the second-pass re-stat trips `changed_during_scan`, which used to withhold the **whole** selected cohort. So a manual `usage import-local` that overlaps an active subagent/workflow could report its real, cleanly-parsed sessions as incomplete — and, since #54's loud-exit, exit non-zero — even though a workflow journal carries no usage rows and is never read by the usage parser.

## Fix

Scoped to journals only: the transient race is still detected and recorded (`claude_transcript_changed_during_scan` stays in the diagnostics, so ingestion health and reconciliation authority are unchanged); it just no longer flips the surrounding sessions' usage rows to incomplete. This is provably safe because a workflow journal never contributes usage events and never touches the shared cross-file dedup map.

## Deliberately out of scope (known limitation)

A *transcript* file that is actively written during its own usage read hits the same transient race, but stays conservative here — it still withholds — because that path mutates the shared cross-file dedup map before the end-of-read change is detected. Simply skipping such a file (instead of withholding) would leave its message-id dedup keys in the shared map, so a sidechain sibling replaying those ids would be deduped to zero and silently under-counted. Making that case safe requires a transactional-dedup refactor of the core counting path (stage each file's dedup keys, commit only after a clean end-fingerprint), which is a larger change to a path every import depends on and is intentionally not bundled here. In practice the residual case only affects a manual run that overlaps a live transcript write; it is transient and self-healing (re-run), and the background watch daemon is unaffected.

## Tests

Updated `test_claude_workflow_journal_mutation_after_validation_fails_closed` to the new behavior (the change is still detected via `error_codes`, but the real session's usage is retained). Full suite: 3064 passed, 1 skipped.
