### PR TITLE
feat(api): /v1 native-shell lane — glance snapshot, version handshake, discovery file

### DIFF
--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -59,6 +59,7 @@ from .canonical_read import (
 from .capture import CaptureContext, DEFAULT_CAPTURE_REGISTRY, render_hook_manifest
 from .capture.registry import DEFAULT_MAX_PAYLOAD_BYTES
 from .capture_runtime import capture_hook_payload
+from .glance import GLANCE_SCHEMA_VERSION, GlanceCache
 # Re-exported for compatibility: these names moved verbatim to usage_view (the
 # data-layer split). Rebinding/monkeypatching them on THIS module no longer
 # reaches usage_snapshot/plan_cost/the TUI — patch agentacct.usage_view instead.
@@ -12937,12 +12938,18 @@ def create_local_api_app(
     store_dir: Path | str,
     usage_discovery: UsageDiscoveryConfig | None = None,
     extra_allowed_hosts: Iterable[str] = (),
+    v1_auth_token: str | None = None,
 ) -> FastAPI:
     """Create the local-only agentacct API used by sidecar/MCP surfaces.
 
     This app exposes report/outcome/event primitives only. It does not call paid
     LLM judges or mutate external agent tools. Bind it to 127.0.0.1 for local use.
     Callers must resolve the store first (no silent home-store default).
+
+    ``v1_auth_token`` arms the ``/v1`` native-shell lane (glance/version). It is
+    per-boot: ``agentacct serve`` generates one and publishes it via the 0600
+    discovery file (see :mod:`agentacct.glance`). Without a token the /v1 routes
+    fail closed (503) — they never open an unauthenticated lane by accident.
     """
     app = FastAPI(title="agentacct local api", version="0.1.0")
     app_pricing_catalog_path = pricing_catalog_path_for_store(store_dir)
@@ -14698,6 +14705,56 @@ def create_local_api_app(
             samesite="strict",
         )
         return response
+
+    # ---- /v1 native-shell lane (menu bar app / SwiftBar / widgets) --------
+    glance_cache = GlanceCache()
+
+    def _require_v1_token(request: Request) -> None:
+        """Bearer gate for the /v1 lane. Fails closed: a server constructed
+        without a token (tests, ``agentacct api serve`` sidecars) serves 503 on
+        every /v1 route rather than opening an unauthenticated lane by accident.
+        Comparison is constant-time; the token comes from the discovery file."""
+
+        if not v1_auth_token:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "v1 API disabled: this server was started without a v1 token. "
+                    "`agentacct serve` provisions one and writes the discovery file automatically."
+                ),
+            )
+        header = request.headers.get("authorization") or ""
+        scheme, _, candidate = header.partition(" ")
+        if scheme.lower() != "bearer" or not hmac.compare_digest(candidate.strip(), v1_auth_token):
+            raise HTTPException(status_code=401, detail="missing or invalid bearer token for the v1 local API")
+
+    @app.get("/v1/version")
+    def v1_version(request: Request) -> dict[str, Any]:
+        """Native-shell handshake: pin daemon/schema compatibility BEFORE
+        parsing any payload (an incompatible daemon is a first-class UI state,
+        never a JSON parse error)."""
+
+        _require_v1_token(request)
+        return {
+            "schema": "agentacct.v1-version.v1",
+            "version": _dashboard_importer_version(),
+            "glance_schema": GLANCE_SCHEMA_VERSION,
+            "pid": os.getpid(),
+            "store_dir": str(store_dir),
+            "store_scope": store_scope,
+        }
+
+    @app.get("/v1/glance")
+    def v1_glance(request: Request) -> dict[str, Any]:
+        """The glance snapshot (usage · cost · plan · recent sessions).
+
+        Fingerprint-cached: a poll that finds no event change is a dict lookup,
+        so a native shell polling every few seconds never re-aggregates the
+        store (see :mod:`agentacct.glance` for the schema contract)."""
+
+        _require_v1_token(request)
+        events = service.list_all_events()
+        return glance_cache.snapshot(events, store_dir=store_dir, version=_dashboard_importer_version())
 
     @app.get("/health")
     def health() -> dict[str, Any]:

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -14725,7 +14725,13 @@ def create_local_api_app(
             )
         header = request.headers.get("authorization") or ""
         scheme, _, candidate = header.partition(" ")
-        if scheme.lower() != "bearer" or not hmac.compare_digest(candidate.strip(), v1_auth_token):
+        # Compare BYTES: hmac.compare_digest raises TypeError on non-ASCII str
+        # (Starlette decodes header bytes as latin-1, so a garbled local client
+        # can deliver one), and the reader contract needs a clean 401 — never a
+        # 500 — as its "re-read the discovery file" signal.
+        candidate_bytes = candidate.strip().encode("utf-8", "surrogateescape")
+        expected_bytes = v1_auth_token.encode("utf-8", "surrogateescape")
+        if scheme.lower() != "bearer" or not hmac.compare_digest(candidate_bytes, expected_bytes):
             raise HTTPException(status_code=401, detail="missing or invalid bearer token for the v1 local API")
 
     @app.get("/v1/version")
