### PR TITLE
refactor(api): extract the shared usage view builder into usage_view.py

### DIFF
--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -59,6 +59,28 @@ from .canonical_read import (
 from .capture import CaptureContext, DEFAULT_CAPTURE_REGISTRY, render_hook_manifest
 from .capture.registry import DEFAULT_MAX_PAYLOAD_BYTES
 from .capture_runtime import capture_hook_payload
+# Re-exported for compatibility: these names moved verbatim to usage_view (the
+# data-layer split). Rebinding/monkeypatching them on THIS module no longer
+# reaches usage_snapshot/plan_cost/the TUI — patch agentacct.usage_view instead.
+from .usage_view import (  # noqa: F401
+    DashboardUsageRecord,
+    DashboardUsageView,
+    _build_usage_view,
+    _cache_creation_tokens,
+    _cache_read_tokens,
+    _estimated_equivalent_cost,
+    _is_usage_activity,
+    _metadata,
+    _metadata_int,
+    _quarantine_ambiguous_dashboard_usage_record,
+    _record_from_client_usage,
+    _record_from_sentinel_event,
+    _safe_float,
+    _safe_nonnegative_event_int,
+    _session_activity_time,
+    _usage_record_time,
+    _usage_records_by_client,
+)
 from .context_bridge import build_usage_context_bridge
 from .connector_runtime import import_connector_records
 from .connectors import (
@@ -693,40 +715,6 @@ def _cap_note(shown: int, total: int, noun: str) -> str:
     )
 
 
-def _metadata(event: dict[str, Any]) -> dict[str, Any]:
-    metadata = event.get("metadata")
-    return metadata if isinstance(metadata, dict) else {}
-
-
-def _metadata_int(event: dict[str, Any], key: str) -> int:
-    try:
-        number = int(_metadata(event).get(key) or 0)
-    except (OverflowError, TypeError, ValueError):
-        return 0
-    return number if number > 0 else 0
-
-
-def _cache_creation_tokens(event: dict[str, Any]) -> int:
-    value = _metadata_int(event, "cache_creation_input_tokens")
-    if value > 0:
-        return value
-    metadata = _metadata(event)
-    if "cache_read_input_tokens" not in metadata:
-        return 0
-    cached = _metadata_int(event, "cached_input_tokens")
-    read = _metadata_int(event, "cache_read_input_tokens")
-    return max(0, cached - read)
-
-
-def _cache_read_tokens(event: dict[str, Any]) -> int:
-    value = _metadata_int(event, "cache_read_input_tokens")
-    if value > 0:
-        return value
-    cached = _metadata_int(event, "cached_input_tokens")
-    creation = _metadata_int(event, "cache_creation_input_tokens")
-    return max(0, cached - creation)
-
-
 def _human_client(value: Any) -> str:
     labels = {
         "claude-code": "Claude Code",
@@ -745,24 +733,6 @@ def _short_text(value: Any, *, max_length: int = 36) -> str:
     if len(text) <= max_length:
         return text
     return text[: max_length - 1] + "…"
-
-
-def _session_activity_time(event: dict[str, Any]) -> float:
-    metadata = _metadata(event)
-    client = str(metadata.get("client") or "").strip()
-    if client == "hermes":
-        preferred = metadata.get("started_at") or metadata.get("updated_at")
-    else:
-        preferred = metadata.get("updated_at") or metadata.get("started_at")
-    try:
-        timestamp = float(preferred or event.get("created_at") or 0.0)
-    except (OverflowError, TypeError, ValueError):
-        return 0.0
-    return timestamp if math.isfinite(timestamp) and timestamp > 0 else 0.0
-
-
-def _is_usage_activity(event: dict[str, Any]) -> bool:
-    return is_local_usage_import_event(event)
 
 
 def _short_session_label(client: Any, session_id: Any, session_labels: dict[tuple[str, str], str]) -> str:
@@ -811,70 +781,6 @@ def _record_reasoning_label(record: DashboardUsageRecord) -> str:
     return f"{_fmt_int(record.reasoning_output_tokens)} reasoning"
 
 
-@dataclass(frozen=True)
-class DashboardUsageRecord:
-    client: str
-    provider: str
-    model: str | None
-    session_id: str
-    session_kind: str
-    input_tokens: int
-    output_tokens: int
-    cached_input_tokens: int
-    cache_creation_input_tokens: int
-    cache_read_input_tokens: int
-    usage_additive: bool = True
-    usage_normalization_state: str | None = None
-    raw_cumulative_input_tokens: int | None = None
-    raw_cumulative_output_tokens: int | None = None
-    raw_cumulative_cached_input_tokens: int | None = None
-    cache_creation_tokens_reported: bool | None = None
-    cache_read_tokens_reported: bool | None = None
-    cache_creation_5m_input_tokens: int = 0
-    cache_creation_1h_input_tokens: int = 0
-    reasoning_output_tokens: int = 0
-    estimated_cost_usd: float | None = None
-    client_reported_cost_usd: float | None = None
-    usage_confidence: str | None = None
-    cost_confidence: str | None = None
-    started_at: float | None = None
-    updated_at: float | None = None
-    source_file: str | None = None
-    project_dir: str | None = None
-    raw_event: dict[str, Any] | None = None
-
-    @property
-    def total_tokens(self) -> int:
-        return self.input_tokens + self.output_tokens
-
-    @property
-    def total_tokens_including_cached(self) -> int:
-        return self.input_tokens + self.output_tokens + self.cached_input_tokens
-
-
-@dataclass(frozen=True)
-class DashboardUsageView:
-    local_records: list[DashboardUsageRecord]
-    saved_records: list[DashboardUsageRecord]
-    excluded_local_records: list[DashboardUsageRecord]
-    excluded_saved_records: list[DashboardUsageRecord]
-    local_by_client: dict[str, list[DashboardUsageRecord]]
-    saved_by_client: dict[str, list[DashboardUsageRecord]]
-    # Recording calls agentacct REFUSED, derived from the same live client-log
-    # scan that produced local_records. Nothing about a refusal is stored, so
-    # this is re-derived on every scan — which is also why refusals that
-    # predate the feature are counted without a backfill.
-    refused_recording: dict[str, Any] = dataclass_field(default_factory=dict)
-
-
-def _safe_float(value: Any) -> float | None:
-    try:
-        number = float(value)
-    except (OverflowError, TypeError, ValueError):
-        return None
-    return number if math.isfinite(number) else None
-
-
 def _safe_int(value: Any) -> int:
     try:
         return int(value or 0)
@@ -907,150 +813,6 @@ def _usage_record_count_cell(stats: dict[str, Any], esc: Any) -> str:
     if not note or note == f"{_fmt_int(value)} main":
         return esc(_fmt_int(value))
     return f"{esc(_fmt_int(value))}<br><span class=\"note\">{esc(note)}</span>"
-
-
-def _usage_record_time(record: DashboardUsageRecord) -> float:
-    preferred = record.started_at if record.client == "hermes" else record.updated_at
-    timestamp = preferred or record.updated_at or record.started_at
-    if timestamp and math.isfinite(timestamp) and timestamp > 0:
-        return timestamp
-    if record.raw_event is not None:
-        return _session_activity_time(record.raw_event)
-    return 0.0
-
-
-def _record_from_client_usage(event: ClientUsageEvent) -> DashboardUsageRecord:
-    estimated_cost = _estimated_equivalent_cost(event)
-    usage_additive, normalization_state = local_usage_additivity(
-        client=event.client,
-        session_kind=event.client_session_kind,
-        parent_client_session_id=event.parent_client_session_id,
-        usage_update_semantics=event.usage_update_semantics,
-        source_namespace_fingerprint=event.source_namespace_fingerprint,
-        parent_source_namespace_fingerprint=(
-            event.source_namespace_fingerprint if event.parent_client_session_id else None
-        ),
-    )
-    return DashboardUsageRecord(
-        client=event.client,
-        provider=event.provider,
-        model=event.model,
-        session_id=event.client_session_id,
-        session_kind=event.client_session_kind or "root",
-        input_tokens=event.input_tokens if usage_additive else 0,
-        output_tokens=event.output_tokens if usage_additive else 0,
-        cached_input_tokens=event.cached_input_tokens if usage_additive else 0,
-        cache_creation_input_tokens=event.cache_creation_input_tokens if usage_additive else 0,
-        cache_read_input_tokens=event.cache_read_input_tokens if usage_additive else 0,
-        usage_additive=usage_additive,
-        usage_normalization_state=normalization_state,
-        raw_cumulative_input_tokens=event.input_tokens if not usage_additive else None,
-        raw_cumulative_output_tokens=event.output_tokens if not usage_additive else None,
-        raw_cumulative_cached_input_tokens=event.cached_input_tokens if not usage_additive else None,
-        cache_creation_tokens_reported=getattr(event, "cache_creation_tokens_reported", None),
-        cache_read_tokens_reported=getattr(event, "cache_read_tokens_reported", None),
-        cache_creation_5m_input_tokens=event.cache_creation_5m_input_tokens if usage_additive else 0,
-        cache_creation_1h_input_tokens=event.cache_creation_1h_input_tokens if usage_additive else 0,
-        reasoning_output_tokens=event.reasoning_output_tokens if usage_additive else 0,
-        estimated_cost_usd=estimated_cost if usage_additive else None,
-        client_reported_cost_usd=event.client_reported_cost_usd if usage_additive else None,
-        usage_confidence="client_reported",
-        cost_confidence=(
-            "client_reported"
-            if usage_additive and event.client_reported_cost_usd is not None
-            else "estimated_from_tokens"
-            if usage_additive and estimated_cost is not None
-            else None
-        ),
-        started_at=float(event.started_at) if event.started_at is not None else None,
-        updated_at=float(event.updated_at) if event.updated_at is not None else None,
-        source_file=event.source_path.name,
-        project_dir=event.cwd,
-    )
-
-
-def _record_from_sentinel_event(event: dict[str, Any]) -> DashboardUsageRecord | None:
-    if not _is_usage_activity(event):
-        return None
-    metadata = _metadata(event)
-    client = str(metadata.get("client") or event.get("source") or "unknown")
-    # Import rows only (guaranteed by _is_usage_activity): normalize away our
-    # own legacy ':model:' key artifact so un-migrated stores stop showing
-    # phantom per-model sessions. Only claude-code rows ever carried the
-    # marker; child ':stem' suffixes are preserved.
-    session_id = normalized_local_usage_session_id(
-        metadata.get("client"), str(metadata.get("client_session_id") or event.get("run_id") or "")
-    )
-    cached = _metadata_int(event, "cached_input_tokens")
-    cache_creation = _cache_creation_tokens(event)
-    cache_read = _cache_read_tokens(event)
-    cost = _safe_float(event.get("estimated_cost_usd"))
-    cost_confidence = str(event.get("cost_confidence") or "") or None
-    usage_additive, normalization_state = local_usage_additivity(
-        client=client,
-        session_kind=metadata.get("client_session_kind"),
-        parent_client_session_id=metadata.get("parent_client_session_id"),
-        usage_update_semantics=metadata.get("usage_update_semantics"),
-        explicit_usage_additive=metadata.get("usage_additive"),
-        source_namespace_fingerprint=metadata.get("source_namespace_fingerprint"),
-        parent_source_namespace_fingerprint=metadata.get("parent_source_namespace_fingerprint"),
-    )
-    input_tokens = _safe_nonnegative_event_int(event, "estimated_input_tokens")
-    output_tokens = _safe_nonnegative_event_int(event, "estimated_output_tokens")
-    return DashboardUsageRecord(
-        client=client,
-        provider=str(event.get("provider") or client),
-        model=str(event.get("model")) if event.get("model") else None,
-        session_id=session_id,
-        session_kind=str(metadata.get("client_session_kind") or "root"),
-        input_tokens=input_tokens if usage_additive else 0,
-        output_tokens=output_tokens if usage_additive else 0,
-        cached_input_tokens=cached if usage_additive else 0,
-        cache_creation_input_tokens=cache_creation if usage_additive else 0,
-        cache_read_input_tokens=cache_read if usage_additive else 0,
-        usage_additive=usage_additive,
-        usage_normalization_state=normalization_state,
-        raw_cumulative_input_tokens=input_tokens if not usage_additive else None,
-        raw_cumulative_output_tokens=output_tokens if not usage_additive else None,
-        raw_cumulative_cached_input_tokens=cached if not usage_additive else None,
-        cache_creation_tokens_reported=(
-            bool(metadata.get("cache_creation_tokens_reported"))
-            if isinstance(metadata.get("cache_creation_tokens_reported"), bool)
-            else None
-        ),
-        cache_read_tokens_reported=(
-            bool(metadata.get("cache_read_tokens_reported"))
-            if isinstance(metadata.get("cache_read_tokens_reported"), bool)
-            else None
-        ),
-        cache_creation_5m_input_tokens=_metadata_int(event, "cache_creation_5m_input_tokens"),
-        cache_creation_1h_input_tokens=_metadata_int(event, "cache_creation_1h_input_tokens"),
-        reasoning_output_tokens=_metadata_int(event, "reasoning_output_tokens") if usage_additive else 0,
-        estimated_cost_usd=cost if usage_additive else None,
-        client_reported_cost_usd=cost if usage_additive and cost_confidence == "client_reported" else None,
-        usage_confidence=str(event.get("usage_confidence") or "") or None,
-        cost_confidence=cost_confidence if usage_additive else None,
-        started_at=_safe_float(metadata.get("started_at")),
-        updated_at=_safe_float(metadata.get("updated_at")),
-        source_file=str(metadata.get("source_file")) if metadata.get("source_file") else None,
-        project_dir=str(metadata.get("project_dir")) if metadata.get("project_dir") else None,
-        raw_event=event,
-    )
-
-
-def _safe_nonnegative_event_int(event: dict[str, Any], key: str) -> int:
-    try:
-        value = int(event.get(key) or 0)
-    except (OverflowError, TypeError, ValueError):
-        return 0
-    return value if value > 0 else 0
-
-
-def _usage_records_by_client(records: list[DashboardUsageRecord]) -> dict[str, list[DashboardUsageRecord]]:
-    by_client: dict[str, list[DashboardUsageRecord]] = {}
-    for record in records:
-        by_client.setdefault(record.client, []).append(record)
-    return by_client
 
 
 def _usage_record_totals(records: list[DashboardUsageRecord]) -> dict[str, Any]:
@@ -1105,75 +867,6 @@ def _usage_exclusion_reason(records: Iterable[DashboardUsageRecord]) -> str:
     # Keep the stable v1 empty-state value for callers that compare the full
     # response shape; no excluded row means this reason is informational only.
     return CODEX_REPLAY_QUARANTINE_STATE
-
-
-def _build_usage_view(local_usage_preview: list[ClientUsageEvent], events: list[dict[str, Any]]) -> DashboardUsageView:
-    all_local_records = [_record_from_client_usage(event) for event in local_usage_preview]
-    # Shared legacy-store rule (usage_truth): stale claude-code base rows
-    # shadowed by ':model:' siblings are excluded exactly like the work ledger
-    # and the context bridge exclude them, so all three surfaces agree.
-    kept_events, _shadowed = split_shadowed_legacy_usage_events(events)
-    ambiguous_source_identities = (
-        local_usage_source_namespace_ambiguous_identities(kept_events)
-    )
-    all_saved_records = [record for event in kept_events if (record := _record_from_sentinel_event(event)) is not None]
-    if ambiguous_source_identities:
-        all_saved_records = [
-            _quarantine_ambiguous_dashboard_usage_record(
-                record,
-                ambiguous_source_identities,
-            )
-            for record in all_saved_records
-        ]
-    local_records = [record for record in all_local_records if record.usage_additive]
-    excluded_local_records = [record for record in all_local_records if not record.usage_additive]
-    saved_records = [record for record in all_saved_records if record.usage_additive]
-    excluded_saved_records = [record for record in all_saved_records if not record.usage_additive]
-    return DashboardUsageView(
-        local_records=local_records,
-        saved_records=saved_records,
-        excluded_local_records=excluded_local_records,
-        excluded_saved_records=excluded_saved_records,
-        local_by_client=_usage_records_by_client(local_records),
-        saved_by_client=_usage_records_by_client(saved_records),
-        # Derived from the raw scan candidates (not the records), because the
-        # summary dedups per base session itself: one Claude Code transcript
-        # becomes several per-model records carrying the SAME refusal counts.
-        refused_recording=summarize_refused_recording_attempts(local_usage_preview),
-    )
-
-
-def _quarantine_ambiguous_dashboard_usage_record(
-    record: DashboardUsageRecord,
-    ambiguous_identities: set[tuple[str, str, str]],
-) -> DashboardUsageRecord:
-    raw_event = record.raw_event
-    identity = (
-        recognized_local_usage_row_identity(raw_event)
-        if isinstance(raw_event, dict)
-        else None
-    )
-    if identity not in ambiguous_identities:
-        return record
-    return replace(
-        record,
-        input_tokens=0,
-        output_tokens=0,
-        cached_input_tokens=0,
-        cache_creation_input_tokens=0,
-        cache_read_input_tokens=0,
-        usage_additive=False,
-        usage_normalization_state="source_namespace_missing_vs_explicit",
-        raw_cumulative_input_tokens=record.input_tokens,
-        raw_cumulative_output_tokens=record.output_tokens,
-        raw_cumulative_cached_input_tokens=record.cached_input_tokens,
-        cache_creation_5m_input_tokens=0,
-        cache_creation_1h_input_tokens=0,
-        reasoning_output_tokens=0,
-        estimated_cost_usd=None,
-        client_reported_cost_usd=None,
-        cost_confidence=None,
-    )
 
 
 def _usage_event_totals(events: list[ClientUsageEvent]) -> dict[str, Any]:
@@ -1968,21 +1661,6 @@ def _raw_event_activity_cell(event: dict[str, Any], esc: Any) -> str:
     if is_diagnostic_event(event):
         return f'{label}<br><span class="status status-needs-import">self-test</span>'
     return label
-
-
-def _estimated_equivalent_cost(event: ClientUsageEvent) -> float | None:
-    if not event.model or not has_model_price(event.provider, event.model):
-        return None
-    return estimate_model_cost_breakdown_usd(
-        event.provider,
-        event.model,
-        input_tokens=event.input_tokens,
-        output_tokens=event.output_tokens,
-        cache_creation_input_tokens=event.cache_creation_input_tokens,
-        cache_read_input_tokens=event.cache_read_input_tokens,
-        cache_creation_5m_input_tokens=event.cache_creation_5m_input_tokens,
-        cache_creation_1h_input_tokens=event.cache_creation_1h_input_tokens,
-    )["total_cost_usd"]
 
 
 def _estimated_cost_parts(

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -213,7 +213,7 @@ def calibrate_plan_weights(
     ``events`` still supplies the 7-day series regardless.
     """
 
-    from .api import _usage_record_time
+    from .usage_view import _usage_record_time
     import time as _time
 
     now_epoch = now if now is not None else _time.time()

--- a/src/agentacct/usage_cube.py
+++ b/src/agentacct/usage_cube.py
@@ -4,7 +4,7 @@ Aggregates SAVED usage rows by client, by (client, provider, model), and by
 local-day / ISO-week period, with a date-range filter. The caller feeds it the
 same ``DashboardUsageRecord`` intake every dashboard surface shares (trusted
 local import rows only — diagnostic events and shadowed legacy rows can never
-enter), plus the ONE canonical row-timestamp rule (``api._usage_record_time``)
+enter), plus the ONE canonical row-timestamp rule (``usage_view._usage_record_time``)
 as ``record_time``; nothing here re-derives identity, trust, or time semantics.
 
 Pure functions: no store access, no live scan, and no clock access unless the

--- a/src/agentacct/usage_snapshot.py
+++ b/src/agentacct/usage_snapshot.py
@@ -7,7 +7,7 @@ authoritative local event log, with no credentials or API calls.
 
 Data paths (factored out of the CLI commands verbatim, so behavior is unchanged):
 
-* **usage/cost** — ``_build_usage_view([], events)`` (:mod:`agentacct.api`) maps
+* **usage/cost** — ``_build_usage_view([], events)`` (:mod:`agentacct.usage_view`) maps
   events to usage records (``model_usage`` only; session / diagnostic / work
   events are excluded), then :func:`agentacct.usage_cube.build_usage_cube` with
   ``days=N`` scopes each calendar window. Expressing a window as ``days=N``
@@ -23,7 +23,7 @@ Data paths (factored out of the CLI commands verbatim, so behavior is unchanged)
   The provider-reported windows carry ``used_percent`` + ``resets_at`` and drive
   the live bars and reset countdown.
 
-The heavy imports (:mod:`agentacct.api`, :mod:`agentacct.usage_cube`,
+The heavy imports (:mod:`agentacct.usage_view`, :mod:`agentacct.usage_cube`,
 :mod:`agentacct.rate_limits`) are deferred into the functions that need them so
 importing this module stays cheap for the CLI's cold start.
 """
@@ -362,7 +362,7 @@ def usage_records(events: list[dict[str, Any]], *, client: str | None = None) ->
     needs so held usage is still counted toward availability.
     """
 
-    from .api import _build_usage_view
+    from .usage_view import _build_usage_view
 
     view = _build_usage_view([], events)
     records = [*view.saved_records, *view.excluded_saved_records]
@@ -398,7 +398,7 @@ def build_usage_snapshot(
     surface a clear error. ``now`` / ``today`` are injectable for tests.
     """
 
-    from .api import _usage_record_time
+    from .usage_view import _usage_record_time
     from .usage_cube import build_usage_cube
 
     if breakdown_window not in NOW_WINDOW_ALIASES:
@@ -465,7 +465,7 @@ def build_usage_page(
     the overview. ``now`` / ``today`` are injectable for tests.
     """
 
-    from .api import _usage_record_time
+    from .usage_view import _usage_record_time
     from .usage_cube import build_usage_cube, resolve_granularity
 
     records = usage_records(events, client=client)

--- a/src/agentacct/usage_view.py
+++ b/src/agentacct/usage_view.py
@@ -1,0 +1,376 @@
+"""Client-neutral usage view building — the shared "usage/cost rows" data layer.
+
+This module owns the one intake every usage surface shares: turning raw
+``ClientUsageEvent`` scan candidates and saved sentinel events into
+``DashboardUsageRecord`` rows and the aggregated ``DashboardUsageView``
+(additivity normalization, legacy-shadow exclusion, ambiguous-identity
+quarantine, refused-recording rollup), plus the ONE canonical row-timestamp
+rule (``_usage_record_time``).
+
+Everything here was extracted verbatim from :mod:`agentacct.api` so that
+non-web consumers (:mod:`agentacct.usage_snapshot`, :mod:`agentacct.plan_cost`,
+and through them the TUI) no longer import the web server module for pure data
+logic. :mod:`agentacct.api` re-imports these names and keeps behaving exactly
+as before.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field as dataclass_field, replace
+from typing import Any
+
+from .client_usage import ClientUsageEvent, is_local_usage_import_event
+from .cost import estimate_model_cost_breakdown_usd, has_model_price
+from .log_evidence import summarize_refused_recording_attempts
+from .usage_truth import (
+    local_usage_additivity,
+    local_usage_source_namespace_ambiguous_identities,
+    normalized_local_usage_session_id,
+    recognized_local_usage_row_identity,
+    split_shadowed_legacy_usage_events,
+)
+
+
+def _metadata(event: dict[str, Any]) -> dict[str, Any]:
+    metadata = event.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _metadata_int(event: dict[str, Any], key: str) -> int:
+    try:
+        number = int(_metadata(event).get(key) or 0)
+    except (OverflowError, TypeError, ValueError):
+        return 0
+    return number if number > 0 else 0
+
+
+def _cache_creation_tokens(event: dict[str, Any]) -> int:
+    value = _metadata_int(event, "cache_creation_input_tokens")
+    if value > 0:
+        return value
+    metadata = _metadata(event)
+    if "cache_read_input_tokens" not in metadata:
+        return 0
+    cached = _metadata_int(event, "cached_input_tokens")
+    read = _metadata_int(event, "cache_read_input_tokens")
+    return max(0, cached - read)
+
+
+def _cache_read_tokens(event: dict[str, Any]) -> int:
+    value = _metadata_int(event, "cache_read_input_tokens")
+    if value > 0:
+        return value
+    cached = _metadata_int(event, "cached_input_tokens")
+    creation = _metadata_int(event, "cache_creation_input_tokens")
+    return max(0, cached - creation)
+
+
+def _session_activity_time(event: dict[str, Any]) -> float:
+    metadata = _metadata(event)
+    client = str(metadata.get("client") or "").strip()
+    if client == "hermes":
+        preferred = metadata.get("started_at") or metadata.get("updated_at")
+    else:
+        preferred = metadata.get("updated_at") or metadata.get("started_at")
+    try:
+        timestamp = float(preferred or event.get("created_at") or 0.0)
+    except (OverflowError, TypeError, ValueError):
+        return 0.0
+    return timestamp if math.isfinite(timestamp) and timestamp > 0 else 0.0
+
+
+def _is_usage_activity(event: dict[str, Any]) -> bool:
+    return is_local_usage_import_event(event)
+
+
+@dataclass(frozen=True)
+class DashboardUsageRecord:
+    client: str
+    provider: str
+    model: str | None
+    session_id: str
+    session_kind: str
+    input_tokens: int
+    output_tokens: int
+    cached_input_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+    usage_additive: bool = True
+    usage_normalization_state: str | None = None
+    raw_cumulative_input_tokens: int | None = None
+    raw_cumulative_output_tokens: int | None = None
+    raw_cumulative_cached_input_tokens: int | None = None
+    cache_creation_tokens_reported: bool | None = None
+    cache_read_tokens_reported: bool | None = None
+    cache_creation_5m_input_tokens: int = 0
+    cache_creation_1h_input_tokens: int = 0
+    reasoning_output_tokens: int = 0
+    estimated_cost_usd: float | None = None
+    client_reported_cost_usd: float | None = None
+    usage_confidence: str | None = None
+    cost_confidence: str | None = None
+    started_at: float | None = None
+    updated_at: float | None = None
+    source_file: str | None = None
+    project_dir: str | None = None
+    raw_event: dict[str, Any] | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+    @property
+    def total_tokens_including_cached(self) -> int:
+        return self.input_tokens + self.output_tokens + self.cached_input_tokens
+
+
+@dataclass(frozen=True)
+class DashboardUsageView:
+    local_records: list[DashboardUsageRecord]
+    saved_records: list[DashboardUsageRecord]
+    excluded_local_records: list[DashboardUsageRecord]
+    excluded_saved_records: list[DashboardUsageRecord]
+    local_by_client: dict[str, list[DashboardUsageRecord]]
+    saved_by_client: dict[str, list[DashboardUsageRecord]]
+    # Recording calls agentacct REFUSED, derived from the same live client-log
+    # scan that produced local_records. Nothing about a refusal is stored, so
+    # this is re-derived on every scan — which is also why refusals that
+    # predate the feature are counted without a backfill.
+    refused_recording: dict[str, Any] = dataclass_field(default_factory=dict)
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _usage_record_time(record: DashboardUsageRecord) -> float:
+    preferred = record.started_at if record.client == "hermes" else record.updated_at
+    timestamp = preferred or record.updated_at or record.started_at
+    if timestamp and math.isfinite(timestamp) and timestamp > 0:
+        return timestamp
+    if record.raw_event is not None:
+        return _session_activity_time(record.raw_event)
+    return 0.0
+
+
+def _estimated_equivalent_cost(event: ClientUsageEvent) -> float | None:
+    if not event.model or not has_model_price(event.provider, event.model):
+        return None
+    return estimate_model_cost_breakdown_usd(
+        event.provider,
+        event.model,
+        input_tokens=event.input_tokens,
+        output_tokens=event.output_tokens,
+        cache_creation_input_tokens=event.cache_creation_input_tokens,
+        cache_read_input_tokens=event.cache_read_input_tokens,
+        cache_creation_5m_input_tokens=event.cache_creation_5m_input_tokens,
+        cache_creation_1h_input_tokens=event.cache_creation_1h_input_tokens,
+    )["total_cost_usd"]
+
+
+def _record_from_client_usage(event: ClientUsageEvent) -> DashboardUsageRecord:
+    estimated_cost = _estimated_equivalent_cost(event)
+    usage_additive, normalization_state = local_usage_additivity(
+        client=event.client,
+        session_kind=event.client_session_kind,
+        parent_client_session_id=event.parent_client_session_id,
+        usage_update_semantics=event.usage_update_semantics,
+        source_namespace_fingerprint=event.source_namespace_fingerprint,
+        parent_source_namespace_fingerprint=(
+            event.source_namespace_fingerprint if event.parent_client_session_id else None
+        ),
+    )
+    return DashboardUsageRecord(
+        client=event.client,
+        provider=event.provider,
+        model=event.model,
+        session_id=event.client_session_id,
+        session_kind=event.client_session_kind or "root",
+        input_tokens=event.input_tokens if usage_additive else 0,
+        output_tokens=event.output_tokens if usage_additive else 0,
+        cached_input_tokens=event.cached_input_tokens if usage_additive else 0,
+        cache_creation_input_tokens=event.cache_creation_input_tokens if usage_additive else 0,
+        cache_read_input_tokens=event.cache_read_input_tokens if usage_additive else 0,
+        usage_additive=usage_additive,
+        usage_normalization_state=normalization_state,
+        raw_cumulative_input_tokens=event.input_tokens if not usage_additive else None,
+        raw_cumulative_output_tokens=event.output_tokens if not usage_additive else None,
+        raw_cumulative_cached_input_tokens=event.cached_input_tokens if not usage_additive else None,
+        cache_creation_tokens_reported=getattr(event, "cache_creation_tokens_reported", None),
+        cache_read_tokens_reported=getattr(event, "cache_read_tokens_reported", None),
+        cache_creation_5m_input_tokens=event.cache_creation_5m_input_tokens if usage_additive else 0,
+        cache_creation_1h_input_tokens=event.cache_creation_1h_input_tokens if usage_additive else 0,
+        reasoning_output_tokens=event.reasoning_output_tokens if usage_additive else 0,
+        estimated_cost_usd=estimated_cost if usage_additive else None,
+        client_reported_cost_usd=event.client_reported_cost_usd if usage_additive else None,
+        usage_confidence="client_reported",
+        cost_confidence=(
+            "client_reported"
+            if usage_additive and event.client_reported_cost_usd is not None
+            else "estimated_from_tokens"
+            if usage_additive and estimated_cost is not None
+            else None
+        ),
+        started_at=float(event.started_at) if event.started_at is not None else None,
+        updated_at=float(event.updated_at) if event.updated_at is not None else None,
+        source_file=event.source_path.name,
+        project_dir=event.cwd,
+    )
+
+
+def _record_from_sentinel_event(event: dict[str, Any]) -> DashboardUsageRecord | None:
+    if not _is_usage_activity(event):
+        return None
+    metadata = _metadata(event)
+    client = str(metadata.get("client") or event.get("source") or "unknown")
+    # Import rows only (guaranteed by _is_usage_activity): normalize away our
+    # own legacy ':model:' key artifact so un-migrated stores stop showing
+    # phantom per-model sessions. Only claude-code rows ever carried the
+    # marker; child ':stem' suffixes are preserved.
+    session_id = normalized_local_usage_session_id(
+        metadata.get("client"), str(metadata.get("client_session_id") or event.get("run_id") or "")
+    )
+    cached = _metadata_int(event, "cached_input_tokens")
+    cache_creation = _cache_creation_tokens(event)
+    cache_read = _cache_read_tokens(event)
+    cost = _safe_float(event.get("estimated_cost_usd"))
+    cost_confidence = str(event.get("cost_confidence") or "") or None
+    usage_additive, normalization_state = local_usage_additivity(
+        client=client,
+        session_kind=metadata.get("client_session_kind"),
+        parent_client_session_id=metadata.get("parent_client_session_id"),
+        usage_update_semantics=metadata.get("usage_update_semantics"),
+        explicit_usage_additive=metadata.get("usage_additive"),
+        source_namespace_fingerprint=metadata.get("source_namespace_fingerprint"),
+        parent_source_namespace_fingerprint=metadata.get("parent_source_namespace_fingerprint"),
+    )
+    input_tokens = _safe_nonnegative_event_int(event, "estimated_input_tokens")
+    output_tokens = _safe_nonnegative_event_int(event, "estimated_output_tokens")
+    return DashboardUsageRecord(
+        client=client,
+        provider=str(event.get("provider") or client),
+        model=str(event.get("model")) if event.get("model") else None,
+        session_id=session_id,
+        session_kind=str(metadata.get("client_session_kind") or "root"),
+        input_tokens=input_tokens if usage_additive else 0,
+        output_tokens=output_tokens if usage_additive else 0,
+        cached_input_tokens=cached if usage_additive else 0,
+        cache_creation_input_tokens=cache_creation if usage_additive else 0,
+        cache_read_input_tokens=cache_read if usage_additive else 0,
+        usage_additive=usage_additive,
+        usage_normalization_state=normalization_state,
+        raw_cumulative_input_tokens=input_tokens if not usage_additive else None,
+        raw_cumulative_output_tokens=output_tokens if not usage_additive else None,
+        raw_cumulative_cached_input_tokens=cached if not usage_additive else None,
+        cache_creation_tokens_reported=(
+            bool(metadata.get("cache_creation_tokens_reported"))
+            if isinstance(metadata.get("cache_creation_tokens_reported"), bool)
+            else None
+        ),
+        cache_read_tokens_reported=(
+            bool(metadata.get("cache_read_tokens_reported"))
+            if isinstance(metadata.get("cache_read_tokens_reported"), bool)
+            else None
+        ),
+        cache_creation_5m_input_tokens=_metadata_int(event, "cache_creation_5m_input_tokens"),
+        cache_creation_1h_input_tokens=_metadata_int(event, "cache_creation_1h_input_tokens"),
+        reasoning_output_tokens=_metadata_int(event, "reasoning_output_tokens") if usage_additive else 0,
+        estimated_cost_usd=cost if usage_additive else None,
+        client_reported_cost_usd=cost if usage_additive and cost_confidence == "client_reported" else None,
+        usage_confidence=str(event.get("usage_confidence") or "") or None,
+        cost_confidence=cost_confidence if usage_additive else None,
+        started_at=_safe_float(metadata.get("started_at")),
+        updated_at=_safe_float(metadata.get("updated_at")),
+        source_file=str(metadata.get("source_file")) if metadata.get("source_file") else None,
+        project_dir=str(metadata.get("project_dir")) if metadata.get("project_dir") else None,
+        raw_event=event,
+    )
+
+
+def _safe_nonnegative_event_int(event: dict[str, Any], key: str) -> int:
+    try:
+        value = int(event.get(key) or 0)
+    except (OverflowError, TypeError, ValueError):
+        return 0
+    return value if value > 0 else 0
+
+
+def _usage_records_by_client(records: list[DashboardUsageRecord]) -> dict[str, list[DashboardUsageRecord]]:
+    by_client: dict[str, list[DashboardUsageRecord]] = {}
+    for record in records:
+        by_client.setdefault(record.client, []).append(record)
+    return by_client
+
+
+def _build_usage_view(local_usage_preview: list[ClientUsageEvent], events: list[dict[str, Any]]) -> DashboardUsageView:
+    all_local_records = [_record_from_client_usage(event) for event in local_usage_preview]
+    # Shared legacy-store rule (usage_truth): stale claude-code base rows
+    # shadowed by ':model:' siblings are excluded exactly like the work ledger
+    # and the context bridge exclude them, so all three surfaces agree.
+    kept_events, _shadowed = split_shadowed_legacy_usage_events(events)
+    ambiguous_source_identities = (
+        local_usage_source_namespace_ambiguous_identities(kept_events)
+    )
+    all_saved_records = [record for event in kept_events if (record := _record_from_sentinel_event(event)) is not None]
+    if ambiguous_source_identities:
+        all_saved_records = [
+            _quarantine_ambiguous_dashboard_usage_record(
+                record,
+                ambiguous_source_identities,
+            )
+            for record in all_saved_records
+        ]
+    local_records = [record for record in all_local_records if record.usage_additive]
+    excluded_local_records = [record for record in all_local_records if not record.usage_additive]
+    saved_records = [record for record in all_saved_records if record.usage_additive]
+    excluded_saved_records = [record for record in all_saved_records if not record.usage_additive]
+    return DashboardUsageView(
+        local_records=local_records,
+        saved_records=saved_records,
+        excluded_local_records=excluded_local_records,
+        excluded_saved_records=excluded_saved_records,
+        local_by_client=_usage_records_by_client(local_records),
+        saved_by_client=_usage_records_by_client(saved_records),
+        # Derived from the raw scan candidates (not the records), because the
+        # summary dedups per base session itself: one Claude Code transcript
+        # becomes several per-model records carrying the SAME refusal counts.
+        refused_recording=summarize_refused_recording_attempts(local_usage_preview),
+    )
+
+
+def _quarantine_ambiguous_dashboard_usage_record(
+    record: DashboardUsageRecord,
+    ambiguous_identities: set[tuple[str, str, str]],
+) -> DashboardUsageRecord:
+    raw_event = record.raw_event
+    identity = (
+        recognized_local_usage_row_identity(raw_event)
+        if isinstance(raw_event, dict)
+        else None
+    )
+    if identity not in ambiguous_identities:
+        return record
+    return replace(
+        record,
+        input_tokens=0,
+        output_tokens=0,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        usage_additive=False,
+        usage_normalization_state="source_namespace_missing_vs_explicit",
+        raw_cumulative_input_tokens=record.input_tokens,
+        raw_cumulative_output_tokens=record.output_tokens,
+        raw_cumulative_cached_input_tokens=record.cached_input_tokens,
+        cache_creation_5m_input_tokens=0,
+        cache_creation_1h_input_tokens=0,
+        reasoning_output_tokens=0,
+        estimated_cost_usd=None,
+        client_reported_cost_usd=None,
+        cost_confidence=None,
+    )

--- a/tests/test_cache_capabilities.py
+++ b/tests/test_cache_capabilities.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from agentacct.api import DashboardUsageRecord, _usage_record_time
+from agentacct.usage_view import DashboardUsageRecord, _usage_record_time
 from agentacct.task_projection import build_task_projection
 from agentacct.usage_cube import build_usage_cube
 from agentacct.work_ledger import build_work_ledger

--- a/tests/test_legacy_model_key_shadowing.py
+++ b/tests/test_legacy_model_key_shadowing.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from agentacct.api import _build_usage_view
+from agentacct.usage_view import _build_usage_view
 from agentacct.cli import app
 from agentacct.context_bridge import build_usage_context_bridge
 from agentacct.usage_truth import (

--- a/tests/test_tokens_explorer.py
+++ b/tests/test_tokens_explorer.py
@@ -20,7 +20,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 import agentacct.api as api_module
-from agentacct.api import DashboardUsageRecord, _usage_record_time, create_local_api_app
+from agentacct.api import create_local_api_app
+from agentacct.usage_view import DashboardUsageRecord, _usage_record_time
 from agentacct.service import SentinelService
 from agentacct.usage_cube import (
     build_usage_cube,


### PR DESCRIPTION
Step 1 of the HTML-dashboard retirement / native-app groundwork: split the shared usage/cost data layer out of the web module so the display layer can shrink without touching the numbers.

## What moved

The 17 usage-view definitions (`DashboardUsageRecord`, `DashboardUsageView`, `_build_usage_view`, `_usage_record_time`, the record builders and their helpers) moved **verbatim** from `api.py` into a new `usage_view.py`. `api.py` re-imports every moved name, so its routes and attributes behave exactly as before. `plan_cost.py` and `usage_snapshot.py` (and 3 test files) now import from `usage_view` — the data layer no longer imports the 15k-line web module for pure data logic, which also makes the CLI/TUI deferred imports much lighter.

## Why zero behavior change holds

- Every moved definition is AST-verified **byte-identical** to the original.
- `api.py`'s re-imported attributes are the **same objects** `usage_view` defines (`is`-checked).
- Full suite: **3067 passed, 1 skipped**.
- 3-lens adversarial review (import side effects / object identity / dynamic references + deletion boundary): **0 defects**. The deletion-boundary audit confirmed the removed set is exactly the 17 names; a dual-process probe (api imported vs never imported) produced byte-identical usage-view JSON over synthetic events covering additive/cumulative/quarantine/shadow/hermes-time paths.
- The one latent note (patching these names on `agentacct.api` no longer propagates to `usage_snapshot`/`plan_cost` — nothing in the repo does this today) is now guarded by a comment at the re-import site pointing future patchers at `agentacct.usage_view`.
