### PR TITLE
feat(app): agentacct menu bar app — SwiftUI skeleton + SwiftBar plugin v0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build/
 /events.jsonl
 /events.jsonl.lock
 /events.authoritative
+apps/agentacct/.build/

--- a/apps/agentacct/Package.swift
+++ b/apps/agentacct/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "agentacct",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(
+            name: "agentacct",
+            path: "Sources/agentacct"
+        )
+    ]
+)

--- a/apps/agentacct/README.md
+++ b/apps/agentacct/README.md
@@ -1,0 +1,45 @@
+# agentacct — the menu bar app (skeleton)
+
+A thin SwiftUI `MenuBarExtra` shell over the daemon's `/v1` lane: today's cost
+in the menu bar; usage windows, provider limit bars, plan-calibration status,
+and recent sessions (with per-session weekly-plan share where calibrated) in
+the dropdown. All aggregation and honesty logic stays in the Python daemon —
+this app only renders what `/v1/glance` vouches for.
+
+## How it connects
+
+No configuration. The daemon (`agentacct serve`, spawned by `agentacct start`)
+claims `<store>/local-api.json` (0600) with its actual port and a per-boot
+bearer token; the app reads that file (default store
+`~/.local/state/agentacct/state`, override with `AGENTACCT_STORE_DIR`) and
+polls `GET /v1/glance` every 30s. A missing file or dead port renders as a
+labeled disconnected state with the start command; a schema mismatch renders
+as a labeled incompatible state (never a parse error); a 401 re-reads the
+discovery file (the daemon restarted with a fresh token).
+
+## Build & run
+
+Requires Xcode (macOS 14+):
+
+```bash
+cd apps/agentacct
+./Scripts/build-app.sh
+open .build/agentacct.app
+```
+
+Or during development: `swift run` (menu bar item appears; Ctrl-C to quit).
+
+## Skeleton status / roadmap
+
+- [x] discovery + bearer + version handshake + 30s poll
+- [x] menu bar: today's cost (complete `$` / partial `~$` / `—`, never a fake $0)
+- [x] dropdown: usage windows · limit bars with stale marker · recent sessions
+      with status glyphs and calibrated-only plan shares · calibrating footnote
+- [ ] adaptive poll cadence (menu-open recency / Low Power Mode — CodexBar's
+      2–30 min policy)
+- [ ] session drill-down, notifications on limit thresholds
+- [ ] Sparkle updates, Developer ID signing + notarization, brew cask
+- [ ] app icon + proper menu bar iconography (text-only today)
+
+A `contrib/swiftbar/agentacct.30s.sh` plugin covers the same glance for
+SwiftBar/xbar users (and doubles as a reference client for the API).

--- a/apps/agentacct/Scripts/build-app.sh
+++ b/apps/agentacct/Scripts/build-app.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Build agentacct.app from the SwiftPM executable (no Xcode project needed).
+# Output: apps/AgentacctBar/.build/AgentacctBar.app — unsigned; drag it to
+# /Applications or run it in place. LSUIElement makes it menu-bar-only.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+swift build -c release
+
+APP=".build/agentacct.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+cp ".build/release/agentacct" "$APP/Contents/MacOS/agentacct"
+
+cat > "$APP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key><string>agentacct</string>
+    <key>CFBundleIdentifier</key><string>dev.agentacct.app</string>
+    <key>CFBundleName</key><string>agentacct</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleShortVersionString</key><string>0.1.0</string>
+    <key>LSMinimumSystemVersion</key><string>14.0</string>
+    <key>LSUIElement</key><true/>
+    <key>NSHighResolutionCapable</key><true/>
+</dict>
+</plist>
+PLIST
+
+echo "built: $PWD/$APP"
+echo "run:   open $PWD/$APP"

--- a/apps/agentacct/Sources/agentacct/AgentacctApp.swift
+++ b/apps/agentacct/Sources/agentacct/AgentacctApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+// The agentacct menu bar app: a thin display shell over the daemon's
+// /v1/glance lane (discovery + bearer token from <store>/local-api.json).
+// All aggregation, calibration, and honesty logic lives in the Python daemon;
+// this process only renders what the API vouches for.
+
+@main
+struct AgentacctApp: App {
+    @StateObject private var state = GlanceState()
+
+    var body: some Scene {
+        MenuBarExtra {
+            MenuContent(state: state)
+        } label: {
+            Text(state.menuBarTitle)
+        }
+        .menuBarExtraStyle(.window)
+    }
+}