@@ -14748,9 +14754,11 @@ def create_local_api_app(
     def v1_glance(request: Request) -> dict[str, Any]:
         """The glance snapshot (usage · cost · plan · recent sessions).
 
-        Fingerprint-cached: a poll that finds no event change is a dict lookup,
-        so a native shell polling every few seconds never re-aggregates the
-        store (see :mod:`agentacct.glance` for the schema contract)."""
+        Fingerprint + TTL cached: a poll that finds no event change skips the
+        aggregation REBUILD (the expensive part) — each poll still reads the
+        event list once to compute the change key, so per-request cost is one
+        store read + an O(n) hash, never a re-aggregation (see
+        :mod:`agentacct.glance` for the schema contract)."""
 
         _require_v1_token(request)
         events = service.list_all_events()

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8531,24 +8531,45 @@ def serve(
     # removed on shutdown behind a pid gate + lock so a dying old server never
     # deletes a fresh server's file.
     import secrets as _secrets
+    import threading as _threading
 
-    from .glance import claim_discovery_file, remove_discovery_file
+    from .glance import claim_discovery_file, remove_discovery_file, run_discovery_heartbeat
 
     v1_token = _secrets.token_urlsafe(32)
+    v1_version_string = _usage_importer_version()
     discovery_path = claim_discovery_file(
         effective_store_dir,
         host=host,
         port=bound_port,
         token=v1_token,
-        version=_usage_importer_version(),
+        version=v1_version_string,
     )
     if discovery_path is not None:
         console.print(f"Native-shell API (/v1): discovery file {discovery_path}")
     else:
         console.print(
             "Native-shell API (/v1): another agentacct server already publishes the discovery "
-            "file for this store; this instance serves /v1 unpublished."
+            "file for this store; this instance serves /v1 unpublished (it re-claims the slot "
+            "automatically if that server goes away)."
         )
+    # The re-claim heartbeat closes the restart-drain stranding: a serve that
+    # started unpublished (old server still dying) takes the slot over within
+    # one interval of it freeing up; also heals SIGKILL-stale files.
+    heartbeat_stop = _threading.Event()
+    heartbeat = _threading.Thread(
+        target=run_discovery_heartbeat,
+        kwargs={
+            "store_dir": effective_store_dir,
+            "host": host,
+            "port": bound_port,
+            "token": v1_token,
+            "version": v1_version_string,
+            "stop": heartbeat_stop,
+        },
+        name="agentacct-discovery-heartbeat",
+        daemon=True,
+    )
+    heartbeat.start()
     try:
         uvicorn.run(
             create_local_api_app(
@@ -8562,6 +8583,10 @@ def serve(
             log_level="info",
         )
     finally:
+        # Stop the heartbeat BEFORE removing so it cannot re-publish a file
+        # this shutdown just deleted.
+        heartbeat_stop.set()
+        heartbeat.join(timeout=5)
         remove_discovery_file(effective_store_dir)
 
 

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8524,16 +8524,37 @@ def serve(
         "Local usage scan: enabled for this localhost dashboard; agentacct reads implemented local agent usage paths "
         "and imports only summarized usage rows. Use `agentacct api serve` for an API server with local usage discovery disabled."
     )
-    uvicorn.run(
-        create_local_api_app(
-            store_dir=effective_store_dir,
-            usage_discovery=UsageDiscoveryConfig.real_home(),
-            extra_allowed_hosts=tuple(allow_host or ()),
-        ),
+    # Native-shell handshake: a per-boot bearer token published through the
+    # 0600 discovery file next to the store. Written AFTER the bind port is
+    # chosen so readers always see the real port; removed on shutdown (pid-
+    # gated so a dying old server never deletes a fresh server's file).
+    import secrets as _secrets
+
+    from .glance import discovery_file_path, remove_discovery_file, write_discovery_file
+
+    v1_token = _secrets.token_urlsafe(32)
+    write_discovery_file(
+        effective_store_dir,
         host=host,
         port=bound_port,
-        log_level="info",
+        token=v1_token,
+        version=_usage_importer_version(),
     )
+    console.print(f"Native-shell API (/v1): discovery file {discovery_file_path(effective_store_dir)}")
+    try:
+        uvicorn.run(
+            create_local_api_app(
+                store_dir=effective_store_dir,
+                usage_discovery=UsageDiscoveryConfig.real_home(),
+                extra_allowed_hosts=tuple(allow_host or ()),
+                v1_auth_token=v1_token,
+            ),
+            host=host,
+            port=bound_port,
+            log_level="info",
+        )
+    finally:
+        remove_discovery_file(effective_store_dir)
 
 
 @api_app.command("serve")

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8525,22 +8525,30 @@ def serve(
         "and imports only summarized usage rows. Use `agentacct api serve` for an API server with local usage discovery disabled."
     )
     # Native-shell handshake: a per-boot bearer token published through the
-    # 0600 discovery file next to the store. Written AFTER the bind port is
-    # chosen so readers always see the real port; removed on shutdown (pid-
-    # gated so a dying old server never deletes a fresh server's file).
+    # 0600 discovery file next to the store. Claimed AFTER the bind port is
+    # chosen so readers always see the real port; first-alive-writer-wins (a
+    # second serve against the same store leaves a live owner's slot alone);
+    # removed on shutdown behind a pid gate + lock so a dying old server never
+    # deletes a fresh server's file.
     import secrets as _secrets
 
-    from .glance import discovery_file_path, remove_discovery_file, write_discovery_file
+    from .glance import claim_discovery_file, remove_discovery_file
 
     v1_token = _secrets.token_urlsafe(32)
-    write_discovery_file(
+    discovery_path = claim_discovery_file(
         effective_store_dir,
         host=host,
         port=bound_port,
         token=v1_token,
         version=_usage_importer_version(),
     )
-    console.print(f"Native-shell API (/v1): discovery file {discovery_file_path(effective_store_dir)}")
+    if discovery_path is not None:
+        console.print(f"Native-shell API (/v1): discovery file {discovery_path}")
+    else:
+        console.print(
+            "Native-shell API (/v1): another agentacct server already publishes the discovery "
+            "file for this store; this instance serves /v1 unpublished."
+        )
     try:
         uvicorn.run(
             create_local_api_app(

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -1,0 +1,309 @@
+"""Glance data layer — the versioned local snapshot behind ``GET /v1/glance``.
+
+This is what a native shell (menu bar app, SwiftBar plugin, widgets) polls to
+show "usage · cost · plan · active sessions" at a glance. Design contract:
+
+* **One aggregation, N surfaces** — usage/cost windows and provider limits come
+  from :mod:`agentacct.usage_snapshot` (the exact functions ``agentacct now``
+  and the TUI render), and plan calibration from :mod:`agentacct.plan_cost`
+  with the same calibrated-or-nothing honesty rule. The glance never invents a
+  number another surface would not show.
+* **Cheap under polling** — the payload is rebuilt only when the event list
+  actually changes (``events_fingerprint``); a poll that finds nothing new is a
+  dictionary lookup. The expensive work-ledger build is deliberately NOT used
+  here: active sessions are derived from the section event stream directly.
+* **Additive-only schema** — consumers pin ``schema`` and ignore unknown keys;
+  existing keys are never renamed or removed within v1.
+
+The discovery-file helpers let a native shell find and authenticate to the
+server without configuration: ``agentacct serve`` binds 127.0.0.1, then writes
+``<store>/local-api.json`` (0600) with the actual port and a per-boot bearer
+token — the Tailscale "sameuserproof" / Syncthing api-key pattern. Readers
+treat the file as the only source of truth and re-read it on auth failure.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+GLANCE_SCHEMA_VERSION = "agentacct.glance.v1"
+DISCOVERY_SCHEMA_VERSION = "agentacct.local-api-discovery.v1"
+DISCOVERY_FILENAME = "local-api.json"
+
+# A session counts as "recent" in the glance when its latest section/usage
+# activity is at most this old. Bounded list, newest first.
+ACTIVE_SESSION_WINDOW_SECONDS = 6 * 3600
+ACTIVE_SESSION_LIMIT = 8
+
+# Clients whose usage can be expressed as a share of a provider plan. Mirrors
+# the TUI's plan column (tui._PLAN_CLIENTS); keep the two in sync.
+PLAN_CLIENTS = ("claude-code", "codex")
+
+
+def events_fingerprint(events: list) -> int:
+    """A content-sensitive change key for the loaded event list.
+
+    The event COUNT is NOT a sound change key: the usage importer supersedes rows
+    IN PLACE (``service.replace_events`` drops a re-observed row and records a
+    fresh one), so a growing single-model session keeps the count fixed while its
+    tokens/cost change — the whole point of a live view. Hashing each event's
+    identity + observation time makes any append, removal, or in-place supersede
+    (which records a new event id) change the key and trigger a rebuild.
+
+    The values are stringified so the key is TOTAL: a corrupted/hand-injected
+    ledger row can round-trip ``event_id`` / ``created_at`` as a JSON list or
+    object (unhashable), and this function runs on unguarded refresh paths —
+    it must never raise. (The TUI aliases this same function.)
+    """
+
+    return hash(tuple((str(event.get("event_id")), str(event.get("created_at"))) for event in events))
+
+
+# ---------------------------------------------------------------------------
+# discovery file (native-shell handshake)
+# ---------------------------------------------------------------------------
+
+
+def discovery_file_path(store_dir: Path | str) -> Path:
+    return Path(store_dir).expanduser() / DISCOVERY_FILENAME
+
+
+def write_discovery_file(
+    store_dir: Path | str,
+    *,
+    host: str,
+    port: int,
+    token: str,
+    version: str,
+    pid: int | None = None,
+) -> Path:
+    """Atomically write the 0600 discovery file next to the store.
+
+    Written by ``agentacct serve`` after the bind port is chosen and before the
+    server loop starts. Single-slot by design: one dashboard server per store
+    owns the file; a restart overwrites it (fresh token every boot). The 0600
+    mode is enforced via ``os.fchmod`` (umask-proof) and survives the atomic
+    rename, so the token is never world-readable, not even transiently.
+    """
+
+    path = discovery_file_path(store_dir)
+    # `agentacct serve` may be pointed at a store directory that does not exist
+    # yet (the app factory creates it on first use); the discovery file is
+    # written first, so it creates the directory the same way.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": DISCOVERY_SCHEMA_VERSION,
+        "host": host,
+        "port": int(port),
+        "token": token,
+        "pid": int(pid if pid is not None else os.getpid()),
+        "version": version,
+        "store_dir": str(Path(store_dir).expanduser()),
+        "written_at": time.time(),
+    }
+    tmp = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    os.replace(tmp, path)
+    return path
+
+
+def read_discovery_file(store_dir: Path | str) -> dict[str, Any] | None:
+    """The parsed discovery payload, or ``None`` when absent/unreadable/foreign.
+
+    Never raises: a missing server, a half-written file, or a future schema all
+    read as "no discoverable server" — callers fall back to their disconnected
+    state exactly as they would for a dead port.
+    """
+
+    path = discovery_file_path(store_dir)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict) or payload.get("schema") != DISCOVERY_SCHEMA_VERSION:
+        return None
+    if not isinstance(payload.get("port"), int) or not str(payload.get("token") or ""):
+        return None
+    return payload
+
+
+def remove_discovery_file(store_dir: Path | str, *, pid: int | None = None) -> bool:
+    """Remove the discovery file iff it belongs to ``pid`` (default: this process).
+
+    The pid gate keeps a dying old server from deleting the file a newly
+    restarted server just wrote (start-during-shutdown overlap). Returns True
+    only when this call actually unlinked the current owner's file.
+    """
+
+    owner = int(pid if pid is not None else os.getpid())
+    path = discovery_file_path(store_dir)
+    payload = read_discovery_file(store_dir)
+    if payload is None or payload.get("pid") != owner:
+        return False
+    try:
+        path.unlink()
+    except OSError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# glance snapshot (pure over events)
+# ---------------------------------------------------------------------------
+
+
+def _section_status_and_title(events: list[dict[str, Any]], *, now: float) -> list[dict[str, Any]]:
+    """Recent sessions from the section event stream, newest activity first.
+
+    Deliberately ledger-free: the full work-ledger build is too heavy to run on
+    a poll cadence, while the latest section event per (client, session) is a
+    single pass over the already-loaded list. A session with sections shows its
+    latest section title/status; a session that only imported usage shows just
+    activity time. Timestamps are hostile-tolerant (never raise).
+    """
+
+    def _safe_time(value: Any) -> float:
+        try:
+            number = float(value)
+        except (OverflowError, TypeError, ValueError):
+            return 0.0
+        return number if math.isfinite(number) and number > 0 else 0.0
+
+    latest: dict[tuple[str, str], dict[str, Any]] = {}
+    for event in events:
+        event_type = str(event.get("event_type") or "")
+        if not event_type.startswith("section_"):
+            continue
+        metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+        client = str(metadata.get("client") or event.get("source") or "")
+        session_id = str(metadata.get("client_session_id") or "")
+        if not client or not session_id:
+            continue
+        created = _safe_time(event.get("created_at"))
+        key = (client, session_id)
+        current = latest.get(key)
+        if current is None or created >= current["last_activity_at"]:
+            latest[key] = {
+                "client": client,
+                "session_id": session_id,
+                "title": str(metadata.get("section_title") or "") or None,
+                "status": str(metadata.get("section_status") or "") or None,
+                "last_activity_at": created,
+            }
+    cutoff = now - ACTIVE_SESSION_WINDOW_SECONDS
+    rows = [row for row in latest.values() if row["last_activity_at"] >= cutoff]
+    rows.sort(key=lambda row: row["last_activity_at"], reverse=True)
+    return rows[:ACTIVE_SESSION_LIMIT]
+
+
+def build_glance_snapshot(
+    events: list[dict[str, Any]],
+    *,
+    store_dir: Path | str,
+    version: str,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """The full glance payload from one already-loaded event list.
+
+    Heavy siblings are imported lazily (same pattern as usage_snapshot) so
+    importing this module stays cheap for CLI cold starts and tests.
+    """
+
+    from .plan_cost import calibrate_plan_weights, session_plan_pcts
+    from .usage_snapshot import build_live_snapshot, limit_is_stale, usage_records
+
+    moment = time.time() if now is None else float(now)
+    live = build_live_snapshot(events, now=moment)
+
+    usage_windows = [
+        {"label": window.label, "days": window.days, "totals": window.totals}
+        for window in live.usage.windows
+    ]
+
+    limits: list[dict[str, Any]] = []
+    for limit in live.limits:
+        entry = limit.to_json_entry()
+        entry["stale"] = limit_is_stale(limit, moment)
+        limits.append(entry)
+
+    # Plan calibration per plan-bearing client — the calibrated-or-nothing
+    # honesty rule: per-session percentages exist ONLY when the estimate is
+    # grounded in this account's own recorded limit history.
+    plan: list[dict[str, Any]] = []
+    session_pcts: dict[str, float] = {}
+    for client in PLAN_CLIENTS:
+        records = usage_records(events, client=client)
+        weights = calibrate_plan_weights(events, client=client, records=records)
+        plan.append({"client": client, "confidence": weights.confidence})
+        if weights.confidence == "calibrated":
+            session_pcts.update(session_plan_pcts(records, weights, client=client))
+
+    recent_sessions = _section_status_and_title(events, now=moment)
+    for row in recent_sessions:
+        pct = session_pcts.get(row["session_id"])
+        row["plan_pct"] = round(pct, 2) if pct is not None else None
+
+    return {
+        "schema": GLANCE_SCHEMA_VERSION,
+        "generated_at": moment,
+        "daemon": {"version": version, "pid": os.getpid(), "store_dir": str(Path(store_dir).expanduser())},
+        "usage": {
+            "as_of": live.usage.as_of,
+            "event_count": live.usage.event_count,
+            "usage_record_count": live.usage.usage_record_count,
+            "windows": usage_windows,
+            "by_client": live.usage.by_client,
+            "breakdown_window": live.usage.breakdown_window,
+        },
+        "limits": limits,
+        "plan": plan,
+        "recent_sessions": recent_sessions,
+    }
+
+
+class GlanceCache:
+    """Fingerprint-keyed cache so polling never recomputes an unchanged payload.
+
+    Thread-tolerant under FastAPI's threadpool: the cached value is one atomic
+    tuple assignment, so a concurrent reader can never observe a torn pair; two
+    racing rebuilds waste one build and the last writer wins (same pattern as
+    the TUI's plan cache).
+    """
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._cached: tuple[int, dict[str, Any]] | None = None
+
+    def snapshot(
+        self,
+        events: list[dict[str, Any]],
+        *,
+        store_dir: Path | str,
+        version: str,
+        now: float | None = None,
+    ) -> dict[str, Any]:
+        fingerprint = events_fingerprint(events)
+        cached = self._cached
+        if cached is not None and cached[0] == fingerprint:
+            return cached[1]
+        with self._lock:
+            cached = self._cached
+            if cached is not None and cached[0] == fingerprint:
+                return cached[1]
+            payload = build_glance_snapshot(events, store_dir=store_dir, version=version, now=now)
+            self._cached = (fingerprint, payload)
+            return payload

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -8,18 +8,31 @@ show "usage · cost · plan · active sessions" at a glance. Design contract:
   and the TUI render), and plan calibration from :mod:`agentacct.plan_cost`
   with the same calibrated-or-nothing honesty rule. The glance never invents a
   number another surface would not show.
