### PR TITLE
feat(api): /v1/sessions lane + shared work-ledger cache + three-state plan payload

### DIFF
--- a/apps/agentacct/Sources/agentacct/GlanceModel.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceModel.swift
@@ -116,6 +116,17 @@ struct LimitWindow: Decodable {
 struct PlanEntry: Decodable {
     let client: String
     let confidence: String
+    /// Three-state display semantic from the daemon: "calibrated",
+    /// "calibrating" (can calibrate, warming up), or "never" (this client's
+    /// meter cannot yield a weekly plan % — codex). Optional so a pre-field
+    /// daemon still decodes; absent means "don't claim calibrating".
+    let calibrationState: String?
+
+    enum CodingKeys: String, CodingKey {
+        case client
+        case confidence
+        case calibrationState = "calibration_state"
+    }
 }
 
 struct RecentSession: Decodable {

--- a/apps/agentacct/Sources/agentacct/MenuContent.swift
+++ b/apps/agentacct/Sources/agentacct/MenuContent.swift
@@ -174,7 +174,10 @@ struct MenuContent: View {
 
     @ViewBuilder
     private func planFootnote(_ plan: [PlanEntry]) -> some View {
-        let calibrating = plan.filter { $0.confidence != "calibrated" }.map(\.client)
+        // Only clients the daemon says are actually warming up. "never"
+        // clients (codex) must not be promised a number that will not arrive,
+        // and an old daemon without the field gets no claim at all.
+        let calibrating = plan.filter { $0.calibrationState == "calibrating" }.map(\.client)
         if !calibrating.isEmpty {
             Text("plan share calibrating from your own limit history: \(calibrating.joined(separator: ", "))")
                 .font(.system(size: 9.5))

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -38,7 +38,13 @@ from .canonical_read import (
 from .capture import CaptureContext, DEFAULT_CAPTURE_REGISTRY, render_hook_manifest
 from .capture.registry import DEFAULT_MAX_PAYLOAD_BYTES
 from .capture_runtime import capture_hook_payload
-from .glance import GLANCE_SCHEMA_VERSION, GlanceCache
+from .glance import GLANCE_SCHEMA_VERSION, GlanceCache, events_fingerprint
+from .v1_sessions import (
+    V1_SESSIONS_SCHEMA_VERSION,
+    V1SessionsCache,
+    build_v1_sessions_view,
+    slice_sessions_payload,
+)
 # Re-exported for compatibility: these names moved verbatim to usage_view (the
 # data-layer split). Rebinding/monkeypatching them on THIS module no longer
 # reaches usage_snapshot/plan_cost/the TUI — patch agentacct.usage_view instead.
@@ -112,7 +118,7 @@ from .usage_cube import (
     usage_bucket_date,
 )
 from .usage_truth import CODEX_REPLAY_QUARANTINE_STATE
-from .work_ledger import _project_identity, _safe_project_label, build_work_ledger
+from .work_ledger import WorkLedgerCache, _project_identity, _safe_project_label, build_work_ledger
 from .work_events import WORK_EVENT_KINDS, WORK_EVENT_STATUSES, WorkEvent
 
 DASHBOARD_USAGE_LIMIT_SESSIONS = 500
@@ -2619,26 +2625,49 @@ def create_local_api_app(
     def _mechanical_projection_envelopes() -> tuple[list[Any], dict[str, int]]:
         return _mechanical_projection_envelopes_for(service, store_dir)
 
-    def _derived_work_ledger() -> dict[str, Any]:
-        mechanical_envelopes, observation_diagnostics = _mechanical_projection_envelopes()
-        session_observations = (
-            build_session_observations(
-                mechanical_envelopes,
-                default_project_label=store_project_label if store_scope == "project" else None,
-                diagnostics=observation_diagnostics,
+    ledger_cache = WorkLedgerCache()
+
+    def _derived_work_ledger(
+        events: list[dict[str, Any]] | None = None,
+        *,
+        fingerprint: int | None = None,
+    ) -> dict[str, Any]:
+        """The derived ledger, fingerprint + TTL cached (see WorkLedgerCache).
+
+        Every ledger-backed route shares one cache: a poll that finds no event
+        change pays one store read + an O(n) hash, never the multi-second
+        rebuild. ``events``/``fingerprint`` may be passed pre-computed by a
+        route that already loaded them (avoids a second store read/hash).
+        """
+
+        if events is None:
+            events = service.list_all_events()
+        if fingerprint is None:
+            fingerprint = events_fingerprint(events)
+        loaded_events = events
+
+        def _build() -> dict[str, Any]:
+            mechanical_envelopes, observation_diagnostics = _mechanical_projection_envelopes()
+            session_observations = (
+                build_session_observations(
+                    mechanical_envelopes,
+                    default_project_label=store_project_label if store_scope == "project" else None,
+                    diagnostics=observation_diagnostics,
+                )
+                if mechanical_envelopes
+                else []
             )
-            if mechanical_envelopes
-            else []
-        )
-        return build_work_ledger(
-            service.list_all_events(),
-            run_reports=_collect_run_reports(limit=100),
-            cost_events=cost_ledger.read_events(),
-            session_observations=session_observations,
-            session_observation_diagnostics=observation_diagnostics,
-            store_project_label=store_project_label,
-            store_scope=store_scope,
-        )
+            return build_work_ledger(
+                loaded_events,
+                run_reports=_collect_run_reports(limit=100),
+                cost_events=cost_ledger.read_events(),
+                session_observations=session_observations,
+                session_observation_diagnostics=observation_diagnostics,
+                store_project_label=store_project_label,
+                store_scope=store_scope,
+            )
+
+        return ledger_cache.ledger(fingerprint, _build)
 
     def _page_data(
         local_usage_preview: list[ClientUsageEvent] | None = None,
@@ -2766,6 +2795,7 @@ def create_local_api_app(
             "schema": "agentacct.v1-version.v1",
             "version": _dashboard_importer_version(),
             "glance_schema": GLANCE_SCHEMA_VERSION,
+            "sessions_schema": V1_SESSIONS_SCHEMA_VERSION,
             "pid": os.getpid(),
             "store_dir": str(store_dir),
             "store_scope": store_scope,
@@ -2784,6 +2814,38 @@ def create_local_api_app(
         _require_v1_token(request)
         events = service.list_all_events()
         return glance_cache.snapshot(events, store_dir=store_dir, version=_dashboard_importer_version())
+
+    v1_sessions_cache = V1SessionsCache()
+
+    @app.get("/v1/sessions")
+    def v1_sessions(
+        request: Request,
+        roots_only: bool = Query(True),
+        limit: int = Query(50, ge=1, le=500),
+        offset: int = Query(0, ge=0),
+    ) -> dict[str, Any]:
+        """The versioned session list for native shells (see agentacct.v1_sessions).
+
+        ``roots_only`` filters BEFORE the recency slice (the "12 root
+        sessions" fix), ``offset``/``limit`` walk the filtered population, and
+        the envelope disclose every cut (totals + ``truncated``). Rows carry
+        per-session weekly-plan shares with children folded into their root
+        (calibrated-or-nothing). Cached like the glance: fingerprint + TTL over
+        the enriched view; the per-request work is a filter + slice.
+        """
+
+        _require_v1_token(request)
+        events = service.list_all_events()
+        fingerprint = events_fingerprint(events)
+        view = v1_sessions_cache.view(
+            fingerprint,
+            lambda: build_v1_sessions_view(
+                _derived_work_ledger(events, fingerprint=fingerprint), events
+            ),
+        )
+        return slice_sessions_payload(
+            view, roots_only=roots_only, limit=limit, offset=offset, generated_at=time.time()
+        )
 
     @app.get("/")
     def index() -> dict[str, Any]:
@@ -2809,6 +2871,7 @@ def create_local_api_app(
                 "/evidence/status",
                 "/v1/version (bearer token from the store's local-api.json)",
                 "/v1/glance (bearer token from the store's local-api.json)",
+                "/v1/sessions (bearer token from the store's local-api.json)",
             ],
         }
 

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -2843,9 +2843,7 @@ def create_local_api_app(
                 _derived_work_ledger(events, fingerprint=fingerprint), events
             ),
         )
-        return slice_sessions_payload(
-            view, roots_only=roots_only, limit=limit, offset=offset, generated_at=time.time()
-        )
+        return slice_sessions_payload(view, roots_only=roots_only, limit=limit, offset=offset)
 
     @app.get("/")
     def index() -> dict[str, Any]:

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -383,6 +383,14 @@ def resolve_fold_top(
         current = parent
 
 
+# Sentinel: a session whose own rows disagree about their source home. Folds
+# into or out of such a session are always refused — the ledger quarantines
+# mixed-source rows the same way (unique-or-quarantine), and any "pick one"
+# rule would make the fold decision depend on event ORDER (round-3
+# adversarial finding: last-non-null-wins flipped folds under reordering).
+_NS_CONFLICT = object()
+
+
 def child_root_plan_fold(
     events: list[dict[str, Any]],
 ) -> dict[tuple[str, str], tuple[str, str]]:
@@ -394,44 +402,67 @@ def child_root_plan_fold(
     and unfoldable rows are absent — a lookup falls through to identity;
     resolve chains with :func:`resolve_fold_top`.
 
-    Fold sources, in authority order: kind/parent metadata on the usage row,
-    then the ``':'`` suffix split for legacy child lanes without parent
-    metadata (not client-gated — a non-claude id containing ':' folds by
-    shape; acceptable while only claude-code carries plan shares, and the
-    sessions lane applies the same rule so the surfaces agree). Either way
-    the fold is namespace-gated (:func:`fold_namespace_compatible`): a parent
-    with NO recorded usage of its own (ghost/orphan) or from a DIFFERENT
-    source home refuses the fold, matching the ledger's refusal — the child
-    stands as its own row instead of sinking its share into a phantom or
-    foreign root.
+    This is the events-only mirror of the ledger's parent join, matched rule
+    by rule so the two /v1 surfaces agree (round-3 adversarial findings):
+
+    * parent ids join RAW (no ``':'`` splitting of a metadata parent id — the
+      rollup joins raw ids; a ``'R:lane'`` parent that is itself a legacy
+      child lane reaches ``R`` through its OWN fold step, gates applied at
+      every hop);
+    * the parent must EXIST on this surface — visible via its own usage or
+      section events. A ghost parent refuses the fold (the child stands as
+      its own row); a sections-only orchestrator counts as existing, exactly
+      as it holds a rollup entry on the sessions lane;
+    * namespaces are unique-or-refuse per session (never "last one wins"),
+      then gated by :func:`fold_namespace_compatible` — same-home evidence or
+      no fold. A session whose rows mix source homes refuses every fold
+      touching it, deterministically, in any event order;
+    * conflicting parent CLAIMS for one child (different rows naming
+      different parents) refuse the fold rather than pick one.
+
+    The ``':'`` suffix fallback applies only to a session with no parent
+    metadata at all (legacy child lanes; not client-gated — acceptable while
+    only claude-code carries plan shares). Residual known divergence, both
+    conservative and sum-preserving: a parent visible ONLY through mechanical
+    observations (no usage, no sections) exists on the sessions lane but not
+    here.
     """
 
     from .client_usage import is_local_usage_import_event
     from .usage_truth import normalized_local_usage_session_id
 
-    ns_by_key: dict[tuple[str, str], str | None] = {}
-    claims: list[tuple[tuple[str, str], tuple[str, str], str | None, str | None]] = []
+    ns_values: dict[tuple[str, str], set[str]] = {}
+    universe: set[tuple[str, str]] = set()
+    # child_key -> {(parent_key, expected_parent_ns)}
+    claims: dict[tuple[str, str], set[tuple[tuple[str, str], str | None]]] = {}
     for event in events:
+        metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+        event_type = str(event.get("event_type") or "")
+        if event_type.startswith("section_"):
+            client = str(metadata.get("client") or event.get("source") or "")
+            session_id = str(metadata.get("client_session_id") or "")
+            if client and session_id:
+                universe.add((client, normalized_local_usage_session_id(metadata.get("client"), session_id)))
+            continue
         if not is_local_usage_import_event(event):
             continue
-        metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         client = str(metadata.get("client") or event.get("source") or "")
         raw_session = str(metadata.get("client_session_id") or event.get("run_id") or "")
         if not client or not raw_session:
             continue
         child_id = normalized_local_usage_session_id(metadata.get("client"), raw_session)
         child_key = (client, child_id)
+        universe.add(child_key)
         own_ns = metadata.get("source_namespace_fingerprint")
-        own_ns = str(own_ns) if own_ns else None
-        if own_ns is not None or child_key not in ns_by_key:
-            ns_by_key[child_key] = own_ns
+        if own_ns:
+            ns_values.setdefault(child_key, set()).add(str(own_ns))
 
         kind = str(metadata.get("client_session_kind") or "root")
         parent = str(metadata.get("parent_client_session_id") or "")
         expected_parent_ns = metadata.get("parent_source_namespace_fingerprint")
         expected_parent_ns = str(expected_parent_ns) if expected_parent_ns else None
         if kind != "root" and parent:
-            folded_raw = parent.split(":", 1)[0] if ":" in parent else parent
+            folded_raw = parent
         elif ":" in raw_session:
             folded_raw = raw_session.split(":", 1)[0]
             expected_parent_ns = None  # legacy lanes carry no parent-home claim
@@ -439,14 +470,32 @@ def child_root_plan_fold(
             continue
         parent_key = (client, normalized_local_usage_session_id(metadata.get("client"), folded_raw))
         if parent_key != child_key:
-            claims.append((child_key, parent_key, own_ns, expected_parent_ns))
+            claims.setdefault(child_key, set()).add((parent_key, expected_parent_ns))
+
+    def _session_ns(key: tuple[str, str]) -> Any:
+        values = ns_values.get(key)
+        if not values:
+            return None
+        if len(values) > 1:
+            return _NS_CONFLICT
+        return next(iter(values))
 
     mapping: dict[tuple[str, str], tuple[str, str]] = {}
-    for child_key, parent_key, child_ns, expected_parent_ns in claims:
-        parent_ns = ns_by_key.get(parent_key)
-        if parent_key not in ns_by_key:
-            continue  # parent has no usage of its own here (ghost/orphan) — no fold
-        if fold_namespace_compatible(child_ns, parent_ns, expected_parent_ns):
+    for child_key, child_claims in claims.items():
+        parent_keys = {parent_key for parent_key, _expected in child_claims}
+        if len(parent_keys) != 1:
+            continue  # conflicting lineage claims — refuse rather than pick one
+        parent_key = next(iter(parent_keys))
+        if parent_key not in universe:
+            continue  # ghost parent — the child stands as its own row
+        child_ns = _session_ns(child_key)
+        parent_ns = _session_ns(parent_key)
+        if child_ns is _NS_CONFLICT or parent_ns is _NS_CONFLICT:
+            continue
+        if all(
+            fold_namespace_compatible(child_ns, parent_ns, expected)
+            for _parent, expected in child_claims
+        ):
             mapping[child_key] = parent_key
     return mapping
 

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -338,6 +338,103 @@ def remove_discovery_file(store_dir: Path | str, *, pid: int | None = None) -> b
 # ---------------------------------------------------------------------------
 
 
+def _fold_root_session_id(metadata: dict[str, Any], raw_session: str) -> str:
+    """The root session id a usage row's session folds into (identity for roots).
+
+    Child sessions (subagents, workflow agents, replay lanes) fold into their
+    root. Kind/parent metadata is authoritative; the ``':'`` suffix split is
+    the defensive fallback for legacy child lanes that carry no parent
+    metadata.
+    """
+
+    kind = str(metadata.get("client_session_kind") or "root")
+    parent = str(metadata.get("parent_client_session_id") or "")
+    folded = raw_session
+    if kind != "root" and parent:
+        folded = parent
+    if ":" in folded:
+        folded = folded.split(":", 1)[0]
+    return folded
+
+
+def child_root_plan_fold(events: list[dict[str, Any]]) -> dict[tuple[str, str], tuple[str, str]]:
+    """``(client, child_session_id) -> (client, root_session_id)`` for usage rows.
+
+    The key space matches :func:`agentacct.plan_cost.session_plan_pcts` (the
+    usage view's normalized session ids), so a per-session plan share can be
+    re-attributed from a child to the root whose row actually shows it. Roots
+    and unfoldable rows are absent — a lookup falls through to identity.
+    """
+
+    from .client_usage import is_local_usage_import_event
+    from .usage_truth import normalized_local_usage_session_id
+
+    mapping: dict[tuple[str, str], tuple[str, str]] = {}
+    for event in events:
+        if not is_local_usage_import_event(event):
+            continue
+        metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+        client = str(metadata.get("client") or event.get("source") or "")
+        raw_session = str(metadata.get("client_session_id") or event.get("run_id") or "")
+        if not client or not raw_session:
+            continue
+        folded_raw = _fold_root_session_id(metadata, raw_session)
+        child_id = normalized_local_usage_session_id(metadata.get("client"), raw_session)
+        root_id = normalized_local_usage_session_id(metadata.get("client"), folded_raw)
+        if child_id != root_id:
+            mapping[(client, child_id)] = (client, root_id)
+    return mapping
+
+
+def fold_plan_pcts_to_roots(
+    session_pcts: dict[tuple[str, str], float],
+    fold_map: dict[tuple[str, str], tuple[str, str]],
+) -> dict[tuple[str, str], float]:
+    """Re-attribute child plan shares onto their roots (sum-preserving).
+
+    A surface that HIDES child sessions must carry their share on the root row
+    it does show — otherwise a workflow-heavy session understates exactly when
+    it matters most. The total across keys is unchanged; a child key vanishes
+    into its root's sum.
+    """
+
+    folded: dict[tuple[str, str], float] = {}
+    for key, pct in session_pcts.items():
+        root_key = fold_map.get(key, key)
+        folded[root_key] = folded.get(root_key, 0.0) + pct
+    return folded
+
+
+def plan_status_and_session_pcts(
+    events: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[tuple[str, str], float]]:
+    """Per-client plan payload entries + calibrated per-session plan shares.
+
+    The calibrated-or-nothing honesty rule is baked in: ``session_pcts`` holds
+    ONLY clients whose estimate is grounded in this account's own recorded
+    limit history, keyed ``(client, session_id)`` so one client's number can
+    never attach to another client's row. Keys are the usage view's normalized
+    session ids, UNFOLDED — apply :func:`fold_plan_pcts_to_roots` on a surface
+    that hides child sessions. Shared by the glance and the /v1 sessions lane
+    so the two can never disagree.
+    """
+
+    from .plan_cost import calibrate_plan_weights, plan_status_entry, session_plan_pcts
+
+    from .usage_snapshot import usage_records
+
+    plan: list[dict[str, Any]] = []
+    session_pcts: dict[tuple[str, str], float] = {}
+    for client in PLAN_CLIENTS:
+        records = usage_records(events, client=client)
+        weights = calibrate_plan_weights(events, client=client, records=records)
+        plan.append(plan_status_entry(weights))
+        if weights.confidence == "calibrated":
+            for session_id, pct in session_plan_pcts(records, weights, client=client).items():
+                session_pcts[(client, session_id)] = pct
+    return plan, session_pcts
+
+
 def _recent_sessions(events: list[dict[str, Any]], *, now: float) -> list[dict[str, Any]]:
     """Recent sessions from the section + usage event streams, newest first.
 
@@ -401,15 +498,9 @@ def _recent_sessions(events: list[dict[str, Any]], *, now: float) -> list[dict[s
                 continue
             # Child sessions (subagents, workflow agents, replay lanes) FOLD
             # into their root: a glance list full of a root's own children is
-            # noise, and every child's plan share is attributed to the root
-            # anyway. Kind/parent metadata is authoritative; the ':' suffix
-            # check is the defensive fallback for legacy child lanes.
-            kind = str(metadata.get("client_session_kind") or "root")
-            parent = str(metadata.get("parent_client_session_id") or "")
-            if kind != "root" and parent:
-                raw_session = parent
-            if ":" in raw_session:
-                raw_session = raw_session.split(":", 1)[0]
+            # noise, and every child's plan share is re-attributed to the root
+            # via fold_plan_pcts_to_roots (same fold rule, one helper).
+            raw_session = _fold_root_session_id(metadata, raw_session)
             # The same id normalization the usage view applies, so these keys
             # join with section session ids and plan_pct session ids.
             session_id = normalized_local_usage_session_id(metadata.get("client"), raw_session)
@@ -461,8 +552,7 @@ def build_glance_snapshot(
     importing this module stays cheap for CLI cold starts and tests.
     """
 
-    from .plan_cost import calibrate_plan_weights, session_plan_pcts
-    from .usage_snapshot import build_live_snapshot, limit_is_stale, usage_records
+    from .usage_snapshot import build_live_snapshot, limit_is_stale
 
     moment = time.time() if now is None else float(now)
     live = build_live_snapshot(events, now=moment)
@@ -478,27 +568,22 @@ def build_glance_snapshot(
         entry["stale"] = limit_is_stale(limit, moment)
         limits.append(entry)
 
-    # Plan calibration per plan-bearing client — the calibrated-or-nothing
-    # honesty rule: per-session percentages exist ONLY when the estimate is
-    # grounded in this account's own recorded limit history. Keyed by
-    # (client, session_id) so one client's number can never attach to another
-    # client's row.
-    plan: list[dict[str, Any]] = []
-    session_pcts: dict[tuple[str, str], float] = {}
-    for client in PLAN_CLIENTS:
-        records = usage_records(events, client=client)
-        weights = calibrate_plan_weights(events, client=client, records=records)
-        plan.append({"client": client, "confidence": weights.confidence})
-        if weights.confidence == "calibrated":
-            for session_id, pct in session_plan_pcts(records, weights, client=client).items():
-                session_pcts[(client, session_id)] = pct
+    # Plan calibration per plan-bearing client (calibrated-or-nothing; see
+    # plan_status_and_session_pcts). The recents list HIDES child sessions
+    # (they fold into their root row), so each root's plan_pct must carry its
+    # children's share too — an unfolded join understates a workflow-heavy
+    # root exactly when it matters most. A child that still appears as its own
+    # row (it records sections but its usage folded away) shows None rather
+    # than a share its root's row already includes.
+    plan, session_pcts = plan_status_and_session_pcts(events)
+    folded_pcts = fold_plan_pcts_to_roots(session_pcts, child_root_plan_fold(events))
 
     recent_sessions = _recent_sessions(events, now=moment)
     for row in recent_sessions:
         # The raw estimate, never rounded here: round(pct, 2) can claim an
         # exact 0 for a nonzero share. Shells format like the TUI does —
         # "≈{pct:.1f}%" with a "<0.1%" band — the payload carries the float.
-        row["plan_pct"] = session_pcts.get((row["client"], row["session_id"]))
+        row["plan_pct"] = folded_pcts.get((row["client"], row["session_id"]))
 
     return {
         "schema": GLANCE_SCHEMA_VERSION,

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -383,7 +383,7 @@ def resolve_fold_top(
         current = parent
 
 
-# Sentinel: a session whose own rows disagree about their source home. Folds
+# Marker value: a session whose own rows disagree about their source home. Folds
 # into or out of such a session are always refused — the ledger quarantines
 # mixed-source rows the same way (unique-or-quarantine), and any "pick one"
 # rule would make the fold decision depend on event ORDER (round-3

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -422,16 +422,24 @@ def child_root_plan_fold(
 
     The ``':'`` suffix fallback applies only to a session with no parent
     metadata at all (legacy child lanes; not client-gated — acceptable while
-    only claude-code carries plan shares). Residual known divergence, both
+    only claude-code carries plan shares). Residual known divergences, all
     conservative and sum-preserving: a parent visible ONLY through mechanical
     observations (no usage, no sections) exists on the sessions lane but not
-    here.
+    here, and a parent POINTER carried only by observation rows is invisible
+    to this events-only pass.
     """
 
     from .client_usage import is_local_usage_import_event
     from .usage_truth import normalized_local_usage_session_id
 
     ns_values: dict[tuple[str, str], set[str]] = {}
+    # Sessions with at least one usage row carrying NO fingerprint. Explicit
+    # alongside missing is identity ambiguity, same as two different values —
+    # the ledger quarantines "source_namespace_missing_vs_explicit" sessions
+    # (the upgrade-boundary store state), and treating the explicit value as
+    # the session's home here folded what the sessions lane quarantines
+    # (round-4 adversarial finding).
+    ns_missing: set[tuple[str, str]] = set()
     universe: set[tuple[str, str]] = set()
     # child_key -> {(parent_key, expected_parent_ns)}
     claims: dict[tuple[str, str], set[tuple[tuple[str, str], str | None]]] = {}
@@ -456,6 +464,8 @@ def child_root_plan_fold(
         own_ns = metadata.get("source_namespace_fingerprint")
         if own_ns:
             ns_values.setdefault(child_key, set()).add(str(own_ns))
+        else:
+            ns_missing.add(child_key)
 
         kind = str(metadata.get("client_session_kind") or "root")
         parent = str(metadata.get("parent_client_session_id") or "")
@@ -475,9 +485,9 @@ def child_root_plan_fold(
     def _session_ns(key: tuple[str, str]) -> Any:
         values = ns_values.get(key)
         if not values:
-            return None
-        if len(values) > 1:
-            return _NS_CONFLICT
+            return None  # no fingerprints at all: a pre-fingerprint session
+        if len(values) > 1 or key in ns_missing:
+            return _NS_CONFLICT  # mixed homes, or explicit-vs-missing ambiguity
         return next(iter(values))
 
     mapping: dict[tuple[str, str], tuple[str, str]] = {}

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -441,8 +441,13 @@ def child_root_plan_fold(
     # (round-4 adversarial finding).
     ns_missing: set[tuple[str, str]] = set()
     universe: set[tuple[str, str]] = set()
-    # child_key -> {(parent_key, expected_parent_ns)}
+    # child_key -> {(parent_key, expected_parent_ns)}. Metadata claims and
+    # ':'-shape claims are collected separately: the shape claim applies only
+    # to a session with NO metadata parent claim at all (per-session, not
+    # per-event — a bare row next to a recorded pointer must not manufacture
+    # a second, conflicting claim; round-5 adversarial finding).
     claims: dict[tuple[str, str], set[tuple[tuple[str, str], str | None]]] = {}
+    shape_claims: dict[tuple[str, str], set[tuple[tuple[str, str], str | None]]] = {}
     for event in events:
         metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
         event_type = str(event.get("event_type") or "")
@@ -473,14 +478,16 @@ def child_root_plan_fold(
         expected_parent_ns = str(expected_parent_ns) if expected_parent_ns else None
         if kind != "root" and parent:
             folded_raw = parent
+            target = claims
         elif ":" in raw_session:
             folded_raw = raw_session.split(":", 1)[0]
             expected_parent_ns = None  # legacy lanes carry no parent-home claim
+            target = shape_claims
         else:
             continue
         parent_key = (client, normalized_local_usage_session_id(metadata.get("client"), folded_raw))
         if parent_key != child_key:
-            claims.setdefault(child_key, set()).add((parent_key, expected_parent_ns))
+            target.setdefault(child_key, set()).add((parent_key, expected_parent_ns))
 
     def _session_ns(key: tuple[str, str]) -> Any:
         values = ns_values.get(key)
@@ -489,6 +496,10 @@ def child_root_plan_fold(
         if len(values) > 1 or key in ns_missing:
             return _NS_CONFLICT  # mixed homes, or explicit-vs-missing ambiguity
         return next(iter(values))
+
+    for child_key, child_shape_claims in shape_claims.items():
+        if child_key not in claims:
+            claims[child_key] = child_shape_claims
 
     mapping: dict[tuple[str, str], tuple[str, str]] = {}
     for child_key, child_claims in claims.items():

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -338,38 +338,79 @@ def remove_discovery_file(store_dir: Path | str, *, pid: int | None = None) -> b
 # ---------------------------------------------------------------------------
 
 
-def _fold_root_session_id(metadata: dict[str, Any], raw_session: str) -> str:
-    """The root session id a usage row's session folds into (identity for roots).
+def fold_namespace_compatible(
+    child_ns: str | None, parent_ns: str | None, expected_parent_ns: str | None
+) -> bool:
+    """The same source-home compatibility rule the ledger's parent join uses
+    (``work_ledger._session_source_parent_compatible``): a child folds into a
+    parent only when both live in the same recorded source home. A mismatch is
+    a cross-home session-id collision — folding would hand one identity's
+    consumption to another identity's row (adversarial-review finding; the
+    ledger refuses the join, and every fold surface must agree with it)."""
 
-    Child sessions (subagents, workflow agents, replay lanes) fold into their
-    root. Kind/parent metadata is authoritative; the ``':'`` suffix split is
-    the defensive fallback for legacy child lanes that carry no parent
-    metadata.
+    if child_ns is None and parent_ns is None:
+        return expected_parent_ns is None
+    if child_ns is None or parent_ns is None or child_ns != parent_ns:
+        return False
+    return expected_parent_ns is None or expected_parent_ns == parent_ns
+
+
+def resolve_fold_top(
+    step: dict[tuple[str, str], tuple[str, str] | None], key: tuple[str, str]
+) -> tuple[str, str]:
+    """The topmost fold target for ``key`` over a single-step fold map.
+
+    Rows normally nest one level; the walk guards hostile chains rather than
+    trusting that. A parent CYCLE (corrupt/hostile client metadata — the
+    ledger guards direct self-parents but not mutual loops) is broken
+    deterministically: every member resolves to the cycle's minimum key, so
+    exactly one member is a root and every share still lands on a visible row
+    (round-2 adversarial finding: an unbroken cycle dropped all members and
+    their shares from the roots page).
     """
 
-    kind = str(metadata.get("client_session_kind") or "root")
-    parent = str(metadata.get("parent_client_session_id") or "")
-    folded = raw_session
-    if kind != "root" and parent:
-        folded = parent
-    if ":" in folded:
-        folded = folded.split(":", 1)[0]
-    return folded
+    seen: list[tuple[str, str]] = [key]
+    seen_set = {key}
+    current = key
+    while True:
+        parent = step.get(current)
+        if parent is None:
+            return current
+        if parent in seen_set:
+            return min(seen[seen.index(parent):])
+        seen.append(parent)
+        seen_set.add(parent)
+        current = parent
 
 
-def child_root_plan_fold(events: list[dict[str, Any]]) -> dict[tuple[str, str], tuple[str, str]]:
-    """``(client, child_session_id) -> (client, root_session_id)`` for usage rows.
+def child_root_plan_fold(
+    events: list[dict[str, Any]],
+) -> dict[tuple[str, str], tuple[str, str]]:
+    """Single-step fold map ``(client, child_session_id) -> (client, parent)``.
 
     The key space matches :func:`agentacct.plan_cost.session_plan_pcts` (the
     usage view's normalized session ids), so a per-session plan share can be
     re-attributed from a child to the root whose row actually shows it. Roots
-    and unfoldable rows are absent — a lookup falls through to identity.
+    and unfoldable rows are absent — a lookup falls through to identity;
+    resolve chains with :func:`resolve_fold_top`.
+
+    Fold sources, in authority order: kind/parent metadata on the usage row,
+    then the ``':'`` suffix split for legacy child lanes without parent
+    metadata (not client-gated — a non-claude id containing ':' folds by
+    shape; acceptable while only claude-code carries plan shares, and the
+    sessions lane applies the same rule so the surfaces agree). Either way
+    the fold is namespace-gated (:func:`fold_namespace_compatible`): a parent
+    with NO recorded usage of its own (ghost/orphan) or from a DIFFERENT
+    source home refuses the fold, matching the ledger's refusal — the child
+    stands as its own row instead of sinking its share into a phantom or
+    foreign root.
     """
 
     from .client_usage import is_local_usage_import_event
     from .usage_truth import normalized_local_usage_session_id
 
-    mapping: dict[tuple[str, str], tuple[str, str]] = {}
+    ns_by_key: dict[tuple[str, str], str | None] = {}
+    claims: list[tuple[tuple[str, str], tuple[str, str], str | None, str | None]] = []
     for event in events:
         if not is_local_usage_import_event(event):
             continue
@@ -378,11 +419,35 @@ def child_root_plan_fold(events: list[dict[str, Any]]) -> dict[tuple[str, str], 
         raw_session = str(metadata.get("client_session_id") or event.get("run_id") or "")
         if not client or not raw_session:
             continue
-        folded_raw = _fold_root_session_id(metadata, raw_session)
         child_id = normalized_local_usage_session_id(metadata.get("client"), raw_session)
-        root_id = normalized_local_usage_session_id(metadata.get("client"), folded_raw)
-        if child_id != root_id:
-            mapping[(client, child_id)] = (client, root_id)
+        child_key = (client, child_id)
+        own_ns = metadata.get("source_namespace_fingerprint")
+        own_ns = str(own_ns) if own_ns else None
+        if own_ns is not None or child_key not in ns_by_key:
+            ns_by_key[child_key] = own_ns
+
+        kind = str(metadata.get("client_session_kind") or "root")
+        parent = str(metadata.get("parent_client_session_id") or "")
+        expected_parent_ns = metadata.get("parent_source_namespace_fingerprint")
+        expected_parent_ns = str(expected_parent_ns) if expected_parent_ns else None
+        if kind != "root" and parent:
+            folded_raw = parent.split(":", 1)[0] if ":" in parent else parent
+        elif ":" in raw_session:
+            folded_raw = raw_session.split(":", 1)[0]
+            expected_parent_ns = None  # legacy lanes carry no parent-home claim
+        else:
+            continue
+        parent_key = (client, normalized_local_usage_session_id(metadata.get("client"), folded_raw))
+        if parent_key != child_key:
+            claims.append((child_key, parent_key, own_ns, expected_parent_ns))
+
+    mapping: dict[tuple[str, str], tuple[str, str]] = {}
+    for child_key, parent_key, child_ns, expected_parent_ns in claims:
+        parent_ns = ns_by_key.get(parent_key)
+        if parent_key not in ns_by_key:
+            continue  # parent has no usage of its own here (ghost/orphan) — no fold
+        if fold_namespace_compatible(child_ns, parent_ns, expected_parent_ns):
+            mapping[child_key] = parent_key
     return mapping
 
 
@@ -390,17 +455,18 @@ def fold_plan_pcts_to_roots(
     session_pcts: dict[tuple[str, str], float],
     fold_map: dict[tuple[str, str], tuple[str, str]],
 ) -> dict[tuple[str, str], float]:
-    """Re-attribute child plan shares onto their roots (sum-preserving).
+    """Re-attribute descendant plan shares onto their topmost roots (sum-preserving).
 
     A surface that HIDES child sessions must carry their share on the root row
     it does show — otherwise a workflow-heavy session understates exactly when
-    it matters most. The total across keys is unchanged; a child key vanishes
-    into its root's sum.
+    it matters most. The total across keys is unchanged; a descendant key
+    vanishes into its root's sum (chains and cycles via
+    :func:`resolve_fold_top`).
     """
 
     folded: dict[tuple[str, str], float] = {}
     for key, pct in session_pcts.items():
-        root_key = fold_map.get(key, key)
+        root_key = resolve_fold_top(fold_map, key)
         folded[root_key] = folded.get(root_key, 0.0) + pct
     return folded
 
@@ -435,7 +501,12 @@ def plan_status_and_session_pcts(
     return plan, session_pcts
 
 
-def _recent_sessions(events: list[dict[str, Any]], *, now: float) -> list[dict[str, Any]]:
+def _recent_sessions(
+    events: list[dict[str, Any]],
+    *,
+    now: float,
+    fold_map: dict[tuple[str, str], tuple[str, str]] | None = None,
+) -> list[dict[str, Any]]:
     """Recent sessions from the section + usage event streams, newest first.
 
     ``status`` is the TUI-parity reduction over each session's PER-SECTION
@@ -448,14 +519,19 @@ def _recent_sessions(events: list[dict[str, Any]], *, now: float) -> list[dict[s
 
     Usage imports advance ``last_activity_at`` (a session burning tokens right
     now stays "recent" even when its last section is hours old) and create
-    status-less rows for clients that never record sections. Deliberately
-    ledger-free: one pass over the already-loaded list; timestamps are
-    hostile-tolerant (never raise).
+    status-less rows for clients that never record sections. Child usage
+    activity folds into the root row through the SAME fold map the plan
+    shares use (``fold_map``, built by :func:`child_root_plan_fold` when not
+    passed) — one fold decision, every use, so a hidden child's activity and
+    its plan share can never land on different rows. Deliberately ledger-free;
+    timestamps are hostile-tolerant (never raise).
     """
 
     from .client_usage import is_local_usage_import_event
     from .usage_truth import normalized_local_usage_session_id
     from .usage_view import _session_activity_time
+
+    fold = child_root_plan_fold(events) if fold_map is None else fold_map
 
     # (client, session) -> {section_id: (created_at, status)} — latest per section.
     sections: dict[tuple[str, str], dict[str, tuple[float, str]]] = {}
@@ -497,14 +573,15 @@ def _recent_sessions(events: list[dict[str, Any]], *, now: float) -> list[dict[s
             if not client or not raw_session:
                 continue
             # Child sessions (subagents, workflow agents, replay lanes) FOLD
-            # into their root: a glance list full of a root's own children is
-            # noise, and every child's plan share is re-attributed to the root
-            # via fold_plan_pcts_to_roots (same fold rule, one helper).
-            raw_session = _fold_root_session_id(metadata, raw_session)
-            # The same id normalization the usage view applies, so these keys
-            # join with section session ids and plan_pct session ids.
+            # into their root through the shared fold map — the same decision
+            # that re-attributes their plan share (fold_plan_pcts_to_roots),
+            # including its refusals (cross-home mismatch, ghost parent).
+            # Normalization first: the map's key space is the usage view's
+            # normalized ids, which is also what joins section session ids
+            # and plan_pct session ids.
             session_id = normalized_local_usage_session_id(metadata.get("client"), raw_session)
-            _touch((client, session_id), _session_activity_time(event))
+            key = resolve_fold_top(fold, (client, session_id))
+            _touch(key, _session_activity_time(event))
 
     def _reduce_status(statuses: set[str]) -> str | None:
         if "blocked" in statuses:
@@ -574,11 +651,13 @@ def build_glance_snapshot(
     # children's share too — an unfolded join understates a workflow-heavy
     # root exactly when it matters most. A child that still appears as its own
     # row (it records sections but its usage folded away) shows None rather
-    # than a share its root's row already includes.
+    # than a share its root's row already includes. ONE fold map drives both
+    # the activity fold and the share fold, so they can never disagree.
     plan, session_pcts = plan_status_and_session_pcts(events)
-    folded_pcts = fold_plan_pcts_to_roots(session_pcts, child_root_plan_fold(events))
+    fold_map = child_root_plan_fold(events)
+    folded_pcts = fold_plan_pcts_to_roots(session_pcts, fold_map)
 
-    recent_sessions = _recent_sessions(events, now=moment)
+    recent_sessions = _recent_sessions(events, now=moment, fold_map=fold_map)
     for row in recent_sessions:
         # The raw estimate, never rounded here: round(pct, 2) can claim an
         # exact 0 for a nonzero share. Shells format like the TUI does —

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -72,6 +72,14 @@ _SCALE_CLAMP = (0.1, 10.0)
 # baseline rather than apply an unreliable (over- or under-stating) scale.
 _TRUSTED_SCALE_BAND = (0.5, 2.5)
 
+# Plan-bearing clients whose meter can actually CALIBRATE to per-session weekly
+# percentages — i.e. a clean weekly-reset cumulative meter. codex's 7-day meter is
+# rolling and opaque (Σdeltas ≫ the window, resets unobservable), so a weekly plan %
+# is undefined for it: it must never be shown as "calibrating", because that promises
+# a number that will never arrive. This is the single source of truth; shells
+# (TUI plan column, glance/app payloads) derive their three-state display from it.
+CALIBRATABLE_CLIENTS = ("claude-code",)
+
 
 @dataclass(frozen=True)
 class PlanWeights:
@@ -333,12 +341,53 @@ def session_plan_pcts(
     return {sid: weights.pct_for_tokens(tokens) for sid, tokens in by_session.items()}
 
 
+def calibration_state(weights: PlanWeights) -> str:
+    """Three-state display semantic for one client's plan estimate.
+
+    ``calibrated`` — per-session percentages are grounded in this account's own
+    recorded limit history and may be shown. ``calibrating`` — the client CAN
+    calibrate but hasn't yet (not enough clean intervals, or the fit fell outside
+    the trusted band); an honest "warming up", not a missing feature.  ``never``
+    — the client's meter cannot yield a weekly plan %% (see
+    :data:`CALIBRATABLE_CLIENTS`); shells must not show "calibrating" for it.
+    """
+
+    if weights.confidence == "calibrated":
+        return "calibrated"
+    return "calibrating" if weights.client in CALIBRATABLE_CLIENTS else "never"
+
+
+def plan_status_entry(weights: PlanWeights) -> dict[str, Any]:
+    """The per-client plan payload entry shared by glance and the /v1 lane.
+
+    Additive superset of the original ``{client, confidence}`` shape: the
+    three-state ``calibration_state`` (so no shell has to hard-code which
+    clients can calibrate), ``calibratable``, and the why-this-number
+    disclosure fields (``basis``/``scale``/``intervals_used``) a detail view
+    renders verbatim. ``scale`` is only meaningful when calibrated; it is
+    reported as-is (1.0 under baseline) with ``confidence`` as its guard.
+    """
+
+    return {
+        "client": weights.client,
+        "confidence": weights.confidence,
+        "calibration_state": calibration_state(weights),
+        "calibratable": weights.client in CALIBRATABLE_CLIENTS,
+        "basis": weights.basis,
+        "scale": weights.scale,
+        "intervals_used": weights.intervals_used,
+    }
+
+
 __all__ = [
     "BASELINE_MODEL_WEIGHTS",
+    "CALIBRATABLE_CLIENTS",
     "PlanWeights",
     "baseline_weight",
     "seven_day_series",
     "calibrate_plan_weights",
+    "calibration_state",
+    "plan_status_entry",
     "session_tokens_by_model",
     "session_plan_pcts",
 ]

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -34,6 +34,7 @@ from textual.screen import Screen
 from textual.theme import Theme
 from textual.widgets import Collapsible, DataTable, Footer, LoadingIndicator, Static
 
+from .plan_cost import CALIBRATABLE_CLIENTS
 from .service import SentinelService
 from .subagent_roles import read_roles_for_children
 from .usage_snapshot import (
@@ -219,11 +220,10 @@ def _session_badge(entry: dict) -> str:
 
 # Clients that have a weekly subscription plan agentacct can estimate against.
 _PLAN_CLIENTS = ("claude-code", "codex")
-# Of those, the ones whose meter can actually calibrate to a per-session weekly %
-# — i.e. a clean weekly-reset cumulative meter. codex's 7-day meter is rolling and
-# opaque (it never yields a stable weekly-reset %), so it never reaches a number and
-# must NOT be shown as "calibrating" (that would promise a value that never arrives).
-_CALIBRATABLE_CLIENTS = ("claude-code",)
+# Of those, the ones whose meter can actually calibrate to a per-session weekly %.
+# The rationale (codex's rolling 7-day meter never yields a weekly-reset %) and the
+# authoritative tuple live in plan_cost; this alias keeps existing call sites.
+_CALIBRATABLE_CLIENTS = CALIBRATABLE_CLIENTS
 
 
 #: Shown in the plan column while a plan-bearing client's estimate is still

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -1,0 +1,267 @@
+"""The ``/v1/sessions`` lane — a stable, versioned session list for native shells.
+
+Contract mirrors ``/v1/glance`` (see :mod:`agentacct.glance`): bearer-gated,
+additive-only within v1 (consumers pin ``schema`` and ignore unknown keys),
+and cheap under polling — the enriched view is cached by events fingerprint +
+TTL; a request that hits the cache pays one envelope slice, never a rebuild.
+
+Why this lane exists next to the legacy ``/sessions`` rollup dump:
+
+* **Curated projection** — a native shell decodes every field it is shown, so
+  this lane serves a deliberate schema (identity, activity, status, usage,
+  work, relations, plan share) rather than "whatever the rollup emits". The
+  rollup's internal plumbing (namespace fingerprints, join-policy bits,
+  grouping keys) stays off the wire.
+* **Server-side roots + pagination** — the "12 root sessions" failure mode:
+  slicing the recency-sorted root+child mix server-side and filtering roots
+  client-side starves the list (one root's subagent children can fill any
+  window). ``roots_only`` filters BEFORE the slice; ``offset``/``limit`` walk
+  the filtered population; ``truncated`` + totals disclose every cut.
+* **Plan share with children folded** — a roots view hides child sessions, so
+  each root row carries its children's weekly-plan share too
+  (:func:`agentacct.glance.fold_plan_pcts_to_roots` rationale). ``plan_pct``
+  is the honest headline (own + children); the split is disclosed alongside.
+
+Pagination is a recency-ordered offset walk: a session landing between two
+polls shifts the window by one — fine for a local UI, disclosed here rather
+than hidden behind a cursor the event log cannot cheaply support.
+"""
+
+from __future__ import annotations
+
+import time
+from threading import Lock
+from typing import Any, Callable
+
+V1_SESSIONS_SCHEMA_VERSION = "agentacct.v1-sessions.v1"
+
+# Same TTL rationale as the glance cache: the view is mostly event-derived, but
+# plan calibration windows are clock-relative (a 21-day fit ages), so an
+# unchanged event list must still refresh eventually.
+V1_SESSIONS_CACHE_MAX_AGE_SECONDS = 60.0
+
+# Session-level status reduction — identical precedence to the glance recents
+# and the TUI badge: blocked > handed_off > in_progress > completed. ``resolved``
+# is a terminal blocker-resolution state and counts as completed.
+_OPEN_ITEM_STATUSES = frozenset({"started", "checkpoint"})
+_DONE_ITEM_STATUSES = frozenset({"completed", "resolved"})
+
+
+def _reduce_work_status(items: Any) -> str | None:
+    """One session badge from its work items' latest statuses.
+
+    A later completed section must never erase a still-open or blocked one —
+    a finished-looking label on unfinished work is exactly the dishonesty
+    class this product exists to fix (same rule as glance._recent_sessions).
+    """
+
+    statuses: set[str] = set()
+    for item in items if isinstance(items, list) else []:
+        if isinstance(item, dict):
+            status = str(item.get("latest_status") or "")
+            if status:
+                statuses.add(status)
+    if "blocked" in statuses:
+        return "blocked"
+    if "handed_off" in statuses:
+        return "handed_off"
+    if statuses & _OPEN_ITEM_STATUSES:
+        return "in_progress"
+    if statuses & _DONE_ITEM_STATUSES:
+        return "completed"
+    return None
+
+
+def _parent_key(entry: dict[str, Any]) -> tuple[str, str] | None:
+    """``(client, parent_session_id)`` for a child entry, else None."""
+
+    related = entry.get("related")
+    parent = related.get("parent") if isinstance(related, dict) else None
+    if not isinstance(parent, dict):
+        return None
+    parent_id = str(parent.get("client_session_id") or "")
+    if not parent_id:
+        return None
+    return (str(entry.get("client") or ""), parent_id)
+
+
+def _project_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """The curated wire row for one rollup entry (plan fields joined later).
+
+    Blocks the app renders (``usage``/``join``/``work``/``related``) pass
+    through verbatim — they are already-built read models with their own
+    honesty semantics (None-not-zero costs, evidence enums); re-projecting
+    them here would just be a second place for those rules to drift.
+    """
+
+    work = entry.get("work") if isinstance(entry.get("work"), dict) else {}
+    # Title fallback chain, mirroring the glance: the client's own transcript
+    # title when it recorded one, else the most recently started work item's
+    # title (a section-only session still deserves a human label).
+    title = entry.get("client_session_title")
+    if not title:
+        items = work.get("items") if isinstance(work.get("items"), list) else []
+        for item in reversed(items):
+            if isinstance(item, dict) and item.get("title"):
+                title = item["title"]
+                break
+    return {
+        "session_key": entry.get("session_key"),
+        "client": entry.get("client"),
+        "client_session_id": entry.get("client_session_id"),
+        "client_session_id_short": entry.get("client_session_id_short"),
+        "session_kind": entry.get("session_kind"),
+        "title": title,
+        "project": entry.get("project"),
+        "project_source": entry.get("project_source"),
+        "status": _reduce_work_status(work.get("items")),
+        "first_activity_at": entry.get("first_activity_at"),
+        "last_activity_at": entry.get("last_activity_at"),
+        "duration_seconds": entry.get("duration_seconds"),
+        "instrumentation_state": entry.get("instrumentation_state"),
+        "instrumentation_state_basis": entry.get("instrumentation_state_basis"),
+        "instrumentation_installed_at": entry.get("instrumentation_installed_at"),
+        "observed_models": entry.get("observed_models"),
+        "usage": entry.get("usage"),
+        "usage_note": entry.get("usage_note"),
+        "join": entry.get("join"),
+        "work": entry.get("work"),
+        "related": entry.get("related"),
+        "plan_pct_own": None,
+        "plan_pct_children": None,
+        "plan_pct": None,
+    }
+
+
+def build_v1_sessions_view(ledger: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+    """The cacheable enriched view: every rollup entry projected + plan-joined.
+
+    Unfiltered and unsliced so one build serves any ``roots_only``/paging
+    combination. Plan shares are the calibrated-or-nothing per-session
+    percentages; a root's ``plan_pct`` sums its own share and its children's
+    (looked up through the rollup's own parent linkage — the ledger is the
+    authority on who is whose child on this surface), so hiding the children
+    never hides their weekly-plan consumption. Raw floats, never rounded here
+    (shells format like the TUI: ``≈{pct:.1f}%`` with a ``<0.1%`` band).
+    """
+
+    from .glance import plan_status_and_session_pcts
+
+    rollup = ledger.get("session_rollup") if isinstance(ledger, dict) else {}
+    entries = rollup.get("sessions") if isinstance(rollup, dict) else []
+    entries = [entry for entry in entries if isinstance(entry, dict)] if isinstance(entries, list) else []
+
+    plan, session_pcts = plan_status_and_session_pcts(events)
+
+    rows: list[dict[str, Any]] = []
+    own_pct_by_key: dict[tuple[str, str], float] = {}
+    children_pct_by_parent: dict[tuple[str, str], float] = {}
+    for entry in entries:
+        key = (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
+        own = session_pcts.get(key)
+        if own is not None:
+            own_pct_by_key[key] = own
+            parent = _parent_key(entry)
+            if parent is not None:
+                children_pct_by_parent[parent] = children_pct_by_parent.get(parent, 0.0) + own
+
+    root_count = 0
+    for entry in entries:
+        row = _project_entry(entry)
+        key = (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
+        is_root = _parent_key(entry) is None
+        if is_root:
+            root_count += 1
+        own = own_pct_by_key.get(key)
+        children = children_pct_by_parent.get(key)
+        row["plan_pct_own"] = own
+        row["plan_pct_children"] = children
+        if own is not None or children is not None:
+            row["plan_pct"] = (own or 0.0) + (children or 0.0)
+        row["is_root"] = is_root
+        rows.append(row)
+
+    return {
+        "rows": rows,
+        "plan": plan,
+        "total_sessions": len(rows),
+        "total_root_sessions": root_count,
+    }
+
+
+def slice_sessions_payload(
+    view: dict[str, Any],
+    *,
+    roots_only: bool,
+    limit: int,
+    offset: int,
+    generated_at: float,
+) -> dict[str, Any]:
+    """The wire envelope for one request — a filter + slice over the cached view.
+
+    Every cut is disclosed: ``total_sessions``/``total_root_sessions`` describe
+    the full store, ``filtered_total`` the population the offset/limit walk,
+    and ``truncated`` says whether rows exist beyond this page — a consumer can
+    never mistake a page for the whole population.
+    """
+
+    rows = view.get("rows") or []
+    pool = [row for row in rows if row.get("is_root")] if roots_only else list(rows)
+    page = pool[offset : offset + limit]
+    # ``is_root`` is view-internal bookkeeping (the wire has related.parent);
+    # strip it without mutating the cached rows.
+    page = [{key: value for key, value in row.items() if key != "is_root"} for row in page]
+    return {
+        "schema": V1_SESSIONS_SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "total_sessions": view.get("total_sessions"),
+        "total_root_sessions": view.get("total_root_sessions"),
+        "filtered_total": len(pool),
+        "roots_only": roots_only,
+        "offset": offset,
+        "limit": limit,
+        "returned": len(page),
+        "truncated": offset + len(page) < len(pool),
+        "plan": view.get("plan"),
+        "sessions": page,
+    }
+
+
+class V1SessionsCache:
+    """Fingerprint + TTL cache for the enriched view (GlanceCache pattern).
+
+    Same concurrency posture: the cached value is one atomic tuple assignment,
+    racing rebuilds waste one build and the last writer wins. The builder is
+    injected per call so the cache stays free of service wiring.
+    """
+
+    def __init__(self, max_age_seconds: float = V1_SESSIONS_CACHE_MAX_AGE_SECONDS) -> None:
+        self._lock = Lock()
+        self._cached: tuple[int, float, dict[str, Any]] | None = None
+        self.max_age_seconds = float(max_age_seconds)
+
+    def _fresh(self, cached: tuple[int, float, dict[str, Any]] | None, fingerprint: int, moment: float) -> bool:
+        return (
+            cached is not None
+            and cached[0] == fingerprint
+            and (moment - cached[1]) < self.max_age_seconds
+        )
+
+    def view(
+        self,
+        fingerprint: int,
+        builder: Callable[[], dict[str, Any]],
+        *,
+        now: float | None = None,
+    ) -> dict[str, Any]:
+        moment = time.time() if now is None else float(now)
+        cached = self._cached
+        if self._fresh(cached, fingerprint, moment):
+            return cached[2]  # type: ignore[index]
+        with self._lock:
+            cached = self._cached
+            if self._fresh(cached, fingerprint, moment):
+                return cached[2]  # type: ignore[index]
+            view = builder()
+            self._cached = (fingerprint, moment, view)
+            return view

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -124,6 +124,13 @@ def _fold_parent_key(
             key = (client, parent_id)
             return key if key in entries_by_key else None
         return None
+    if isinstance(related, dict) and related.get("note"):
+        # The ledger REFUSED a recorded parent link (conflicting or
+        # self-referencing pointers — related.note carries the refusal).
+        # "Missing beats wrong" must not be overridden by an id-shape guess:
+        # falling through to the ':' fallback here re-folded exactly what the
+        # ledger refused (round-4 adversarial finding).
+        return None
     session_id = str(entry.get("client_session_id") or "")
     if ":" in session_id:
         key = (client, session_id.split(":", 1)[0])

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -83,7 +83,7 @@ def _reduce_work_status(items: Any) -> str | None:
 
 
 def _fold_parent_key(
-    entry: dict[str, Any], existing_keys: set[tuple[str, str]]
+    entry: dict[str, Any], entries_by_key: dict[tuple[str, str], dict[str, Any]]
 ) -> tuple[str, str] | None:
     """The entry's fold parent ON THIS SURFACE, or None (= shown as a root).
 
@@ -101,10 +101,17 @@ def _fold_parent_key(
       orphan as its own root; so does this surface.
 
     A legacy ``':stem'`` child lane with no parent metadata folds into its
-    prefix root when that root exists — the same defensive fallback the
-    glance applies, so the two /v1 surfaces agree on the root's headline
-    number instead of the sessions lane re-counting legacy children as roots.
+    prefix root when that root exists AND lives in the same source home
+    (:func:`agentacct.glance.fold_namespace_compatible` — the ledger has no
+    link to refuse for these lanes, so the namespace gate is applied here) —
+    the same defensive fallback the glance applies, so the two /v1 surfaces
+    agree on the root's headline number instead of the sessions lane
+    re-counting legacy children as roots. Like the glance, the fallback is
+    not client-gated (a non-claude id containing ':' folds by shape);
+    acceptable while only claude-code carries plan shares.
     """
+
+    from .glance import fold_namespace_compatible
 
     client = str(entry.get("client") or "")
     related = entry.get("related")
@@ -115,13 +122,21 @@ def _fold_parent_key(
         parent_id = str(parent.get("client_session_id") or "")
         if parent_id:
             key = (client, parent_id)
-            return key if key in existing_keys else None
+            return key if key in entries_by_key else None
         return None
     session_id = str(entry.get("client_session_id") or "")
     if ":" in session_id:
         key = (client, session_id.split(":", 1)[0])
-        if key in existing_keys:
-            return key
+        prefix_entry = entries_by_key.get(key)
+        if prefix_entry is not None:
+            child_ns = entry.get("source_namespace_fingerprint")
+            parent_ns = prefix_entry.get("source_namespace_fingerprint")
+            if fold_namespace_compatible(
+                str(child_ns) if child_ns else None,
+                str(parent_ns) if parent_ns else None,
+                None,
+            ):
+                return key
     return None
 
 
@@ -136,17 +151,23 @@ def _project_entry(entry: dict[str, Any]) -> dict[str, Any]:
 
     work = entry.get("work") if isinstance(entry.get("work"), dict) else {}
     # Title fallback chain, mirroring the glance: the client's own transcript
-    # title when it recorded one, else the newest work item's title (a
+    # title when it recorded one, else the newest HUMAN-titled work item (a
     # section-only session still deserves a human label). work.items arrives
     # NEWEST-FIRST from the rollup (build_work_items sorts by updated_at
     # descending) — iterate forward; reversed() picked the oldest title
-    # (adversarial-review finding).
+    # (adversarial-review finding). build_work_items backfills an untitled
+    # item's title with its work_id/section_id — skip those placeholders so a
+    # newer untitled section can't shadow an older human title (round-2
+    # finding: the glance only considers real section titles).
     title = entry.get("client_session_title")
     if not title:
         items = work.get("items") if isinstance(work.get("items"), list) else []
         for item in items:
-            if isinstance(item, dict) and item.get("title"):
-                title = item["title"]
+            if not isinstance(item, dict):
+                continue
+            candidate = item.get("title")
+            if candidate and candidate != item.get("work_id") and candidate != item.get("section_id"):
+                title = candidate
                 break
     return {
         "session_key": entry.get("session_key"),
@@ -196,7 +217,7 @@ def build_v1_sessions_view(
 
     import time as _time
 
-    from .glance import plan_status_and_session_pcts
+    from .glance import plan_status_and_session_pcts, resolve_fold_top
 
     rollup = ledger.get("session_rollup") if isinstance(ledger, dict) else {}
     entries = rollup.get("sessions") if isinstance(rollup, dict) else []
@@ -207,20 +228,13 @@ def build_v1_sessions_view(
     def _key(entry: dict[str, Any]) -> tuple[str, str]:
         return (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
 
-    existing_keys = {_key(entry) for entry in entries}
-    fold_step = {_key(entry): _fold_parent_key(entry, existing_keys) for entry in entries}
-
-    def _fold_top(key: tuple[str, str]) -> tuple[str, str]:
-        # Resolve to the topmost existing ancestor (rows normally nest one
-        # level; the loop guards hostile chains/cycles rather than trusting
-        # that). A share must land on a row the roots page actually shows.
-        seen = {key}
-        while True:
-            parent = fold_step.get(key)
-            if parent is None or parent in seen:
-                return key
-            seen.add(parent)
-            key = parent
+    entries_by_key = {_key(entry): entry for entry in entries}
+    fold_step = {key: _fold_parent_key(entry, entries_by_key) for key, entry in entries_by_key.items()}
+    # Rootness and share attribution come from the SAME fixpoint: a row is a
+    # root iff it is its own fold top. resolve_fold_top breaks parent cycles
+    # deterministically (min member), so cycle members can never all vanish
+    # from the roots page with their shares (round-2 adversarial finding).
+    fold_top_by_key = {key: resolve_fold_top(fold_step, key) for key in entries_by_key}
 
     descendant_pct_by_top: dict[tuple[str, str], float] = {}
     for entry in entries:
@@ -228,7 +242,7 @@ def build_v1_sessions_view(
         own = session_pcts.get(key)
         if own is None:
             continue
-        top = _fold_top(key)
+        top = fold_top_by_key.get(key, key)
         if top != key:
             descendant_pct_by_top[top] = descendant_pct_by_top.get(top, 0.0) + own
 
@@ -237,7 +251,7 @@ def build_v1_sessions_view(
     for entry in entries:
         row = _project_entry(entry)
         key = _key(entry)
-        is_root = fold_step.get(key) is None
+        is_root = fold_top_by_key.get(key, key) == key
         if is_root:
             root_count += 1
         own = session_pcts.get(key)

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -35,14 +35,23 @@ from typing import Any, Callable
 
 V1_SESSIONS_SCHEMA_VERSION = "agentacct.v1-sessions.v1"
 
-# Same TTL rationale as the glance cache: the view is mostly event-derived, but
-# plan calibration windows are clock-relative (a 21-day fit ages), so an
-# unchanged event list must still refresh eventually.
-V1_SESSIONS_CACHE_MAX_AGE_SECONDS = 60.0
+# TTL rationale: the view is mostly event-derived (the fingerprint catches
+# those changes), but plan calibration windows are clock-relative and the
+# ledger's secondary inputs are fingerprint-invisible. 30s matches the ledger
+# cache's TTL so the two stack to a bounded ≤60s worst case for
+# fingerprint-invisible inputs — a 60s view TTL over a 30s ledger TTL
+# compounded to ~90s (adversarial-review finding).
+V1_SESSIONS_CACHE_MAX_AGE_SECONDS = 30.0
 
-# Session-level status reduction — identical precedence to the glance recents
-# and the TUI badge: blocked > handed_off > in_progress > completed. ``resolved``
-# is a terminal blocker-resolution state and counts as completed.
+# Session-level status reduction — same precedence as the TUI badge:
+# blocked > handed_off > in_progress > completed, with ``resolved`` (the
+# terminal blocker-resolution state a machine check can stamp on a work item)
+# counting as completed. NOTE an honest divergence: the ledger-free glance
+# recents reduce raw section events and never see machine-check blocker
+# resolutions, so after a resolution the glance can still show "blocked"
+# while this lane and the TUI show "completed" — the stale side errs in the
+# conservative direction (unfinished-looking finished work, never the
+# reverse).
 _OPEN_ITEM_STATUSES = frozenset({"started", "checkpoint"})
 _DONE_ITEM_STATUSES = frozenset({"completed", "resolved"})
 
@@ -52,7 +61,8 @@ def _reduce_work_status(items: Any) -> str | None:
 
     A later completed section must never erase a still-open or blocked one —
     a finished-looking label on unfinished work is exactly the dishonesty
-    class this product exists to fix (same rule as glance._recent_sessions).
+    class this product exists to fix (same precedence as the TUI badge; see
+    the module-level note on the glance's blocker-resolution lag).
     """
 
     statuses: set[str] = set()
@@ -72,17 +82,47 @@ def _reduce_work_status(items: Any) -> str | None:
     return None
 
 
-def _parent_key(entry: dict[str, Any]) -> tuple[str, str] | None:
-    """``(client, parent_session_id)`` for a child entry, else None."""
+def _fold_parent_key(
+    entry: dict[str, Any], existing_keys: set[tuple[str, str]]
+) -> tuple[str, str] | None:
+    """The entry's fold parent ON THIS SURFACE, or None (= shown as a root).
 
+    The rollup's parent linkage is the starting authority, but two of its
+    states mean "do NOT fold here" (adversarial-review findings, both
+    repro-confirmed):
+
+    * the ledger REFUSED the join (``parent_source_namespace_mismatch``) —
+      folding would hand one identity's plan share to a same-id root from a
+      different source home, on a row whose own ``child_session_count`` says 0;
+    * the parent has no rollup entry (orphan child — "no stub entry") —
+      folding would sink the share under a key no row carries, silently
+      dropping a live session and its weekly-plan consumption from the
+      default roots page. The ledger's own instrumentation pass treats an
+      orphan as its own root; so does this surface.
+
+    A legacy ``':stem'`` child lane with no parent metadata folds into its
+    prefix root when that root exists — the same defensive fallback the
+    glance applies, so the two /v1 surfaces agree on the root's headline
+    number instead of the sessions lane re-counting legacy children as roots.
+    """
+
+    client = str(entry.get("client") or "")
     related = entry.get("related")
     parent = related.get("parent") if isinstance(related, dict) else None
-    if not isinstance(parent, dict):
+    if isinstance(parent, dict):
+        if related.get("parent_source_namespace_mismatch"):
+            return None
+        parent_id = str(parent.get("client_session_id") or "")
+        if parent_id:
+            key = (client, parent_id)
+            return key if key in existing_keys else None
         return None
-    parent_id = str(parent.get("client_session_id") or "")
-    if not parent_id:
-        return None
-    return (str(entry.get("client") or ""), parent_id)
+    session_id = str(entry.get("client_session_id") or "")
+    if ":" in session_id:
+        key = (client, session_id.split(":", 1)[0])
+        if key in existing_keys:
+            return key
+    return None
 
 
 def _project_entry(entry: dict[str, Any]) -> dict[str, Any]:
@@ -96,12 +136,15 @@ def _project_entry(entry: dict[str, Any]) -> dict[str, Any]:
 
     work = entry.get("work") if isinstance(entry.get("work"), dict) else {}
     # Title fallback chain, mirroring the glance: the client's own transcript
-    # title when it recorded one, else the most recently started work item's
-    # title (a section-only session still deserves a human label).
+    # title when it recorded one, else the newest work item's title (a
+    # section-only session still deserves a human label). work.items arrives
+    # NEWEST-FIRST from the rollup (build_work_items sorts by updated_at
+    # descending) — iterate forward; reversed() picked the oldest title
+    # (adversarial-review finding).
     title = entry.get("client_session_title")
     if not title:
         items = work.get("items") if isinstance(work.get("items"), list) else []
-        for item in reversed(items):
+        for item in items:
             if isinstance(item, dict) and item.get("title"):
                 title = item["title"]
                 break
@@ -133,17 +176,25 @@ def _project_entry(entry: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def build_v1_sessions_view(ledger: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+def build_v1_sessions_view(
+    ledger: dict[str, Any], events: list[dict[str, Any]], *, now: float | None = None
+) -> dict[str, Any]:
     """The cacheable enriched view: every rollup entry projected + plan-joined.
 
     Unfiltered and unsliced so one build serves any ``roots_only``/paging
     combination. Plan shares are the calibrated-or-nothing per-session
-    percentages; a root's ``plan_pct`` sums its own share and its children's
-    (looked up through the rollup's own parent linkage — the ledger is the
-    authority on who is whose child on this surface), so hiding the children
-    never hides their weekly-plan consumption. Raw floats, never rounded here
-    (shells format like the TUI: ``≈{pct:.1f}%`` with a ``<0.1%`` band).
+    percentages; every descendant's share is accumulated onto the TOPMOST
+    ancestor that exists as an entry on this surface (see
+    :func:`_fold_parent_key` for the three do-not-fold states), so the sum of
+    the visible roots' ``plan_pct`` always equals the total attributed share —
+    hiding a child never hides its weekly-plan consumption. Raw floats, never
+    rounded here (shells format like the TUI: ``≈{pct:.1f}%`` with a ``<0.1%``
+    band). ``generated_at`` is the BUILD time (glance contract: freshness is
+    judged from the HTTP response itself, and the stamp never claims a cached
+    view is fresher than it is).
     """
+
+    import time as _time
 
     from .glance import plan_status_and_session_pcts
 
@@ -153,35 +204,53 @@ def build_v1_sessions_view(ledger: dict[str, Any], events: list[dict[str, Any]])
 
     plan, session_pcts = plan_status_and_session_pcts(events)
 
-    rows: list[dict[str, Any]] = []
-    own_pct_by_key: dict[tuple[str, str], float] = {}
-    children_pct_by_parent: dict[tuple[str, str], float] = {}
+    def _key(entry: dict[str, Any]) -> tuple[str, str]:
+        return (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
+
+    existing_keys = {_key(entry) for entry in entries}
+    fold_step = {_key(entry): _fold_parent_key(entry, existing_keys) for entry in entries}
+
+    def _fold_top(key: tuple[str, str]) -> tuple[str, str]:
+        # Resolve to the topmost existing ancestor (rows normally nest one
+        # level; the loop guards hostile chains/cycles rather than trusting
+        # that). A share must land on a row the roots page actually shows.
+        seen = {key}
+        while True:
+            parent = fold_step.get(key)
+            if parent is None or parent in seen:
+                return key
+            seen.add(parent)
+            key = parent
+
+    descendant_pct_by_top: dict[tuple[str, str], float] = {}
     for entry in entries:
-        key = (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
+        key = _key(entry)
         own = session_pcts.get(key)
-        if own is not None:
-            own_pct_by_key[key] = own
-            parent = _parent_key(entry)
-            if parent is not None:
-                children_pct_by_parent[parent] = children_pct_by_parent.get(parent, 0.0) + own
+        if own is None:
+            continue
+        top = _fold_top(key)
+        if top != key:
+            descendant_pct_by_top[top] = descendant_pct_by_top.get(top, 0.0) + own
 
     root_count = 0
+    rows: list[dict[str, Any]] = []
     for entry in entries:
         row = _project_entry(entry)
-        key = (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
-        is_root = _parent_key(entry) is None
+        key = _key(entry)
+        is_root = fold_step.get(key) is None
         if is_root:
             root_count += 1
-        own = own_pct_by_key.get(key)
-        children = children_pct_by_parent.get(key)
+        own = session_pcts.get(key)
+        descendants = descendant_pct_by_top.get(key)
         row["plan_pct_own"] = own
-        row["plan_pct_children"] = children
-        if own is not None or children is not None:
-            row["plan_pct"] = (own or 0.0) + (children or 0.0)
+        row["plan_pct_children"] = descendants
+        if own is not None or descendants is not None:
+            row["plan_pct"] = (own or 0.0) + (descendants or 0.0)
         row["is_root"] = is_root
         rows.append(row)
 
     return {
+        "generated_at": _time.time() if now is None else float(now),
         "rows": rows,
         "plan": plan,
         "total_sessions": len(rows),
@@ -195,14 +264,15 @@ def slice_sessions_payload(
     roots_only: bool,
     limit: int,
     offset: int,
-    generated_at: float,
 ) -> dict[str, Any]:
     """The wire envelope for one request — a filter + slice over the cached view.
 
     Every cut is disclosed: ``total_sessions``/``total_root_sessions`` describe
     the full store, ``filtered_total`` the population the offset/limit walk,
     and ``truncated`` says whether rows exist beyond this page — a consumer can
-    never mistake a page for the whole population.
+    never mistake a page for the whole population. ``generated_at`` is the
+    cached view's BUILD time, never the request time — stamping fresh clocks
+    on cached content would be a freshness lie (adversarial-review finding).
     """
 
     rows = view.get("rows") or []
@@ -213,7 +283,7 @@ def slice_sessions_payload(
     page = [{key: value for key, value in row.items() if key != "is_root"} for row in page]
     return {
         "schema": V1_SESSIONS_SCHEMA_VERSION,
-        "generated_at": generated_at,
+        "generated_at": view.get("generated_at"),
         "total_sessions": view.get("total_sessions"),
         "total_root_sessions": view.get("total_root_sessions"),
         "filtered_total": len(pool),

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -4733,3 +4733,54 @@ def _provider_model_label(provider: Any, model: Any) -> str:
     if provider_text and model_text:
         return f"{provider_text}/{model_text}"
     return provider_text or model_text or "unknown model"
+
+
+class WorkLedgerCache:
+    """Fingerprint + TTL cache for the derived work ledger (API-serving path).
+
+    Every ledger-backed route used to rebuild the ENTIRE ledger from the full
+    event list on every request — a multi-second build under any polling
+    client. Same pattern as ``glance.GlanceCache``: the events fingerprint
+    catches every event-list change (append, supersede, namespace bind);
+    ``max_age_seconds`` bounds the staleness of the ledger's SECONDARY inputs
+    (run reports, cost events, mechanical session observations), which the
+    fingerprint deliberately does not cover — hashing three more stores per
+    request would cost more than it saves, and a bounded lag on those lanes is
+    acceptable where a wrong total would not be.
+
+    Concurrency posture (same as GlanceCache): the cached value is one atomic
+    tuple assignment, so a reader never observes a torn triple; two racing
+    rebuilds waste one build and the last writer wins. A rebuild racing an
+    import can briefly win with a slightly older event list — one poll may
+    regress and self-heals on the next; it never fabricates a number.
+    """
+
+    def __init__(self, max_age_seconds: float = 30.0) -> None:
+        from threading import Lock
+
+        self._lock = Lock()
+        # (fingerprint, built_at, ledger) — always assigned as one tuple.
+        self._cached: tuple[int, float, dict[str, Any]] | None = None
+        self.max_age_seconds = float(max_age_seconds)
+
+    def _fresh(self, cached: tuple[int, float, dict[str, Any]] | None, fingerprint: int, moment: float) -> bool:
+        return (
+            cached is not None
+            and cached[0] == fingerprint
+            and (moment - cached[1]) < self.max_age_seconds
+        )
+
+    def ledger(self, fingerprint: int, builder: Any, *, now: float | None = None) -> dict[str, Any]:
+        import time as _time
+
+        moment = _time.time() if now is None else float(now)
+        cached = self._cached
+        if self._fresh(cached, fingerprint, moment):
+            return cached[2]
+        with self._lock:
+            cached = self._cached
+            if self._fresh(cached, fingerprint, moment):
+                return cached[2]
+            ledger = builder()
+            self._cached = (fingerprint, moment, ledger)
+            return ledger

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -85,6 +85,7 @@ def _record_child_usage(
     session_id: str,
     parent_session_id: str,
     updated_at: float,
+    namespace: str | None = None,
 ) -> None:
     event = ClientUsageEvent(
         client=client,
@@ -108,7 +109,7 @@ def _record_child_usage(
         updated_at=updated_at,
         turn_count=1,
         usage_row_lane="model:claude-opus-4-8",
-        source_namespace_fingerprint=f"sha256:{client}",
+        source_namespace_fingerprint=namespace or f"sha256:{client}",
         input_tokens_reported=True,
         output_tokens_reported=True,
         reasoning_output_tokens_reported=True,
@@ -639,6 +640,49 @@ def test_folded_root_plan_pct_includes_child_shares(tmp_path):
     # own 10 Mtok + child 20 tokens (≈0), both at the calibrated opus weight.
     expected = (10.0 + 20 / 1_000_000) * opus * scale
     assert abs(rows["root-a"]["plan_pct"] - expected) < 1e-6
+
+
+def test_glance_refuses_cross_home_child_fold(tmp_path):
+    """A child from a DIFFERENT source home must not fold its activity or its
+    plan share into a same-id root — the glance applies the ledger's own
+    namespace refusal (round-2 adversarial finding: the glance kept folding
+    what the sessions lane refused, so the two surfaces showed different
+    money for the same root)."""
+
+    from agentacct import plan_cost as pc
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    move = 100.0 * opus
+    t0 = now - 5 * 3600
+    pct = 10.0
+    _record_7d_limit(service, captured=t0, pct=pct, index=0)
+    for i in range(4):
+        _record_usage(service, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"cal-{i}", input_tokens=100_000_000, output_tokens=0,
+                      updated_at=t0 + i * 3600 + 1800)
+        pct += move
+        _record_7d_limit(service, captured=t0 + (i + 1) * 3600, pct=pct, index=i + 1)
+
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="root-a",
+                  input_tokens=10_000_000, output_tokens=0, updated_at=now - 600)
+    _record_child_usage(service, client="claude-code",
+                        session_id="55555555-aaaa-bbbb-cccc-666666666666",
+                        parent_session_id="root-a", updated_at=now - 60,
+                        namespace="sha256:other-home")
+
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = api_client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"}).json()
+    plan = {entry["client"]: entry for entry in payload["plan"]}
+    assert plan["claude-code"]["confidence"] == "calibrated"
+    scale = plan["claude-code"]["scale"]
+    rows = {row["session_id"]: row for row in payload["recent_sessions"]}
+    # The root keeps only its OWN share; the foreign child stands as its own
+    # row with its own share — nothing misattributed, nothing hidden.
+    assert abs(rows["root-a"]["plan_pct"] - 10.0 * opus * scale) < 1e-9
+    foreign = rows["55555555-aaaa-bbbb-cccc-666666666666"]
+    assert foreign["plan_pct"] is not None and foreign["plan_pct"] > 0
 
 
 def test_non_ascii_bearer_token_yields_401_not_500(tmp_path):

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -217,7 +217,7 @@ def test_read_discovery_file_never_raises(tmp_path):
 def test_v1_routes_fail_closed_without_configured_token(tmp_path):
     SentinelService(tmp_path)
     client = TestClient(create_local_api_app(store_dir=tmp_path))
-    for route in ("/v1/glance", "/v1/version"):
+    for route in ("/v1/glance", "/v1/version", "/v1/sessions"):
         response = client.get(route, headers={"Authorization": "Bearer anything"})
         assert response.status_code == 503, route
 
@@ -580,6 +580,65 @@ def test_recent_session_plan_pct_is_gated_by_client(tmp_path):
     # the lookup key carries the client.
     assert rows[("claude-code", shared_session)]["plan_pct"] is None
     assert rows[("codex", shared_session)]["plan_pct"] is None
+
+
+def test_glance_plan_entries_carry_three_state_and_basis(tmp_path):
+    """Additive plan fields: the payload itself says which clients can ever
+    calibrate (codex: never), so no shell hard-codes that knowledge again."""
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s1",
+                  input_tokens=100, output_tokens=0, updated_at=time.time() - 60)
+
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = api_client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"}).json()
+    plan = {entry["client"]: entry for entry in payload["plan"]}
+    assert plan["claude-code"]["confidence"] == "baseline"  # the original key survives
+    assert plan["claude-code"]["calibration_state"] == "calibrating"
+    assert plan["claude-code"]["calibratable"] is True
+    assert plan["codex"]["calibration_state"] == "never"
+    assert plan["codex"]["calibratable"] is False
+    assert plan["claude-code"]["basis"]
+
+
+def test_folded_root_plan_pct_includes_child_shares(tmp_path):
+    """The recents list HIDES child sessions, so the root row's plan_pct must
+    carry their share — an unfolded join understates a workflow-heavy root
+    exactly when it matters most (the #65 fold moved only the activity key)."""
+
+    from agentacct import plan_cost as pc
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    # Calibration history: observed movement == baseline prediction → scale ~1.
+    move = 100.0 * opus
+    t0 = now - 5 * 3600
+    pct = 10.0
+    _record_7d_limit(service, captured=t0, pct=pct, index=0)
+    for i in range(4):
+        _record_usage(service, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"cal-{i}", input_tokens=100_000_000, output_tokens=0,
+                      updated_at=t0 + i * 3600 + 1800)
+        pct += move
+        _record_7d_limit(service, captured=t0 + (i + 1) * 3600, pct=pct, index=i + 1)
+
+    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="root-a",
+                  input_tokens=10_000_000, output_tokens=0, updated_at=now - 600)
+    _record_child_usage(service, client="claude-code",
+                        session_id="11111111-aaaa-bbbb-cccc-222222222222",
+                        parent_session_id="root-a", updated_at=now - 60)
+
+    api_client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = api_client.get("/v1/glance", headers={"Authorization": f"Bearer {TOKEN}"}).json()
+    plan = {entry["client"]: entry for entry in payload["plan"]}
+    assert plan["claude-code"]["confidence"] == "calibrated"
+    scale = plan["claude-code"]["scale"]
+    rows = {row["session_id"]: row for row in payload["recent_sessions"]}
+    assert "root-a" in rows
+    # own 10 Mtok + child 20 tokens (≈0), both at the calibrated opus weight.
+    expected = (10.0 + 20 / 1_000_000) * opus * scale
+    assert abs(rows["root-a"]["plan_pct"] - expected) < 1e-6
 
 
 def test_non_ascii_bearer_token_yields_401_not_500(tmp_path):

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -537,6 +537,59 @@ def test_metadata_parent_id_joins_raw_not_prefix_split(tmp_path):
     assert abs(glance_rows["rootr:lane"]["plan_pct"] - v1_pct) < 1e-9
 
 
+def test_ledger_parent_refusal_blocks_the_suffix_fallback(tmp_path):
+    """When the ledger refused a recorded parent link (conflicting pointers —
+    'missing beats wrong'), the ':' id-shape fallback must not re-fold what
+    the ledger refused; both surfaces keep the lane as its own root."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    _record_usage(service, session_id="r5", tokens=10_000_000, updated_at=now - 700)
+    _record_usage(service, session_id="r5:lane", tokens=3_000_000, updated_at=now - 600,
+                  session_kind="child", parent_session_id="r5")
+    _record_usage(service, model="claude-fable-5", session_id="r5:lane", tokens=2_000_000,
+                  updated_at=now - 500, session_kind="child", parent_session_id="q5")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=50)
+    rows = _rows_by_id(payload)
+    lane = rows.get("r5:lane")
+    assert lane is not None, "a refused-parent lane must stand as its own root"
+    assert rows["r5"]["plan_pct_children"] is None
+    glance = client.get("/v1/glance", headers=AUTH).json()
+    glance_rows = {row["session_id"]: row for row in glance["recent_sessions"]}
+    assert "r5:lane" in glance_rows
+    assert abs(glance_rows["r5:lane"]["plan_pct"] - lane["plan_pct"]) < 1e-9
+
+
+def test_explicit_vs_missing_namespace_refuses_the_fold(tmp_path):
+    """A parent whose rows mix a fingerprint with fingerprint-less rows (the
+    upgrade-boundary state the ledger quarantines) must refuse folds on the
+    glance too — the child keeps its own share on both surfaces."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    _record_usage(service, session_id="root-m", tokens=1_000_000, updated_at=now - 900,
+                  namespace=None)
+    _record_usage(service, model="claude-fable-5", session_id="root-m", tokens=1_000_000,
+                  updated_at=now - 800)
+    _record_usage(service, session_id="66666666-aaaa-bbbb-cccc-777777777777",
+                  tokens=5_000_000, updated_at=now - 300,
+                  session_kind="child", parent_session_id="root-m")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    rows = _rows_by_id(_sessions(client, limit=50))
+    child = rows.get("66666666-aaaa-bbbb-cccc-777777777777")
+    assert child is not None, "the child must stand as its own root"
+    assert child["plan_pct"] is not None and child["plan_pct_children"] is None
+    glance = client.get("/v1/glance", headers=AUTH).json()
+    glance_rows = {row["session_id"]: row for row in glance["recent_sessions"]}
+    g_child = glance_rows["66666666-aaaa-bbbb-cccc-777777777777"]
+    assert abs(g_child["plan_pct"] - child["plan_pct"]) < 1e-9
+
+
 def test_generated_at_is_the_view_build_time(tmp_path):
     """A cache-hit response must not stamp a fresh clock on cached content."""
 

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -1,0 +1,394 @@
+"""Tests for the /v1/sessions lane and the shared work-ledger cache.
+
+Contract under test: bearer gate parity with the other /v1 routes, server-side
+roots_only filtering BEFORE the slice (the "12 root sessions" regression),
+offset/limit pagination with disclosed totals + truncation, per-session
+weekly-plan shares with children folded into their root (calibrated-or-nothing),
+the three-state plan calibration payload, and the fingerprint+TTL caches that
+keep polling cheap (one ledger build shared across routes and polls).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import agentacct.api as api_module
+from agentacct import plan_cost as pc
+from agentacct.api import create_local_api_app
+from agentacct.client_usage import ClientUsageEvent
+from agentacct.service import SentinelService
+from agentacct.v1_sessions import V1_SESSIONS_SCHEMA_VERSION
+from agentacct.work_ledger import WorkLedgerCache
+
+TOKEN = "test-v1-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+def _record_usage(
+    service: SentinelService,
+    *,
+    client: str = "claude-code",
+    model: str = "claude-opus-4-8",
+    session_id: str,
+    tokens: int,
+    updated_at: float,
+    session_kind: str | None = None,
+    parent_session_id: str | None = None,
+) -> None:
+    event = ClientUsageEvent(
+        client=client,
+        client_session_id=session_id,
+        client_session_kind=session_kind,
+        parent_client_session_id=parent_session_id,
+        source_path=Path(f"/tmp/{client}/{session_id}.jsonl"),
+        title=None,
+        cwd="/tmp/project",
+        model=model,
+        input_tokens=tokens,
+        output_tokens=0,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name=client,
+        started_at=updated_at,
+        updated_at=updated_at,
+        turn_count=1,
+        usage_row_lane=f"model:{model}",
+        source_namespace_fingerprint=f"sha256:{client}",
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=tokens,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    service.record_event(event, trusted_usage_import=True)
+
+
+def _record_7d(service: SentinelService, *, captured: float, pct: float, client: str = "claude-code", index: int = 0) -> None:
+    service.record_event({
+        "event_id": f"evt_rl_{client}_{index}",
+        "created_at": captured,
+        "source": client,
+        "event_type": "rate_limit_observed",
+        "metadata": {
+            "client": client,
+            "captured_at": captured,
+            "windows": [{"kind": "7d", "window_minutes": 10080, "used_percent": pct}],
+        },
+    })
+
+
+def _record_section(
+    service: SentinelService,
+    *,
+    client: str = "claude-code",
+    session_id: str,
+    status: str,
+    title: str = "t",
+    created_at: float,
+    section_id: str | None = None,
+) -> None:
+    resolved_section = section_id or f"sec-{session_id}-{status}"
+    service.append_events_preserving_identity([
+        {
+            "event_id": f"evt_sec_{client}_{session_id}_{resolved_section}_{int(created_at)}",
+            "created_at": created_at,
+            "source": client,
+            "event_type": f"section_{status}",
+            "metadata": {
+                "client": client,
+                "client_session_id": session_id,
+                "section_id": resolved_section,
+                "section_status": status,
+                "section_title": title,
+            },
+        }
+    ])
+
+
+def _calibrate_claude(service: SentinelService, *, now: float) -> None:
+    """Recorded 7d history whose movement matches the baseline exactly → the
+    fitted scale is ~1.0 (inside the trusted band) and claude-code calibrates.
+    The calibration burner sessions are named ``cal-N``."""
+
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    move = 100.0 * opus  # 100M Opus tokens per interval → observed == predicted
+    t0 = now - 5 * 3600
+    pct = 10.0
+    _record_7d(service, captured=t0, pct=pct, index=0)
+    for i in range(4):
+        mid = t0 + i * 3600 + 1800
+        _record_usage(service, session_id=f"cal-{i}", tokens=100_000_000, updated_at=mid)
+        pct += move
+        _record_7d(service, captured=t0 + (i + 1) * 3600, pct=pct, index=i + 1)
+
+
+def _sessions(client: TestClient, **params) -> dict:
+    response = client.get("/v1/sessions", headers=AUTH, params=params)
+    assert response.status_code == 200
+    return response.json()
+
+
+def _rows_by_id(payload: dict) -> dict[str, dict]:
+    return {row["client_session_id"]: row for row in payload["sessions"]}
+
+
+# ---------------------------------------------------------------------------
+# auth parity
+# ---------------------------------------------------------------------------
+
+
+def test_v1_sessions_requires_the_bearer_token(tmp_path):
+    SentinelService(tmp_path)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    assert client.get("/v1/sessions").status_code == 401
+    assert client.get("/v1/sessions", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    ok = client.get("/v1/sessions", headers=AUTH)
+    assert ok.status_code == 200
+    assert ok.json()["schema"] == V1_SESSIONS_SCHEMA_VERSION
+    # The Host guard covers /v1/sessions like every other route.
+    assert client.get("/v1/sessions", headers={**AUTH, "Host": "evil.example"}).status_code == 403
+
+
+def test_version_advertises_the_sessions_schema(tmp_path):
+    SentinelService(tmp_path)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    body = client.get("/v1/version", headers=AUTH).json()
+    assert body["sessions_schema"] == V1_SESSIONS_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# roots_only + pagination (the "12 root sessions" fix)
+# ---------------------------------------------------------------------------
+
+
+def test_roots_only_filters_before_the_slice(tmp_path):
+    """A root whose subagent children dominate the recency window must still
+    be served: the filter runs server-side BEFORE offset/limit, so children
+    can never starve roots out of a page."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, session_id="root-a", tokens=1000, updated_at=now - 3600)
+    for i in range(6):  # six children, all more recent than the root itself
+        _record_usage(
+            service,
+            session_id=f"11111111-aaaa-bbbb-cccc-00000000000{i}",
+            tokens=10,
+            updated_at=now - 60 - i,
+            session_kind="child",
+            parent_session_id="root-a",
+        )
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=3)  # roots_only defaults to true
+    ids = [row["client_session_id"] for row in payload["sessions"]]
+    assert ids == ["root-a"]
+    assert payload["roots_only"] is True
+    assert payload["total_sessions"] == 7
+    assert payload["total_root_sessions"] == 1
+    assert payload["filtered_total"] == 1
+    assert payload["truncated"] is False
+    # Internal bookkeeping never leaks to the wire.
+    assert "is_root" not in payload["sessions"][0]
+    assert "namespace_fingerprint" not in payload["sessions"][0]
+
+    everyone = _sessions(client, roots_only="false", limit=50)
+    assert everyone["filtered_total"] == 7
+    child_rows = [row for row in everyone["sessions"] if (row["related"] or {}).get("parent")]
+    assert len(child_rows) == 6
+
+
+def test_pagination_disclose_totals_and_truncation(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    for i in range(3):
+        _record_usage(service, session_id=f"root-{i}", tokens=100, updated_at=now - 100 * (i + 1))
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    first = _sessions(client, limit=2)
+    assert [row["client_session_id"] for row in first["sessions"]] == ["root-0", "root-1"]
+    assert first["returned"] == 2
+    assert first["truncated"] is True
+
+    rest = _sessions(client, limit=2, offset=2)
+    assert [row["client_session_id"] for row in rest["sessions"]] == ["root-2"]
+    assert rest["returned"] == 1
+    assert rest["truncated"] is False
+
+    beyond = _sessions(client, limit=2, offset=10)
+    assert beyond["sessions"] == []
+    assert beyond["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
+# status + row shape
+# ---------------------------------------------------------------------------
+
+
+def test_row_status_uses_blocked_over_completed_precedence(tmp_path):
+    """A later completed section must not erase a blocked one (TUI/glance
+    badge parity)."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, session_id="root-a", tokens=100, updated_at=now - 500)
+    _record_section(service, session_id="root-a", status="blocked", created_at=now - 400, section_id="s1")
+    _record_section(service, session_id="root-a", status="completed", created_at=now - 300, section_id="s2")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    row = _rows_by_id(_sessions(client))["root-a"]
+    assert row["status"] == "blocked"
+    assert row["title"] == "t"
+    # The pass-through blocks the app renders are present.
+    assert isinstance(row["usage"], dict) and isinstance(row["work"], dict)
+    assert isinstance(row["related"], dict)
+
+
+# ---------------------------------------------------------------------------
+# plan shares (calibrated-or-nothing, children folded into their root)
+# ---------------------------------------------------------------------------
+
+
+def test_plan_pct_folds_children_into_the_root_row(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    _record_usage(service, session_id="root-a", tokens=10_000_000, updated_at=now - 600)
+    _record_usage(
+        service,
+        session_id="22222222-aaaa-bbbb-cccc-333333333333",
+        tokens=5_000_000,
+        updated_at=now - 300,
+        session_kind="child",
+        parent_session_id="root-a",
+    )
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=50)
+    plan_by_client = {entry["client"]: entry for entry in payload["plan"]}
+    assert plan_by_client["claude-code"]["confidence"] == "calibrated"
+    scale = plan_by_client["claude-code"]["scale"]
+
+    row = _rows_by_id(payload)["root-a"]
+    own = 10.0 * opus * scale       # 10 Mtok
+    children = 5.0 * opus * scale   # 5 Mtok
+    assert abs(row["plan_pct_own"] - own) < 1e-6
+    assert abs(row["plan_pct_children"] - children) < 1e-6
+    assert abs(row["plan_pct"] - (own + children)) < 1e-6
+
+    # The child row (visible without roots_only) carries only its OWN share —
+    # the root's headline already includes it; summing a mixed list must not
+    # double-count within one row.
+    everyone = _rows_by_id(_sessions(client, roots_only="false", limit=50))
+    child = everyone["22222222-aaaa-bbbb-cccc-333333333333"]
+    assert abs(child["plan_pct"] - children) < 1e-6
+    assert child["plan_pct_children"] is None
+
+
+def test_plan_pct_is_none_when_uncalibrated(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, session_id="root-a", tokens=10_000_000, updated_at=now - 600)
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client)
+    row = _rows_by_id(payload)["root-a"]
+    assert row["plan_pct"] is None and row["plan_pct_own"] is None
+
+
+def test_plan_entries_carry_the_three_state_semantic(tmp_path):
+    """codex can never calibrate: the payload must say so (``never``), so no
+    shell can render a 'calibrating' promise that will not arrive. claude-code
+    without history is honestly ``calibrating``."""
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="root-a", tokens=1000, updated_at=time.time() - 60)
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    plan = {entry["client"]: entry for entry in _sessions(client)["plan"]}
+    assert plan["claude-code"]["calibration_state"] == "calibrating"
+    assert plan["claude-code"]["calibratable"] is True
+    assert plan["codex"]["calibration_state"] == "never"
+    assert plan["codex"]["calibratable"] is False
+    for entry in plan.values():
+        assert isinstance(entry["basis"], str) and entry["basis"]
+        assert "scale" in entry and "intervals_used" in entry
+
+
+# ---------------------------------------------------------------------------
+# caches (one ledger build shared across routes and polls)
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_routes_share_one_cached_build(tmp_path, monkeypatch):
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="root-a", tokens=100, updated_at=time.time() - 60)
+
+    calls = {"count": 0}
+    real_build = api_module.build_work_ledger
+
+    def _counting_build(*args, **kwargs):
+        calls["count"] += 1
+        return real_build(*args, **kwargs)
+
+    monkeypatch.setattr(api_module, "build_work_ledger", _counting_build)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+
+    assert client.get("/sessions").status_code == 200
+    assert client.get("/overview").status_code == 200
+    assert client.get("/v1/sessions", headers=AUTH).status_code == 200
+    assert calls["count"] == 1  # one build served all three routes
+
+    _record_usage(service, session_id="root-b", tokens=100, updated_at=time.time() - 30)
+    assert client.get("/sessions").status_code == 200
+    assert calls["count"] == 2  # the fingerprint saw the new event
+
+
+def test_sessions_view_cache_rebuilds_only_on_event_change(tmp_path, monkeypatch):
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="root-a", tokens=100, updated_at=time.time() - 60)
+
+    calls = {"count": 0}
+    real_build = api_module.build_v1_sessions_view
+
+    def _counting_build(*args, **kwargs):
+        calls["count"] += 1
+        return real_build(*args, **kwargs)
+
+    monkeypatch.setattr(api_module, "build_v1_sessions_view", _counting_build)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+
+    assert client.get("/v1/sessions", headers=AUTH).status_code == 200
+    assert client.get("/v1/sessions", headers=AUTH, params={"roots_only": "false"}).status_code == 200
+    assert client.get("/v1/sessions", headers=AUTH, params={"offset": 1}).status_code == 200
+    assert calls["count"] == 1  # every paging/filter combination slices one cached view
+
+    _record_usage(service, session_id="root-b", tokens=100, updated_at=time.time() - 30)
+    assert client.get("/v1/sessions", headers=AUTH).status_code == 200
+    assert calls["count"] == 2
+
+
+def test_ledger_cache_expires_by_age_even_when_events_are_unchanged():
+    """The ledger's secondary inputs (run reports, cost events, observations)
+    are outside the fingerprint — the TTL is what bounds their staleness."""
+
+    calls = {"count": 0}
+
+    def _build():
+        calls["count"] += 1
+        return {"n": calls["count"]}
+
+    cache = WorkLedgerCache(max_age_seconds=30.0)
+    t0 = time.time()
+    assert cache.ledger(1, _build, now=t0) == {"n": 1}
+    assert cache.ledger(1, _build, now=t0 + 29) == {"n": 1}   # fresh: same fp, inside TTL
+    assert cache.ledger(1, _build, now=t0 + 31) == {"n": 2}   # TTL expired → rebuild
+    assert cache.ledger(2, _build, now=t0 + 31.5) == {"n": 3}  # fp change → rebuild

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -420,6 +420,50 @@ def test_title_prefers_the_newest_work_item(tmp_path):
     assert _rows_by_id(_sessions(client))["root-a"]["title"] == "new goal"
 
 
+def test_mutual_parent_cycle_keeps_shares_on_a_visible_root(tmp_path):
+    """Corrupt/hostile mutual parent pointers must not make sessions and
+    their money vanish from the default roots page: the cycle breaks
+    deterministically (min member becomes the root) and carries every
+    member's share — on BOTH /v1 surfaces."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    _record_usage(service, session_id="cyc-b", tokens=5_000_000, updated_at=now - 300,
+                  session_kind="child", parent_session_id="cyc-a")
+    _record_usage(service, session_id="cyc-a", tokens=10_000_000, updated_at=now - 200,
+                  session_kind="child", parent_session_id="cyc-b")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=50)
+    rows = _rows_by_id(payload)
+    assert "cyc-a" in rows and "cyc-b" not in rows  # min member is the canonical root
+    scale = {entry["client"]: entry for entry in payload["plan"]}["claude-code"]["scale"]
+    expected_total = 15.0 * opus * scale
+    assert abs(rows["cyc-a"]["plan_pct"] - expected_total) < 1e-6
+    glance = client.get("/v1/glance", headers=AUTH).json()
+    glance_rows = {row["session_id"]: row for row in glance["recent_sessions"]}
+    assert "cyc-a" in glance_rows and "cyc-b" not in glance_rows
+    assert abs(glance_rows["cyc-a"]["plan_pct"] - expected_total) < 1e-6
+
+
+def test_title_skips_untitled_item_placeholders(tmp_path):
+    """A newer UNTITLED section (whose item title is backfilled with its
+    work_id) must not shadow an older human title."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, session_id="root-a", tokens=100, updated_at=now - 900)
+    _record_section(service, session_id="root-a", status="completed", title="human goal",
+                    created_at=now - 800, section_id="s1")
+    _record_section(service, session_id="root-a", status="started", title="",
+                    created_at=now - 100, section_id="s2")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    assert _rows_by_id(_sessions(client))["root-a"]["title"] == "human goal"
+
+
 def test_generated_at_is_the_view_build_time(tmp_path):
     """A cache-hit response must not stamp a fresh clock on cached content."""
 

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -37,7 +37,7 @@ def _record_usage(
     updated_at: float,
     session_kind: str | None = None,
     parent_session_id: str | None = None,
-    namespace: str | None = None,
+    namespace: str | None = "__default__",
 ) -> None:
     event = ClientUsageEvent(
         client=client,
@@ -61,7 +61,7 @@ def _record_usage(
         updated_at=updated_at,
         turn_count=1,
         usage_row_lane=f"model:{model}",
-        source_namespace_fingerprint=namespace or f"sha256:{client}",
+        source_namespace_fingerprint=(f"sha256:{client}" if namespace == "__default__" else namespace),
         input_tokens_reported=True,
         output_tokens_reported=True,
         reasoning_output_tokens_reported=True,
@@ -462,6 +462,79 @@ def test_title_skips_untitled_item_placeholders(tmp_path):
 
     client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
     assert _rows_by_id(_sessions(client))["root-a"]["title"] == "human goal"
+
+
+def test_fold_decision_is_event_order_independent(tmp_path):
+    """A session whose rows mix source homes must refuse every fold touching
+    it, in ANY event order — never 'last fingerprint wins' (round-3 finding:
+    reordering the same events flipped the fold decision)."""
+
+    from agentacct.glance import child_root_plan_fold
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, session_id="mixed-p", tokens=100, updated_at=now - 900,
+                  namespace="sha256:home-1")
+    _record_usage(service, model="claude-fable-5", session_id="mixed-p", tokens=100,
+                  updated_at=now - 800, namespace="sha256:home-2")
+    _record_usage(service, session_id="77777777-aaaa-bbbb-cccc-888888888888", tokens=100,
+                  updated_at=now - 700, session_kind="child", parent_session_id="mixed-p",
+                  namespace="sha256:home-1")
+
+    events = service.list_all_events()
+    forward = child_root_plan_fold(events)
+    backward = child_root_plan_fold(list(reversed(events)))
+    assert forward == backward == {}
+
+
+def test_sections_only_parent_receives_the_fold_on_both_surfaces(tmp_path):
+    """An orchestrator that records sections but imports no usage of its own
+    still EXISTS — a legacy (fingerprint-less) child's share folds onto it on
+    BOTH /v1 surfaces (round-3 finding: the glance treated it as a ghost
+    while the sessions lane folded)."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    _record_section(service, session_id="sec-root", status="started", title="orchestrating",
+                    created_at=now - 700)
+    _record_usage(service, session_id="99999999-aaaa-bbbb-cccc-000000000000",
+                  tokens=5_000_000, updated_at=now - 300,
+                  session_kind="child", parent_session_id="sec-root", namespace=None)
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=50)
+    rows = _rows_by_id(payload)
+    assert "99999999-aaaa-bbbb-cccc-000000000000" not in rows
+    v1_pct = rows["sec-root"]["plan_pct"]
+    assert v1_pct is not None
+    glance = client.get("/v1/glance", headers=AUTH).json()
+    glance_rows = {row["session_id"]: row for row in glance["recent_sessions"]}
+    assert "99999999-aaaa-bbbb-cccc-000000000000" not in glance_rows
+    assert abs(glance_rows["sec-root"]["plan_pct"] - v1_pct) < 1e-9
+
+
+def test_metadata_parent_id_joins_raw_not_prefix_split(tmp_path):
+    """A metadata parent id like 'rootr:lane' joins RAW (the rollup's rule).
+    The glance must not split it and gate against 'rootr' — a session the
+    metadata never named (round-3 finding)."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    _record_usage(service, session_id="rootr:lane", tokens=10_000_000, updated_at=now - 600)
+    _record_usage(service, session_id="88888888-aaaa-bbbb-cccc-111111111111",
+                  tokens=5_000_000, updated_at=now - 300,
+                  session_kind="child", parent_session_id="rootr:lane")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=50)
+    rows = _rows_by_id(payload)
+    assert "88888888-aaaa-bbbb-cccc-111111111111" not in rows
+    v1_pct = rows["rootr:lane"]["plan_pct"]
+    glance = client.get("/v1/glance", headers=AUTH).json()
+    glance_rows = {row["session_id"]: row for row in glance["recent_sessions"]}
+    assert abs(glance_rows["rootr:lane"]["plan_pct"] - v1_pct) < 1e-9
 
 
 def test_generated_at_is_the_view_build_time(tmp_path):

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -37,6 +37,7 @@ def _record_usage(
     updated_at: float,
     session_kind: str | None = None,
     parent_session_id: str | None = None,
+    namespace: str | None = None,
 ) -> None:
     event = ClientUsageEvent(
         client=client,
@@ -60,7 +61,7 @@ def _record_usage(
         updated_at=updated_at,
         turn_count=1,
         usage_row_lane=f"model:{model}",
-        source_namespace_fingerprint=f"sha256:{client}",
+        source_namespace_fingerprint=namespace or f"sha256:{client}",
         input_tokens_reported=True,
         output_tokens_reported=True,
         reasoning_output_tokens_reported=True,
@@ -321,6 +322,113 @@ def test_plan_entries_carry_the_three_state_semantic(tmp_path):
     for entry in plan.values():
         assert isinstance(entry["basis"], str) and entry["basis"]
         assert "scale" in entry and "intervals_used" in entry
+
+
+# ---------------------------------------------------------------------------
+# review-finding regressions (adversarial review of PR #66)
+# ---------------------------------------------------------------------------
+
+
+def test_refused_namespace_parent_join_is_not_folded(tmp_path):
+    """The ledger refuses a cross-home parent join (namespace mismatch) — the
+    plan fold must respect that refusal: the foreign child stays visible as
+    its own root with its own share, and the same-id 'parent' row never claims
+    another identity's weekly-plan consumption."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    _record_usage(service, session_id="root-a", tokens=10_000_000, updated_at=now - 600)
+    _record_usage(
+        service,
+        session_id="44444444-aaaa-bbbb-cccc-555555555555",
+        tokens=5_000_000,
+        updated_at=now - 300,
+        session_kind="child",
+        parent_session_id="root-a",
+        namespace="sha256:other-home",
+    )
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=50)
+    rows = _rows_by_id(payload)
+    root = rows["root-a"]
+    # The ledger's own view of this root says zero children — the plan share
+    # must agree, not contradict the same row's related block.
+    assert (root["related"] or {}).get("child_session_count") == 0
+    assert root["plan_pct_children"] is None
+    foreign = rows.get("44444444-aaaa-bbbb-cccc-555555555555")
+    assert foreign is not None, "the refused child must stay visible on the roots page"
+    assert foreign["plan_pct"] is not None and foreign["plan_pct_children"] is None
+
+
+def test_orphan_child_appears_as_root_with_its_share(tmp_path):
+    """A child whose parent has no rollup entry (no stub entries) is its own
+    root on this surface — previously it vanished from the default roots page
+    together with its plan share."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    _record_usage(
+        service,
+        session_id="33333333-aaaa-bbbb-cccc-666666666666",
+        tokens=5_000_000,
+        updated_at=now - 300,
+        session_kind="child",
+        parent_session_id="ghost-root",
+    )
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=50)
+    row = _rows_by_id(payload).get("33333333-aaaa-bbbb-cccc-666666666666")
+    assert row is not None, "an orphan child must not vanish from the roots page"
+    assert row["plan_pct"] is not None
+
+
+def test_legacy_suffix_lane_folds_like_the_glance(tmp_path):
+    """A legacy ':stem' child lane without parent metadata folds into its
+    prefix root — and the two /v1 surfaces report the SAME headline number
+    for that root instead of the sessions lane re-counting the child as a
+    root."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    _record_usage(service, session_id="root-b", tokens=10_000_000, updated_at=now - 600)
+    _record_usage(service, session_id="root-b:wf1", tokens=5_000_000, updated_at=now - 300)
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = _sessions(client, limit=50)
+    rows = _rows_by_id(payload)
+    assert "root-b:wf1" not in rows, "the legacy child lane must not be listed as a root"
+    glance = client.get("/v1/glance", headers=AUTH).json()
+    glance_root = {row["session_id"]: row for row in glance["recent_sessions"]}["root-b"]
+    assert abs(rows["root-b"]["plan_pct"] - glance_root["plan_pct"]) < 1e-9
+
+
+def test_title_prefers_the_newest_work_item(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, session_id="root-a", tokens=100, updated_at=now - 900)
+    _record_section(service, session_id="root-a", status="completed", title="old goal",
+                    created_at=now - 800, section_id="s1")
+    _record_section(service, session_id="root-a", status="started", title="new goal",
+                    created_at=now - 100, section_id="s2")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    assert _rows_by_id(_sessions(client))["root-a"]["title"] == "new goal"
+
+
+def test_generated_at_is_the_view_build_time(tmp_path):
+    """A cache-hit response must not stamp a fresh clock on cached content."""
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="root-a", tokens=100, updated_at=time.time() - 60)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    first = _sessions(client)
+    second = _sessions(client, offset=0)
+    assert second["generated_at"] == first["generated_at"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The daemon half of the app-v3 plan (PR-D core: D1/D2/D5). Second half (session-detail endpoint + plan aggregates) follows in its own PR.

## What

**D1 — `WorkLedgerCache` (fingerprint + TTL, 30s).** Every ledger-backed route (`/sessions`, `/overview`, `/timeline`, `/work-items*`, `/attention`) previously re-derived the entire work ledger from the full event store on every request — a multi-second build under any polling client. They now share one cached build per API process. The events fingerprint (same key as the glance/TUI caches) catches every event-list change; the TTL bounds staleness of the ledger's secondary inputs (run reports, cost events, mechanical observations), which the fingerprint deliberately does not cover.

**D2 — `GET /v1/sessions` (bearer lane, schema `agentacct.v1-sessions.v1`).** The "12 root sessions" fix: the legacy `/sessions` slices the recency-sorted root+child mix server-side, so a client filtering roots afterwards starves (live measurement: limit=300 → 13 roots / 287 children; the store actually holds 180 roots). The new lane filters `roots_only` BEFORE the slice, paginates with `offset`/`limit`, and discloses every cut (`total_sessions`, `total_root_sessions`, `filtered_total`, `returned`, `truncated`). Rows are a curated projection (identity, activity, status badge with TUI-precedence reduction, verbatim `usage`/`join`/`work`/`related` blocks, instrumentation state) — the rollup's internal plumbing stays off the wire. Cached by the same fingerprint+TTL pattern; every paging combination slices one cached view.

**Plan shares with children folded.** Each root row carries `plan_pct_own` / `plan_pct_children` / `plan_pct` (own+children, calibrated-or-nothing, raw floats). Live check (trust band widened in-process to force the calibrated state): 100% of claude-code rows with usage rows join a share (1562/1562), and the fold is dramatic where it matters — a workflow-heavy root showing own 5.7% actually consumed 39% of the weekly plan once its children's share rides on it.

**D5 — three-state plan payload + glance fold fix.** `plan[]` entries (glance and the new lane, one shared builder) gain `calibration_state` (`calibrated`/`calibrating`/`never`), `calibratable`, and the why-this-number fields (`basis`/`scale`/`intervals_used`). `CALIBRATABLE_CLIENTS` moves to `plan_cost` as the single source of truth (codex's rolling 7d meter can never yield a weekly %, so it must never be shown as "calibrating" — the Swift app currently gets this wrong because the payload couldn't say it). Also fixes the #65 gap where the glance child fold moved only the activity key: the child's plan share now folds into the root row too (`child_root_plan_fold` + sum-preserving `fold_plan_pcts_to_roots`, shared with `_recent_sessions`).

## Compatibility

- Legacy `/sessions` and all other routes: payloads unchanged (only now cached; a poll that finds no event change skips the rebuild).
- `/v1/glance`: additive plan fields only; `recent_sessions[].plan_pct` semantics corrected as above.
- `/v1/version`: additive `sessions_schema` key.

## Tests

10 new tests (bearer/Host-guard parity, roots-before-slice, pagination totals+truncation, status precedence, child fold arithmetic incl. no-double-count on mixed lists, calibrated-or-nothing, three-state payload, shared-ledger-build counting across routes, view-cache invalidation, TTL expiry). Full suite: 2882 passed / 1 skipped.