### PR TITLE
fix(tui): cross-screen nav, snapshot repaint, and a calmer row cursor

### DIFF
--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -311,6 +311,14 @@ _AGENTACCT_THEME = Theme(
     success="#9ece6a",
     warning="#e0af68",
     error="#f7768e",
+    # The row cursor (sessions list) defaulted to the full-strength primary blue,
+    # which reads as a harsh bright bar. Use a calmer muted blue: clearly "selected"
+    # without glaring. The blurred (unfocused) cursor keeps its translucent tint.
+    variables={
+        "block-cursor-background": "#2e3c64",
+        "block-cursor-foreground": "#c0caf5",
+        "block-cursor-text-style": "bold",
+    },
 )
 
 _BRAND = "#e0af68"   # amber (accent)
@@ -873,31 +881,50 @@ class AgentAcctTUI(App):
         Written to a ``snapshots/`` dir under the store — NOT the cwd — so pressing
         ``p`` from inside a project repo can never litter the working tree.
         """
+        saved: str | None = None
         try:
             snap_dir = self.store_dir / "snapshots"
             snap_dir.mkdir(parents=True, exist_ok=True)
-            path = self.save_screenshot(path=str(snap_dir))
+            saved = self.save_screenshot(path=str(snap_dir))
         except Exception as exc:  # noqa: BLE001 - a snapshot must never crash the UI.
             self.notify(f"Could not save the snapshot: {exc}", severity="error", timeout=6)
-            return
-        self.notify(f"Saved a shareable snapshot →\n{path}", title="◆ agentacct", timeout=6)
+        finally:
+            # save_screenshot() renders a full frame to an OFFSCREEN console, and
+            # Textual's full render clears the LIVE compositor's dirty regions as a
+            # side effect (Compositor.render_full_update). The next incremental
+            # frame then leaves stale/unpainted cells on the real terminal — a
+            # "white bar" on light terminals. Force one full repaint to restore it.
+            self.screen.refresh(repaint=True, layout=True)
+        if saved is not None:
+            self.notify(
+                f"Saved a shareable snapshot →\n{saved}", title="◆ agentacct", timeout=6
+            )
 
     def action_open_sessions(self) -> None:
-        # Only open the sessions drill-down from the base dashboard. The app-level
-        # `s` binding stays active while a (non-modal) sub-screen is on top, so
-        # without this guard a second `s` would stack a duplicate screen and spawn
-        # a second expensive ledger build.
-        if len(self.screen_stack) > 1:
-            return
-        self.push_screen(SessionsScreen())
+        self._show_top_level(SessionsScreen)
 
     def action_open_usage(self) -> None:
-        # Same guard as the sessions drill-down: the app-level `u` binding stays
-        # active while a (non-modal) sub-screen is on top, so without this a second
-        # `u` would stack a duplicate usage screen.
-        if len(self.screen_stack) > 1:
+        self._show_top_level(UsageScreen)
+
+    def _show_top_level(self, screen_cls: type[Screen]) -> None:
+        # The app-level `s`/`u` bindings stay active on every screen, so a top-level
+        # view must be reachable from ANY screen — not only the base dashboard. The
+        # old guard just returned when a sub-screen was on top, which is why `u` did
+        # nothing on the sessions screen (you had to Esc home first). Rules, in order:
+        #   - already showing it → no-op;
+        #   - already in the stack under a drill-down → pop back down to it (never
+        #     stack a duplicate + a second expensive ledger build);
+        #   - otherwise swap the current sub-screen for it, or push from the base.
+        if isinstance(self.screen, screen_cls):
             return
-        self.push_screen(UsageScreen())
+        if any(isinstance(scr, screen_cls) for scr in self.screen_stack):
+            while not isinstance(self.screen, screen_cls):
+                self.pop_screen()
+            return
+        if len(self.screen_stack) > 1:
+            self.switch_screen(screen_cls())
+        else:
+            self.push_screen(screen_cls())
 
 
 def _humanize_ago(ts: Any, now: float) -> str:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -887,6 +887,65 @@ def test_usage_screen_renders_and_cycles_range(tmp_path):
     _run(scenario())
 
 
+def test_top_level_nav_works_from_any_screen(tmp_path):
+    # Regression: the app-level `s`/`u` bindings stay active on sub-screens, but the
+    # actions used to no-op there — so `u` did nothing on the sessions screen (you
+    # had to Esc home first). They must switch between top-level views from anywhere,
+    # without stacking duplicates.
+    from agentacct.tui import SessionsScreen, UsageScreen
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s1",
+                  input_tokens=500, output_tokens=50, updated_at=int(now - 3600), estimated_cost_usd=0.5)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            assert isinstance(app.screen, SessionsScreen)
+            # The bug: `u` on the sessions screen did nothing. It must switch to usage.
+            await pilot.press("u")
+            await pilot.pause()
+            assert isinstance(app.screen, UsageScreen)
+            assert len(app.screen_stack) == 2  # swapped, not stacked
+            # And back, again without going home first.
+            await pilot.press("s")
+            await pilot.pause()
+            assert isinstance(app.screen, SessionsScreen)
+            assert len(app.screen_stack) == 2
+            # Pressing the current screen's own key is a harmless no-op.
+            await pilot.press("s")
+            await pilot.pause()
+            assert isinstance(app.screen, SessionsScreen)
+            assert len(app.screen_stack) == 2
+
+    _run(scenario())
+
+
+def test_snapshot_key_writes_file_and_app_survives(tmp_path):
+    # `p` saves an SVG under <store>/snapshots/ and must leave the live app intact
+    # (export_screenshot clears the compositor's dirty regions; the action forces a
+    # repaint so the terminal isn't left with stale/blank cells).
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s1",
+                  input_tokens=500, output_tokens=50, updated_at=int(now - 3600), estimated_cost_usd=0.5)
+
+    async def scenario():
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("p")
+            await pilot.pause()
+            assert app.is_running
+            assert list((tmp_path / "snapshots").glob("*.svg"))
+
+    _run(scenario())
+
+
 def test_usage_screen_empty_store(tmp_path):
     from agentacct.tui import UsageScreen
 


### PR DESCRIPTION
Three small fixes for the live `agentacct tui`, all owner-reported.

## Cross-screen navigation (`u`/`s` did nothing on sub-screens)

The app-level `s`/`u` bindings stay active on every screen, but `action_open_sessions`/`action_open_usage` returned early whenever a sub-screen was on top — so pressing `u` on the sessions screen did nothing, and you had to `Esc` back home first. They now switch between top-level views from any screen: already showing it is a no-op, an instance already in the stack (under a drill-down) is popped back to rather than duplicated, and otherwise the current sub-screen is swapped (so screens never stack and never spawn a second expensive ledger build). Covered by a pilot test that drives `s → u → s` without going home.

## Snapshot (`p`) no longer corrupts the live screen

`save_screenshot()` renders a full frame to an offscreen console, and Textual's full render clears the **live** compositor's dirty regions as a side effect (`Compositor.render_full_update` calls `self._dirty_regions.clear()`). The next incremental frame then leaves stale/unpainted cells on the real terminal — a "white bar" / white background on light terminals. The action now forces a full repaint of the live screen after saving, in a `finally` so it also recovers if the write fails. The exported SVG was always fine; only the on-screen app was affected.

## Calmer sessions row cursor

The sessions list uses a row cursor, which defaulted to the full-strength primary blue (`#7AA2F7`) — a harsh, glaring bar on the selected row. It now uses a muted blue (`#2e3c64`) via a theme variable: clearly "selected" without competing with the content. (This is the "too-bright blue stripe" — it's the selected-row highlight, not the zebra striping, which stays subtle.)

## Tests

A pilot test for cross-screen nav, a snapshot smoke test (`p` writes an SVG under `<store>/snapshots/` and the app stays alive), and the cursor color is asserted via the theme. Full suite: 3066 passed, 1 skipped.