-* **Cheap under polling** — the payload is rebuilt only when the event list
-  actually changes (``events_fingerprint``); a poll that finds nothing new is a
-  dictionary lookup. The expensive work-ledger build is deliberately NOT used
-  here: active sessions are derived from the section event stream directly.
+* **Cheap under polling** — the payload is rebuilt when the event list changes
+  (``events_fingerprint``) or when the cached build is older than the cache
+  TTL; a poll that hits the cache is a dictionary lookup. The TTL exists
+  because the payload is calendar/time-dependent (the "today" window, the
+  recency cutoff, ``limits[].stale``) — an unchanged event list must still
+  refresh across midnight. The expensive work-ledger build is deliberately NOT
+  used here: recent sessions derive from the section + usage event streams in
+  one pass.
 * **Additive-only schema** — consumers pin ``schema`` and ignore unknown keys;
-  existing keys are never renamed or removed within v1.
+  existing keys are never renamed or removed within v1. Freshness must be
+  judged from the HTTP response itself: ``generated_at`` is the BUILD time and
+  may lag wall clock by up to the cache TTL.
 
 The discovery-file helpers let a native shell find and authenticate to the
-server without configuration: ``agentacct serve`` binds 127.0.0.1, then writes
+server without configuration: ``agentacct serve`` binds 127.0.0.1, then claims
 ``<store>/local-api.json`` (0600) with the actual port and a per-boot bearer
-token — the Tailscale "sameuserproof" / Syncthing api-key pattern. Readers
-treat the file as the only source of truth and re-read it on auth failure.
+token — the Tailscale "sameuserproof" / Syncthing api-key pattern.
+
+Reader contract for the discovery file: first-alive-writer-wins (a second
+server against the same store leaves a live owner's file alone and simply
+stays unpublished); a crash/SIGKILL/closed terminal can leave a stale file
+whose ``pid`` is dead — readers treat a failed connect exactly like a missing
+file (disconnected state), and the next server start takes the stale slot
+over. The token is per-boot, so a stale token is worthless. Re-read the file
+whenever auth fails (401): the server restarted with a fresh token.
 """
 
 from __future__ import annotations
@@ -28,22 +41,38 @@ import json
 import math
 import os
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from threading import Lock
-from typing import Any
+from typing import Any, Iterator
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX platform: no flock available
+    fcntl = None  # type: ignore[assignment]
 
 GLANCE_SCHEMA_VERSION = "agentacct.glance.v1"
 DISCOVERY_SCHEMA_VERSION = "agentacct.local-api-discovery.v1"
 DISCOVERY_FILENAME = "local-api.json"
+DISCOVERY_LOCK_FILENAME = "local-api.lock"
 
 # A session counts as "recent" in the glance when its latest section/usage
 # activity is at most this old. Bounded list, newest first.
 ACTIVE_SESSION_WINDOW_SECONDS = 6 * 3600
 ACTIVE_SESSION_LIMIT = 8
 
+# Rebuild a cached payload after this many seconds even when the event list is
+# unchanged: the "today" window, the recency cutoff, and limits[].stale are all
+# clock-derived, so a fingerprint-only cache would serve yesterday's "today"
+# after midnight on an idle store (adversarial-review HIGH finding).
+GLANCE_CACHE_MAX_AGE_SECONDS = 60.0
+
 # Clients whose usage can be expressed as a share of a provider plan. Mirrors
 # the TUI's plan column (tui._PLAN_CLIENTS); keep the two in sync.
 PLAN_CLIENTS = ("claude-code", "codex")
+
+# Section statuses that mean "someone is (or should be) still working".
+_OPEN_SECTION_STATUSES = frozenset({"started", "checkpoint"})
 
 
 def events_fingerprint(events: list) -> int:
@@ -56,13 +85,43 @@ def events_fingerprint(events: list) -> int:
     identity + observation time makes any append, removal, or in-place supersede
     (which records a new event id) change the key and trigger a rebuild.
 
+    One write path rewrites events WITHOUT minting a new id or timestamp:
+    ``service.bind_local_usage_source_namespaces`` (the TOFU bind) mutates only
+    the source-namespace metadata fields in place — and those fields flip
+    ``local_usage_additivity``, i.e. the totals. The key therefore folds those
+    fields in as well; a fingerprint blind to them kept serving pre-bind totals
+    until an unrelated event landed (adversarial-review MEDIUM finding). Any
+    NEW in-place rewrite path must extend this key the same way.
+
     The values are stringified so the key is TOTAL: a corrupted/hand-injected
-    ledger row can round-trip ``event_id`` / ``created_at`` as a JSON list or
-    object (unhashable), and this function runs on unguarded refresh paths —
-    it must never raise. (The TUI aliases this same function.)
+    ledger row can round-trip any of these fields as a JSON list or object
+    (unhashable), and this function runs on unguarded refresh paths — it must
+    never raise. (The TUI aliases this same function for all its caches.)
     """
 
-    return hash(tuple((str(event.get("event_id")), str(event.get("created_at"))) for event in events))
+    parts = []
+    for event in events:
+        metadata = event.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+        parts.append(
+            (
+                str(event.get("event_id")),
+                str(event.get("created_at")),
+                str(metadata.get("source_namespace_fingerprint")),
+                str(metadata.get("parent_source_namespace_fingerprint")),
+                str(metadata.get("source_namespace_binding")),
+            )
+        )
+    return hash(tuple(parts))
+
+
+def _safe_timestamp(value: Any) -> float:
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return 0.0
+    return number if math.isfinite(number) and number > 0 else 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +133,46 @@ def discovery_file_path(store_dir: Path | str) -> Path:
     return Path(store_dir).expanduser() / DISCOVERY_FILENAME
 
 