--- a/apps/agentacct/Sources/agentacct/GlanceClient.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceClient.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+// Finds and talks to the local agentacct daemon.
+//
+// Discovery follows the documented reader contract (glance.py): the daemon
+// claims `<store>/local-api.json` (0600) carrying the actual bound port and a
+// per-boot bearer token; a missing/stale file or a dead port both mean
+// "disconnected" (identical UX), and a 401 means the daemon restarted with a
+// fresh token — re-read the file and retry once.
+
+struct Discovery: Decodable {
+    let schema: String
+    let host: String?
+    let port: Int
+    let token: String
+    let pid: Int?
+    let version: String?
+}
+
+enum GlanceClientError: Error, CustomStringConvertible {
+    case noDiscovery(String)
+    case http(Int)
+    case transport(String)
+    case incompatible(daemonVersion: String, schema: String)
+
+    var description: String {
+        switch self {
+        case .noDiscovery(let path):
+            return "no discovery file at \(path)"
+        case .http(let code):
+            return "daemon answered HTTP \(code)"
+        case .transport(let message):
+            return message
+        case .incompatible(let version, let schema):
+            return "daemon \(version) serves \(schema)"
+        }
+    }
+}
+
+struct GlanceSnapshot {
+    let glance: Glance
+    let daemonVersion: String
+}
+
+final class GlanceClient {
+    static let supportedGlanceSchema = "agentacct.glance.v1"
+
+    private let session: URLSession
+
+    init() {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 20
+        session = URLSession(configuration: config)
+    }
+
+    static func storeDir() -> URL {
+        let env = ProcessInfo.processInfo.environment
+        if let override = env["AGENTACCT_STORE_DIR"], !override.isEmpty {
+            return URL(fileURLWithPath: (override as NSString).expandingTildeInPath)
+        }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(".local/state/agentacct/state")
+    }
+
+    static func discoveryPath() -> URL {
+        storeDir().appendingPathComponent("local-api.json")
+    }
+
+    func loadDiscovery() throws -> Discovery {
+        let path = Self.discoveryPath()
+        guard let data = try? Data(contentsOf: path) else {
+            throw GlanceClientError.noDiscovery(path.path)
+        }
+        guard let discovery = try? JSONDecoder().decode(Discovery.self, from: data),
+              discovery.schema == "agentacct.local-api-discovery.v1"
+        else {
+            throw GlanceClientError.noDiscovery(path.path)
+        }
+        return discovery
+    }
+
+    func fetch() async throws -> GlanceSnapshot {
+        do {
+            return try await fetchOnce(discovery: loadDiscovery())
+        } catch GlanceClientError.http(401) {
+            // The daemon restarted with a fresh per-boot token: the reader
+            // contract says re-read the discovery file and retry once.
+            return try await fetchOnce(discovery: loadDiscovery())
+        }
+    }
+
+    private func fetchOnce(discovery: Discovery) async throws -> GlanceSnapshot {
+        let version: VersionInfo = try await get("/v1/version", discovery: discovery)
+        guard version.glanceSchema == Self.supportedGlanceSchema else {
+            // An incompatible daemon is a first-class state, never a parse error.
+            throw GlanceClientError.incompatible(
+                daemonVersion: version.version, schema: version.glanceSchema
+            )
+        }
+        let glance: Glance = try await get("/v1/glance", discovery: discovery)
+        return GlanceSnapshot(glance: glance, daemonVersion: version.version)
+    }
+
+    private func get<T: Decodable>(_ path: String, discovery: Discovery) async throws -> T {
+        let host = discovery.host ?? "127.0.0.1"
+        guard let url = URL(string: "http://\(host):\(discovery.port)\(path)") else {
+            throw GlanceClientError.transport("bad daemon URL")
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(discovery.token)", forHTTPHeaderField: "Authorization")
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw GlanceClientError.transport(error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw GlanceClientError.transport("not an HTTP response")
+        }
+        guard http.statusCode == 200 else {
+            throw GlanceClientError.http(http.statusCode)
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw GlanceClientError.transport("payload decode failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/apps/agentacct/Sources/agentacct/GlanceModel.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceModel.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+// The /v1/glance payload (schema agentacct.glance.v1). Additive-only on the
+// wire: decode tolerantly, ignore unknown keys, never invent a number a field
+// does not carry — an absent cost renders as absent, not $0.00.
+
+struct Glance: Decodable {
+    let schema: String
+    let generatedAt: Double?
+    let daemon: DaemonInfo?
+    let usage: Usage
+    let limits: [LimitEntry]
+    let plan: [PlanEntry]
+    let recentSessions: [RecentSession]
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case generatedAt = "generated_at"
+        case daemon, usage, limits, plan
+        case recentSessions = "recent_sessions"
+    }
+}
+
+struct DaemonInfo: Decodable {
+    let version: String?
+    let pid: Int?
+}
+
+struct Usage: Decodable {
+    let windows: [UsageWindow]
+    let usageRecordCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case windows
+        case usageRecordCount = "usage_record_count"
+    }
+}
+
+struct UsageWindow: Decodable {
+    let label: String
+    let days: Int?
+    let totals: UsageTotals
+}
+
+struct UsageTotals: Decodable {
+    let freshTokens: Int?
+    let totalTokensIncludingCached: Int?
+    let estimatedCostUsd: Double?
+    let costComplete: Bool?
+    let knownAdditiveCostUsd: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case freshTokens = "fresh_tokens"
+        case totalTokensIncludingCached = "total_tokens_including_cached"
+        case estimatedCostUsd = "estimated_cost_usd"
+        case costComplete = "cost_complete"
+        case knownAdditiveCostUsd = "known_additive_cost_usd"
+    }
+
+    /// The one shared cost rule (mirrors usage_snapshot.cost_text): a plain
+    /// dollar figure ONLY when the cube vouches completeness; a partial subtotal
+    /// is marked approximate; nothing priced renders as an em-dash — never $0.
+    var costText: String {
+        if costComplete == true, let cost = estimatedCostUsd {
+            return String(format: "$%.2f", cost)
+        }
+        if let known = knownAdditiveCostUsd {
+            return String(format: "~$%.2f", known)
+        }
+        return "—"
+    }
+
+    var tokensText: String {
+        guard let tokens = freshTokens else { return "—" }
+        return Self.compact(tokens)
+    }
+
+    static func compact(_ value: Int) -> String {
+        let magnitude = abs(value)
+        switch magnitude {
+        case 1_000_000_000...: return String(format: "%.1fB", Double(value) / 1_000_000_000)
+        case 1_000_000...: return String(format: "%.1fM", Double(value) / 1_000_000)
+        case 1_000...: return String(format: "%.1fk", Double(value) / 1_000)
+        default: return "\(value)"
+        }
+    }
+}
+
+struct LimitEntry: Decodable {
+    let client: String?
+    let planType: String?
+    let stale: Bool?
+    let windows: [LimitWindow]?
+
+    enum CodingKeys: String, CodingKey {
+        case client
+        case planType = "plan_type"
+        case stale, windows
+    }
+}
+
+struct LimitWindow: Decodable {
+    let kind: String?
+    let usedPercent: Double?
+    let windowMinutes: Double?
+    let resetsAt: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case usedPercent = "used_percent"
+        case windowMinutes = "window_minutes"
+        case resetsAt = "resets_at"
+    }
+}
+
+struct PlanEntry: Decodable {
+    let client: String
+    let confidence: String
+}
+
+struct RecentSession: Decodable {
+    let client: String
+    let sessionId: String
+    let title: String?
+    let status: String?
+    let lastActivityAt: Double?
+    let planPct: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case client
+        case sessionId = "session_id"
+        case title, status
+        case lastActivityAt = "last_activity_at"
+        case planPct = "plan_pct"
+    }
+
+    var shortSessionId: String { String(sessionId.prefix(8)) }
+
+    /// TUI-parity plan share formatting: one decimal with the approximation
+    /// marker, a "<0.1%" band instead of a fake exact zero, nothing when the
+    /// estimate is withheld (uncalibrated).
+    var planPctText: String? {
+        guard let pct = planPct else { return nil }
+        if pct > 0 && pct < 0.1 { return "≈<0.1%" }
+        return String(format: "≈%.1f%%", pct)
+    }
+
+    var statusGlyph: String {
+        switch status {
+        case "blocked": return "⚠"
+        case "handed_off": return "↗"
+        case "in_progress": return "▶"
+        case "completed": return "✓"
+        default: return "·"
+        }
+    }
+}
+
+struct VersionInfo: Decodable {
+    let version: String
+    let glanceSchema: String
+    let storeDir: String?
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case glanceSchema = "glance_schema"
+        case storeDir = "store_dir"
+    }
+}

