### PR TITLE
feat(app): the full agentacct window + menu bar polish + glance child folding

### DIFF
--- a/apps/agentacct/README.md
+++ b/apps/agentacct/README.md
@@ -29,15 +29,21 @@ open .build/agentacct.app
 
 Or during development: `swift run` (menu bar item appears; Ctrl-C to quit).
 
-## Skeleton status / roadmap
+## Status / roadmap
 
 - [x] discovery + bearer + version handshake + 30s poll
 - [x] menu bar: today's cost (complete `$` / partial `~$` / `—`, never a fake $0)
-- [x] dropdown: usage windows · limit bars with stale marker · recent sessions
-      with status glyphs and calibrated-only plan shares · calibrating footnote
+- [x] dropdown: usage windows · live limit bars (stale accounts hidden) ·
+      root-only recent sessions with status glyphs and calibrated-only plan
+      shares · refresh spinner + updated-ago · click a session to open the
+      full window
+- [x] the full window: Sessions (root list → detail: usage, work items with
+      check evidence, attribution, subagent rollup) · Usage by agent and by
+      model (30d cube) · Limits with a show-stale toggle
 - [ ] adaptive poll cadence (menu-open recency / Low Power Mode — CodexBar's
       2–30 min policy)
-- [ ] session drill-down, notifications on limit thresholds
+- [ ] usage window picker (7d/30d/all), per-session plan share in the window
+- [ ] notifications on limit thresholds
 - [ ] Sparkle updates, Developer ID signing + notarization, brew cask
 - [ ] app icon + proper menu bar iconography (text-only today)
 

--- a/apps/agentacct/Sources/agentacct/AgentacctApp.swift
+++ b/apps/agentacct/Sources/agentacct/AgentacctApp.swift
@@ -1,20 +1,34 @@
 import SwiftUI
 
-// The agentacct menu bar app: a thin display shell over the daemon's
-// /v1/glance lane (discovery + bearer token from <store>/local-api.json).
-// All aggregation, calibration, and honesty logic lives in the Python daemon;
-// this process only renders what the API vouches for.
+// agentacct, native: a persistent MenuBarExtra glance plus the full window
+// (Sessions → detail, Usage by agent/model, Limits). The menu bar is for
+// looking; the window is for digging — clicking a session in the dropdown
+// opens the window on that session. All aggregation and honesty logic lives
+// in the Python daemon; this process only renders what the API vouches for.
 
 @main
 struct AgentacctApp: App {
-    @StateObject private var state = GlanceState()
+    @StateObject private var glance = GlanceState()
+    @StateObject private var dashboard = DashboardStore()
+    @StateObject private var selection = AppSelection()
 
     var body: some Scene {
         MenuBarExtra {
-            MenuContent(state: state)
+            MenuContent()
+                .environmentObject(glance)
+                .environmentObject(dashboard)
+                .environmentObject(selection)
         } label: {
-            Text(state.menuBarTitle)
+            Text(glance.menuBarTitle)
         }
         .menuBarExtraStyle(.window)
+
+        Window("agentacct", id: "main") {
+            MainWindow()
+                .environmentObject(glance)
+                .environmentObject(dashboard)
+                .environmentObject(selection)
+        }
+        .defaultSize(width: 980, height: 620)
     }
 }

--- a/apps/agentacct/Sources/agentacct/AgentacctApp.swift
+++ b/apps/agentacct/Sources/agentacct/AgentacctApp.swift
@@ -6,7 +6,6 @@ import SwiftUI
 // opens the window on that session. All aggregation and honesty logic lives
 // in the Python daemon; this process only renders what the API vouches for.
 
-@main
 struct AgentacctApp: App {
     @StateObject private var glance = GlanceState()
     @StateObject private var dashboard = DashboardStore()
@@ -29,6 +28,7 @@ struct AgentacctApp: App {
                 .environmentObject(dashboard)
                 .environmentObject(selection)
         }
-        .defaultSize(width: 980, height: 620)
+        .windowStyle(.hiddenTitleBar)
+        .defaultSize(width: 1040, height: 640)
     }
 }

--- a/apps/agentacct/Sources/agentacct/DashboardModel.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardModel.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+// Models for the full window: the /sessions rollup and /usage/summary cube.
+// Same decoding stance as the glance: tolerant, selective, never inventing a
+// number an absent field does not carry.
+
+struct SessionsPayload: Decodable {
+    let sessions: [SessionEntry]
+    let totalSessions: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case sessions
+        case totalSessions = "total_sessions"
+    }
+}
+
+struct SessionEntry: Decodable, Identifiable {
+    let client: String
+    let clientSessionId: String
+    let shortId: String?
+    let title: String?
+    let sessionKind: String?
+    let project: String?
+    let durationSeconds: Double?
+    let lastActivityAt: Double?
+    let usage: SessionUsage?
+    let join: SessionJoin?
+    let work: SessionWork?
+    let related: SessionRelated?
+    let usageNote: String?
+    let observedModels: [String]?
+
+    var id: String { "\(client)::\(clientSessionId)" }
+    var isRoot: Bool { (related?.parent ?? nil) == nil }
+    var displayTitle: String { title ?? "\(client) · \(shortId ?? String(clientSessionId.prefix(8)))" }
+
+    enum CodingKeys: String, CodingKey {
+        case client
+        case clientSessionId = "client_session_id"
+        case shortId = "client_session_id_short"
+        case title = "client_session_title"
+        case sessionKind = "session_kind"
+        case project
+        case durationSeconds = "duration_seconds"
+        case lastActivityAt = "last_activity_at"
+        case usage, join, work, related
+        case usageNote = "usage_note"
+        case observedModels = "observed_models"
+    }
+}
+
+struct SessionUsage: Decodable {
+    let rows: Int?
+    let freshTokens: Int?
+    let cacheCreationTokens: Int?
+    let cacheReadTokens: Int?
+    let totalTokens: Int?
+    let estimatedCostUsd: Double?
+    let costConfidence: String?
+    let turnsTotal: Int?
+    let excludedNonAdditiveRows: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case rows
+        case freshTokens = "fresh_tokens"
+        case cacheCreationTokens = "cache_creation_tokens"
+        case cacheReadTokens = "cache_read_tokens"
+        case totalTokens = "total_tokens"
+        case estimatedCostUsd = "estimated_cost_usd"
+        case costConfidence = "cost_confidence"
+        case turnsTotal = "turns_total"
+        case excludedNonAdditiveRows = "excluded_non_additive_rows"
+    }
+
+    /// Per-session cost honesty: an estimate renders as an estimate, an
+    /// unpriced session renders as an em-dash — never $0.00.
+    var costText: String {
+        guard let cost = estimatedCostUsd else { return "—" }
+        let prefix = costConfidence == "client_reported" ? "$" : "≈$"
+        return String(format: "%@%.2f", prefix, cost)
+    }
+}
+
+struct SessionJoin: Decodable {
+    let state: String?
+    let reason: String?
+}
+
+struct SessionWork: Decodable {
+    let items: [WorkItem]?
+}
+
+struct WorkItem: Decodable, Identifiable {
+    let workId: String?
+    let sectionId: String?
+    let title: String?
+    let latestStatus: String?
+    let evidenceStatus: String?
+
+    var id: String { workId ?? sectionId ?? UUID().uuidString }
+
+    enum CodingKeys: String, CodingKey {
+        case workId = "work_id"
+        case sectionId = "section_id"
+        case title
+        case latestStatus = "latest_status"
+        case evidenceStatus = "evidence_status"
+    }
+
+    var statusGlyph: String {
+        switch latestStatus {
+        case "blocked": return "⚠"
+        case "handed_off": return "↗"
+        case "started", "checkpoint": return "▶"
+        case "completed": return "✓"
+        default: return "·"
+        }
+    }
+}
+
+struct SessionRelated: Decodable {
+    let parent: String?
+    let childSessionCount: Int?
+    let childrenUsage: ChildrenUsage?
+
+    enum CodingKeys: String, CodingKey {
+        case parent
+        case childSessionCount = "child_session_count"
+        case childrenUsage = "children_usage"
+    }
+}
+
+struct ChildrenUsage: Decodable {
+    let sessions: Int?
+    let freshTokens: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case sessions
+        case freshTokens = "fresh_tokens"
+    }
+}
+
+// /usage/summary
+
+struct UsageSummary: Decodable {
+    let byClient: [UsageBucket]
+    let byModel: [UsageBucket]
+    let totals: UsageBucket?
+
+    enum CodingKeys: String, CodingKey {
+        case byClient = "by_client"
+        case byModel = "by_model"
+        case totals
+    }
+}
+
+struct UsageBucket: Decodable, Identifiable {
+    let client: String?
+    let model: String?
+    let sessions: Int?
+    let freshTokens: Int?
+    let cacheReadTokens: Int?
+    let estimatedCostUsd: Double?
+    let costComplete: Bool?
+    let knownAdditiveCostUsd: Double?
+    let costConfidenceLabel: String?
+
+    var id: String { "\(client ?? "?")::\(model ?? "*")" }
+
+    enum CodingKeys: String, CodingKey {
+        case client, model, sessions
+        case freshTokens = "fresh_tokens"
+        case cacheReadTokens = "cache_read_tokens"
+        case estimatedCostUsd = "estimated_cost_usd"
+        case costComplete = "cost_complete"
+        case knownAdditiveCostUsd = "known_additive_cost_usd"
+        case costConfidenceLabel = "cost_confidence_label"
+    }
+
+    /// The shared cube cost rule: complete `$` / partial `~$` / `—`.
+    var costText: String {
+        if costComplete == true, let cost = estimatedCostUsd {
+            return String(format: "$%.2f", cost)
+        }
+        if let known = knownAdditiveCostUsd {
+            return String(format: "~$%.2f", known)
+        }
+        return "—"
+    }
+}

--- a/apps/agentacct/Sources/agentacct/DashboardModel.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardModel.swift
@@ -76,8 +76,7 @@ struct SessionUsage: Decodable {
     /// unpriced session renders as an em-dash — never $0.00.
     var costText: String {
         guard let cost = estimatedCostUsd else { return "—" }
-        let prefix = costConfidence == "client_reported" ? "$" : "≈$"
-        return String(format: "%@%.2f", prefix, cost)
+        return Fmt.dollars(cost, prefix: costConfidence == "client_reported" ? "$" : "≈$")
     }
 }
 
@@ -119,7 +118,7 @@ struct WorkItem: Decodable, Identifiable {
 }
 
 struct SessionRelated: Decodable {
-    let parent: String?
+    let parent: ParentRef?
     let childSessionCount: Int?
     let childrenUsage: ChildrenUsage?
 
@@ -127,6 +126,16 @@ struct SessionRelated: Decodable {
         case parent
         case childSessionCount = "child_session_count"
         case childrenUsage = "children_usage"
+    }
+}
+
+struct ParentRef: Decodable {
+    let clientSessionId: String?
+    let label: String?
+
+    enum CodingKeys: String, CodingKey {
+        case clientSessionId = "client_session_id"
+        case label
     }
 }
 
@@ -145,12 +154,45 @@ struct ChildrenUsage: Decodable {
 struct UsageSummary: Decodable {
     let byClient: [UsageBucket]
     let byModel: [UsageBucket]
+    let byPeriod: [PeriodBucket]?
     let totals: UsageBucket?
 
     enum CodingKeys: String, CodingKey {
         case byClient = "by_client"
         case byModel = "by_model"
+        case byPeriod = "by_period"
         case totals
+    }
+}
+
+struct PeriodBucket: Decodable, Identifiable {
+    let period: String?
+    let freshTokens: Int?
+    let estimatedCostUsd: Double?
+    let costComplete: Bool?
+    let byClient: [String: PeriodClientSlice]?
+
+    var id: String { period ?? UUID().uuidString }
+    /// "08-05" from "2026-08-05" for axis labels.
+    var shortLabel: String {
+        guard let period, period.count >= 10 else { return period ?? "" }
+        return String(period.dropFirst(5))
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case period
+        case freshTokens = "fresh_tokens"
+        case estimatedCostUsd = "estimated_cost_usd"
+        case costComplete = "cost_complete"
+        case byClient = "by_client"
+    }
+}
+
+struct PeriodClientSlice: Decodable {
+    let freshTokens: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case freshTokens = "fresh_tokens"
     }
 }
 