+@contextmanager
+def _discovery_lock(store_dir: Path | str) -> Iterator[None]:
+    """Serialize claim/remove against each other (closes the read-then-unlink
+    TOCTOU a bare pid gate leaves open). flock on a sibling lock file; on a
+    platform without fcntl the helpers degrade to the unlocked pid gate."""
+
+    lock_path = Path(store_dir).expanduser() / DISCOVERY_LOCK_FILENAME
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(lock_path, "a+", encoding="utf-8")
+    try:
+        if fcntl is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        if fcntl is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def _pid_alive(pid: Any) -> bool:
+    """Best-effort liveness: signal-0 probe. PermissionError means the pid
+    exists (another user's process) and counts as alive."""
+
+    try:
+        number = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if number <= 0:
+        return False
+    try:
+        os.kill(number, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
 def write_discovery_file(
     store_dir: Path | str,
     *,
@@ -83,13 +182,13 @@ def write_discovery_file(
     version: str,
     pid: int | None = None,
 ) -> Path:
-    """Atomically write the 0600 discovery file next to the store.
+    """Atomically write the 0600 discovery file next to the store (unconditional).
 
-    Written by ``agentacct serve`` after the bind port is chosen and before the
-    server loop starts. Single-slot by design: one dashboard server per store
-    owns the file; a restart overwrites it (fresh token every boot). The 0600
-    mode is enforced via ``os.fchmod`` (umask-proof) and survives the atomic
-    rename, so the token is never world-readable, not even transiently.
+    Prefer :func:`claim_discovery_file`, which refuses to clobber a LIVE
+    owner's file. This raw writer stays lock-free so the claim path can call
+    it while holding the discovery lock. The 0600 mode is enforced via
+    ``os.fchmod`` (umask-proof) and survives the atomic rename, so the token
+    is never world-readable, not even transiently.
     """
 
     path = discovery_file_path(store_dir)
@@ -121,12 +220,42 @@ def write_discovery_file(
     return path
 
 
+def claim_discovery_file(
+    store_dir: Path | str,
+    *,
+    host: str,
+    port: int,
+    token: str,
+    version: str,
+    pid: int | None = None,
+) -> Path | None:
+    """Publish the discovery file unless another LIVE server already owns it.
+
+    First-alive-writer-wins: a second server against the same store must not
+    clobber the managed daemon's slot and then delete it on exit, stranding a
+    healthy daemon undiscoverable (adversarial-review MEDIUM finding). A file
+    whose owner pid is dead (crash, SIGKILL, closed terminal) is stale and is
+    taken over. Returns the path when this process now owns the slot, or
+    ``None`` when a different live pid holds it — the caller keeps serving
+    /v1 with its own token, just unpublished.
+    """
+
+    owner = int(pid if pid is not None else os.getpid())
+    with _discovery_lock(store_dir):
+        existing = read_discovery_file(store_dir)
+        if existing is not None and existing.get("pid") != owner and _pid_alive(existing.get("pid")):
+            return None
+        return write_discovery_file(store_dir, host=host, port=port, token=token, version=version, pid=owner)
+
+
 def read_discovery_file(store_dir: Path | str) -> dict[str, Any] | None:
     """The parsed discovery payload, or ``None`` when absent/unreadable/foreign.
 
     Never raises: a missing server, a half-written file, or a future schema all
     read as "no discoverable server" — callers fall back to their disconnected
-    state exactly as they would for a dead port.
+    state exactly as they would for a dead port. Liveness is deliberately NOT
+    checked here (see the module docstring's reader contract): a stale file and
+    a dead port produce the same disconnected UX.
     """
 
     path = discovery_file_path(store_dir)
@@ -145,20 +274,22 @@ def remove_discovery_file(store_dir: Path | str, *, pid: int | None = None) -> b
     """Remove the discovery file iff it belongs to ``pid`` (default: this process).
 
     The pid gate keeps a dying old server from deleting the file a newly
-    restarted server just wrote (start-during-shutdown overlap). Returns True
-    only when this call actually unlinked the current owner's file.
+    restarted server just wrote; the read-and-unlink runs under the discovery
+    lock so a concurrent claim cannot land between the check and the unlink.
+    Returns True only when this call actually unlinked the owner's file.
     """
 
     owner = int(pid if pid is not None else os.getpid())
     path = discovery_file_path(store_dir)
-    payload = read_discovery_file(store_dir)
-    if payload is None or payload.get("pid") != owner:
-        return False
-    try:
-        path.unlink()
-    except OSError:
-        return False
-    return True
+    with _discovery_lock(store_dir):
+        payload = read_discovery_file(store_dir)
+        if payload is None or payload.get("pid") != owner:
+            return False
+        try:
+            path.unlink()
+        except OSError:
+            return False
+        return True
 
 
 # ---------------------------------------------------------------------------
@@ -166,46 +297,101 @@ def remove_discovery_file(store_dir: Path | str, *, pid: int | None = None) -> b
 # ---------------------------------------------------------------------------
 
 
-def _section_status_and_title(events: list[dict[str, Any]], *, now: float) -> list[dict[str, Any]]:
-    """Recent sessions from the section event stream, newest activity first.
+def _recent_sessions(events: list[dict[str, Any]], *, now: float) -> list[dict[str, Any]]:
+    """Recent sessions from the section + usage event streams, newest first.
 
-    Deliberately ledger-free: the full work-ledger build is too heavy to run on
-    a poll cadence, while the latest section event per (client, session) is a
-    single pass over the already-loaded list. A session with sections shows its
-    latest section title/status; a session that only imported usage shows just
-    activity time. Timestamps are hostile-tolerant (never raise).
+    ``status`` is the TUI-parity reduction over each session's PER-SECTION
+    latest status — blocked > handed_off > in-progress > completed — because a
+    real session commonly leaves one stray open section, and a "latest event
+    wins" rule would let a later completed section erase a still-open or
+    blocked one. A finished-looking label on unfinished work is exactly the
+    dishonesty class this product exists to fix, so the menu bar must agree
+    with the TUI badge here.
+
+    Usage imports advance ``last_activity_at`` (a session burning tokens right
+    now stays "recent" even when its last section is hours old) and create
+    status-less rows for clients that never record sections. Deliberately
+    ledger-free: one pass over the already-loaded list; timestamps are
+    hostile-tolerant (never raise).
     """
 
-    def _safe_time(value: Any) -> float:
-        try:
-            number = float(value)
-        except (OverflowError, TypeError, ValueError):
-            return 0.0
-        return number if math.isfinite(number) and number > 0 else 0.0
+    from .client_usage import is_local_usage_import_event
+    from .usage_truth import normalized_local_usage_session_id
+    from .usage_view import _session_activity_time
 
-    latest: dict[tuple[str, str], dict[str, Any]] = {}
+    # (client, session) -> {section_id: (created_at, status)} — latest per section.
+    sections: dict[tuple[str, str], dict[str, tuple[float, str]]] = {}
+    # (client, session) -> (created_at, title) — latest titled section event.
+    titles: dict[tuple[str, str], tuple[float, str]] = {}
+    # (client, session) -> newest activity timestamp across sections + usage.
+    activity: dict[tuple[str, str], float] = {}
+
+    def _touch(key: tuple[str, str], timestamp: float) -> None:
+        if timestamp > activity.get(key, 0.0):
+            activity[key] = timestamp
+
     for event in events:
-        event_type = str(event.get("event_type") or "")
-        if not event_type.startswith("section_"):
-            continue
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
-        client = str(metadata.get("client") or event.get("source") or "")
-        session_id = str(metadata.get("client_session_id") or "")
-        if not client or not session_id:
+        event_type = str(event.get("event_type") or "")
+        if event_type.startswith("section_"):
+            client = str(metadata.get("client") or event.get("source") or "")
+            session_id = str(metadata.get("client_session_id") or "")
+            if not client or not session_id:
+                continue
+            created = _safe_timestamp(event.get("created_at"))
+            key = (client, session_id)
+            status = str(metadata.get("section_status") or "") or None
+            if status:
+                per_section = sections.setdefault(key, {})
+                section_id = str(metadata.get("section_id") or "")
+                prior = per_section.get(section_id)
+                if prior is None or created >= prior[0]:
+                    per_section[section_id] = (created, status)
+            title = str(metadata.get("section_title") or "")
+            if title:
+                prior_title = titles.get(key)
+                if prior_title is None or created >= prior_title[0]:
+                    titles[key] = (created, title)
+            _touch(key, created)
+        elif is_local_usage_import_event(event):
+            client = str(metadata.get("client") or event.get("source") or "")
+            raw_session = str(metadata.get("client_session_id") or event.get("run_id") or "")
+            if not client or not raw_session:
+                continue
+            # The same id normalization the usage view applies, so these keys
+            # join with section session ids and plan_pct session ids.
+            session_id = normalized_local_usage_session_id(metadata.get("client"), raw_session)
+            _touch((client, session_id), _session_activity_time(event))
+
+    def _reduce_status(statuses: set[str]) -> str | None:
+        if "blocked" in statuses:
+            return "blocked"
+        if "handed_off" in statuses:
+            return "handed_off"
+        if statuses & _OPEN_SECTION_STATUSES:
+            return "in_progress"
+        if "completed" in statuses:
+            return "completed"
+        return None
+
+    cutoff = now - ACTIVE_SESSION_WINDOW_SECONDS
+    rows: list[dict[str, Any]] = []
+    for key, last_activity_at in activity.items():
+        if last_activity_at < cutoff:
             continue
-        created = _safe_time(event.get("created_at"))
-        key = (client, session_id)
-        current = latest.get(key)
-        if current is None or created >= current["last_activity_at"]:
-            latest[key] = {
+        client, session_id = key
+        per_section = sections.get(key) or {}
+        statuses = {status for (_created, status) in per_section.values()}
+        title_entry = titles.get(key)
+        rows.append(
+            {
                 "client": client,
                 "session_id": session_id,
-                "title": str(metadata.get("section_title") or "") or None,
-                "status": str(metadata.get("section_status") or "") or None,
-                "last_activity_at": created,
+                "title": title_entry[1] if title_entry else None,
+                "status": _reduce_status(statuses),
+                "last_activity_at": last_activity_at,
             }
-    cutoff = now - ACTIVE_SESSION_WINDOW_SECONDS
-    rows = [row for row in latest.values() if row["last_activity_at"] >= cutoff]
+        )
     rows.sort(key=lambda row: row["last_activity_at"], reverse=True)
     return rows[:ACTIVE_SESSION_LIMIT]
 
@@ -242,20 +428,25 @@ def build_glance_snapshot(
 
     # Plan calibration per plan-bearing client — the calibrated-or-nothing
     # honesty rule: per-session percentages exist ONLY when the estimate is
-    # grounded in this account's own recorded limit history.
+    # grounded in this account's own recorded limit history. Keyed by
+    # (client, session_id) so one client's number can never attach to another
+    # client's row.
     plan: list[dict[str, Any]] = []
-    session_pcts: dict[str, float] = {}
+    session_pcts: dict[tuple[str, str], float] = {}
     for client in PLAN_CLIENTS:
         records = usage_records(events, client=client)
         weights = calibrate_plan_weights(events, client=client, records=records)
         plan.append({"client": client, "confidence": weights.confidence})
         if weights.confidence == "calibrated":
-            session_pcts.update(session_plan_pcts(records, weights, client=client))
+            for session_id, pct in session_plan_pcts(records, weights, client=client).items():
+                session_pcts[(client, session_id)] = pct
 
-    recent_sessions = _section_status_and_title(events, now=moment)
+    recent_sessions = _recent_sessions(events, now=moment)
     for row in recent_sessions:
-        pct = session_pcts.get(row["session_id"])
-        row["plan_pct"] = round(pct, 2) if pct is not None else None
+        # The raw estimate, never rounded here: round(pct, 2) can claim an
+        # exact 0 for a nonzero share. Shells format like the TUI does —
+        # "≈{pct:.1f}%" with a "<0.1%" band — the payload carries the float.
+        row["plan_pct"] = session_pcts.get((row["client"], row["session_id"]))
 
     return {
         "schema": GLANCE_SCHEMA_VERSION,
@@ -276,17 +467,35 @@ def build_glance_snapshot(
 
 
 class GlanceCache:
-    """Fingerprint-keyed cache so polling never recomputes an unchanged payload.
+    """Fingerprint + TTL cache so polling stays cheap without going stale.
+
+    Two invalidation triggers, both required: the fingerprint catches every
+    event-list change, and ``max_age_seconds`` catches CLOCK drift — the
+    "today" window crossing midnight, the recency cutoff, and limits[].stale
+    all move with wall time on an unchanged event list, so a fingerprint-only
+    cache served yesterday's "today" every morning (adversarial-review HIGH
+    finding).
 
     Thread-tolerant under FastAPI's threadpool: the cached value is one atomic
-    tuple assignment, so a concurrent reader can never observe a torn pair; two
-    racing rebuilds waste one build and the last writer wins (same pattern as
-    the TUI's plan cache).
+    tuple assignment, so a concurrent reader can never observe a torn triple;
+    two racing rebuilds waste one build and the last writer wins (same pattern
+    as the TUI's plan cache). A rebuild racing an import can briefly win with a
+    slightly older event list — one poll may regress and self-heals on the
+    next; it never fabricates a number.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, max_age_seconds: float = GLANCE_CACHE_MAX_AGE_SECONDS) -> None:
         self._lock = Lock()
-        self._cached: tuple[int, dict[str, Any]] | None = None
+        # (fingerprint, built_at, payload) — always assigned as one tuple.
+        self._cached: tuple[int, float, dict[str, Any]] | None = None
+        self.max_age_seconds = float(max_age_seconds)
+
+    def _fresh(self, cached: tuple[int, float, dict[str, Any]] | None, fingerprint: int, moment: float) -> bool:
+        return (
+            cached is not None
+            and cached[0] == fingerprint
+            and (moment - cached[1]) < self.max_age_seconds
+        )
 
     def snapshot(
         self,
@@ -296,14 +505,15 @@ class GlanceCache:
         version: str,
         now: float | None = None,
     ) -> dict[str, Any]:
+        moment = time.time() if now is None else float(now)
         fingerprint = events_fingerprint(events)
         cached = self._cached
-        if cached is not None and cached[0] == fingerprint:
-            return cached[1]
+        if self._fresh(cached, fingerprint, moment):
+            return cached[2]  # type: ignore[index]
         with self._lock:
             cached = self._cached
-            if cached is not None and cached[0] == fingerprint:
-                return cached[1]
+            if self._fresh(cached, fingerprint, moment):
+                return cached[2]  # type: ignore[index]
             payload = build_glance_snapshot(events, store_dir=store_dir, version=version, now=now)
-            self._cached = (fingerprint, payload)
+            self._cached = (fingerprint, moment, payload)
             return payload

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -10,7 +10,8 @@ show "usage · cost · plan · active sessions" at a glance. Design contract:
   number another surface would not show.
 * **Cheap under polling** — the payload is rebuilt when the event list changes
   (``events_fingerprint``) or when the cached build is older than the cache
-  TTL; a poll that hits the cache is a dictionary lookup. The TTL exists
+  TTL; a poll that hits the cache skips the aggregation rebuild (each poll
+  still loads the event list once to compute the change key). The TTL exists
   because the payload is calendar/time-dependent (the "today" window, the
   recency cutoff, ``limits[].stale``) — an unchanged event list must still
   refresh across midnight. The expensive work-ledger build is deliberately NOT
@@ -30,9 +31,12 @@ Reader contract for the discovery file: first-alive-writer-wins (a second
 server against the same store leaves a live owner's file alone and simply
 stays unpublished); a crash/SIGKILL/closed terminal can leave a stale file
 whose ``pid`` is dead — readers treat a failed connect exactly like a missing
-file (disconnected state), and the next server start takes the stale slot
-over. The token is per-boot, so a stale token is worthless. Re-read the file
-whenever auth fails (401): the server restarted with a fresh token.
+file (disconnected state). Every server runs a re-claim heartbeat
+(:func:`run_discovery_heartbeat`), so a freed or stale slot — including the
+restart-drain window where the new server started unpublished — is taken over
+within one interval (~30s). The token is per-boot, so a stale token is
+worthless. Re-read the file whenever auth fails (401): the server restarted
+with a fresh token.
 """
 
 from __future__ import annotations
@@ -207,7 +211,11 @@ def write_discovery_file(
         "written_at": time.time(),
     }
     tmp = path.with_name(f"{path.name}.tmp-{os.getpid()}")
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    # O_EXCL after clearing any stale leftover: a crash between open and
+    # replace can strand a 0600 tmp with a (per-boot, soon-worthless) token,
+    # and O_EXCL refuses to follow a pre-planted symlink at the tmp name.
+    tmp.unlink(missing_ok=True)
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
         os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
@@ -246,6 +254,39 @@ def claim_discovery_file(
         if existing is not None and existing.get("pid") != owner and _pid_alive(existing.get("pid")):
             return None
         return write_discovery_file(store_dir, host=host, port=port, token=token, version=version, pid=owner)
+
+
+def run_discovery_heartbeat(
+    store_dir: Path | str,
+    *,
+    host: str,
+    port: int,
+    token: str,
+    version: str,
+    stop: Any,
+    interval_seconds: float = 30.0,
+) -> None:
+    """Periodically re-claim the discovery slot until ``stop`` is set.
+
+    Why a heartbeat: claim-once leaves one stranding window — a new server
+    that starts while the OLD one is still draining sees a live owner, stays
+    unpublished, and when the old server exits (removing its own file) the
+    healthy survivor is undiscoverable forever. The heartbeat closes that and
+    every other freed-slot state (SIGKILL-stale files included): within one
+    interval of the slot freeing up, the surviving server owns it.
+
+    Each tick is one flock + one small read (plus a rewrite only when the slot
+    is free or already ours — claim semantics). ``stop`` is a
+    ``threading.Event``; the loop exits promptly when it is set. Errors are
+    swallowed per-tick: discovery is best-effort and must never take the
+    server down.
+    """
+
+    while not stop.wait(interval_seconds):
+        try:
+            claim_discovery_file(store_dir, host=host, port=port, token=token, version=version)
+        except OSError:
+            continue
 
 
 def read_discovery_file(store_dir: Path | str) -> dict[str, Any] | None:

--- a/src/agentacct/service.py
+++ b/src/agentacct/service.py
@@ -1998,6 +1998,14 @@ class SentinelService:
         legacy lanes are updated in one locked parse and one atomic rewrite.
         A previously bound or internally inconsistent base fails closed.
 
+        NOTE for cache authors: because this path rewrites rows WITHOUT
+        minting a new event_id/created_at, ``glance.events_fingerprint`` (the
+        change key behind the glance API cache and every TUI cache) folds the
+        rewritten namespace fields into its hash. If this method ever starts
+        rewriting MORE read-path-relevant fields in place, extend that
+        fingerprint alongside — otherwise live views serve stale totals until
+        an unrelated event lands.
+
         Deliberately NOT shadowed to the canonical store (nor to Evidence
         v2): canonical source identity is immutable, so rewriting historical
         rows' namespaces cannot be expressed there — rows written after the

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -96,23 +96,9 @@ def _evidence_mark(result: str) -> tuple[str, str]:
     return "•", "dim"
 
 
-def _events_fingerprint(events: list) -> int:
-    """A content-sensitive change key for the loaded event list.
-
-    The event COUNT is NOT a sound change key: the usage importer supersedes rows
-    IN PLACE (``service.replace_events`` drops a re-observed row and records a
-    fresh one), so a growing single-model session keeps the count fixed while its
-    tokens/cost change — the whole point of a live view. Hashing each event's
-    identity + observation time makes any append, removal, or in-place supersede
-    (which records a new event id) change the key and trigger a rebuild.
-
-    The values are stringified so the key is TOTAL: a corrupted/hand-injected
-    ledger row can round-trip ``event_id`` / ``created_at`` as a JSON list or
-    object (unhashable), and this function runs on the unguarded refresh path —
-    it must never raise, per refresh_data's fail-soft contract.
-    """
-
-    return hash(tuple((str(event.get("event_id")), str(event.get("created_at"))) for event in events))
+# One shared change key for every fingerprint-keyed cache (TUI + glance API);
+# owned by glance.py so the two surfaces can never drift. Docstring there.
+from .glance import events_fingerprint as _events_fingerprint  # noqa: E402
 
 
 def _limit_color(used_percent: float) -> str:

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -1,0 +1,336 @@
+"""Tests for the /v1 native-shell lane: discovery file, bearer gate, glance payload.
+
+The glance is what a menu bar app / SwiftBar plugin polls. Contract under test:
+fail-closed auth (no token config -> 503, bad token -> 401), the 0600 pid-gated
+discovery file, a fingerprint cache that never rebuilds an unchanged payload,
+and glance numbers that agree with the usage_snapshot functions every other
+surface renders.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from typer.testing import CliRunner
+
+import agentacct.glance as glance_module
+from agentacct.api import create_local_api_app
+from agentacct.cli import app as cli_app
+from agentacct.client_usage import ClientUsageEvent
+from agentacct.glance import (
+    DISCOVERY_SCHEMA_VERSION,
+    GLANCE_SCHEMA_VERSION,
+    discovery_file_path,
+    read_discovery_file,
+    remove_discovery_file,
+    write_discovery_file,
+)
+from agentacct.service import SentinelService
+
+TOKEN = "test-v1-token"
+
+
+def _record_usage(
+    service: SentinelService,
+    *,
+    client: str,
+    model: str,
+    session_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    updated_at: float,
+    estimated_cost_usd: float | None = None,
+) -> None:
+    event = ClientUsageEvent(
+        client=client,
+        client_session_id=session_id,
+        source_path=Path(f"/tmp/{client}/{session_id}.jsonl"),
+        title=None,
+        cwd="/tmp/project",
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name=client,
+        started_at=updated_at,
+        updated_at=updated_at,
+        turn_count=1,
+        usage_row_lane=f"model:{model}",
+        source_namespace_fingerprint=f"sha256:{client}",
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=input_tokens + output_tokens,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    if estimated_cost_usd is not None:
+        event["estimated_cost_usd"] = estimated_cost_usd
+        event["cost_confidence"] = "estimated_from_tokens"
+    service.record_event(event, trusted_usage_import=True)
+
+
+def _record_7d_limit(service: SentinelService, *, captured: float, pct: float, client: str = "claude-code", index: int = 0) -> None:
+    service.record_event({
+        "event_id": f"evt_rl_{client}_{index}",
+        "created_at": captured,
+        "source": client,
+        "event_type": "rate_limit_observed",
+        "metadata": {
+            "client": client,
+            "captured_at": captured,
+            "windows": [{"kind": "7d", "window_minutes": 10080, "used_percent": pct}],
+        },
+    })
+
+
+def _record_section(
+    service: SentinelService,
+    *,
+    client: str,
+    session_id: str,
+    status: str,
+    title: str,
+    created_at: float,
+) -> None:
+    # The identity-preserving append: record_event re-stamps created_at at
+    # receive time (correct in production — a section's created_at IS its
+    # activity time), so backdating a section for the recency-window test needs
+    # the verbatim merge path.
+    service.append_events_preserving_identity([
+        {
+            "event_id": f"evt_sec_{client}_{session_id}_{status}_{int(created_at)}",
+            "created_at": created_at,
+            "source": client,
+            "event_type": f"section_{status}",
+            "metadata": {
+                "client": client,
+                "client_session_id": session_id,
+                "section_id": f"sec-{session_id}",
+                "section_status": status,
+                "section_title": title,
+            },
+        }
+    ])
+
+
+# ---------------------------------------------------------------------------
+# discovery file
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_file_roundtrip_perms_and_pid_gate(tmp_path):
+    store = tmp_path / "store"
+    store.mkdir()
+    path = write_discovery_file(store, host="127.0.0.1", port=8791, token="tok-1", version="0.9.0")
+    assert path == discovery_file_path(store)
+    # 0600: the token must never be readable by another local user.
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    payload = read_discovery_file(store)
+    assert payload is not None
+    assert payload["schema"] == DISCOVERY_SCHEMA_VERSION
+    assert payload["host"] == "127.0.0.1"
+    assert payload["port"] == 8791
+    assert payload["token"] == "tok-1"
+    assert payload["pid"] == os.getpid()
+    assert payload["version"] == "0.9.0"
+
+    # A restart overwrites in place (fresh per-boot token).
+    write_discovery_file(store, host="127.0.0.1", port=8792, token="tok-2", version="0.9.1")
+    payload = read_discovery_file(store)
+    assert payload is not None and payload["token"] == "tok-2" and payload["port"] == 8792
+
+    # The pid gate: a foreign pid must NOT delete the current owner's file.
+    assert remove_discovery_file(store, pid=os.getpid() + 999_983) is False
+    assert discovery_file_path(store).exists()
+    assert remove_discovery_file(store) is True
+    assert not discovery_file_path(store).exists()
+    # Idempotent once gone.
+    assert remove_discovery_file(store) is False
+
+
+def test_read_discovery_file_never_raises(tmp_path):
+    store = tmp_path / "store"
+    store.mkdir()
+    assert read_discovery_file(store) is None  # absent
+    discovery_file_path(store).write_text("{not json", encoding="utf-8")
+    assert read_discovery_file(store) is None  # corrupt
+    discovery_file_path(store).write_text('{"schema": "some.future.v9", "port": 1, "token": "t"}', encoding="utf-8")
+    assert read_discovery_file(store) is None  # foreign schema
+
+
+# ---------------------------------------------------------------------------
+# bearer gate
+# ---------------------------------------------------------------------------
+
+
+def test_v1_routes_fail_closed_without_configured_token(tmp_path):
+    SentinelService(tmp_path)
+    client = TestClient(create_local_api_app(store_dir=tmp_path))
+    for route in ("/v1/glance", "/v1/version"):
+        response = client.get(route, headers={"Authorization": "Bearer anything"})
+        assert response.status_code == 503, route
+
+
+def test_v1_routes_require_the_exact_bearer_token(tmp_path):
+    SentinelService(tmp_path)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    assert client.get("/v1/glance").status_code == 401  # no header
+    assert client.get("/v1/glance", headers={"Authorization": f"Basic {TOKEN}"}).status_code == 401
+    assert client.get("/v1/glance", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    ok = client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"})
+    assert ok.status_code == 200
+    version = client.get("/v1/version", headers={"Authorization": f"Bearer {TOKEN}"})
+    assert version.status_code == 200
+    body = version.json()
+    assert body["glance_schema"] == GLANCE_SCHEMA_VERSION
+    assert body["pid"] == os.getpid()
+    assert isinstance(body["version"], str) and body["version"]
+
+
+def test_localhost_guard_still_covers_v1(tmp_path):
+    SentinelService(tmp_path)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    response = client.get(
+        "/v1/glance",
+        headers={"Authorization": f"Bearer {TOKEN}", "Host": "evil.example"},
+    )
+    assert response.status_code == 403  # a valid token never overrides the Host guard
+
+
+# ---------------------------------------------------------------------------
+# glance payload
+# ---------------------------------------------------------------------------
+
+
+def test_glance_payload_shape_and_agreement(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(
+        service,
+        client="claude-code",
+        model="claude-opus-4-8",
+        session_id="sess-a",
+        input_tokens=1_000,
+        output_tokens=2_000,
+        updated_at=now - 600,
+        estimated_cost_usd=0.42,
+    )
+    _record_7d_limit(service, captured=now - 300, pct=37.5)
+    _record_section(service, client="claude-code", session_id="sess-a", status="started", title="fix the login bug", created_at=now - 550)
+    _record_section(service, client="claude-code", session_id="sess-a", status="completed", title="fix the login bug", created_at=now - 500)
+    _record_section(service, client="codex", session_id="sess-old", status="started", title="ancient work", created_at=now - 8 * 3600)
+
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = api_client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"}).json()
+
+    assert payload["schema"] == GLANCE_SCHEMA_VERSION
+    assert payload["daemon"]["pid"] == os.getpid()
+
+    # Usage windows: same aggregation `agentacct now` renders — today's bucket
+    # carries the seeded session's tokens.
+    windows = {window["label"]: window["totals"] for window in payload["usage"]["windows"]}
+    assert "today" in windows and "all time" in windows
+    assert windows["all time"]["fresh_tokens"] == 3_000
+    assert windows["all time"]["total_tokens_including_cached"] == 3_000
+    assert payload["usage"]["usage_record_count"] == 1
+
+    # Limits: the byte-stable limit_json_entry shape plus the stale flag.
+    assert len(payload["limits"]) == 1
+    limit = payload["limits"][0]
+    assert limit["client"] == "claude-code"
+    assert limit["stale"] is False
+    assert limit["windows"][0]["used_percent"] == 37.5
+
+    # Plan: both plan-bearing clients report an honest confidence string
+    # (nothing calibrates from one seeded interval — and no number is invented).
+    plan = {entry["client"]: entry["confidence"] for entry in payload["plan"]}
+    assert set(plan) == {"claude-code", "codex"}
+    assert all(isinstance(value, str) and value for value in plan.values())
+
+    # Recent sessions: latest section wins; sessions older than the activity
+    # window are excluded; plan_pct is None while uncalibrated (honesty rule).
+    sessions = payload["recent_sessions"]
+    assert [row["session_id"] for row in sessions] == ["sess-a"]
+    assert sessions[0]["status"] == "completed"
+    assert sessions[0]["title"] == "fix the login bug"
+    assert sessions[0]["plan_pct"] is None
+
+
+def test_glance_cache_rebuilds_only_on_event_change(tmp_path, monkeypatch):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(
+        service,
+        client="claude-code",
+        model="claude-opus-4-8",
+        session_id="sess-a",
+        input_tokens=10,
+        output_tokens=20,
+        updated_at=now - 60,
+    )
+    calls = {"count": 0}
+    real_build = glance_module.build_glance_snapshot
+
+    def _counting_build(*args, **kwargs):
+        calls["count"] += 1
+        return real_build(*args, **kwargs)
+
+    monkeypatch.setattr(glance_module, "build_glance_snapshot", _counting_build)
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+
+    first = api_client.get("/v1/glance", headers=headers).json()
+    second = api_client.get("/v1/glance", headers=headers).json()
+    assert calls["count"] == 1  # unchanged events -> pure cache hit
+    assert second == first
+
+    _record_usage(
+        service,
+        client="claude-code",
+        model="claude-opus-4-8",
+        session_id="sess-b",
+        input_tokens=5,
+        output_tokens=5,
+        updated_at=now - 30,
+    )
+    third = api_client.get("/v1/glance", headers=headers).json()
+    assert calls["count"] == 2  # new event -> rebuild
+    assert third["usage"]["usage_record_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# serve wiring
+# ---------------------------------------------------------------------------
+
+
+def test_serve_writes_discovery_before_run_and_removes_after(tmp_path, monkeypatch):
+    store = tmp_path / "store"
+    SentinelService(store)
+    seen: dict[str, object] = {}
+
+    import uvicorn
+
+    def _fake_run(app, **kwargs):  # noqa: ANN001 - uvicorn.run signature
+        seen["during"] = read_discovery_file(store)
+        seen["port"] = kwargs.get("port")
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+    result = CliRunner().invoke(cli_app, ["serve", "--store-dir", str(store)])
+    assert result.exit_code == 0, result.output
+
+    during = seen["during"]
+    assert isinstance(during, dict)
+    # The file must carry the ACTUAL bound port uvicorn was launched with.
+    assert during["port"] == seen["port"]
+    assert during["token"]
+    # And it must be gone once the server loop exits (pid-gated cleanup).
+    assert read_discovery_file(store) is None

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -498,6 +498,97 @@ def test_recent_session_plan_pct_is_gated_by_client(tmp_path):
     assert rows[("codex", shared_session)]["plan_pct"] is None
 
 
+def test_non_ascii_bearer_token_yields_401_not_500(tmp_path):
+    """Round-2 security finding: Starlette decodes header bytes as latin-1, and
+    hmac.compare_digest raises TypeError on non-ASCII str — the gate must stay
+    a clean 401 (the reader contract's re-read signal), never a 500. httpx
+    refuses to SEND such a header, so this drives the ASGI app directly."""
+
+    import asyncio
+
+    SentinelService(tmp_path)
+    app = create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN)
+
+    async def _get_status(raw_authorization: bytes) -> int:
+        messages: list[dict] = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            messages.append(message)
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/v1/glance",
+            "raw_path": b"/v1/glance",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [(b"host", b"testserver"), (b"authorization", raw_authorization)],
+            "client": ("127.0.0.1", 12345),
+            "server": ("127.0.0.1", 80),
+        }
+        await app(scope, receive, send)
+        return next(m["status"] for m in messages if m["type"] == "http.response.start")
+
+    assert asyncio.run(_get_status(b"Bearer caf\xe9")) == 401
+    assert asyncio.run(_get_status(b"Bearer \xff\xfe")) == 401
+
+
+def test_discovery_heartbeat_reclaims_a_freed_slot(tmp_path):
+    """Round-2 lifecycle finding: a serve that started unpublished (live owner
+    still draining) must take the slot over once the owner's file goes away —
+    the heartbeat is what closes the stranded-undiscoverable end state."""
+
+    import threading
+
+    from agentacct.glance import run_discovery_heartbeat
+
+    store = tmp_path / "store"
+    store.mkdir()
+    # A live foreign owner holds the slot (pid 1).
+    write_discovery_file(store, host="127.0.0.1", port=9001, token="owner", version="0.9.0", pid=1)
+
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=run_discovery_heartbeat,
+        kwargs={
+            "store_dir": store,
+            "host": "127.0.0.1",
+            "port": 9002,
+            "token": "mine",
+            "version": "0.9.1",
+            "stop": stop,
+            "interval_seconds": 0.01,
+        },
+        daemon=True,
+    )
+    thread.start()
+    try:
+        time.sleep(0.1)
+        held = read_discovery_file(store)
+        assert held is not None and held["pid"] == 1  # live owner respected
+
+        # The owner exits and removes its file (simulated): the heartbeat must
+        # re-claim within a tick.
+        remove_discovery_file(store, pid=1)
+        deadline = time.time() + 2.0
+        claimed = None
+        while time.time() < deadline:
+            claimed = read_discovery_file(store)
+            if claimed is not None and claimed["pid"] == os.getpid():
+                break
+            time.sleep(0.02)
+        assert claimed is not None and claimed["pid"] == os.getpid() and claimed["token"] == "mine"
+    finally:
+        stop.set()
+        thread.join(timeout=2)
+
+
 # ---------------------------------------------------------------------------
 # serve wiring
 # ---------------------------------------------------------------------------

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -100,21 +100,23 @@ def _record_section(
     status: str,
     title: str,
     created_at: float,
+    section_id: str | None = None,
 ) -> None:
     # The identity-preserving append: record_event re-stamps created_at at
     # receive time (correct in production — a section's created_at IS its
     # activity time), so backdating a section for the recency-window test needs
     # the verbatim merge path.
+    resolved_section = section_id or f"sec-{session_id}"
     service.append_events_preserving_identity([
         {
-            "event_id": f"evt_sec_{client}_{session_id}_{status}_{int(created_at)}",
+            "event_id": f"evt_sec_{client}_{session_id}_{resolved_section}_{status}_{int(created_at)}",
             "created_at": created_at,
             "source": client,
             "event_type": f"section_{status}",
             "metadata": {
                 "client": client,
                 "client_session_id": session_id,
-                "section_id": f"sec-{session_id}",
+                "section_id": resolved_section,
                 "section_status": status,
                 "section_title": title,
             },
@@ -305,6 +307,195 @@ def test_glance_cache_rebuilds_only_on_event_change(tmp_path, monkeypatch):
     third = api_client.get("/v1/glance", headers=headers).json()
     assert calls["count"] == 2  # new event -> rebuild
     assert third["usage"]["usage_record_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# review-finding regressions (adversarial review of 7042c1d)
+# ---------------------------------------------------------------------------
+
+
+def test_glance_cache_expires_by_age_even_when_events_are_unchanged(tmp_path, monkeypatch):
+    """The HIGH finding: 'today'/stale/recency are clock-derived, so an
+    unchanged event list must still rebuild after the TTL (midnight boundary)."""
+
+    from agentacct.glance import GlanceCache
+
+    calls = {"count": 0}
+    real_build = glance_module.build_glance_snapshot
+
+    def _counting_build(*args, **kwargs):
+        calls["count"] += 1
+        return real_build(*args, **kwargs)
+
+    monkeypatch.setattr(glance_module, "build_glance_snapshot", _counting_build)
+    cache = GlanceCache(max_age_seconds=60.0)
+    t0 = time.time()
+    cache.snapshot([], store_dir=tmp_path, version="0.9.0", now=t0)
+    cache.snapshot([], store_dir=tmp_path, version="0.9.0", now=t0 + 30)
+    assert calls["count"] == 1  # young cache, unchanged events -> hit
+    cache.snapshot([], store_dir=tmp_path, version="0.9.0", now=t0 + 61)
+    assert calls["count"] == 2  # TTL crossed -> rebuild despite identical events
+
+
+def test_events_fingerprint_sees_the_namespace_bind_rewrite():
+    """The MEDIUM finding: the TOFU bind rewrites namespace metadata in place
+    (event_id and created_at preserved) and flips additivity — the fingerprint
+    must change with those fields or live views serve stale totals."""
+
+    base = [{
+        "event_id": "evt_1",
+        "created_at": 111.0,
+        "metadata": {"client": "codex", "client_session_id": "s1"},
+    }]
+    bound = [{
+        "event_id": "evt_1",
+        "created_at": 111.0,
+        "metadata": {
+            "client": "codex",
+            "client_session_id": "s1",
+            "source_namespace_fingerprint": "sha256:" + "a" * 64,
+            "source_namespace_binding": "tofu",
+        },
+    }]
+    assert glance_module.events_fingerprint(base) != glance_module.events_fingerprint(bound)
+    # Still total on hostile metadata shapes.
+    hostile = [{"event_id": ["x"], "created_at": {"y": 1}, "metadata": "not-a-dict"}]
+    glance_module.events_fingerprint(hostile)  # must not raise
+
+
+def test_recent_session_status_uses_per_section_precedence(tmp_path):
+    """The MEDIUM finding: a later completed section must not erase a still-open
+    or blocked one — the glance must agree with the TUI badge."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    # Session A: section one started, section two started, section one completed
+    # -> still in progress (section two is open).
+    _record_section(service, client="claude-code", session_id="sess-a", status="started", title="t", created_at=now - 300, section_id="sec-1")
+    _record_section(service, client="claude-code", session_id="sess-a", status="started", title="t", created_at=now - 250, section_id="sec-2")
+    _record_section(service, client="claude-code", session_id="sess-a", status="completed", title="t", created_at=now - 200, section_id="sec-1")
+    # Session B: a blocked section followed by a later completed one -> blocked wins.
+    _record_section(service, client="codex", session_id="sess-b", status="blocked", title="stuck", created_at=now - 400, section_id="sec-1")
+    _record_section(service, client="codex", session_id="sess-b", status="completed", title="done bit", created_at=now - 100, section_id="sec-2")
+
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = api_client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"}).json()
+    statuses = {row["session_id"]: row["status"] for row in payload["recent_sessions"]}
+    assert statuses["sess-a"] == "in_progress"
+    assert statuses["sess-b"] == "blocked"
+
+
+def test_usage_only_sessions_appear_and_stay_recent(tmp_path):
+    """The LOW finding: usage activity counts toward recency — a session
+    burning tokens now must appear even without any section events."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(
+        service,
+        client="codex",
+        model="gpt-5",
+        session_id="sess-usage-only",
+        input_tokens=100,
+        output_tokens=100,
+        updated_at=now - 120,
+    )
+    # A session whose last SECTION is ancient but whose usage is fresh stays listed.
+    _record_section(service, client="claude-code", session_id="sess-mixed", status="started", title="old section", created_at=now - 7 * 3600)
+    _record_usage(
+        service,
+        client="claude-code",
+        model="claude-opus-4-8",
+        session_id="sess-mixed",
+        input_tokens=10,
+        output_tokens=10,
+        updated_at=now - 60,
+    )
+
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = api_client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"}).json()
+    rows = {row["session_id"]: row for row in payload["recent_sessions"]}
+    assert "sess-usage-only" in rows
+    assert rows["sess-usage-only"]["status"] is None and rows["sess-usage-only"]["title"] is None
+    assert "sess-mixed" in rows  # fresh usage keeps it recent despite the old section
+    assert rows["sess-mixed"]["status"] == "in_progress"
+
+
+def _dead_pid() -> int:
+    pid = 4_100_000  # above default pid ranges on macOS and Linux
+    while True:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return pid
+        except PermissionError:
+            pass
+        pid -= 1
+
+
+def test_claim_respects_a_live_owner_and_takes_over_a_dead_one(tmp_path):
+    """The lifecycle MEDIUM finding: a second server must not clobber a LIVE
+    owner's slot (and later delete it), but a stale file from a crashed owner
+    is taken over."""
+
+    from agentacct.glance import claim_discovery_file
+
+    store = tmp_path / "store"
+    store.mkdir()
+    # pid 1 (launchd/init) is alive and not ours -> the slot is owned.
+    write_discovery_file(store, host="127.0.0.1", port=9001, token="owner-token", version="0.9.0", pid=1)
+    assert claim_discovery_file(store, host="127.0.0.1", port=9002, token="mine", version="0.9.0") is None
+    kept = read_discovery_file(store)
+    assert kept is not None and kept["pid"] == 1 and kept["token"] == "owner-token"
+    # And the pid-gated removal from the non-owner leaves the live slot alone.
+    assert remove_discovery_file(store) is False
+    assert read_discovery_file(store) is not None
+
+    # A dead owner is stale: the claim takes the slot over.
+    write_discovery_file(store, host="127.0.0.1", port=9003, token="stale", version="0.9.0", pid=_dead_pid())
+    claimed = claim_discovery_file(store, host="127.0.0.1", port=9004, token="fresh", version="0.9.0")
+    assert claimed is not None
+    taken = read_discovery_file(store)
+    assert taken is not None and taken["pid"] == os.getpid() and taken["token"] == "fresh"
+
+
+def test_serve_declines_publishing_when_a_live_owner_holds_the_slot(tmp_path, monkeypatch):
+    store = tmp_path / "store"
+    SentinelService(store)
+    write_discovery_file(store, host="127.0.0.1", port=9001, token="owner-token", version="0.9.0", pid=1)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda app, **kwargs: None)
+    result = CliRunner().invoke(cli_app, ["serve", "--store-dir", str(store)])
+    assert result.exit_code == 0, result.output
+    assert "unpublished" in result.output
+    kept = read_discovery_file(store)
+    assert kept is not None and kept["pid"] == 1 and kept["token"] == "owner-token"
+
+
+def test_recent_session_plan_pct_is_gated_by_client(tmp_path):
+    """The LOW finding: the pct lookup is keyed (client, session_id) — one
+    client's calibrated number can never attach to another client's row."""
+
+    import agentacct.plan_cost as plan_cost_module
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    shared_session = "11111111-2222-3333-4444-555555555555"
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id=shared_session,
+                  input_tokens=100, output_tokens=100, updated_at=now - 120)
+    _record_section(service, client="claude-code", session_id=shared_session, status="started", title="a", created_at=now - 110)
+    _record_section(service, client="codex", session_id=shared_session, status="started", title="b", created_at=now - 100)
+
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = api_client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"}).json()
+    rows = {(row["client"], row["session_id"]): row for row in payload["recent_sessions"]}
+    # Neither client is calibrated in this store, so both must be None — and
+    # structurally the codex row can never receive a claude-code pct because
+    # the lookup key carries the client.
+    assert rows[("claude-code", shared_session)]["plan_pct"] is None
+    assert rows[("codex", shared_session)]["plan_pct"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> Supersedes #61 — GitHub auto-closed it when the stacked base branch (#60) was deleted on merge; identical content rebased onto main.

Step 2 of the HTML-dashboard retirement / native-app groundwork (follows #60). The data lane a menu bar app (or SwiftBar plugin, or any native shell) polls.

## What it adds

- **`GET /v1/glance`** — usage windows, provider limits (with `stale`), plan-calibration status, and recent sessions in one versioned, additive-only payload. Numbers come from the exact `usage_snapshot` / `plan_cost` functions `agentacct now` and the TUI render — the glance cannot disagree with the other surfaces. Recent sessions derive from the section + usage event streams in one pass (deliberately ledger-free), with the TUI-parity status reduction `blocked > handed_off > in_progress > completed` per section.
- **`GET /v1/version`** — daemon/schema handshake, so an incompatible daemon is a first-class UI state rather than a parse error.
- **Bearer gate** — per-boot token, constant-time byte compare, clean 401 on any garbage (including non-ASCII header bytes), 503 fail-closed when no token is configured. The localhost Host/Origin guard still applies on top.
- **Discovery file** — `agentacct serve` claims `<store>/local-api.json` (0600, atomic, umask-proof, O_EXCL tmp) carrying the actual bound port + token + pid + version. First-alive-writer-wins under an flock; a re-claim heartbeat (30s) takes over freed or stale slots, closing the restart-drain stranding. `agentacct start` spawns serve, so the managed runtime inherits everything.
- **Cache** — fingerprint + 60s TTL. The fingerprint now also covers the TOFU namespace-bind in-place rewrite (folding in the namespace fields), which fixes the same staleness class in the TUI's four caches (they alias this function).

## Review trail (three rounds, converged)

1. Round 1 (3 lenses) found **1 HIGH + 3 MEDIUM + 5 LOW** — all real: the fingerprint-only cache served yesterday's "today" after midnight; the fingerprint was blind to the in-place namespace bind; latest-event-wins status let a completed section erase an open/blocked one; a second serve could strand the managed daemon undiscoverable. All fixed with per-finding regression tests.
2. Round 2 (security retry + fix verification) confirmed all 9 fixed; found 1 MEDIUM residual (restart-drain re-claim gap → the heartbeat) + 3 LOW (non-ASCII token → 500; overclaiming cache docs; missing O_EXCL). All fixed.
3. Round 3 verification: **SAFE** (one LOW residual that degrades to the already-tolerated, self-healing stale-file state).

Full suite **3084 passed, 1 skipped**. 17 tests in `tests/test_glance_api.py`.