--- a/apps/agentacct/Sources/agentacct/GlanceState.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceState.swift
@@ -1,0 +1,74 @@
+import Foundation
+import SwiftUI
+
+// The app's one state machine. Poll cadence is a fixed 30s in the skeleton
+// (the daemon's glance cache makes polls cheap); CodexBar-style adaptive
+// cadence is a follow-up. Phases mirror the precedents this design copied:
+// a daemon that is down or incompatible is an explicit, labeled UI state.
+
+@MainActor
+final class GlanceState: ObservableObject {
+    enum Phase {
+        case connecting
+        case disconnected(String)
+        case incompatible(String)
+        case connected(GlanceSnapshot)
+    }
+
+    @Published private(set) var phase: Phase = .connecting
+    @Published private(set) var lastUpdated: Date?
+
+    private let client = GlanceClient()
+    private var pollTask: Task<Void, Never>?
+    private let pollIntervalSeconds: UInt64 = 30
+
+    init() {
+        start()
+    }
+
+    func start() {
+        pollTask?.cancel()
+        pollTask = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                await self.poll()
+                try? await Task.sleep(nanoseconds: self.pollIntervalSeconds * 1_000_000_000)
+            }
+        }
+    }
+
+    func refreshNow() {
+        Task { await poll() }
+    }
+
+    private func poll() async {
+        do {
+            let snapshot = try await client.fetch()
+            phase = .connected(snapshot)
+            lastUpdated = Date()
+        } catch let error as GlanceClientError {
+            switch error {
+            case .incompatible(let version, let schema):
+                phase = .incompatible("daemon \(version) serves \(schema); this app expects \(GlanceClient.supportedGlanceSchema). Update one of them.")
+            default:
+                phase = .disconnected(error.description)
+            }
+        } catch {
+            phase = .disconnected(error.localizedDescription)
+        }
+    }
+
+    /// Menu bar label: today's cost when connected (the number a glance is
+    /// for), a quiet marker otherwise — never a fabricated figure.
+    var menuBarTitle: String {
+        switch phase {
+        case .connected(let snapshot):
+            let today = snapshot.glance.usage.windows.first { $0.label == "today" }
+            let cost = today?.totals.costText ?? "—"
+            return "⏺ \(cost)"
+        case .connecting:
+            return "⏺ …"
+        case .disconnected, .incompatible:
+            return "⏺ ∅"
+        }
+    }
+}