@@ -180,10 +222,10 @@ struct UsageBucket: Decodable, Identifiable {
     /// The shared cube cost rule: complete `$` / partial `~$` / `—`.
     var costText: String {
         if costComplete == true, let cost = estimatedCostUsd {
-            return String(format: "$%.2f", cost)
+            return Fmt.dollars(cost)
         }
         if let known = knownAdditiveCostUsd {
-            return String(format: "~$%.2f", known)
+            return Fmt.dollars(known, prefix: "~$")
         }
         return "—"
     }

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -1,0 +1,79 @@
+import Foundation
+import SwiftUI
+
+// Data for the full window: the /sessions rollup and the /usage/summary cube.
+// These are the daemon's machine-local JSON surfaces (localhost-guarded, no
+// bearer); the port comes from the same discovery file the glance uses.
+
+@MainActor
+final class DashboardStore: ObservableObject {
+    @Published private(set) var sessions: [SessionEntry] = []
+    @Published private(set) var totalSessions: Int?
+    @Published private(set) var usage: UsageSummary?
+    @Published private(set) var errorText: String?
+    @Published private(set) var isRefreshing = false
+    @Published private(set) var lastUpdated: Date?
+
+    private let session: URLSession
+
+    init() {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 30
+        session = URLSession(configuration: config)
+    }
+
+    func refresh() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        do {
+            guard let data = try? Data(contentsOf: GlanceClient.discoveryPath()),
+                  let discovery = try? JSONDecoder().decode(Discovery.self, from: data)
+            else {
+                errorText = "daemon not running (no discovery file) — start it with `agentacct start`"
+                return
+            }
+            let host = discovery.host ?? "127.0.0.1"
+            let base = "http://\(host):\(discovery.port)"
+            let payload: SessionsPayload = try await get("\(base)/sessions?limit=300")
+            let summary: UsageSummary = try await get("\(base)/usage/summary?days=30")
+            // Root sessions only, newest first: the rollup lists child lanes as
+            // their own entries (related.parent set); the window folds them —
+            // a child's usage is already summarized under its root.
+            sessions = payload.sessions
+                .filter(\.isRoot)
+                .sorted { ($0.lastActivityAt ?? 0) > ($1.lastActivityAt ?? 0) }
+            totalSessions = payload.totalSessions
+            usage = summary
+            errorText = nil
+            lastUpdated = Date()
+        } catch {
+            errorText = "daemon fetch failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func get<T: Decodable>(_ urlString: String) async throws -> T {
+        guard let url = URL(string: urlString) else {
+            throw GlanceClientError.transport("bad URL")
+        }
+        let (data, response) = try await session.data(from: url)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw GlanceClientError.http((response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}
+
+/// The menu bar → main window selection channel.
+@MainActor
+final class AppSelection: ObservableObject {
+    @Published var sessionId: String?
+    @Published var pane: MainPane = .sessions
+}
+
+enum MainPane: String, CaseIterable, Identifiable {
+    case sessions = "Sessions"
+    case usage = "Usage"
+    case limits = "Limits"
+    var id: String { rawValue }
+}

--- a/apps/agentacct/Sources/agentacct/GlanceModel.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceModel.swift
@@ -62,10 +62,10 @@ struct UsageTotals: Decodable {
     /// is marked approximate; nothing priced renders as an em-dash — never $0.
     var costText: String {
         if costComplete == true, let cost = estimatedCostUsd {
-            return String(format: "$%.2f", cost)
+            return Fmt.dollars(cost)
         }
         if let known = knownAdditiveCostUsd {
-            return String(format: "~$%.2f", known)
+            return Fmt.dollars(known, prefix: "~$")
         }
         return "—"
     }

--- a/apps/agentacct/Sources/agentacct/GlanceState.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceState.swift
@@ -17,6 +17,7 @@ final class GlanceState: ObservableObject {
 
     @Published private(set) var phase: Phase = .connecting
     @Published private(set) var lastUpdated: Date?
+    @Published private(set) var isRefreshing = false
 
     private let client = GlanceClient()
     private var pollTask: Task<Void, Never>?
@@ -41,6 +42,8 @@ final class GlanceState: ObservableObject {
     }
 
     private func poll() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
         do {
             let snapshot = try await client.fetch()
             phase = .connected(snapshot)

--- a/apps/agentacct/Sources/agentacct/GlanceState.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceState.swift
@@ -27,6 +27,12 @@ final class GlanceState: ObservableObject {
         start()
     }
 
+    /// Snapshot/tooling: a fixed state, no polling.
+    init(preloaded: GlanceSnapshot) {
+        phase = .connected(preloaded)
+        lastUpdated = Date()
+    }
+
     func start() {
         pollTask?.cancel()
         pollTask = Task { [weak self] in

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
-// The full window: Sessions (list → detail), Usage (by agent / by model),
-// Limits. The menu bar is the glance; this is where details live.
+// The full window, committed to the brand: a dark Tokyo Night surface with
+// custom chrome (no system sidebar), like the TUI is. The menu bar is the
+// glance; this is where details live.
 
 struct MainWindow: View {
     @EnvironmentObject var dashboard: DashboardStore
@@ -9,18 +10,9 @@ struct MainWindow: View {
     @EnvironmentObject var selection: AppSelection
 
     var body: some View {
-        NavigationSplitView {
-            List(selection: paneBinding) {
-                Section {
-                    ForEach(MainPane.allCases) { pane in
-                        Label(pane.rawValue, systemImage: pane.icon)
-                            .tag(pane)
-                    }
-                }
-            }
-            .listStyle(.sidebar)
-            .navigationSplitViewColumnWidth(min: 150, ideal: 160)
-        } detail: {
+        VStack(spacing: 0) {
+            TopBar()
+            Rectangle().fill(Theme.border).frame(height: 1)
             Group {
                 switch selection.pane {
                 case .sessions: SessionsPane()
@@ -28,40 +20,118 @@ struct MainWindow: View {
                 case .limits: LimitsPane()
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(minWidth: 900, minHeight: 540)
+        .background(Theme.bg)
+        .preferredColorScheme(.dark)
+        .frame(minWidth: 960, minHeight: 560)
         .task { await dashboard.refresh() }
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                if dashboard.isRefreshing {
-                    ProgressView().controlSize(.small)
-                } else {
-                    Button {
-                        Task { await dashboard.refresh() }
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
+    }
+}
+
+// MARK: - Top bar
+
+struct TopBar: View {
+    @EnvironmentObject var dashboard: DashboardStore
+    @EnvironmentObject var selection: AppSelection
+
+    var body: some View {
+        HStack(spacing: 14) {
+            HStack(spacing: 7) {
+                Circle().fill(Theme.blue.gradient).frame(width: 9, height: 9)
+                Text("agentacct")
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundStyle(Theme.text)
+            }
+            .padding(.leading, 76)  // clear the traffic lights (hidden titlebar)
+
+            HStack(spacing: 3) {
+                ForEach(MainPane.allCases) { pane in
+                    PaneTab(pane: pane, selected: selection.pane == pane) {
+                        selection.pane = pane
                     }
-                    .help("Refresh")
                 }
             }
-        }
-    }
+            .padding(3)
+            .background(Theme.surface, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
 
-    private var paneBinding: Binding<MainPane?> {
-        Binding(
-            get: { selection.pane },
-            set: { selection.pane = $0 ?? .sessions }
-        )
+            Spacer()
+
+            if let updated = dashboard.lastUpdated {
+                Text(updated, style: .relative)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Theme.textFaint)
+            }
+            if dashboard.isRefreshing {
+                ProgressView().controlSize(.small).tint(Theme.textMuted)
+            } else {
+                Button {
+                    Task { await dashboard.refresh() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(Theme.textMuted)
+                }
+                .buttonStyle(.plain)
+                .help("Refresh")
+            }
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 46)
+        .background(Theme.bg)
+    }
+}
+
+struct PaneTab: View {
+    let pane: MainPane
+    let selected: Bool
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: pane.icon).font(.system(size: 10.5, weight: .medium))
+                Text(pane.rawValue).font(.system(size: 12, weight: .medium))
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 5)
+            .foregroundStyle(selected ? Theme.text : (hovering ? Theme.textMuted : Theme.textFaint))
+            .background(
+                selected ? AnyShapeStyle(Theme.cardAlt) : AnyShapeStyle(.clear),
+                in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
     }
 }
 
 extension MainPane {
     var icon: String {
         switch self {
-        case .sessions: return "rectangle.stack"
-        case .usage: return "chart.bar.xaxis"
-        case .limits: return "gauge.with.needle"
+        case .sessions: return "rectangle.stack.fill"
+        case .usage: return "chart.bar.fill"
+        case .limits: return "gauge.with.needle.fill"
         }
+    }
+}
+
+// MARK: - Shared dark card
+
+struct DarkCard<Content: View>: View {
+    var padding: CGFloat = 12
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        content()
+            .padding(padding)
+            .background(Theme.surface, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(Theme.border, lineWidth: 1)
+            )
     }
 }
 
@@ -72,27 +142,32 @@ struct SessionsPane: View {
     @EnvironmentObject var selection: AppSelection
 
     var body: some View {
-        HSplitView {
+        HStack(spacing: 0) {
             VStack(spacing: 0) {
-                List(dashboard.sessions, selection: $selection.sessionId) { entry in
-                    SessionRow(entry: entry)
-                        .tag(entry.id)
-                        .listRowSeparator(.hidden)
+                ScrollBox {
+                    VStack(spacing: 2) {
+                        ForEach(dashboard.sessions) { entry in
+                            SessionRow(entry: entry, selected: selection.sessionId == entry.id)
+                                .onTapGesture { selection.sessionId = entry.id }
+                        }
+                    }
+                    .padding(10)
                 }
-                .listStyle(.inset)
                 if let total = dashboard.totalSessions {
-                    Divider()
+                    Rectangle().fill(Theme.border).frame(height: 1)
                     Text("\(dashboard.sessions.count) root sessions · \(total) total in the store")
                         .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(Theme.textFaint)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
                 }
             }
-            .frame(minWidth: 400)
+            .frame(width: 430)
+            Rectangle().fill(Theme.border).frame(width: 1)
             detail
-                .frame(minWidth: 360, maxWidth: .infinity, maxHeight: .infinity)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Theme.surface.opacity(0.4))
         }
         .overlay(alignment: .bottom) {
             if let error = dashboard.errorText {
@@ -100,7 +175,7 @@ struct SessionsPane: View {
                     .font(.caption)
                     .foregroundStyle(Theme.red)
                     .padding(8)
-                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                    .background(Theme.card, in: RoundedRectangle(cornerRadius: 8))
                     .padding(.bottom, 10)
             }
         }
@@ -112,13 +187,13 @@ struct SessionsPane: View {
            let entry = dashboard.sessions.first(where: { $0.id == id }) {
             SessionDetail(entry: entry)
         } else {
-            VStack(spacing: 8) {
+            VStack(spacing: 10) {
                 Image(systemName: "rectangle.stack")
-                    .font(.system(size: 30))
-                    .foregroundStyle(.quaternary)
+                    .font(.system(size: 34, weight: .light))
+                    .foregroundStyle(Theme.textFaint)
                 Text("Select a session")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Theme.textMuted)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
@@ -127,10 +202,10 @@ struct SessionsPane: View {
 
 struct SessionRow: View {
     let entry: SessionEntry
+    let selected: Bool
+    @State private var hovering = false
 
     private var workStatus: String? {
-        // Show the most severe work state on the row, mirroring the shared
-        // reduction: blocked > handed_off > in progress > completed.
         let statuses = Set((entry.work?.items ?? []).compactMap(\.latestStatus))
         if statuses.contains("blocked") { return "blocked" }
         if statuses.contains("handed_off") { return "handed_off" }
@@ -141,44 +216,57 @@ struct SessionRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            RoundedRectangle(cornerRadius: 2)
-                .fill(Theme.statusColor(workStatus))
-                .frame(width: 3, height: 34)
-            VStack(alignment: .leading, spacing: 2.5) {
+            StatusDot(color: Theme.statusColor(workStatus), size: 7)
+            VStack(alignment: .leading, spacing: 3) {
                 Text(entry.displayTitle)
                     .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(Theme.text)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 HStack(spacing: 6) {
-                    Chip(text: entry.client, tint: Theme.clientColor(entry.client))
+                    Text(entry.client)
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .foregroundStyle(Theme.clientColor(entry.client))
                     if let project = entry.project {
                         Text(project)
-                            .font(.system(size: 10.5))
-                            .foregroundStyle(.tertiary)
+                            .font(.system(size: 10))
+                            .foregroundStyle(Theme.textFaint)
                     }
                 }
             }
             Spacer(minLength: 10)
-            VStack(alignment: .trailing, spacing: 2.5) {
+            VStack(alignment: .trailing, spacing: 3) {
                 Text(entry.usage?.costText ?? "—")
                     .font(.system(size: 12, weight: .semibold, design: .rounded))
                     .monospacedDigit()
+                    .foregroundStyle(Theme.text)
                 HStack(spacing: 5) {
                     if let tokens = entry.usage?.freshTokens {
                         Text(UsageTotals.compact(tokens))
-                            .font(.system(size: 10))
+                            .font(.system(size: 9.5))
                             .monospacedDigit()
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(Theme.textFaint)
                     }
                     if let ts = entry.lastActivityAt {
                         Text(Date(timeIntervalSince1970: ts), style: .relative)
-                            .font(.system(size: 10))
-                            .foregroundStyle(.tertiary)
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(Theme.textFaint)
                     }
                 }
             }
         }
-        .padding(.vertical, 3)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 8)
+        .background(
+            selected ? AnyShapeStyle(Theme.cardAlt) : (hovering ? AnyShapeStyle(Theme.surface) : AnyShapeStyle(.clear)),
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(selected ? Theme.blue.opacity(0.45) : .clear, lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
     }
 }
 
@@ -186,18 +274,18 @@ struct SessionDetail: View {
     let entry: SessionEntry
 
     var body: some View {
-        ScrollView {
+        ScrollBox {
             VStack(alignment: .leading, spacing: 16) {
-                // Hero
-                VStack(alignment: .leading, spacing: 7) {
+                VStack(alignment: .leading, spacing: 8) {
                     Text(entry.displayTitle)
-                        .font(.system(size: 17, weight: .semibold))
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Theme.text)
                         .lineLimit(3)
                     HStack(spacing: 6) {
                         Chip(text: entry.client, tint: Theme.clientColor(entry.client))
-                        if let project = entry.project { Chip(text: project) }
+                        if let project = entry.project { Chip(text: project, tint: Theme.textMuted) }
                         if let duration = entry.durationSeconds {
-                            Chip(text: Self.duration(duration))
+                            Chip(text: SessionDetail.duration(duration), tint: Theme.textMuted)
                         }
                         if let models = entry.observedModels, !models.isEmpty {
                             Chip(text: models.joined(separator: " · "), tint: Theme.purple)
@@ -207,77 +295,81 @@ struct SessionDetail: View {
 
                 if let usage = entry.usage {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4), spacing: 8) {
-                        StatTile(label: "cost", value: usage.costText,
-                                 detail: usage.costConfidence?.replacingOccurrences(of: "_", with: " "),
-                                 accent: Theme.blue)
-                        StatTile(label: "fresh", value: usage.freshTokens.map(UsageTotals.compact) ?? "—")
-                        StatTile(label: "cache read", value: usage.cacheReadTokens.map(UsageTotals.compact) ?? "—")
-                        StatTile(label: "turns", value: usage.turnsTotal.map(String.init) ?? "—")
+                        DarkStatTile(label: "cost", value: usage.costText,
+                                     detail: usage.costConfidence?.replacingOccurrences(of: "_", with: " "),
+                                     accent: Theme.blue)
+                        DarkStatTile(label: "fresh", value: usage.freshTokens.map(UsageTotals.compact) ?? "—")
+                        DarkStatTile(label: "cache read", value: usage.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                        DarkStatTile(label: "turns", value: usage.turnsTotal.map(String.init) ?? "—")
                     }
                 }
 
                 if let note = entry.usageNote {
                     Text(note)
                         .font(.system(size: 10.5))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(Theme.textFaint)
                 }
 
                 if let items = entry.work?.items, !items.isEmpty {
                     VStack(alignment: .leading, spacing: 8) {
-                        SectionCaption(text: "Work")
-                        VStack(alignment: .leading, spacing: 0) {
-                            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-                                HStack(spacing: 9) {
-                                    StatusDot(color: Theme.statusColor(item.latestStatus))
-                                    Text(item.title ?? item.sectionId ?? "untitled")
-                                        .font(.system(size: 12))
-                                        .lineLimit(2)
-                                    Spacer(minLength: 8)
-                                    if let evidence = item.evidenceStatus {
-                                        Chip(text: evidence.replacingOccurrences(of: "_", with: " "),
-                                             tint: evidence.contains("verified") ? Theme.green : .secondary)
+                        DarkSectionCaption(text: "Work")
+                        DarkCard(padding: 4) {
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                                    HStack(spacing: 9) {
+                                        StatusDot(color: Theme.statusColor(item.latestStatus))
+                                        Text(item.title ?? item.sectionId ?? "untitled")
+                                            .font(.system(size: 12))
+                                            .foregroundStyle(Theme.text)
+                                            .lineLimit(2)
+                                        Spacer(minLength: 8)
+                                        if let evidence = item.evidenceStatus {
+                                            Chip(text: evidence.replacingOccurrences(of: "_", with: " "),
+                                                 tint: evidence.contains("verified") ? Theme.green : Theme.textMuted)
+                                        }
+                                    }
+                                    .padding(.horizontal, 9)
+                                    .padding(.vertical, 7)
+                                    if index < items.count - 1 {
+                                        Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
                                     }
                                 }
-                                .padding(.vertical, 6)
-                                if index < items.count - 1 { Divider().opacity(0.5) }
                             }
                         }
-                        .padding(.horizontal, 11)
-                        .padding(.vertical, 4)
-                        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
                     }
                 }
 
                 if let join = entry.join {
                     VStack(alignment: .leading, spacing: 8) {
-                        SectionCaption(text: "Attribution")
+                        DarkSectionCaption(text: "Attribution")
                         HStack(alignment: .firstTextBaseline, spacing: 8) {
                             Chip(text: join.state ?? "unknown", tint: joinTint(join.state))
                             if let reason = join.reason {
                                 Text(reason)
                                     .font(.system(size: 10.5))
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(Theme.textMuted)
                             }
                         }
                     }
                 }
 
                 if let related = entry.related, (related.childSessionCount ?? 0) > 0 {
-                    HStack(spacing: 8) {
-                        Image(systemName: "point.3.connected.trianglepath.dotted")
-                            .foregroundStyle(.secondary)
-                        Text("\(related.childSessionCount ?? 0) subagent sessions")
-                            .font(.system(size: 11.5))
-                        Spacer()
-                        if let fresh = related.childrenUsage?.freshTokens {
-                            Text("\(UsageTotals.compact(fresh)) fresh tok")
-                                .font(.system(size: 11))
-                                .monospacedDigit()
-                                .foregroundStyle(.secondary)
+                    DarkCard {
+                        HStack(spacing: 8) {
+                            Image(systemName: "point.3.connected.trianglepath.dotted")
+                                .foregroundStyle(Theme.textMuted)
+                            Text("\(related.childSessionCount ?? 0) subagent sessions")
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(Theme.text)
+                            Spacer()
+                            if let fresh = related.childrenUsage?.freshTokens {
+                                Text("\(UsageTotals.compact(fresh)) fresh tok")
+                                    .font(.system(size: 11))
+                                    .monospacedDigit()
+                                    .foregroundStyle(Theme.textMuted)
+                            }
                         }
                     }
-                    .padding(10)
-                    .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
                 }
             }
             .padding(16)
@@ -289,7 +381,7 @@ struct SessionDetail: View {
         case "attributed": return Theme.green
         case "ambiguous": return Theme.orange
         case "sections_only": return Theme.blue
-        default: return .secondary
+        default: return Theme.textMuted
         }
     }
 
@@ -302,42 +394,89 @@ struct SessionDetail: View {
     }
 }
 
+/// Dark-surface stat tile (window variant of StatTile).
+struct DarkStatTile: View {
+    let label: String
+    let value: String
+    var detail: String? = nil
+    var accent: Color = Theme.text
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label.uppercased())
+                .font(.system(size: 9, weight: .semibold))
+                .tracking(0.7)
+                .foregroundStyle(Theme.textFaint)
+            Text(value)
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(accent)
+            if let detail {
+                Text(detail)
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(Theme.textFaint)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(11)
+        .background(Theme.surface, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .strokeBorder(Theme.border, lineWidth: 1)
+        )
+    }
+}
+
+struct DarkSectionCaption: View {
+    let text: String
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.9)
+            .foregroundStyle(Theme.textFaint)
+    }
+}
+
 // MARK: - Usage
 
 struct UsagePane: View {
     @EnvironmentObject var dashboard: DashboardStore
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
+        ScrollBox {
+            VStack(alignment: .leading, spacing: 16) {
                 if let usage = dashboard.usage {
                     if let totals = usage.totals {
                         HStack(spacing: 8) {
-                            StatTile(label: "30d cost", value: totals.costText, accent: Theme.blue)
-                            StatTile(label: "30d fresh tokens",
-                                     value: totals.freshTokens.map(UsageTotals.compact) ?? "—")
-                            StatTile(label: "cache read",
-                                     value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—")
-                            StatTile(label: "sessions",
-                                     value: totals.sessions.map(String.init) ?? "—")
+                            DarkStatTile(label: "30d cost", value: totals.costText, accent: Theme.blue)
+                            DarkStatTile(label: "30d fresh tokens",
+                                         value: totals.freshTokens.map(UsageTotals.compact) ?? "—")
+                            DarkStatTile(label: "cache read",
+                                         value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                            DarkStatTile(label: "sessions",
+                                         value: totals.sessions.map(String.init) ?? "—")
                         }
+                    }
+                    if let periods = usage.byPeriod, periods.count > 1 {
+                        DailyChart(periods: periods)
                     }
                     bucketSection(title: "By agent", buckets: usage.byClient) { bucket in
                         (bucket.client ?? "?", Theme.clientColor(bucket.client))
                     }
                     bucketSection(title: "By model", buckets: usage.byModel) { bucket in
-                        ("\(bucket.model ?? "?")", Theme.clientColor(bucket.client))
+                        (bucket.model ?? "?", Theme.clientColor(bucket.client))
                     }
                 } else {
-                    VStack(spacing: 8) {
+                    VStack(spacing: 10) {
                         Image(systemName: "chart.bar.xaxis")
-                            .font(.system(size: 30))
-                            .foregroundStyle(.quaternary)
+                            .font(.system(size: 32, weight: .light))
+                            .foregroundStyle(Theme.textFaint)
                         Text("No usage loaded")
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(Theme.textMuted)
                     }
                     .frame(maxWidth: .infinity)
-                    .padding(.top, 80)
+                    .padding(.top, 90)
                 }
             }
             .padding(16)
@@ -352,35 +491,109 @@ struct UsagePane: View {
         let sorted = buckets.sorted { ($0.freshTokens ?? 0) > ($1.freshTokens ?? 0) }
         let maxFresh = Double(sorted.first?.freshTokens ?? 1)
         return VStack(alignment: .leading, spacing: 8) {
-            SectionCaption(text: title + " · last 30 days")
-            VStack(spacing: 0) {
-                ForEach(Array(sorted.enumerated()), id: \.element.id) { index, bucket in
-                    let (name, tint) = nameOf(bucket)
-                    HStack(spacing: 10) {
-                        StatusDot(color: tint, size: 6)
-                        Text(name)
-                            .font(.system(size: 12, weight: .medium))
-                            .lineLimit(1)
-                            .frame(width: 170, alignment: .leading)
-                        MeterBar(fraction: Double(bucket.freshTokens ?? 0) / max(maxFresh, 1),
-                                 tint: tint, height: 6)
-                        Text(bucket.freshTokens.map(UsageTotals.compact) ?? "—")
-                            .font(.system(size: 11.5))
-                            .monospacedDigit()
-                            .foregroundStyle(.secondary)
-                            .frame(width: 58, alignment: .trailing)
-                        Text(bucket.costText)
-                            .font(.system(size: 11.5, weight: .medium))
-                            .monospacedDigit()
-                            .frame(width: 78, alignment: .trailing)
+            DarkSectionCaption(text: title + " · last 30 days")
+            DarkCard(padding: 6) {
+                VStack(spacing: 0) {
+                    ForEach(Array(sorted.enumerated()), id: \.element.id) { index, bucket in
+                        let (name, tint) = nameOf(bucket)
+                        HStack(spacing: 10) {
+                            StatusDot(color: tint, size: 6)
+                            Text(name)
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(Theme.text)
+                                .lineLimit(1)
+                                .frame(width: 168, alignment: .leading)
+                            MeterBar(fraction: Double(bucket.freshTokens ?? 0) / max(maxFresh, 1),
+                                     tint: tint, height: 7)
+                            Text(bucket.freshTokens.map(UsageTotals.compact) ?? "—")
+                                .font(.system(size: 11.5))
+                                .monospacedDigit()
+                                .foregroundStyle(Theme.textMuted)
+                                .frame(width: 58, alignment: .trailing)
+                            Text(bucket.costText)
+                                .font(.system(size: 11.5, weight: .semibold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(Theme.text)
+                                .frame(width: 82, alignment: .trailing)
+                        }
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 7)
+                        if index < sorted.count - 1 {
+                            Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
+                        }
                     }
-                    .padding(.vertical, 6.5)
-                    if index < sorted.count - 1 { Divider().opacity(0.5) }
                 }
             }
-            .padding(.horizontal, 11)
-            .padding(.vertical, 4)
-            .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+        }
+    }
+}
+
+/// The 30-day stacked daily bars, client-colored — the dashboard's centerpiece.
+struct DailyChart: View {
+    let periods: [PeriodBucket]
+
+    private var clients: [String] {
+        var seen: [String] = []
+        for period in periods {
+            for client in (period.byClient ?? [:]).keys where !seen.contains(client) {
+                seen.append(client)
+            }
+        }
+        return seen.sorted()
+    }
+
+    private var maxTokens: Double {
+        max(Double(periods.compactMap(\.freshTokens).max() ?? 1), 1)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                DarkSectionCaption(text: "Daily fresh tokens")
+                Spacer()
+                ForEach(clients, id: \.self) { client in
+                    HStack(spacing: 4) {
+                        StatusDot(color: Theme.clientColor(client), size: 5)
+                        Text(client)
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(Theme.textMuted)
+                    }
+                }
+            }
+            DarkCard(padding: 12) {
+                VStack(spacing: 6) {
+                    HStack(alignment: .bottom, spacing: 3) {
+                        ForEach(periods) { period in
+                            VStack(spacing: 0) {
+                                let total = Double(period.freshTokens ?? 0)
+                                let height = 110 * total / maxTokens
+                                VStack(spacing: 0.5) {
+                                    ForEach(clients, id: \.self) { client in
+                                        let slice = Double(period.byClient?[client]?.freshTokens ?? 0)
+                                        if slice > 0, total > 0 {
+                                            RoundedRectangle(cornerRadius: 1)
+                                                .fill(Theme.clientColor(client).gradient)
+                                                .frame(height: max(1.5, height * slice / total))
+                                        }
+                                    }
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .bottom)
+                        }
+                    }
+                    .frame(height: 112, alignment: .bottom)
+                    HStack {
+                        Text(periods.first?.shortLabel ?? "")
+                        Spacer()
+                        Text(periods[periods.count / 2].shortLabel)
+                        Spacer()
+                        Text(periods.last?.shortLabel ?? "")
+                    }
+                    .font(.system(size: 9))
+                    .foregroundStyle(Theme.textFaint)
+                }
+            }
         }
     }
 }
@@ -392,29 +605,30 @@ struct LimitsPane: View {
     @State private var showStale = false
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
+        ScrollBox {
+            VStack(alignment: .leading, spacing: 12) {
                 HStack {
-                    SectionCaption(text: "Provider limits")
+                    DarkSectionCaption(text: "Provider limits")
                     Spacer()
                     Toggle("Show stale accounts", isOn: $showStale)
                         .toggleStyle(.checkbox)
                         .font(.system(size: 11))
+                        .foregroundStyle(Theme.textMuted)
                 }
                 if case .connected(let snapshot) = glance.phase {
                     let limits = snapshot.glance.limits.filter { showStale || $0.stale != true }
                     if limits.isEmpty {
                         Text("No live limit readings.")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
+                            .font(.system(size: 12))
+                            .foregroundStyle(Theme.textMuted)
                     }
                     ForEach(Array(limits.enumerated()), id: \.offset) { _, limit in
                         limitCard(limit)
                     }
                 } else {
                     Text("Daemon not connected.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.textMuted)
                 }
             }
             .padding(16)
@@ -422,41 +636,43 @@ struct LimitsPane: View {
     }
 
     private func limitCard(_ limit: LimitEntry) -> some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 7) {
-                StatusDot(color: Theme.clientColor(limit.client))
-                Text(limit.client ?? "?")
-                    .font(.system(size: 12.5, weight: .semibold))
-                if let plan = limit.planType {
-                    Chip(text: plan, tint: Theme.clientColor(limit.client))
+        DarkCard {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 7) {
+                    StatusDot(color: Theme.clientColor(limit.client))
+                    Text(limit.client ?? "?")
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(Theme.text)
+                    if let plan = limit.planType {
+                        Chip(text: plan, tint: Theme.clientColor(limit.client))
+                    }
+                    if limit.stale == true {
+                        Chip(text: "stale", tint: Theme.textMuted)
+                    }
+                    Spacer()
                 }
-                if limit.stale == true {
-                    Chip(text: "stale", tint: .secondary)
-                }
-                Spacer()
-            }
-            ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
-                if let used = window.usedPercent {
-                    HStack(spacing: 10) {
-                        Text(window.kind ?? "")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 26, alignment: .leading)
-                        MeterBar(fraction: used / 100.0,
-                                 tint: Theme.limitColor(usedPercent: used), height: 7)
-                        Text(String(format: "%.0f%%", used))
-                            .font(.system(size: 11.5, weight: .medium))
-                            .monospacedDigit()
-                            .frame(width: 36, alignment: .trailing)
-                        Text(Theme.resetsIn(window.resetsAt).map { "resets in \($0)" } ?? "")
-                            .font(.system(size: 10))
-                            .foregroundStyle(.tertiary)
-                            .frame(width: 96, alignment: .trailing)
+                ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
+                    if let used = window.usedPercent {
+                        HStack(spacing: 10) {
+                            Text(window.kind ?? "")
+                                .font(.system(size: 11))
+                                .foregroundStyle(Theme.textMuted)
+                                .frame(width: 26, alignment: .leading)
+                            MeterBar(fraction: used / 100.0,
+                                     tint: Theme.limitColor(usedPercent: used), height: 8)
+                            Text(String(format: "%.0f%%", used))
+                                .font(.system(size: 11.5, weight: .semibold))
+                                .monospacedDigit()
+                                .foregroundStyle(Theme.text)
+                                .frame(width: 36, alignment: .trailing)
+                            Text(Theme.resetsIn(window.resetsAt).map { "resets in \($0)" } ?? "")
+                                .font(.system(size: 10))
+                                .foregroundStyle(Theme.textFaint)
+                                .frame(width: 100, alignment: .trailing)
+                        }
                     }
                 }
             }
         }
-        .padding(12)
-        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 }

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -10,10 +10,16 @@ struct MainWindow: View {
 
     var body: some View {
         NavigationSplitView {
-            List(MainPane.allCases, selection: paneBinding) { pane in
-                Text(pane.rawValue).tag(pane)
+            List(selection: paneBinding) {
+                Section {
+                    ForEach(MainPane.allCases) { pane in
+                        Label(pane.rawValue, systemImage: pane.icon)
+                            .tag(pane)
+                    }
+                }
             }
-            .navigationSplitViewColumnWidth(min: 140, ideal: 150)
+            .listStyle(.sidebar)
+            .navigationSplitViewColumnWidth(min: 150, ideal: 160)
         } detail: {
             Group {
                 switch selection.pane {
@@ -23,7 +29,7 @@ struct MainWindow: View {
                 }
             }
         }
-        .frame(minWidth: 860, minHeight: 520)
+        .frame(minWidth: 900, minHeight: 540)
         .task { await dashboard.refresh() }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -49,6 +55,16 @@ struct MainWindow: View {
     }
 }
 
+extension MainPane {
+    var icon: String {
+        switch self {
+        case .sessions: return "rectangle.stack"
+        case .usage: return "chart.bar.xaxis"
+        case .limits: return "gauge.with.needle"
+        }
+    }
+}
+
 // MARK: - Sessions
 
 struct SessionsPane: View {
@@ -57,21 +73,35 @@ struct SessionsPane: View {
 
     var body: some View {
         HSplitView {
-            List(dashboard.sessions, selection: $selection.sessionId) { entry in
-                SessionRow(entry: entry).tag(entry.id)
+            VStack(spacing: 0) {
+                List(dashboard.sessions, selection: $selection.sessionId) { entry in
+                    SessionRow(entry: entry)
+                        .tag(entry.id)
+                        .listRowSeparator(.hidden)
+                }
+                .listStyle(.inset)
+                if let total = dashboard.totalSessions {
+                    Divider()
+                    Text("\(dashboard.sessions.count) root sessions · \(total) total in the store")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                }
             }
-            .frame(minWidth: 380)
+            .frame(minWidth: 400)
             detail
-                .frame(minWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
+                .frame(minWidth: 360, maxWidth: .infinity, maxHeight: .infinity)
         }
         .overlay(alignment: .bottom) {
             if let error = dashboard.errorText {
-                Text(error)
+                Label(error, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
-                    .foregroundStyle(.red)
-                    .padding(6)
-                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6))
-                    .padding(.bottom, 8)
+                    .foregroundStyle(Theme.red)
+                    .padding(8)
+                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                    .padding(.bottom, 10)
             }
         }
     }
@@ -82,58 +112,73 @@ struct SessionsPane: View {
            let entry = dashboard.sessions.first(where: { $0.id == id }) {
             SessionDetail(entry: entry)
         } else {
-            ContentUnavailableView(
-                "Select a session",
-                systemImage: "list.bullet.rectangle",
-                description: Text(footerText)
-            )
+            VStack(spacing: 8) {
+                Image(systemName: "rectangle.stack")
+                    .font(.system(size: 30))
+                    .foregroundStyle(.quaternary)
+                Text("Select a session")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-    }
-
-    private var footerText: String {
-        if let total = dashboard.totalSessions {
-            return "\(dashboard.sessions.count) root sessions shown · \(total) sessions in the store"
-        }
-        return ""
     }
 }
 
 struct SessionRow: View {
     let entry: SessionEntry
 
+    private var workStatus: String? {
+        // Show the most severe work state on the row, mirroring the shared
+        // reduction: blocked > handed_off > in progress > completed.
+        let statuses = Set((entry.work?.items ?? []).compactMap(\.latestStatus))
+        if statuses.contains("blocked") { return "blocked" }
+        if statuses.contains("handed_off") { return "handed_off" }
+        if !statuses.isDisjoint(with: ["started", "checkpoint"]) { return "in_progress" }
+        if statuses.contains("completed") { return "completed" }
+        return nil
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
+        HStack(spacing: 10) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Theme.statusColor(workStatus))
+                .frame(width: 3, height: 34)
+            VStack(alignment: .leading, spacing: 2.5) {
                 Text(entry.displayTitle)
+                    .font(.system(size: 12.5, weight: .medium))
                     .lineLimit(1)
                     .truncationMode(.tail)
-                Spacer()
-                if let ts = entry.lastActivityAt {
-                    Text(Date(timeIntervalSince1970: ts), style: .relative)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    Chip(text: entry.client, tint: Theme.clientColor(entry.client))
+                    if let project = entry.project {
+                        Text(project)
+                            .font(.system(size: 10.5))
+                            .foregroundStyle(.tertiary)
+                    }
                 }
             }
-            HStack(spacing: 8) {
-                Text(entry.client)
-                    .font(.caption)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
-                    .background(.quaternary, in: Capsule())
-                if let project = entry.project {
-                    Text(project).font(.caption).foregroundStyle(.secondary)
-                }
-                Spacer()
-                if let tokens = entry.usage?.freshTokens {
-                    Text(UsageTotals.compact(tokens) + " tok")
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.secondary)
-                }
+            Spacer(minLength: 10)
+            VStack(alignment: .trailing, spacing: 2.5) {
                 Text(entry.usage?.costText ?? "—")
-                    .font(.caption.monospacedDigit())
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                HStack(spacing: 5) {
+                    if let tokens = entry.usage?.freshTokens {
+                        Text(UsageTotals.compact(tokens))
+                            .font(.system(size: 10))
+                            .monospacedDigit()
+                            .foregroundStyle(.tertiary)
+                    }
+                    if let ts = entry.lastActivityAt {
+                        Text(Date(timeIntervalSince1970: ts), style: .relative)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
             }
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, 3)
     }
 }
 
@@ -142,105 +187,109 @@ struct SessionDetail: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(entry.displayTitle).font(.title3.bold())
-                    HStack(spacing: 10) {
-                        Text(entry.client)
-                        if let project = entry.project { Text(project) }
+            VStack(alignment: .leading, spacing: 16) {
+                // Hero
+                VStack(alignment: .leading, spacing: 7) {
+                    Text(entry.displayTitle)
+                        .font(.system(size: 17, weight: .semibold))
+                        .lineLimit(3)
+                    HStack(spacing: 6) {
+                        Chip(text: entry.client, tint: Theme.clientColor(entry.client))
+                        if let project = entry.project { Chip(text: project) }
                         if let duration = entry.durationSeconds {
-                            Text(Self.duration(duration))
+                            Chip(text: Self.duration(duration))
                         }
                         if let models = entry.observedModels, !models.isEmpty {
-                            Text(models.joined(separator: ", "))
+                            Chip(text: models.joined(separator: " · "), tint: Theme.purple)
                         }
                     }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
                 }
 
                 if let usage = entry.usage {
-                    GroupBox("Usage") {
-                        Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 4) {
-                            GridRow {
-                                stat("fresh", usage.freshTokens)
-                                stat("cache read", usage.cacheReadTokens)
-                                stat("cache write", usage.cacheCreationTokens)
-                            }
-                            GridRow {
-                                stat("total", usage.totalTokens)
-                                statText("turns", usage.turnsTotal.map(String.init) ?? "—")
-                                statText("cost", usage.costText)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4), spacing: 8) {
+                        StatTile(label: "cost", value: usage.costText,
+                                 detail: usage.costConfidence?.replacingOccurrences(of: "_", with: " "),
+                                 accent: Theme.blue)
+                        StatTile(label: "fresh", value: usage.freshTokens.map(UsageTotals.compact) ?? "—")
+                        StatTile(label: "cache read", value: usage.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                        StatTile(label: "turns", value: usage.turnsTotal.map(String.init) ?? "—")
                     }
                 }
 
                 if let note = entry.usageNote {
-                    Text(note).font(.caption).foregroundStyle(.secondary)
+                    Text(note)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(.tertiary)
                 }
 
                 if let items = entry.work?.items, !items.isEmpty {
-                    GroupBox("Work") {
-                        VStack(alignment: .leading, spacing: 5) {
-                            ForEach(items) { item in
-                                HStack(spacing: 6) {
-                                    Text(item.statusGlyph)
-                                        .foregroundStyle(item.latestStatus == "blocked" ? .orange : .secondary)
+                    VStack(alignment: .leading, spacing: 8) {
+                        SectionCaption(text: "Work")
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                                HStack(spacing: 9) {
+                                    StatusDot(color: Theme.statusColor(item.latestStatus))
                                     Text(item.title ?? item.sectionId ?? "untitled")
+                                        .font(.system(size: 12))
                                         .lineLimit(2)
-                                    Spacer()
+                                    Spacer(minLength: 8)
                                     if let evidence = item.evidenceStatus {
-                                        Text(evidence)
-                                            .font(.caption2)
-                                            .foregroundStyle(.secondary)
+                                        Chip(text: evidence.replacingOccurrences(of: "_", with: " "),
+                                             tint: evidence.contains("verified") ? Theme.green : .secondary)
                                     }
                                 }
+                                .padding(.vertical, 6)
+                                if index < items.count - 1 { Divider().opacity(0.5) }
                             }
                         }
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 4)
+                        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
                     }
                 }
 
                 if let join = entry.join {
-                    GroupBox("Attribution") {
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text(join.state ?? "unknown").font(.callout)
+                    VStack(alignment: .leading, spacing: 8) {
+                        SectionCaption(text: "Attribution")
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Chip(text: join.state ?? "unknown", tint: joinTint(join.state))
                             if let reason = join.reason {
-                                Text(reason).font(.caption).foregroundStyle(.secondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-
-                if let related = entry.related, (related.childSessionCount ?? 0) > 0 {
-                    GroupBox("Subagents") {
-                        HStack {
-                            Text("\(related.childSessionCount ?? 0) child sessions")
-                            Spacer()
-                            if let fresh = related.childrenUsage?.freshTokens {
-                                Text(UsageTotals.compact(fresh) + " fresh tok")
-                                    .font(.callout.monospacedDigit())
+                                Text(reason)
+                                    .font(.system(size: 10.5))
                                     .foregroundStyle(.secondary)
                             }
                         }
                     }
                 }
+
+                if let related = entry.related, (related.childSessionCount ?? 0) > 0 {
+                    HStack(spacing: 8) {
+                        Image(systemName: "point.3.connected.trianglepath.dotted")
+                            .foregroundStyle(.secondary)
+                        Text("\(related.childSessionCount ?? 0) subagent sessions")
+                            .font(.system(size: 11.5))
+                        Spacer()
+                        if let fresh = related.childrenUsage?.freshTokens {
+                            Text("\(UsageTotals.compact(fresh)) fresh tok")
+                                .font(.system(size: 11))
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(10)
+                    .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                }
             }
-            .padding(14)
+            .padding(16)
         }
     }
 
-    private func stat(_ label: String, _ value: Int?) -> some View {
-        statText(label, value.map(UsageTotals.compact) ?? "—")
-    }
-
-    private func statText(_ label: String, _ value: String) -> some View {
-        VStack(alignment: .leading, spacing: 1) {
-            Text(label).font(.caption2).foregroundStyle(.secondary)
-            Text(value).font(.body.monospacedDigit())
+    private func joinTint(_ state: String?) -> Color {
+        switch state {
+        case "attributed": return Theme.green
+        case "ambiguous": return Theme.orange
+        case "sections_only": return Theme.blue
+        default: return .secondary
         }
     }
 
@@ -260,46 +309,79 @@ struct UsagePane: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 18) {
                 if let usage = dashboard.usage {
-                    GroupBox("By agent · last 30 days") {
-                        bucketTable(usage.byClient, nameOf: { $0.client ?? "?" })
+                    if let totals = usage.totals {
+                        HStack(spacing: 8) {
+                            StatTile(label: "30d cost", value: totals.costText, accent: Theme.blue)
+                            StatTile(label: "30d fresh tokens",
+                                     value: totals.freshTokens.map(UsageTotals.compact) ?? "—")
+                            StatTile(label: "cache read",
+                                     value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                            StatTile(label: "sessions",
+                                     value: totals.sessions.map(String.init) ?? "—")
+                        }
                     }
-                    GroupBox("By model · last 30 days") {
-                        bucketTable(usage.byModel, nameOf: { "\($0.model ?? "?")  (\($0.client ?? "?"))" })
+                    bucketSection(title: "By agent", buckets: usage.byClient) { bucket in
+                        (bucket.client ?? "?", Theme.clientColor(bucket.client))
+                    }
+                    bucketSection(title: "By model", buckets: usage.byModel) { bucket in
+                        ("\(bucket.model ?? "?")", Theme.clientColor(bucket.client))
                     }
                 } else {
-                    ContentUnavailableView("No usage loaded", systemImage: "chart.bar")
+                    VStack(spacing: 8) {
+                        Image(systemName: "chart.bar.xaxis")
+                            .font(.system(size: 30))
+                            .foregroundStyle(.quaternary)
+                        Text("No usage loaded")
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 80)
                 }
             }
-            .padding(14)
+            .padding(16)
         }
     }
 
-    private func bucketTable(_ buckets: [UsageBucket], nameOf: @escaping (UsageBucket) -> String) -> some View {
-        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
-            GridRow {
-                Text("").gridColumnAlignment(.leading)
-                Text("sessions").font(.caption).foregroundStyle(.secondary)
-                Text("fresh tok").font(.caption).foregroundStyle(.secondary)
-                Text("cache read").font(.caption).foregroundStyle(.secondary)
-                Text("cost").font(.caption).foregroundStyle(.secondary)
-            }
-            ForEach(buckets.sorted { ($0.freshTokens ?? 0) > ($1.freshTokens ?? 0) }) { bucket in
-                GridRow {
-                    Text(nameOf(bucket)).lineLimit(1)
-                    Text(bucket.sessions.map(String.init) ?? "—")
-                        .font(.body.monospacedDigit())
-                    Text(bucket.freshTokens.map(UsageTotals.compact) ?? "—")
-                        .font(.body.monospacedDigit())
-                    Text(bucket.cacheReadTokens.map(UsageTotals.compact) ?? "—")
-                        .font(.body.monospacedDigit())
-                    Text(bucket.costText)
-                        .font(.body.monospacedDigit())
+    private func bucketSection(
+        title: String,
+        buckets: [UsageBucket],
+        nameOf: @escaping (UsageBucket) -> (String, Color)
+    ) -> some View {
+        let sorted = buckets.sorted { ($0.freshTokens ?? 0) > ($1.freshTokens ?? 0) }
+        let maxFresh = Double(sorted.first?.freshTokens ?? 1)
+        return VStack(alignment: .leading, spacing: 8) {
+            SectionCaption(text: title + " · last 30 days")
+            VStack(spacing: 0) {
+                ForEach(Array(sorted.enumerated()), id: \.element.id) { index, bucket in
+                    let (name, tint) = nameOf(bucket)
+                    HStack(spacing: 10) {
+                        StatusDot(color: tint, size: 6)
+                        Text(name)
+                            .font(.system(size: 12, weight: .medium))
+                            .lineLimit(1)
+                            .frame(width: 170, alignment: .leading)
+                        MeterBar(fraction: Double(bucket.freshTokens ?? 0) / max(maxFresh, 1),
+                                 tint: tint, height: 6)
+                        Text(bucket.freshTokens.map(UsageTotals.compact) ?? "—")
+                            .font(.system(size: 11.5))
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                            .frame(width: 58, alignment: .trailing)
+                        Text(bucket.costText)
+                            .font(.system(size: 11.5, weight: .medium))
+                            .monospacedDigit()
+                            .frame(width: 78, alignment: .trailing)
+                    }
+                    .padding(.vertical, 6.5)
+                    if index < sorted.count - 1 { Divider().opacity(0.5) }
                 }
             }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 4)
+            .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -310,44 +392,71 @@ struct LimitsPane: View {
     @State private var showStale = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Toggle("Show stale accounts", isOn: $showStale)
-                .toggleStyle(.checkbox)
-            if case .connected(let snapshot) = glance.phase {
-                let limits = snapshot.glance.limits.filter { showStale || $0.stale != true }
-                if limits.isEmpty {
-                    Text("No live limit readings.").foregroundStyle(.secondary)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack {
+                    SectionCaption(text: "Provider limits")
+                    Spacer()
+                    Toggle("Show stale accounts", isOn: $showStale)
+                        .toggleStyle(.checkbox)
+                        .font(.system(size: 11))
                 }
-                ForEach(Array(limits.enumerated()), id: \.offset) { _, limit in
-                    GroupBox(limit.client ?? "?") {
-                        VStack(alignment: .leading, spacing: 6) {
-                            ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
-                                if let used = window.usedPercent {
-                                    HStack(spacing: 8) {
-                                        Text(window.kind ?? "")
-                                            .frame(width: 30, alignment: .leading)
-                                            .foregroundStyle(.secondary)
-                                        ProgressView(value: min(max(used / 100.0, 0), 1))
-                                            .tint(used >= 90 ? .red : used >= 70 ? .orange : .green)
-                                        Text(String(format: "%.0f%%", used))
-                                            .font(.callout.monospacedDigit())
-                                            .frame(width: 44, alignment: .trailing)
-                                        if limit.stale == true {
-                                            Text("stale").font(.caption2).foregroundStyle(.secondary)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                if case .connected(let snapshot) = glance.phase {
+                    let limits = snapshot.glance.limits.filter { showStale || $0.stale != true }
+                    if limits.isEmpty {
+                        Text("No live limit readings.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(Array(limits.enumerated()), id: \.offset) { _, limit in
+                        limitCard(limit)
+                    }
+                } else {
+                    Text("Daemon not connected.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private func limitCard(_ limit: LimitEntry) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 7) {
+                StatusDot(color: Theme.clientColor(limit.client))
+                Text(limit.client ?? "?")
+                    .font(.system(size: 12.5, weight: .semibold))
+                if let plan = limit.planType {
+                    Chip(text: plan, tint: Theme.clientColor(limit.client))
+                }
+                if limit.stale == true {
+                    Chip(text: "stale", tint: .secondary)
+                }
+                Spacer()
+            }
+            ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
+                if let used = window.usedPercent {
+                    HStack(spacing: 10) {
+                        Text(window.kind ?? "")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 26, alignment: .leading)
+                        MeterBar(fraction: used / 100.0,
+                                 tint: Theme.limitColor(usedPercent: used), height: 7)
+                        Text(String(format: "%.0f%%", used))
+                            .font(.system(size: 11.5, weight: .medium))
+                            .monospacedDigit()
+                            .frame(width: 36, alignment: .trailing)
+                        Text(Theme.resetsIn(window.resetsAt).map { "resets in \($0)" } ?? "")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.tertiary)
+                            .frame(width: 96, alignment: .trailing)
                     }
                 }
-            } else {
-                Text("Daemon not connected.").foregroundStyle(.secondary)
             }
-            Spacer()
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 }

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -1,0 +1,353 @@
+import SwiftUI
+
+// The full window: Sessions (list → detail), Usage (by agent / by model),
+// Limits. The menu bar is the glance; this is where details live.
+
+struct MainWindow: View {
+    @EnvironmentObject var dashboard: DashboardStore
+    @EnvironmentObject var glance: GlanceState
+    @EnvironmentObject var selection: AppSelection
+
+    var body: some View {
+        NavigationSplitView {
+            List(MainPane.allCases, selection: paneBinding) { pane in
+                Text(pane.rawValue).tag(pane)
+            }
+            .navigationSplitViewColumnWidth(min: 140, ideal: 150)
+        } detail: {
+            Group {
+                switch selection.pane {
+                case .sessions: SessionsPane()
+                case .usage: UsagePane()
+                case .limits: LimitsPane()
+                }
+            }
+        }
+        .frame(minWidth: 860, minHeight: 520)
+        .task { await dashboard.refresh() }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                if dashboard.isRefreshing {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Button {
+                        Task { await dashboard.refresh() }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .help("Refresh")
+                }
+            }
+        }
+    }
+
+    private var paneBinding: Binding<MainPane?> {
+        Binding(
+            get: { selection.pane },
+            set: { selection.pane = $0 ?? .sessions }
+        )
+    }
+}
+
+// MARK: - Sessions
+
+struct SessionsPane: View {
+    @EnvironmentObject var dashboard: DashboardStore
+    @EnvironmentObject var selection: AppSelection
+
+    var body: some View {
+        HSplitView {
+            List(dashboard.sessions, selection: $selection.sessionId) { entry in
+                SessionRow(entry: entry).tag(entry.id)
+            }
+            .frame(minWidth: 380)
+            detail
+                .frame(minWidth: 340, maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .overlay(alignment: .bottom) {
+            if let error = dashboard.errorText {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(6)
+                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 6))
+                    .padding(.bottom, 8)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if let id = selection.sessionId,
+           let entry = dashboard.sessions.first(where: { $0.id == id }) {
+            SessionDetail(entry: entry)
+        } else {
+            ContentUnavailableView(
+                "Select a session",
+                systemImage: "list.bullet.rectangle",
+                description: Text(footerText)
+            )
+        }
+    }
+
+    private var footerText: String {
+        if let total = dashboard.totalSessions {
+            return "\(dashboard.sessions.count) root sessions shown · \(total) sessions in the store"
+        }
+        return ""
+    }
+}
+
+struct SessionRow: View {
+    let entry: SessionEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(entry.displayTitle)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+                if let ts = entry.lastActivityAt {
+                    Text(Date(timeIntervalSince1970: ts), style: .relative)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            HStack(spacing: 8) {
+                Text(entry.client)
+                    .font(.caption)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(.quaternary, in: Capsule())
+                if let project = entry.project {
+                    Text(project).font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                if let tokens = entry.usage?.freshTokens {
+                    Text(UsageTotals.compact(tokens) + " tok")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                Text(entry.usage?.costText ?? "—")
+                    .font(.caption.monospacedDigit())
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct SessionDetail: View {
+    let entry: SessionEntry
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.displayTitle).font(.title3.bold())
+                    HStack(spacing: 10) {
+                        Text(entry.client)
+                        if let project = entry.project { Text(project) }
+                        if let duration = entry.durationSeconds {
+                            Text(Self.duration(duration))
+                        }
+                        if let models = entry.observedModels, !models.isEmpty {
+                            Text(models.joined(separator: ", "))
+                        }
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
+                if let usage = entry.usage {
+                    GroupBox("Usage") {
+                        Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 4) {
+                            GridRow {
+                                stat("fresh", usage.freshTokens)
+                                stat("cache read", usage.cacheReadTokens)
+                                stat("cache write", usage.cacheCreationTokens)
+                            }
+                            GridRow {
+                                stat("total", usage.totalTokens)
+                                statText("turns", usage.turnsTotal.map(String.init) ?? "—")
+                                statText("cost", usage.costText)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+
+                if let note = entry.usageNote {
+                    Text(note).font(.caption).foregroundStyle(.secondary)
+                }
+
+                if let items = entry.work?.items, !items.isEmpty {
+                    GroupBox("Work") {
+                        VStack(alignment: .leading, spacing: 5) {
+                            ForEach(items) { item in
+                                HStack(spacing: 6) {
+                                    Text(item.statusGlyph)
+                                        .foregroundStyle(item.latestStatus == "blocked" ? .orange : .secondary)
+                                    Text(item.title ?? item.sectionId ?? "untitled")
+                                        .lineLimit(2)
+                                    Spacer()
+                                    if let evidence = item.evidenceStatus {
+                                        Text(evidence)
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+
+                if let join = entry.join {
+                    GroupBox("Attribution") {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(join.state ?? "unknown").font(.callout)
+                            if let reason = join.reason {
+                                Text(reason).font(.caption).foregroundStyle(.secondary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+
+                if let related = entry.related, (related.childSessionCount ?? 0) > 0 {
+                    GroupBox("Subagents") {
+                        HStack {
+                            Text("\(related.childSessionCount ?? 0) child sessions")
+                            Spacer()
+                            if let fresh = related.childrenUsage?.freshTokens {
+                                Text(UsageTotals.compact(fresh) + " fresh tok")
+                                    .font(.callout.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func stat(_ label: String, _ value: Int?) -> some View {
+        statText(label, value.map(UsageTotals.compact) ?? "—")
+    }
+
+    private func statText(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(label).font(.caption2).foregroundStyle(.secondary)
+            Text(value).font(.body.monospacedDigit())
+        }
+    }
+
+    static func duration(_ seconds: Double) -> String {
+        let total = Int(seconds)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        if hours > 0 { return "\(hours)h \(minutes)m" }
+        return "\(minutes)m"
+    }
+}
+
+// MARK: - Usage
+
+struct UsagePane: View {
+    @EnvironmentObject var dashboard: DashboardStore
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let usage = dashboard.usage {
+                    GroupBox("By agent · last 30 days") {
+                        bucketTable(usage.byClient, nameOf: { $0.client ?? "?" })
+                    }
+                    GroupBox("By model · last 30 days") {
+                        bucketTable(usage.byModel, nameOf: { "\($0.model ?? "?")  (\($0.client ?? "?"))" })
+                    }
+                } else {
+                    ContentUnavailableView("No usage loaded", systemImage: "chart.bar")
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func bucketTable(_ buckets: [UsageBucket], nameOf: @escaping (UsageBucket) -> String) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
+            GridRow {
+                Text("").gridColumnAlignment(.leading)
+                Text("sessions").font(.caption).foregroundStyle(.secondary)
+                Text("fresh tok").font(.caption).foregroundStyle(.secondary)
+                Text("cache read").font(.caption).foregroundStyle(.secondary)
+                Text("cost").font(.caption).foregroundStyle(.secondary)
+            }
+            ForEach(buckets.sorted { ($0.freshTokens ?? 0) > ($1.freshTokens ?? 0) }) { bucket in
+                GridRow {
+                    Text(nameOf(bucket)).lineLimit(1)
+                    Text(bucket.sessions.map(String.init) ?? "—")
+                        .font(.body.monospacedDigit())
+                    Text(bucket.freshTokens.map(UsageTotals.compact) ?? "—")
+                        .font(.body.monospacedDigit())
+                    Text(bucket.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                        .font(.body.monospacedDigit())
+                    Text(bucket.costText)
+                        .font(.body.monospacedDigit())
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Limits
+
+struct LimitsPane: View {
+    @EnvironmentObject var glance: GlanceState
+    @State private var showStale = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle("Show stale accounts", isOn: $showStale)
+                .toggleStyle(.checkbox)
+            if case .connected(let snapshot) = glance.phase {
+                let limits = snapshot.glance.limits.filter { showStale || $0.stale != true }
+                if limits.isEmpty {
+                    Text("No live limit readings.").foregroundStyle(.secondary)
+                }
+                ForEach(Array(limits.enumerated()), id: \.offset) { _, limit in
+                    GroupBox(limit.client ?? "?") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
+                                if let used = window.usedPercent {
+                                    HStack(spacing: 8) {
+                                        Text(window.kind ?? "")
+                                            .frame(width: 30, alignment: .leading)
+                                            .foregroundStyle(.secondary)
+                                        ProgressView(value: min(max(used / 100.0, 0), 1))
+                                            .tint(used >= 90 ? .red : used >= 70 ? .orange : .green)
+                                        Text(String(format: "%.0f%%", used))
+                                            .font(.callout.monospacedDigit())
+                                            .frame(width: 44, alignment: .trailing)
+                                        if limit.stale == true {
+                                            Text("stale").font(.caption2).foregroundStyle(.secondary)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            } else {
+                Text("Daemon not connected.").foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}

--- a/apps/agentacct/Sources/agentacct/MenuContent.swift
+++ b/apps/agentacct/Sources/agentacct/MenuContent.swift
@@ -1,13 +1,18 @@
 import SwiftUI
 
-// The dropdown: usage · limits · plan · recent sessions, in that order.
-// Honesty rules carried over from the TUI: costs are complete-$ / partial-~$ /
-// em-dash (never a fabricated $0), plan shares only when calibrated, statuses
-// use the blocked > handed_off > in_progress > completed reduction the glance
-// already applied server-side.
+// The dropdown: a glance, not a workspace. Usage · limits · recent sessions;
+// anything deeper (session detail, per-agent breakdowns) opens the full
+// window. Honesty rules carried from the TUI: costs are complete-$ /
+// partial-~$ / em-dash (never a fabricated $0), plan shares only when
+// calibrated, statuses use the server-side blocked > handed_off >
+// in_progress > completed reduction. Stale limit accounts are hidden here
+// (the full window has the toggle).
 
 struct MenuContent: View {
-    @ObservedObject var state: GlanceState
+    @EnvironmentObject var state: GlanceState
+    @EnvironmentObject var dashboard: DashboardStore
+    @EnvironmentObject var selection: AppSelection
+    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -50,7 +55,6 @@ struct MenuContent: View {
     private func connectedView(snapshot: GlanceSnapshot) -> some View {
         let glance = snapshot.glance
 
-        // Usage windows (today / 7d / 30d)
         VStack(alignment: .leading, spacing: 4) {
             Text("Usage").font(.headline)
             ForEach(glance.usage.windows.filter { $0.label != "all time" }, id: \.label) { window in
@@ -69,11 +73,12 @@ struct MenuContent: View {
             }
         }
 
-        if !glance.limits.isEmpty {
+        let liveLimits = glance.limits.filter { $0.stale != true }
+        if !liveLimits.isEmpty {
             Divider()
             VStack(alignment: .leading, spacing: 6) {
                 Text("Limits").font(.headline)
-                ForEach(Array(glance.limits.enumerated()), id: \.offset) { _, limit in
+                ForEach(Array(liveLimits.enumerated()), id: \.offset) { _, limit in
                     limitRows(limit)
                 }
             }
@@ -105,11 +110,6 @@ struct MenuContent: View {
                     Text(String(format: "%.0f%%", used))
                         .font(.callout.monospacedDigit())
                         .frame(width: 44, alignment: .trailing)
-                    if limit.stale == true {
-                        Text("stale")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
                 }
                 .font(.callout)
             }
@@ -117,21 +117,28 @@ struct MenuContent: View {
     }
 
     private func sessionRow(_ session: RecentSession) -> some View {
-        HStack(spacing: 6) {
-            Text(session.statusGlyph)
-                .frame(width: 14)
-                .foregroundStyle(session.status == "blocked" ? .orange : .secondary)
-            Text(session.title ?? "\(session.client) · \(session.shortSessionId)")
-                .lineLimit(1)
-                .truncationMode(.tail)
-            Spacer()
-            if let pct = session.planPctText {
-                Text(pct)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+        Button {
+            openMain(selecting: "\(session.client)::\(session.sessionId)")
+        } label: {
+            HStack(spacing: 6) {
+                Text(session.statusGlyph)
+                    .frame(width: 14)
+                    .foregroundStyle(session.status == "blocked" ? .orange : .secondary)
+                Text(session.title ?? "\(session.client) · \(session.shortSessionId)")
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+                if let pct = session.planPctText {
+                    Text(pct)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
             }
+            .font(.callout)
+            .contentShape(Rectangle())
         }
-        .font(.callout)
+        .buttonStyle(.plain)
+        .help("Open in the agentacct window")
     }
 
     @ViewBuilder
@@ -145,15 +152,37 @@ struct MenuContent: View {
     }
 
     private var footer: some View {
-        HStack {
-            Button("Refresh") { state.refreshNow() }
+        HStack(spacing: 10) {
+            Button("Open agentacct") { openMain(selecting: nil) }
             Spacer()
+            if state.isRefreshing {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Button {
+                    state.refreshNow()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.plain)
+                .help("Refresh now")
+            }
             if let updated = state.lastUpdated {
-                Text(updated, style: .time)
+                Text(updated, style: .relative)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
             Button("Quit") { NSApplication.shared.terminate(nil) }
         }
+    }
+
+    private func openMain(selecting sessionId: String?) {
+        if let sessionId {
+            selection.pane = .sessions
+            selection.sessionId = sessionId
+        }
+        openWindow(id: "main")
+        NSApp.activate(ignoringOtherApps: true)
+        Task { await dashboard.refresh() }
     }
 }

--- a/apps/agentacct/Sources/agentacct/MenuContent.swift
+++ b/apps/agentacct/Sources/agentacct/MenuContent.swift
@@ -1,12 +1,11 @@
 import SwiftUI
 
-// The dropdown: a glance, not a workspace. Usage · limits · recent sessions;
-// anything deeper (session detail, per-agent breakdowns) opens the full
-// window. Honesty rules carried from the TUI: costs are complete-$ /
+// The dropdown: a glance, not a workspace. A today hero, compact window
+// stats, live limit meters, and root sessions — click anything deep to open
+// the full window. Honesty rules carried from the TUI: costs are complete-$ /
 // partial-~$ / em-dash (never a fabricated $0), plan shares only when
-// calibrated, statuses use the server-side blocked > handed_off >
-// in_progress > completed reduction. Stale limit accounts are hidden here
-// (the full window has the toggle).
+// calibrated, statuses use the server-side reduction. Stale limit accounts
+// are hidden here (the full window has the toggle).
 
 struct MenuContent: View {
     @EnvironmentObject var state: GlanceState
@@ -15,69 +14,98 @@ struct MenuContent: View {
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 12) {
             switch state.phase {
             case .connecting:
-                Text("Connecting to the agentacct daemon…")
-                    .foregroundStyle(.secondary)
+                waitingView("Connecting to the agentacct daemon…")
             case .disconnected(let reason):
                 disconnectedView(reason: reason)
             case .incompatible(let message):
-                Label {
-                    Text(message)
-                } icon: {
-                    Image(systemName: "exclamationmark.triangle")
-                }
-                .foregroundStyle(.orange)
+                Label { Text(message) } icon: { Image(systemName: "exclamationmark.triangle.fill") }
+                    .font(.callout)
+                    .foregroundStyle(Theme.orange)
             case .connected(let snapshot):
                 connectedView(snapshot: snapshot)
             }
-            Divider()
             footer
         }
-        .padding(12)
-        .frame(width: 340)
+        .padding(14)
+        .frame(width: 360)
+    }
+
+    // MARK: states
+
+    private func waitingView(_ text: String) -> some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text(text).foregroundStyle(.secondary)
+        }
+        .font(.callout)
+        .padding(.vertical, 12)
     }
 
     private func disconnectedView(reason: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Label("agentacct daemon not reachable", systemImage: "bolt.slash")
+        VStack(alignment: .leading, spacing: 7) {
+            Label("Daemon not reachable", systemImage: "bolt.slash.fill")
+                .font(.callout.weight(.medium))
                 .foregroundStyle(.secondary)
             Text(reason)
                 .font(.caption)
-                .foregroundStyle(.secondary)
-            Text("Start it with:  agentacct start")
+                .foregroundStyle(.tertiary)
+                .lineLimit(2)
+            Text("agentacct start")
                 .font(.caption.monospaced())
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
         }
+        .padding(.vertical, 6)
     }
+
+    // MARK: connected
 
     @ViewBuilder
     private func connectedView(snapshot: GlanceSnapshot) -> some View {
         let glance = snapshot.glance
+        let windows = Dictionary(uniqueKeysWithValues: glance.usage.windows.map { ($0.label, $0.totals) })
 
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Usage").font(.headline)
-            ForEach(glance.usage.windows.filter { $0.label != "all time" }, id: \.label) { window in
-                HStack {
-                    Text(window.label)
-                        .frame(width: 90, alignment: .leading)
-                        .foregroundStyle(.secondary)
-                    Text(window.totals.tokensText + " tok")
-                        .frame(width: 80, alignment: .trailing)
-                        .font(.body.monospacedDigit())
-                    Spacer()
-                    Text(window.totals.costText)
-                        .font(.body.monospacedDigit())
+        // Hero: today.
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("TODAY")
+                    .font(.system(size: 10, weight: .semibold))
+                    .tracking(0.8)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if state.isRefreshing {
+                    ProgressView().controlSize(.mini)
+                } else if let updated = state.lastUpdated {
+                    Text(updated, style: .relative)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
                 }
-                .font(.callout)
             }
+            Text(windows["today"]?.costText ?? "—")
+                .font(.system(size: 30, weight: .bold, design: .rounded))
+                .monospacedDigit()
+            Text("\(windows["today"]?.tokensText ?? "—") fresh tokens")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+
+        HStack(spacing: 8) {
+            StatTile(label: "7 days",
+                     value: windows["last 7 days"]?.costText ?? "—",
+                     detail: (windows["last 7 days"]?.tokensText).map { "\($0) tok" })
+            StatTile(label: "30 days",
+                     value: windows["last 30 days"]?.costText ?? "—",
+                     detail: (windows["last 30 days"]?.tokensText).map { "\($0) tok" })
         }
 
         let liveLimits = glance.limits.filter { $0.stale != true }
         if !liveLimits.isEmpty {
-            Divider()
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Limits").font(.headline)
+            VStack(alignment: .leading, spacing: 7) {
+                SectionCaption(text: "Limits")
                 ForEach(Array(liveLimits.enumerated()), id: \.offset) { _, limit in
                     limitRows(limit)
                 }
@@ -85,9 +113,8 @@ struct MenuContent: View {
         }
 
         if !glance.recentSessions.isEmpty {
-            Divider()
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Recent sessions").font(.headline)
+            VStack(alignment: .leading, spacing: 3) {
+                SectionCaption(text: "Sessions")
                 ForEach(Array(glance.recentSessions.prefix(6).enumerated()), id: \.offset) { _, session in
                     sessionRow(session)
                 }
@@ -102,43 +129,47 @@ struct MenuContent: View {
         ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
             if let used = window.usedPercent {
                 HStack(spacing: 8) {
+                    StatusDot(color: Theme.clientColor(limit.client), size: 6)
                     Text("\(limit.client ?? "?") \(window.kind ?? "")")
-                        .frame(width: 110, alignment: .leading)
+                        .font(.system(size: 11.5))
                         .foregroundStyle(.secondary)
-                    ProgressView(value: min(max(used / 100.0, 0), 1))
-                        .tint(used >= 90 ? .red : used >= 70 ? .orange : .green)
+                        .frame(width: 96, alignment: .leading)
+                    MeterBar(fraction: used / 100.0, tint: Theme.limitColor(usedPercent: used))
                     Text(String(format: "%.0f%%", used))
-                        .font(.callout.monospacedDigit())
+                        .font(.system(size: 11.5, weight: .medium))
+                        .monospacedDigit()
+                        .frame(width: 34, alignment: .trailing)
+                    Text(Theme.resetsIn(window.resetsAt) ?? "")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
                         .frame(width: 44, alignment: .trailing)
                 }
-                .font(.callout)
             }
         }
     }
 
     private func sessionRow(_ session: RecentSession) -> some View {
-        Button {
+        MenuHoverButton {
             openMain(selecting: "\(session.client)::\(session.sessionId)")
-        } label: {
-            HStack(spacing: 6) {
-                Text(session.statusGlyph)
-                    .frame(width: 14)
-                    .foregroundStyle(session.status == "blocked" ? .orange : .secondary)
+        } content: {
+            HStack(spacing: 8) {
+                StatusDot(color: Theme.statusColor(session.status), size: 7)
                 Text(session.title ?? "\(session.client) · \(session.shortSessionId)")
+                    .font(.system(size: 12))
                     .lineLimit(1)
                     .truncationMode(.tail)
-                Spacer()
+                Spacer(minLength: 8)
                 if let pct = session.planPctText {
                     Text(pct)
-                        .font(.caption.monospacedDigit())
+                        .font(.system(size: 10.5, weight: .medium))
+                        .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(.quaternary)
             }
-            .font(.callout)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .help("Open in the agentacct window")
     }
 
     @ViewBuilder
@@ -146,34 +177,42 @@ struct MenuContent: View {
         let calibrating = plan.filter { $0.confidence != "calibrated" }.map(\.client)
         if !calibrating.isEmpty {
             Text("plan share calibrating from your own limit history: \(calibrating.joined(separator: ", "))")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+                .font(.system(size: 9.5))
+                .foregroundStyle(.tertiary)
         }
     }
 
     private var footer: some View {
         HStack(spacing: 10) {
-            Button("Open agentacct") { openMain(selecting: nil) }
+            Button {
+                openMain(selecting: nil)
+            } label: {
+                Label("Open agentacct", systemImage: "macwindow")
+                    .font(.system(size: 11.5, weight: .medium))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Theme.blue)
             Spacer()
-            if state.isRefreshing {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Button {
-                    state.refreshNow()
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.plain)
-                .help("Refresh now")
+            Button {
+                state.refreshNow()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 11))
             }
-            if let updated = state.lastUpdated {
-                Text(updated, style: .relative)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Refresh now")
+            Button {
+                NSApplication.shared.terminate(nil)
+            } label: {
+                Image(systemName: "power")
+                    .font(.system(size: 11))
             }
-            Button("Quit") { NSApplication.shared.terminate(nil) }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Quit agentacct")
         }
+        .padding(.top, 2)
     }
 
     private func openMain(selecting sessionId: String?) {
@@ -184,5 +223,27 @@ struct MenuContent: View {
         openWindow(id: "main")
         NSApp.activate(ignoringOtherApps: true)
         Task { await dashboard.refresh() }
+    }
+}
+
+/// A plain row button with a soft hover highlight (menu-item feel).
+struct MenuHoverButton<Content: View>: View {
+    let action: () -> Void
+    @ViewBuilder let content: () -> Content
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            content()
+                .padding(.horizontal, 7)
+                .padding(.vertical, 4.5)
+                .background(
+                    hovering ? AnyShapeStyle(.quaternary.opacity(0.7)) : AnyShapeStyle(.clear),
+                    in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
     }
 }

--- a/apps/agentacct/Sources/agentacct/SnapshotRunner.swift
+++ b/apps/agentacct/Sources/agentacct/SnapshotRunner.swift
@@ -1,0 +1,70 @@
+import AppKit
+import SwiftUI
+
+// Offscreen renders of the real UI with real daemon data. Development tooling:
+// lets the design be SEEN (and reviewed) without driving the live screen.
+
+enum SnapshotRunner {
+    static func run(outputDir: String) {
+        let out = URL(fileURLWithPath: (outputDir as NSString).expandingTildeInPath)
+        try? FileManager.default.createDirectory(at: out, withIntermediateDirectories: true)
+
+        // Pump the main run loop while the MainActor task works — a semaphore
+        // wait on the main thread would deadlock the very actor doing the
+        // rendering.
+        SnapshotMode.enabled = true
+        var finished = false
+        Task { @MainActor in
+            defer { finished = true }
+            do {
+                let snapshot = try await GlanceClient().fetch()
+                let glance = GlanceState(preloaded: snapshot)
+                let dashboard = DashboardStore()
+                await dashboard.refresh()
+                let selection = AppSelection()
+                selection.sessionId = dashboard.sessions.first?.id
+
+                for pane in MainPane.allCases {
+                    selection.pane = pane
+                    let window = MainWindow()
+                        .environmentObject(glance)
+                        .environmentObject(dashboard)
+                        .environmentObject(selection)
+                        .frame(width: 1120, height: 680)
+                    try render(window, to: out.appendingPathComponent("window-\(pane.rawValue.lowercased()).png"))
+                }
+
+                let menu = MenuContent()
+                    .environmentObject(glance)
+                    .environmentObject(dashboard)
+                    .environmentObject(selection)
+                    .background(.regularMaterial)
+                    .frame(width: 360)
+                    .preferredColorScheme(.dark)
+                try render(menu, to: out.appendingPathComponent("menu.png"))
+                print("snapshots written to \(out.path)")
+            } catch {
+                FileHandle.standardError.write(Data("snapshot failed: \(error)\n".utf8))
+                exit(1)
+            }
+        }
+        while !finished {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        exit(0)
+    }
+
+    @MainActor
+    private static func render(_ view: some View, to url: URL) throws {
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        guard let cgImage = renderer.cgImage else {
+            throw NSError(domain: "snapshot", code: 1, userInfo: [NSLocalizedDescriptionKey: "render produced no image"])
+        }
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        guard let png = rep.representation(using: .png, properties: [:]) else {
+            throw NSError(domain: "snapshot", code: 2, userInfo: [NSLocalizedDescriptionKey: "png encode failed"])
+        }
+        try png.write(to: url)
+    }
+}

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -4,7 +4,34 @@ import SwiftUI
 // theme. Accents carry the brand; surfaces stay adaptive (light/dark) via
 // system materials so the app always looks native.
 
+enum Fmt {
+    static let usd: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        formatter.groupingSeparator = ","
+        formatter.usesGroupingSeparator = true
+        return formatter
+    }()
+
+    static func dollars(_ value: Double, prefix: String = "$") -> String {
+        prefix + (usd.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value))
+    }
+}
+
 enum Theme {
+    // The committed dark surface system (Tokyo Night storm): the window owns
+    // its identity like the TUI does, instead of dressing up system chrome.
+    static let bg = Color(red: 0.086, green: 0.086, blue: 0.118)        // #16161e
+    static let surface = Color(red: 0.102, green: 0.106, blue: 0.149)   // #1a1b26
+    static let card = Color(red: 0.122, green: 0.137, blue: 0.208)      // #1f2335
+    static let cardAlt = Color(red: 0.141, green: 0.157, blue: 0.231)   // #24283b
+    static let border = Color(red: 0.161, green: 0.180, blue: 0.259)    // #292e42
+    static let text = Color(red: 0.753, green: 0.792, blue: 0.961)      // #c0caf5
+    static let textMuted = Color(red: 0.471, green: 0.487, blue: 0.600) // #787c99
+    static let textFaint = Color(red: 0.337, green: 0.371, blue: 0.537) // #565f89
+
     // Tokyo Night accents (shared identity with `agentacct tui`).
     static let blue = Color(red: 0.478, green: 0.635, blue: 0.969)     // #7aa2f7
     static let purple = Color(red: 0.733, green: 0.604, blue: 0.969)   // #bb9af7
@@ -142,5 +169,26 @@ struct SectionCaption: View {
             .font(.system(size: 10, weight: .semibold))
             .tracking(0.8)
             .foregroundStyle(.secondary)
+    }
+}
+
+
+// MARK: - Snapshot support
+
+/// Offscreen ImageRenderer can't lay out ScrollViews/lazy stacks; snapshot
+/// mode swaps them for plain containers so renders match the live app.
+enum SnapshotMode {
+    nonisolated(unsafe) static var enabled = false
+}
+
+struct ScrollBox<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        if SnapshotMode.enabled {
+            content().frame(maxHeight: .infinity, alignment: .top)
+        } else {
+            ScrollView(showsIndicators: false) { content() }
+        }
     }
 }

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+// The agentacct visual system — the native sibling of the TUI's Tokyo Night
+// theme. Accents carry the brand; surfaces stay adaptive (light/dark) via
+// system materials so the app always looks native.
+
+enum Theme {
+    // Tokyo Night accents (shared identity with `agentacct tui`).
+    static let blue = Color(red: 0.478, green: 0.635, blue: 0.969)     // #7aa2f7
+    static let purple = Color(red: 0.733, green: 0.604, blue: 0.969)   // #bb9af7
+    static let green = Color(red: 0.620, green: 0.808, blue: 0.416)    // #9ece6a
+    static let orange = Color(red: 0.878, green: 0.686, blue: 0.408)   // #e0af68
+    static let red = Color(red: 0.969, green: 0.463, blue: 0.557)      // #f7768e
+    static let cyan = Color(red: 0.490, green: 0.812, blue: 1.0)       // #7dcfff
+
+    static func clientColor(_ client: String?) -> Color {
+        switch client {
+        case "claude-code": return blue
+        case "codex": return green
+        case "cursor": return orange
+        case "hermes": return purple
+        case "opencode": return cyan
+        case "openclaw": return red
+        default: return .secondary.opacity(0.8)
+        }
+    }
+
+    static func statusColor(_ status: String?) -> Color {
+        switch status {
+        case "blocked": return orange
+        case "handed_off": return purple
+        case "in_progress", "started", "checkpoint": return blue
+        case "completed": return green
+        default: return .secondary.opacity(0.5)
+        }
+    }
+
+    static func limitColor(usedPercent: Double) -> Color {
+        if usedPercent >= 90 { return red }
+        if usedPercent >= 70 { return orange }
+        return green
+    }
+
+    static func resetsIn(_ resetsAt: Double?, now: Date = Date()) -> String? {
+        guard let resetsAt else { return nil }
+        let delta = resetsAt - now.timeIntervalSince1970
+        guard delta > 0 else { return nil }
+        let total = Int(delta)
+        let days = total / 86400
+        let hours = (total % 86400) / 3600
+        let minutes = (total % 3600) / 60
+        if days > 0 { return "\(days)d \(hours)h" }
+        if hours > 0 { return "\(hours)h \(minutes)m" }
+        return "\(minutes)m"
+    }
+}
+
+// MARK: - Reusable components
+
+/// A caption + big monospaced value, on a soft card.
+struct StatTile: View {
+    let label: String
+    let value: String
+    var detail: String? = nil
+    var accent: Color = .primary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label.uppercased())
+                .font(.system(size: 9.5, weight: .semibold))
+                .tracking(0.6)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 17, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(accent)
+            if let detail {
+                Text(detail)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+    }
+}
+
+/// A slim rounded meter (limits, shares).
+struct MeterBar: View {
+    let fraction: Double
+    var tint: Color
+    var height: CGFloat = 5
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(.quaternary.opacity(0.6))
+                Capsule()
+                    .fill(tint.gradient)
+                    .frame(width: max(height, proxy.size.width * min(max(fraction, 0), 1)))
+            }
+        }
+        .frame(height: height)
+    }
+}
+
+/// A small tinted label chip.
+struct Chip: View {
+    let text: String
+    var tint: Color = .secondary
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 10, weight: .medium))
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2.5)
+            .background(tint.opacity(0.16), in: Capsule())
+            .foregroundStyle(tint)
+    }
+}
+
+/// A colored status dot.
+struct StatusDot: View {
+    let color: Color
+    var size: CGFloat = 7
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: size, height: size)
+            .shadow(color: color.opacity(0.5), radius: 2)
+    }
+}
+
+/// Section header caption used across the dropdown and window.
+struct SectionCaption: View {
+    let text: String
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.8)
+            .foregroundStyle(.secondary)
+    }
+}

--- a/apps/agentacct/Sources/agentacct/main.swift
+++ b/apps/agentacct/Sources/agentacct/main.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+// Entry point. `agentacct --snapshot <dir>` renders the window and the menu
+// dropdown to PNGs from live daemon data (offscreen, no screen capture) —
+// design iteration eyes and future README screenshots. Anything else launches
+// the app.
+
+if let flagIndex = CommandLine.arguments.firstIndex(of: "--snapshot"),
+   CommandLine.arguments.count > flagIndex + 1 {
+    SnapshotRunner.run(outputDir: CommandLine.arguments[flagIndex + 1])
+} else {
+    AgentacctApp.main()
+}

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -399,6 +399,17 @@ def _recent_sessions(events: list[dict[str, Any]], *, now: float) -> list[dict[s
             raw_session = str(metadata.get("client_session_id") or event.get("run_id") or "")
             if not client or not raw_session:
                 continue
+            # Child sessions (subagents, workflow agents, replay lanes) FOLD
+            # into their root: a glance list full of a root's own children is
+            # noise, and every child's plan share is attributed to the root
+            # anyway. Kind/parent metadata is authoritative; the ':' suffix
+            # check is the defensive fallback for legacy child lanes.
+            kind = str(metadata.get("client_session_kind") or "root")
+            parent = str(metadata.get("parent_client_session_id") or "")
+            if kind != "root" and parent:
+                raw_session = parent
+            if ":" in raw_session:
+                raw_session = raw_session.split(":", 1)[0]
             # The same id normalization the usage view applies, so these keys
             # join with section session ids and plan_pct session ids.
             session_id = normalized_local_usage_session_id(metadata.get("client"), raw_session)

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -78,6 +78,46 @@ def _record_usage(
     service.record_event(event, trusted_usage_import=True)
 
 
+def _record_child_usage(
+    service: SentinelService,
+    *,
+    client: str,
+    session_id: str,
+    parent_session_id: str,
+    updated_at: float,
+) -> None:
+    event = ClientUsageEvent(
+        client=client,
+        client_session_id=session_id,
+        client_session_kind="child",
+        parent_client_session_id=parent_session_id,
+        source_path=Path(f"/tmp/{client}/{session_id}.jsonl"),
+        title=None,
+        cwd="/tmp/project",
+        model="claude-opus-4-8",
+        input_tokens=10,
+        output_tokens=10,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name=client,
+        started_at=updated_at,
+        updated_at=updated_at,
+        turn_count=1,
+        usage_row_lane="model:claude-opus-4-8",
+        source_namespace_fingerprint=f"sha256:{client}",
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=20,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    service.record_event(event, trusted_usage_import=True)
+
+
 def _record_7d_limit(service: SentinelService, *, captured: float, pct: float, client: str = "claude-code", index: int = 0) -> None:
     service.record_event({
         "event_id": f"evt_rl_{client}_{index}",
@@ -307,6 +347,50 @@ def test_glance_cache_rebuilds_only_on_event_change(tmp_path, monkeypatch):
     third = api_client.get("/v1/glance", headers=headers).json()
     assert calls["count"] == 2  # new event -> rebuild
     assert third["usage"]["usage_record_count"] == 2
+
+
+def test_recent_sessions_fold_children_into_their_root(tmp_path):
+    """A glance list full of a root's own subagent children is noise: child
+    usage activity folds into the root row (kind/parent metadata first, the
+    ':' suffix as the legacy fallback), keeping the root's recency fresh."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(
+        service,
+        client="claude-code",
+        model="claude-opus-4-8",
+        session_id="root-a",
+        input_tokens=100,
+        output_tokens=100,
+        updated_at=now - 3600,
+    )
+    # A subagent child (own uuid, kind child + parent metadata) more recent
+    # than the root's own activity.
+    _record_child_usage(
+        service,
+        client="claude-code",
+        session_id="11111111-aaaa-bbbb-cccc-222222222222",
+        parent_session_id="root-a",
+        updated_at=now - 60,
+    )
+    # A legacy ':'-suffixed child lane without parent metadata.
+    _record_usage(
+        service,
+        client="claude-code",
+        model="claude-opus-4-8",
+        session_id="root-a:agentstem",
+        input_tokens=5,
+        output_tokens=5,
+        updated_at=now - 30,
+    )
+
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = api_client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"}).json()
+    rows = payload["recent_sessions"]
+    assert [row["session_id"] for row in rows] == ["root-a"]
+    # The root's recency reflects its children's freshest activity.
+    assert rows[0]["last_activity_at"] >= now - 31
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The menu bar is a glance and an entry point; the full window is where details live (owner-directed shape).

## App
- **Full window**: Sessions (root-only list → detail: usage block, work items with check evidence, attribution state, subagent rollup) · Usage by agent / by model (30d cube, shared cost-honesty rule) · Limits with a show-stale toggle.
- **Menu bar**: click a recent session → the window opens on it; refresh spinner + updated-ago; stale accounts hidden in the dropdown.

## Daemon
- `/v1/glance` recent_sessions folds child sessions (subagents / workflow agents / legacy `:` lanes) into their root — the child-noise fix, server-side so every shell benefits. Regression test included.

Addresses the first-feedback list: refresh progress indicator ✅ · stale accounts hidden ✅ · usage by agent ✅ · child-session noise ✅ · session detail lives in the full window ✅.

Verified: swift build clean; full pytest **2869 passed**.