--- a/apps/agentacct/Sources/agentacct/MenuContent.swift
+++ b/apps/agentacct/Sources/agentacct/MenuContent.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+// The dropdown: usage · limits · plan · recent sessions, in that order.
+// Honesty rules carried over from the TUI: costs are complete-$ / partial-~$ /
+// em-dash (never a fabricated $0), plan shares only when calibrated, statuses
+// use the blocked > handed_off > in_progress > completed reduction the glance
+// already applied server-side.
+
+struct MenuContent: View {
+    @ObservedObject var state: GlanceState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            switch state.phase {
+            case .connecting:
+                Text("Connecting to the agentacct daemon…")
+                    .foregroundStyle(.secondary)
+            case .disconnected(let reason):
+                disconnectedView(reason: reason)
+            case .incompatible(let message):
+                Label {
+                    Text(message)
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle")
+                }
+                .foregroundStyle(.orange)
+            case .connected(let snapshot):
+                connectedView(snapshot: snapshot)
+            }
+            Divider()
+            footer
+        }
+        .padding(12)
+        .frame(width: 340)
+    }
+
+    private func disconnectedView(reason: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("agentacct daemon not reachable", systemImage: "bolt.slash")
+                .foregroundStyle(.secondary)
+            Text(reason)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text("Start it with:  agentacct start")
+                .font(.caption.monospaced())
+        }
+    }
+
+    @ViewBuilder
+    private func connectedView(snapshot: GlanceSnapshot) -> some View {
+        let glance = snapshot.glance
+
+        // Usage windows (today / 7d / 30d)
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Usage").font(.headline)
+            ForEach(glance.usage.windows.filter { $0.label != "all time" }, id: \.label) { window in
+                HStack {
+                    Text(window.label)
+                        .frame(width: 90, alignment: .leading)
+                        .foregroundStyle(.secondary)
+                    Text(window.totals.tokensText + " tok")
+                        .frame(width: 80, alignment: .trailing)
+                        .font(.body.monospacedDigit())
+                    Spacer()
+                    Text(window.totals.costText)
+                        .font(.body.monospacedDigit())
+                }
+                .font(.callout)
+            }
+        }
+
+        if !glance.limits.isEmpty {
+            Divider()
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Limits").font(.headline)
+                ForEach(Array(glance.limits.enumerated()), id: \.offset) { _, limit in
+                    limitRows(limit)
+                }
+            }
+        }
+
+        if !glance.recentSessions.isEmpty {
+            Divider()
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Recent sessions").font(.headline)
+                ForEach(Array(glance.recentSessions.prefix(6).enumerated()), id: \.offset) { _, session in
+                    sessionRow(session)
+                }
+            }
+        }
+
+        planFootnote(glance.plan)
+    }
+
+    @ViewBuilder
+    private func limitRows(_ limit: LimitEntry) -> some View {
+        ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
+            if let used = window.usedPercent {
+                HStack(spacing: 8) {
+                    Text("\(limit.client ?? "?") \(window.kind ?? "")")
+                        .frame(width: 110, alignment: .leading)
+                        .foregroundStyle(.secondary)
+                    ProgressView(value: min(max(used / 100.0, 0), 1))
+                        .tint(used >= 90 ? .red : used >= 70 ? .orange : .green)
+                    Text(String(format: "%.0f%%", used))
+                        .font(.callout.monospacedDigit())
+                        .frame(width: 44, alignment: .trailing)
+                    if limit.stale == true {
+                        Text("stale")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .font(.callout)
+            }
+        }
+    }
+
+    private func sessionRow(_ session: RecentSession) -> some View {
+        HStack(spacing: 6) {
+            Text(session.statusGlyph)
+                .frame(width: 14)
+                .foregroundStyle(session.status == "blocked" ? .orange : .secondary)
+            Text(session.title ?? "\(session.client) · \(session.shortSessionId)")
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer()
+            if let pct = session.planPctText {
+                Text(pct)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.callout)
+    }
+
+    @ViewBuilder
+    private func planFootnote(_ plan: [PlanEntry]) -> some View {
+        let calibrating = plan.filter { $0.confidence != "calibrated" }.map(\.client)
+        if !calibrating.isEmpty {
+            Text("plan share calibrating from your own limit history: \(calibrating.joined(separator: ", "))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Refresh") { state.refreshNow() }
+            Spacer()
+            if let updated = state.lastUpdated {
+                Text(updated, style: .time)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Button("Quit") { NSApplication.shared.terminate(nil) }
+        }
+    }
+}

--- a/contrib/swiftbar/agentacct.30s.sh
+++ b/contrib/swiftbar/agentacct.30s.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# <xbar.title>agentacct</xbar.title>
+# <xbar.version>v0.1</xbar.version>
+# <xbar.desc>Today's coding-agent cost + provider limits from the local agentacct daemon.</xbar.desc>
+# <xbar.dependencies>jq,curl</xbar.dependencies>
+#
+# SwiftBar/xbar plugin: drop into your plugin folder. Reads the daemon's
+# discovery file (port + per-boot bearer token, 0600) — no configuration.
+# Doubles as the reference /v1/glance client.
+set -uo pipefail
+
+STORE="${AGENTACCT_STORE_DIR:-$HOME/.local/state/agentacct/state}"
+DISCOVERY="$STORE/local-api.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "⏺ agentacct"
+  echo "---"
+  echo "jq is required (brew install jq)"
+  exit 0
+fi
+
+if [ ! -r "$DISCOVERY" ]; then
+  echo "⏺ ∅"
+  echo "---"
+  echo "agentacct daemon not running"
+  echo "Start it: agentacct start | font=Menlo"
+  exit 0
+fi
+
+PORT=$(jq -r '.port' "$DISCOVERY")
+TOKEN=$(jq -r '.token' "$DISCOVERY")
+
+GLANCE=$(curl -s -m 10 -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:${PORT}/v1/glance") || GLANCE=""
+if [ -z "$GLANCE" ] || ! echo "$GLANCE" | jq -e '.schema == "agentacct.glance.v1"' >/dev/null 2>&1; then
+  echo "⏺ ∅"
+  echo "---"
+  echo "daemon not reachable on port ${PORT} (or incompatible)"
+  echo "Start it: agentacct start | font=Menlo"
+  exit 0
+fi
+
+# Menu bar: today's cost — complete "$", partial "~$", nothing priced "—".
+TODAY_COST=$(echo "$GLANCE" | jq -r '
+  (.usage.windows[] | select(.label == "today") | .totals) as $t |
+  if ($t.cost_complete == true and ($t.estimated_cost_usd != null)) then "$" + ($t.estimated_cost_usd * 100 | round / 100 | tostring)
+  elif ($t.known_additive_cost_usd != null) then "~$" + ($t.known_additive_cost_usd * 100 | round / 100 | tostring)
+  else "—" end')
+echo "⏺ ${TODAY_COST}"
+echo "---"
+
+echo "$GLANCE" | jq -r '
+  "Usage",
+  (.usage.windows[] | select(.label != "all time") |
+    "\(.label): \(if .totals.fresh_tokens != null then (.totals.fresh_tokens | tostring) else "—" end) tok · " +
+    (.totals as $t |
+      if ($t.cost_complete == true and ($t.estimated_cost_usd != null)) then "$" + ($t.estimated_cost_usd * 100 | round / 100 | tostring)
+      elif ($t.known_additive_cost_usd != null) then "~$" + ($t.known_additive_cost_usd * 100 | round / 100 | tostring)
+      else "—" end) + " | font=Menlo")'
+
+echo "---"
+echo "$GLANCE" | jq -r '
+  "Limits",
+  (.limits[] | . as $l | ($l.windows // [])[] | select(.used_percent != null) |
+    "\($l.client // "?") \(.kind // ""): \(.used_percent | round)%\(if $l.stale == true then " (stale)" else "" end) | font=Menlo")'
+
+echo "---"
+echo "$GLANCE" | jq -r '
+  "Recent sessions",
+  (.recent_sessions[:5][] |
+    (if .status == "blocked" then "⚠" elif .status == "in_progress" then "▶"
+     elif .status == "completed" then "✓" elif .status == "handed_off" then "↗" else "·" end) + " " +
+    (.title // (.client + " · " + (.session_id[:8]))) +
+    (if .plan_pct != null then (if (.plan_pct > 0 and .plan_pct < 0.1) then " ≈<0.1%" else " ≈" + ((.plan_pct * 10 | round) / 10 | tostring) + "%" end) else "" end) +
+    " | font=Menlo trim=false")'


### PR DESCRIPTION
The native shell over the /v1 glance lane (#62):

- apps/AgentacctBar: a SwiftPM MenuBarExtra app (macOS 14+, zero
  dependencies). Reads the daemon's 0600 discovery file (port + per-boot
  bearer token), handshakes /v1/version (an incompatible daemon is a labeled
  state, not a parse error), polls /v1/glance every 30s, and re-reads
  discovery on 401 per the reader contract. Menu bar shows today's cost under
  the shared honesty rule (complete $ / partial ~$ / em-dash, never a
  fabricated $0); the dropdown renders usage windows, per-client limit bars
  with stale markers, recent sessions with server-reduced status glyphs and
  calibrated-only plan shares (TUI-parity ≈x.x% / <0.1% band), and a
  calibrating footnote for uncalibrated plan clients. Disconnected state
  carries the start command. Scripts/build-app.sh assembles an unsigned
  LSUIElement .app from the SwiftPM build.
- contrib/swiftbar/agentacct.30s.sh: the ~90-line SwiftBar/xbar plugin over
  the same lane — instant dogfood and the API's reference client.

Verified: swift build clean; the plugin ran against the live daemon and
rendered real data (usage windows, limit bars, this session's own recent
sessions with plan shares).

Skeleton follow-ups tracked in apps/AgentacctBar/README.md: adaptive poll
cadence, notifications, Sparkle + signing + brew cask, iconography. CI note:
tests.yml is pytest-only — a macOS swift-build workflow is a follow-up.

🛠 Pure addition (no Python changes); tests.yml runs unaffected pytest.