### PR TITLE
feat(api): /v1/session detail + /v1/plan aggregates

### DIFF
--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -39,9 +39,12 @@ from .capture import CaptureContext, DEFAULT_CAPTURE_REGISTRY, render_hook_manif
 from .capture.registry import DEFAULT_MAX_PAYLOAD_BYTES
 from .capture_runtime import capture_hook_payload
 from .glance import GLANCE_SCHEMA_VERSION, GlanceCache, events_fingerprint
+from .plan_cost import V1_PLAN_SCHEMA_VERSION, build_v1_plan_payload
 from .v1_sessions import (
+    V1_SESSION_DETAIL_SCHEMA_VERSION,
     V1_SESSIONS_SCHEMA_VERSION,
     V1SessionsCache,
+    build_v1_session_detail,
     build_v1_sessions_view,
     slice_sessions_payload,
 )
@@ -2796,6 +2799,8 @@ def create_local_api_app(
             "version": _dashboard_importer_version(),
             "glance_schema": GLANCE_SCHEMA_VERSION,
             "sessions_schema": V1_SESSIONS_SCHEMA_VERSION,
+            "session_detail_schema": V1_SESSION_DETAIL_SCHEMA_VERSION,
+            "plan_schema": V1_PLAN_SCHEMA_VERSION,
             "pid": os.getpid(),
             "store_dir": str(store_dir),
             "store_scope": store_scope,
@@ -2845,6 +2850,65 @@ def create_local_api_app(
         )
         return slice_sessions_payload(view, roots_only=roots_only, limit=limit, offset=offset)
 
+    @app.get("/v1/session")
+    def v1_session_detail(
+        request: Request,
+        client: str = Query(..., min_length=1),
+        session_id: str = Query(..., min_length=1),
+    ) -> dict[str, Any]:
+        """One session's deep view: the list row + expandable steps (status,
+        kind, per-step usage, attributed model lanes, machine checks) +
+        descendants + the plan why-this-number block. Query params rather
+        than a path segment because session ids legally contain ':' and other
+        separator-shaped characters. 404 when the store has no such session —
+        never an empty fabrication."""
+
+        _require_v1_token(request)
+        events = service.list_all_events()
+        fingerprint = events_fingerprint(events)
+        view = v1_sessions_cache.view(
+            fingerprint,
+            lambda: build_v1_sessions_view(
+                _derived_work_ledger(events, fingerprint=fingerprint), events
+            ),
+        )
+        detail = build_v1_session_detail(
+            view,
+            _derived_work_ledger(events, fingerprint=fingerprint),
+            events,
+            client=client,
+            session_id=session_id,
+        )
+        if detail is None:
+            raise HTTPException(status_code=404, detail="unknown session for this store")
+        return detail
+
+    # (fingerprint, built_at, payload) per requested day-range; bounded by the
+    # route's ge/le so this can never grow past a handful of keys.
+    v1_plan_cache: dict[int, tuple[int, float, dict[str, Any]]] = {}
+
+    @app.get("/v1/plan")
+    def v1_plan(
+        request: Request,
+        days: int = Query(30, ge=1, le=90),
+    ) -> dict[str, Any]:
+        """Attributed plan aggregates per plan-bearing client (calibrated-or-
+        nothing): today/7d/30d window shares, a daily series aligned with the
+        /usage/summary calendar buckets, a by-model split, and the unknown-time
+        disclosure. The account-wide provider truth stays in glance limits[]
+        — a different quantity, deliberately not duplicated here."""
+
+        _require_v1_token(request)
+        events = service.list_all_events()
+        fingerprint = events_fingerprint(events)
+        moment = time.time()
+        cached = v1_plan_cache.get(days)
+        if cached is not None and cached[0] == fingerprint and (moment - cached[1]) < 30.0:
+            return cached[2]
+        payload = build_v1_plan_payload(events, days=days, now=moment)
+        v1_plan_cache[days] = (fingerprint, moment, payload)
+        return payload
+
     @app.get("/")
     def index() -> dict[str, Any]:
         """A machine-readable front door (the HTML dashboard is retired).
@@ -2870,6 +2934,8 @@ def create_local_api_app(
                 "/v1/version (bearer token from the store's local-api.json)",
                 "/v1/glance (bearer token from the store's local-api.json)",
                 "/v1/sessions (bearer token from the store's local-api.json)",
+                "/v1/session?client=&session_id= (bearer token from the store's local-api.json)",
+                "/v1/plan (bearer token from the store's local-api.json)",
             ],
         }
 

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -2866,19 +2866,12 @@ def create_local_api_app(
         _require_v1_token(request)
         events = service.list_all_events()
         fingerprint = events_fingerprint(events)
+        ledger = _derived_work_ledger(events, fingerprint=fingerprint)
         view = v1_sessions_cache.view(
             fingerprint,
-            lambda: build_v1_sessions_view(
-                _derived_work_ledger(events, fingerprint=fingerprint), events
-            ),
+            lambda: build_v1_sessions_view(ledger, events),
         )
-        detail = build_v1_session_detail(
-            view,
-            _derived_work_ledger(events, fingerprint=fingerprint),
-            events,
-            client=client,
-            session_id=session_id,
-        )
+        detail = build_v1_session_detail(view, ledger, client=client, session_id=session_id)
         if detail is None:
             raise HTTPException(status_code=404, detail="unknown session for this store")
         return detail

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -543,7 +543,12 @@ def fold_plan_pcts_to_roots(
 
 def plan_status_and_session_pcts(
     events: list[dict[str, Any]],
-) -> tuple[list[dict[str, Any]], dict[tuple[str, str], float]]:
+) -> tuple[
+    list[dict[str, Any]],
+    dict[tuple[str, str], float],
+    dict[str, Any],
+    dict[str, list[Any]],
+]:
     """Per-client plan payload entries + calibrated per-session plan shares.
 
     The calibrated-or-nothing honesty rule is baked in: ``session_pcts`` holds
@@ -553,6 +558,12 @@ def plan_status_and_session_pcts(
     session ids, UNFOLDED — apply :func:`fold_plan_pcts_to_roots` on a surface
     that hides child sessions. Shared by the glance and the /v1 sessions lane
     so the two can never disagree.
+
+    Also returns the fitted ``weights_by_client`` and ``records_by_client``
+    this ONE computation used, so a caller deriving further numbers (the
+    session-detail by-model split) works from the same fit — recomputing
+    per-request produced payloads whose plan block disagreed with its own
+    cached pct values (adversarial-review finding).
     """
 
     from .plan_cost import calibrate_plan_weights, plan_status_entry, session_plan_pcts
@@ -561,14 +572,18 @@ def plan_status_and_session_pcts(
 
     plan: list[dict[str, Any]] = []
     session_pcts: dict[tuple[str, str], float] = {}
+    weights_by_client: dict[str, Any] = {}
+    records_by_client: dict[str, list[Any]] = {}
     for client in PLAN_CLIENTS:
         records = usage_records(events, client=client)
         weights = calibrate_plan_weights(events, client=client, records=records)
         plan.append(plan_status_entry(weights))
+        weights_by_client[client] = weights
+        records_by_client[client] = records
         if weights.confidence == "calibrated":
             for session_id, pct in session_plan_pcts(records, weights, client=client).items():
                 session_pcts[(client, session_id)] = pct
-    return plan, session_pcts
+    return plan, session_pcts, weights_by_client, records_by_client
 
 
 def _recent_sessions(
@@ -723,7 +738,7 @@ def build_glance_snapshot(
     # row (it records sections but its usage folded away) shows None rather
     # than a share its root's row already includes. ONE fold map drives both
     # the activity fold and the share fold, so they can never disagree.
-    plan, session_pcts = plan_status_and_session_pcts(events)
+    plan, session_pcts, _weights, _records = plan_status_and_session_pcts(events)
     fold_map = child_root_plan_fold(events)
     folded_pcts = fold_plan_pcts_to_roots(session_pcts, fold_map)
 

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -341,6 +341,156 @@ def session_plan_pcts(
     return {sid: weights.pct_for_tokens(tokens) for sid, tokens in by_session.items()}
 
 
+def plan_pct_aggregates(
+    records: Sequence[Any],
+    weights: PlanWeights,
+    *,
+    client: str,
+    days: int = 30,
+    today: Any = None,
+) -> dict[str, Any]:
+    """Windowed/daily/by-model plan-share aggregates for one client, one pass.
+
+    Mirrors the usage cube's calendar semantics exactly
+    (:func:`agentacct.usage_cube.usage_bucket_date`: local calendar days,
+    trailing ranges ending ``today``, a session-lane's tokens landing on its
+    latest-update day) so a plan-share daily series lines up column-for-column
+    with the /usage/summary cost chart. Tokens whose timestamp fails the
+    bad-timestamp guard cannot honestly join a bounded range; their share is
+    DISCLOSED as ``unknown_time_pct`` rather than silently dropped.
+
+    Returns ``{window_pcts: {today,7d,30d}, daily: [{date, pct}] (ascending,
+    empty days included), by_model: [{model, total_tokens, pct}] over the
+    trailing ``days`` range, unknown_time_pct}``. Raw floats, never rounded.
+    The calibrated-or-nothing rule is the CALLER's job (attach these only
+    when ``weights.confidence == "calibrated"``), same as session shares.
+    """
+
+    from datetime import date as _date, timedelta as _timedelta
+
+    from .usage_cube import usage_bucket_date
+    from .usage_view import _usage_record_time
+
+    resolved_today: _date = today or _date.today()
+    start = resolved_today - _timedelta(days=days - 1)
+    window_starts = {
+        "today": resolved_today,
+        "7d": resolved_today - _timedelta(days=6),
+        "30d": resolved_today - _timedelta(days=29),
+    }
+
+    daily_tokens: dict[_date, dict[str, float]] = {}
+    window_tokens: dict[str, dict[str, float]] = {label: {} for label in window_starts}
+    model_tokens: dict[str, float] = {}
+    unknown_tokens: dict[str, float] = {}
+    for record in records:
+        if str(getattr(record, "client", "") or "") != client:
+            continue
+        model = str(getattr(record, "model", "") or "")
+        if not model:
+            continue
+        total = _finite(getattr(record, "total_tokens_including_cached", None)) or 0.0
+        if total <= 0:
+            continue
+        day = usage_bucket_date(_usage_record_time(record))
+        if day is None:
+            unknown_tokens[model] = unknown_tokens.get(model, 0.0) + total
+            continue
+        if day > resolved_today:
+            continue
+        if start <= day:
+            bucket = daily_tokens.setdefault(day, {})
+            bucket[model] = bucket.get(model, 0.0) + total
+            model_tokens[model] = model_tokens.get(model, 0.0) + total
+        for label, window_start in window_starts.items():
+            if window_start <= day:
+                window_bucket = window_tokens[label]
+                window_bucket[model] = window_bucket.get(model, 0.0) + total
+
+    daily: list[dict[str, Any]] = []
+    cursor = start
+    while cursor <= resolved_today:
+        daily.append(
+            {
+                "date": cursor.isoformat(),
+                "pct": weights.pct_for_tokens(daily_tokens.get(cursor) or {}),
+            }
+        )
+        cursor += _timedelta(days=1)
+
+    by_model = sorted(
+        (
+            {
+                "model": model,
+                "total_tokens": tokens,
+                "pct": weights.pct_for_tokens({model: tokens}),
+            }
+            for model, tokens in model_tokens.items()
+        ),
+        key=lambda entry: (-entry["pct"], entry["model"]),
+    )
+
+    return {
+        "window_pcts": {
+            label: weights.pct_for_tokens(tokens) for label, tokens in window_tokens.items()
+        },
+        "daily": daily,
+        "by_model": by_model,
+        "unknown_time_pct": (
+            weights.pct_for_tokens(unknown_tokens) if unknown_tokens else None
+        ),
+    }
+
+
+V1_PLAN_SCHEMA_VERSION = "agentacct.v1-plan.v1"
+
+
+def build_v1_plan_payload(
+    events: list[dict[str, Any]],
+    *,
+    days: int = 30,
+    now: float | None = None,
+    today: Any = None,
+) -> dict[str, Any]:
+    """The ``GET /v1/plan`` body: per-client plan status + attributed aggregates.
+
+    One entry per plan-bearing client (the glance's PLAN_CLIENTS): the
+    three-state calibration status with its why-this-number disclosure, and —
+    calibrated-or-nothing — the attributed weekly-plan aggregates from
+    :func:`plan_pct_aggregates` (window_pcts / daily series / by_model /
+    unknown_time_pct). An uncalibrated client carries explicit ``None``
+    aggregates next to its state, never fabricated numbers. These are
+    ATTRIBUTED estimates over tracked sessions; the account-wide provider
+    truth (7d used %) lives in the glance ``limits[]`` and is deliberately
+    not duplicated here — the two are different quantities and shells must
+    label them apart.
+    """
+
+    import time as _time
+
+    from .glance import PLAN_CLIENTS
+    from .usage_snapshot import usage_records
+
+    clients: list[dict[str, Any]] = []
+    for client in PLAN_CLIENTS:
+        records = usage_records(events, client=client)
+        weights = calibrate_plan_weights(events, client=client, records=records)
+        entry: dict[str, Any] = plan_status_entry(weights)
+        if weights.confidence == "calibrated":
+            entry.update(plan_pct_aggregates(records, weights, client=client, days=days, today=today))
+        else:
+            entry.update(
+                {"window_pcts": None, "daily": None, "by_model": None, "unknown_time_pct": None}
+            )
+        clients.append(entry)
+    return {
+        "schema": V1_PLAN_SCHEMA_VERSION,
+        "generated_at": _time.time() if now is None else float(now),
+        "days": days,
+        "clients": clients,
+    }
+
+
 def calibration_state(weights: PlanWeights) -> str:
     """Three-state display semantic for one client's plan estimate.
 
@@ -382,11 +532,14 @@ def plan_status_entry(weights: PlanWeights) -> dict[str, Any]:
 __all__ = [
     "BASELINE_MODEL_WEIGHTS",
     "CALIBRATABLE_CLIENTS",
+    "V1_PLAN_SCHEMA_VERSION",
     "PlanWeights",
     "baseline_weight",
+    "build_v1_plan_payload",
     "seven_day_series",
     "calibrate_plan_weights",
     "calibration_state",
+    "plan_pct_aggregates",
     "plan_status_entry",
     "session_tokens_by_model",
     "session_plan_pcts",

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -235,6 +235,23 @@ def calibrate_plan_weights(
     model_names = observed_models | set(BASELINE_MODEL_WEIGHTS)
     base = {m: baseline_weight(m, cost_per_mtok.get(m)) for m in model_names if m}
 
+    if client not in CALIBRATABLE_CLIENTS:
+        # A rolling/opaque meter (codex) can land 3 numerically-clean intervals
+        # inside the trusted band by coincidence — but its weekly plan %% is
+        # UNDEFINED by design, so a fit here would confidently label a number
+        # that means nothing (adversarial-review finding: /v1/plan served
+        # "calibrated" codex aggregates). The gate lives HERE, not in each
+        # display surface, so no surface can ever receive one.
+        return PlanWeights(
+            weights=base,
+            default_weight=BASELINE_MODEL_WEIGHTS["claude-opus-4-8"],
+            scale=1.0,
+            confidence="baseline",
+            basis="weekly plan %% is undefined for this client's rolling meter (it never calibrates)",
+            intervals_used=0,
+            client=client,
+        )
+
     series = seven_day_series(events, client=client)
     window_start = now_epoch - _CALIBRATION_WINDOW_DAYS * 86400.0
     observed = 0.0

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -234,7 +234,7 @@ def build_v1_sessions_view(
     entries = rollup.get("sessions") if isinstance(rollup, dict) else []
     entries = [entry for entry in entries if isinstance(entry, dict)] if isinstance(entries, list) else []
 
-    plan, session_pcts = plan_status_and_session_pcts(events)
+    plan, session_pcts, weights_by_client, records_by_client = plan_status_and_session_pcts(events)
 
     def _key(entry: dict[str, Any]) -> tuple[str, str]:
         return (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
@@ -278,12 +278,41 @@ def build_v1_sessions_view(
         row["fold_top"] = fold_top_by_key.get(key, key)
         rows.append(row)
 
+    # Step-join indexes, built once per view so the detail route is pure
+    # lookups instead of per-request ledger scans + a full usage-view rebuild
+    # (adversarial-review finding: /v1/session cost ~10x /v1/sessions per
+    # poll). Everything under plan_context/step_join is VIEW-INTERNAL — the
+    # wire never carries it (slice/detail project explicit fields only).
+    attributions_by_work: dict[str, list[dict[str, Any]]] = {}
+    for attribution in ledger.get("attributions") or []:
+        if isinstance(attribution, dict):
+            work_id = str(attribution.get("work_id") or "")
+            if work_id:
+                attributions_by_work.setdefault(work_id, []).append(attribution)
+    usage_event_models: dict[str, tuple[str | None, str | None]] = {}
+    for usage_event in ledger.get("usage_events") or []:
+        if isinstance(usage_event, dict):
+            usage_event_id = str(usage_event.get("usage_event_id") or "")
+            if usage_event_id:
+                usage_event_models[usage_event_id] = (
+                    usage_event.get("model"),
+                    usage_event.get("provider"),
+                )
+
     return {
         "generated_at": _time.time() if now is None else float(now),
         "rows": rows,
         "plan": plan,
         "total_sessions": len(rows),
         "total_root_sessions": root_count,
+        "plan_context": {
+            "weights_by_client": weights_by_client,
+            "records_by_client": records_by_client,
+        },
+        "step_join": {
+            "attributions_by_work": attributions_by_work,
+            "usage_event_models": usage_event_models,
+        },
     }
 
 
@@ -374,9 +403,14 @@ class V1SessionsCache:
 # ---------------------------------------------------------------------------
 
 _STEP_CHECK_FIELDS = (
-    # Curated check projection: display-relevant fields only, always the
-    # REDACTED variants of anything path/command-shaped (the raw twins stay
-    # off this wire even though machine-local siblings serve them).
+    # Curated check projection, passed through from the ledger's evidence
+    # events VERBATIM under their real names and types. In that projection
+    # ``artifact_path``/``artifact_url`` are ALREADY the sanitized-safe
+    # strings, the ``*_redacted`` twins are BOOLEAN was-withheld disclosures,
+    # and no raw command string exists at all (``command_redacted`` says one
+    # was recorded). Round-1 adversarial finding: an earlier draft mistook
+    # the boolean flags for redacted strings and served ``command: true``
+    # while dropping the safe artifact values.
     "event_id",
     "created_at",
     "evidence_type",
@@ -391,19 +425,16 @@ _STEP_CHECK_FIELDS = (
     "resolves_blocked_event_id",
     "files",
     "artifact_ref",
+    "artifact_path",
+    "artifact_url",
+    "command_redacted",
+    "artifact_path_redacted",
+    "artifact_url_redacted",
 )
-_STEP_CHECK_REDACTED_FIELDS = {
-    "command": "command_redacted",
-    "artifact_url": "artifact_url_redacted",
-    "artifact_path": "artifact_path_redacted",
-}
 
 
 def _project_check(event: dict[str, Any]) -> dict[str, Any]:
-    check = {name: event.get(name) for name in _STEP_CHECK_FIELDS}
-    for wire_name, source_name in _STEP_CHECK_REDACTED_FIELDS.items():
-        check[wire_name] = event.get(source_name)
-    return check
+    return {name: event.get(name) for name in _STEP_CHECK_FIELDS}
 
 
 def _project_step(item: dict[str, Any], models: list[dict[str, Any]]) -> dict[str, Any]:
@@ -431,7 +462,17 @@ def _project_step(item: dict[str, Any], models: list[dict[str, Any]]) -> dict[st
             "fresh_tokens": item.get("usage_fresh_total"),
             "cache_read_tokens": item.get("usage_cache_read_total"),
             "cache_creation_tokens": item.get("usage_cache_creation_total"),
-            "estimated_cost_usd": item.get("estimated_cost_total"),
+            # The ledger's internal sum defaults to 0.0; under the wire name
+            # estimated_cost_usd the product-wide contract is None-never-$0
+            # when nothing was priced (adversarial-review finding). A value
+            # with unpriced rows alongside is a PARTIAL subtotal — the counts
+            # below are the shell's completeness signal.
+            "estimated_cost_usd": (
+                item.get("estimated_cost_total")
+                if isinstance(item.get("priced_usage_records"), int)
+                and item.get("priced_usage_records", 0) > 0
+                else None
+            ),
             "linked_usage_records": item.get("linked_usage_records"),
             "priced_usage_records": item.get("priced_usage_records"),
             "unpriced_usage_records": item.get("unpriced_usage_records"),
@@ -460,9 +501,13 @@ def _step_models(
     lanes: dict[tuple[str | None, str | None], float] = {}
     for attribution in attributions_by_work.get(work_id, []):
         usage_event_id = str(attribution.get("usage_event_id") or "")
-        model, provider = usage_event_models.get(usage_event_id, (None, None))
-        if model is None:
-            continue
+        lane_identity = usage_event_models.get(usage_event_id)
+        if lane_identity is None:
+            continue  # dangling attribution — we know nothing about this event
+        model, provider = lane_identity
+        # A known event with NO model keeps its lane (model: null) — dropping
+        # it made the lane sum silently undercount the step total (the
+        # session rollup's model_lanes keep null lanes for the same reason).
         key = (model, provider)
         tokens = attribution.get("usage_tokens")
         amount = float(tokens) if isinstance(tokens, (int, float)) and not isinstance(tokens, bool) else 0.0
@@ -498,7 +543,6 @@ def _descendant_row(row: dict[str, Any]) -> dict[str, Any]:
 def build_v1_session_detail(
     view: dict[str, Any],
     ledger: dict[str, Any],
-    events: list[dict[str, Any]],
     *,
     client: str,
     session_id: str,
@@ -510,19 +554,17 @@ def build_v1_session_detail(
     rollup's embedded mini-rows lack timestamps/usage/checks), filtered by
     (client, session_id) exactly like the TUI's detail screen, newest first.
     Each step carries its attributed model lanes and its machine checks
-    (curated, redacted variants). Descendants are every view row whose fold
-    fixpoint is this session — the same accounting behind the list row's
+    (curated projection). Descendants are every view row whose fold fixpoint
+    is this session — the same accounting behind the list row's
     ``plan_pct_children``, so the numbers can never disagree. The per-session
     plan block adds the why-this-number disclosure (basis/scale) and a
-    by-model split of the session's OWN share (calibrated-or-nothing).
+    by-model split of the session's OWN share (calibrated-or-nothing), all
+    derived from the CACHED view's own fit and indexes — a per-request
+    recompute both cost a full usage-view rebuild per poll and could disagree
+    with the very pct values it shipped next to (adversarial-review findings).
     """
 
-    from .plan_cost import (
-        calibrate_plan_weights,
-        plan_status_entry,
-        session_tokens_by_model,
-    )
-    from .usage_snapshot import usage_records
+    from .plan_cost import plan_status_entry, session_tokens_by_model
 
     key = (client, session_id)
     row = next(
@@ -544,21 +586,9 @@ def build_v1_session_detail(
         and str(item.get("client_session_id") or "") == session_id
     ]
 
-    attributions_by_work: dict[str, list[dict[str, Any]]] = {}
-    for attribution in ledger.get("attributions") or []:
-        if isinstance(attribution, dict):
-            work_id = str(attribution.get("work_id") or "")
-            if work_id:
-                attributions_by_work.setdefault(work_id, []).append(attribution)
-    usage_event_models: dict[str, tuple[str | None, str | None]] = {}
-    for usage_event in ledger.get("usage_events") or []:
-        if isinstance(usage_event, dict):
-            usage_event_id = str(usage_event.get("usage_event_id") or "")
-            if usage_event_id:
-                usage_event_models[usage_event_id] = (
-                    usage_event.get("model"),
-                    usage_event.get("provider"),
-                )
+    step_join = view.get("step_join") if isinstance(view.get("step_join"), dict) else {}
+    attributions_by_work = step_join.get("attributions_by_work") or {}
+    usage_event_models = step_join.get("usage_event_models") or {}
 
     steps = [
         _project_step(
@@ -575,29 +605,37 @@ def build_v1_session_detail(
         and (candidate.get("client"), candidate.get("client_session_id")) != key
     ]
 
-    records = usage_records(events, client=client)
-    weights = calibrate_plan_weights(events, client=client, records=records)
-    plan: dict[str, Any] = dict(plan_status_entry(weights))
+    plan_context = view.get("plan_context") if isinstance(view.get("plan_context"), dict) else {}
+    weights = (plan_context.get("weights_by_client") or {}).get(client)
+    records = (plan_context.get("records_by_client") or {}).get(client) or []
+    plan: dict[str, Any]
+    if weights is not None:
+        plan = dict(plan_status_entry(weights))
+        if weights.confidence == "calibrated":
+            tokens_by_model = session_tokens_by_model(
+                client=client, session_id=session_id, records=records
+            )
+            plan["by_model"] = sorted(
+                (
+                    {
+                        "model": model,
+                        "total_tokens": tokens,
+                        "pct": weights.pct_for_tokens({model: tokens}),
+                    }
+                    for model, tokens in tokens_by_model.items()
+                ),
+                key=lambda entry: (-entry["pct"], entry["model"]),
+            )
+        else:
+            plan["by_model"] = None
+    else:
+        # Not a plan-bearing client: an explicit no-plan block, not a guess.
+        plan = {"client": client, "confidence": None, "calibration_state": None,
+                "calibratable": False, "basis": None, "scale": None,
+                "intervals_used": None, "by_model": None}
     plan["pct_own"] = row.get("plan_pct_own")
     plan["pct_children"] = row.get("plan_pct_children")
     plan["pct"] = row.get("plan_pct")
-    if weights.confidence == "calibrated":
-        tokens_by_model = session_tokens_by_model(
-            client=client, session_id=session_id, records=records
-        )
-        plan["by_model"] = sorted(
-            (
-                {
-                    "model": model,
-                    "total_tokens": tokens,
-                    "pct": weights.pct_for_tokens({model: tokens}),
-                }
-                for model, tokens in tokens_by_model.items()
-            ),
-            key=lambda entry: (-entry["pct"], entry["model"]),
-        )
-    else:
-        plan["by_model"] = None
 
     session = {name: value for name, value in row.items() if name not in _VIEW_INTERNAL_KEYS}
     return {

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -34,6 +34,10 @@ from threading import Lock
 from typing import Any, Callable
 
 V1_SESSIONS_SCHEMA_VERSION = "agentacct.v1-sessions.v1"
+V1_SESSION_DETAIL_SCHEMA_VERSION = "agentacct.v1-session-detail.v1"
+
+# Row keys that exist only for the view's own bookkeeping, never on the wire.
+_VIEW_INTERNAL_KEYS = frozenset({"is_root", "fold_top"})
 
 # TTL rationale: the view is mostly event-derived (the fingerprint catches
 # those changes), but plan calibration windows are clock-relative and the
@@ -268,6 +272,10 @@ def build_v1_sessions_view(
         if own is not None or descendants is not None:
             row["plan_pct"] = (own or 0.0) + (descendants or 0.0)
         row["is_root"] = is_root
+        # View-internal (stripped from the wire like is_root): the fixpoint
+        # this row's share folds to — the detail endpoint lists a root's
+        # descendants by matching it.
+        row["fold_top"] = fold_top_by_key.get(key, key)
         rows.append(row)
 
     return {
@@ -299,9 +307,12 @@ def slice_sessions_payload(
     rows = view.get("rows") or []
     pool = [row for row in rows if row.get("is_root")] if roots_only else list(rows)
     page = pool[offset : offset + limit]
-    # ``is_root`` is view-internal bookkeeping (the wire has related.parent);
-    # strip it without mutating the cached rows.
-    page = [{key: value for key, value in row.items() if key != "is_root"} for row in page]
+    # ``is_root``/``fold_top`` are view-internal bookkeeping (the wire has
+    # related.parent); strip them without mutating the cached rows.
+    page = [
+        {key: value for key, value in row.items() if key not in _VIEW_INTERNAL_KEYS}
+        for row in page
+    ]
     return {
         "schema": V1_SESSIONS_SCHEMA_VERSION,
         "generated_at": view.get("generated_at"),
@@ -356,3 +367,244 @@ class V1SessionsCache:
             view = builder()
             self._cached = (fingerprint, moment, view)
             return view
+
+
+# ---------------------------------------------------------------------------
+# session detail (the expandable-steps view — the depth the TUI sets the bar for)
+# ---------------------------------------------------------------------------
+
+_STEP_CHECK_FIELDS = (
+    # Curated check projection: display-relevant fields only, always the
+    # REDACTED variants of anything path/command-shaped (the raw twins stay
+    # off this wire even though machine-local siblings serve them).
+    "event_id",
+    "created_at",
+    "evidence_type",
+    "result",
+    "summary",
+    "exit_code",
+    "check_identity",
+    "supersession_state",
+    "superseded_by_event_id",
+    "resolution_scope",
+    "resolution_summary",
+    "resolves_blocked_event_id",
+    "files",
+    "artifact_ref",
+)
+_STEP_CHECK_REDACTED_FIELDS = {
+    "command": "command_redacted",
+    "artifact_url": "artifact_url_redacted",
+    "artifact_path": "artifact_path_redacted",
+}
+
+
+def _project_check(event: dict[str, Any]) -> dict[str, Any]:
+    check = {name: event.get(name) for name in _STEP_CHECK_FIELDS}
+    for wire_name, source_name in _STEP_CHECK_REDACTED_FIELDS.items():
+        check[wire_name] = event.get(source_name)
+    return check
+
+
+def _project_step(item: dict[str, Any], models: list[dict[str, Any]]) -> dict[str, Any]:
+    evidence_events = item.get("evidence_events")
+    checks = [
+        _project_check(event)
+        for event in (evidence_events if isinstance(evidence_events, list) else [])
+        if isinstance(event, dict)
+    ]
+    return {
+        "work_id": item.get("work_id"),
+        "section_id": item.get("section_id"),
+        "title": item.get("title"),
+        "latest_status": item.get("latest_status"),
+        "kind": item.get("kind"),
+        "phase": item.get("phase"),
+        "started_at": item.get("started_at"),
+        "updated_at": item.get("updated_at"),
+        "summary": item.get("summary"),
+        "files": item.get("files"),
+        "blocker": item.get("blocker"),
+        "next_step": item.get("next_step"),
+        "usage": {
+            "total_tokens": item.get("usage_total"),
+            "fresh_tokens": item.get("usage_fresh_total"),
+            "cache_read_tokens": item.get("usage_cache_read_total"),
+            "cache_creation_tokens": item.get("usage_cache_creation_total"),
+            "estimated_cost_usd": item.get("estimated_cost_total"),
+            "linked_usage_records": item.get("linked_usage_records"),
+            "priced_usage_records": item.get("priced_usage_records"),
+            "unpriced_usage_records": item.get("unpriced_usage_records"),
+        },
+        "join_confidence": item.get("join_confidence"),
+        "join_explanation": item.get("join_explanation"),
+        "evidence_status": item.get("evidence_status"),
+        "models": models,
+        "checks": checks,
+    }
+
+
+def _step_models(
+    work_id: str,
+    attributions_by_work: dict[str, list[dict[str, Any]]],
+    usage_event_models: dict[str, tuple[str | None, str | None]],
+) -> list[dict[str, Any]]:
+    """Per-step model lanes via the attribution join.
+
+    A step has no model of its own — models ride on usage events, and the
+    ledger's attributions are the ONLY honest link between the two. Tokens
+    come from the attribution rows (the attributed slice), never re-guessed.
+    Unattributed steps simply return [] — missing beats invented.
+    """
+
+    lanes: dict[tuple[str | None, str | None], float] = {}
+    for attribution in attributions_by_work.get(work_id, []):
+        usage_event_id = str(attribution.get("usage_event_id") or "")
+        model, provider = usage_event_models.get(usage_event_id, (None, None))
+        if model is None:
+            continue
+        key = (model, provider)
+        tokens = attribution.get("usage_tokens")
+        amount = float(tokens) if isinstance(tokens, (int, float)) and not isinstance(tokens, bool) else 0.0
+        lanes[key] = lanes.get(key, 0.0) + amount
+    return sorted(
+        (
+            {"model": model, "provider": provider, "total_tokens": tokens}
+            for (model, provider), tokens in lanes.items()
+        ),
+        key=lambda lane: (-lane["total_tokens"], str(lane["model"])),
+    )
+
+
+def _descendant_row(row: dict[str, Any]) -> dict[str, Any]:
+    usage = row.get("usage") if isinstance(row.get("usage"), dict) else {}
+    return {
+        "client": row.get("client"),
+        "client_session_id": row.get("client_session_id"),
+        "client_session_id_short": row.get("client_session_id_short"),
+        "title": row.get("title"),
+        "status": row.get("status"),
+        "last_activity_at": row.get("last_activity_at"),
+        "usage": {
+            "total_tokens": usage.get("total_tokens"),
+            "fresh_tokens": usage.get("fresh_tokens"),
+            "estimated_cost_usd": usage.get("estimated_cost_usd"),
+            "cost_confidence": usage.get("cost_confidence"),
+        },
+        "plan_pct": row.get("plan_pct_own"),
+    }
+
+
+def build_v1_session_detail(
+    view: dict[str, Any],
+    ledger: dict[str, Any],
+    events: list[dict[str, Any]],
+    *,
+    client: str,
+    session_id: str,
+) -> dict[str, Any] | None:
+    """The one-session deep view: the list row + expandable steps + descendants.
+
+    ``None`` when the session has no rollup entry (the route 404s — never an
+    empty fabrication). Steps come from the ledger's full work_items (the
+    rollup's embedded mini-rows lack timestamps/usage/checks), filtered by
+    (client, session_id) exactly like the TUI's detail screen, newest first.
+    Each step carries its attributed model lanes and its machine checks
+    (curated, redacted variants). Descendants are every view row whose fold
+    fixpoint is this session — the same accounting behind the list row's
+    ``plan_pct_children``, so the numbers can never disagree. The per-session
+    plan block adds the why-this-number disclosure (basis/scale) and a
+    by-model split of the session's OWN share (calibrated-or-nothing).
+    """
+
+    from .plan_cost import (
+        calibrate_plan_weights,
+        plan_status_entry,
+        session_tokens_by_model,
+    )
+    from .usage_snapshot import usage_records
+
+    key = (client, session_id)
+    row = next(
+        (
+            candidate
+            for candidate in (view.get("rows") or [])
+            if (candidate.get("client"), candidate.get("client_session_id")) == key
+        ),
+        None,
+    )
+    if row is None:
+        return None
+
+    items = [
+        item
+        for item in (ledger.get("work_items") or [])
+        if isinstance(item, dict)
+        and str(item.get("client") or "") == client
+        and str(item.get("client_session_id") or "") == session_id
+    ]
+
+    attributions_by_work: dict[str, list[dict[str, Any]]] = {}
+    for attribution in ledger.get("attributions") or []:
+        if isinstance(attribution, dict):
+            work_id = str(attribution.get("work_id") or "")
+            if work_id:
+                attributions_by_work.setdefault(work_id, []).append(attribution)
+    usage_event_models: dict[str, tuple[str | None, str | None]] = {}
+    for usage_event in ledger.get("usage_events") or []:
+        if isinstance(usage_event, dict):
+            usage_event_id = str(usage_event.get("usage_event_id") or "")
+            if usage_event_id:
+                usage_event_models[usage_event_id] = (
+                    usage_event.get("model"),
+                    usage_event.get("provider"),
+                )
+
+    steps = [
+        _project_step(
+            item,
+            _step_models(str(item.get("work_id") or ""), attributions_by_work, usage_event_models),
+        )
+        for item in items
+    ]
+
+    descendants = [
+        _descendant_row(candidate)
+        for candidate in (view.get("rows") or [])
+        if candidate.get("fold_top") == key
+        and (candidate.get("client"), candidate.get("client_session_id")) != key
+    ]
+
+    records = usage_records(events, client=client)
+    weights = calibrate_plan_weights(events, client=client, records=records)
+    plan: dict[str, Any] = dict(plan_status_entry(weights))
+    plan["pct_own"] = row.get("plan_pct_own")
+    plan["pct_children"] = row.get("plan_pct_children")
+    plan["pct"] = row.get("plan_pct")
+    if weights.confidence == "calibrated":
+        tokens_by_model = session_tokens_by_model(
+            client=client, session_id=session_id, records=records
+        )
+        plan["by_model"] = sorted(
+            (
+                {
+                    "model": model,
+                    "total_tokens": tokens,
+                    "pct": weights.pct_for_tokens({model: tokens}),
+                }
+                for model, tokens in tokens_by_model.items()
+            ),
+            key=lambda entry: (-entry["pct"], entry["model"]),
+        )
+    else:
+        plan["by_model"] = None
+
+    session = {name: value for name, value in row.items() if name not in _VIEW_INTERNAL_KEYS}
+    return {
+        "schema": V1_SESSION_DETAIL_SCHEMA_VERSION,
+        "generated_at": view.get("generated_at"),
+        "session": session,
+        "steps": steps,
+        "descendants": descendants,
+        "plan": plan,
+    }

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -218,7 +218,13 @@ def test_read_discovery_file_never_raises(tmp_path):
 def test_v1_routes_fail_closed_without_configured_token(tmp_path):
     SentinelService(tmp_path)
     client = TestClient(create_local_api_app(store_dir=tmp_path))
-    for route in ("/v1/glance", "/v1/version", "/v1/sessions"):
+    for route in (
+        "/v1/glance",
+        "/v1/version",
+        "/v1/sessions",
+        "/v1/session?client=x&session_id=y",
+        "/v1/plan",
+    ):
         response = client.get(route, headers={"Authorization": "Bearer anything"})
         assert response.status_code == 503, route
 

--- a/tests/test_plan_cost.py
+++ b/tests/test_plan_cost.py
@@ -177,6 +177,31 @@ def test_calibrate_skips_untracked_movement(tmp_path):
     assert weights.intervals_used == 0
 
 
+def test_codex_never_calibrates_even_with_numerically_clean_history(tmp_path):
+    """A rolling meter can land 3 clean intervals in the trusted band by
+    coincidence, but codex's weekly plan % is UNDEFINED by design — the gate
+    lives in calibrate_plan_weights so NO surface can ever receive a
+    'calibrated' codex fit (adversarial-review finding: /v1/plan served
+    confidently-labeled aggregates of an undefined quantity)."""
+
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    anchor = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]  # unknown codex model -> anchor weight
+    move = 100.0 * anchor  # observed == predicted -> scale ~1.0, inside the band
+    pct = 10.0
+    _record_7d(service, captured=float(t0), pct=pct, client="codex", index=0)
+    for i in range(4):
+        _record_usage(service, client="codex", model="gpt-5.2-codex", session_id=f"c{i}",
+                      tokens=100_000_000, updated_at=t0 + i * 3600 + 1800, cost=None)
+        pct += move
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, client="codex", index=i + 1)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="codex",
+                                        now=float(t0 + 5 * 3600))
+    assert weights.confidence == "baseline"
+    assert pc.calibration_state(weights) == "never"
+    assert "undefined" in weights.basis
+
+
 def test_calibrate_untrusted_scale_falls_back_to_baseline(tmp_path):
     # Regression (review): if the meter moved ~10x what local tokens predict (heavy
     # untracked usage, or a very different tier we can't identify), the fitted scale is

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -94,20 +94,59 @@ def _record_section(
     title: str = "t",
     created_at: float,
     section_id: str | None = None,
+    kind: str | None = None,
+    summary: str | None = None,
 ) -> None:
     resolved_section = section_id or f"sec-{session_id}-{status}"
+    metadata: dict = {
+        "client": client,
+        "client_session_id": session_id,
+        "section_id": resolved_section,
+        "section_status": status,
+        "section_title": title,
+    }
+    if kind is not None:
+        metadata["kind"] = kind
+    if summary is not None:
+        metadata["summary"] = summary
     service.append_events_preserving_identity([
         {
             "event_id": f"evt_sec_{client}_{session_id}_{resolved_section}_{int(created_at)}",
             "created_at": created_at,
             "source": client,
             "event_type": f"section_{status}",
+            "metadata": metadata,
+        }
+    ])
+
+
+def _record_check(
+    service: SentinelService,
+    *,
+    client: str = "claude-code",
+    session_id: str,
+    section_id: str,
+    result: str = "passed",
+    evidence_type: str = "test",
+    summary: str = "suite green",
+    created_at: float,
+) -> None:
+    service.append_events_preserving_identity([
+        {
+            "event_id": f"evt_chk_{client}_{session_id}_{section_id}_{result}_{int(created_at)}",
+            "created_at": created_at,
+            "source": client,
+            "event_type": "machine_check",
             "metadata": {
+                "sentinel_semantic_kind": "evidence",
                 "client": client,
                 "client_session_id": session_id,
-                "section_id": resolved_section,
-                "section_status": status,
-                "section_title": title,
+                "section_id": section_id,
+                "evidence_type": evidence_type,
+                "result": result,
+                "summary": summary,
+                "command": "pytest -q --token secret",
+                "exit_code": 0 if result == "passed" else 1,
             },
         }
     ])
@@ -670,3 +709,163 @@ def test_ledger_cache_expires_by_age_even_when_events_are_unchanged():
     assert cache.ledger(1, _build, now=t0 + 29) == {"n": 1}   # fresh: same fp, inside TTL
     assert cache.ledger(1, _build, now=t0 + 31) == {"n": 2}   # TTL expired → rebuild
     assert cache.ledger(2, _build, now=t0 + 31.5) == {"n": 3}  # fp change → rebuild
+
+
+# ---------------------------------------------------------------------------
+# /v1/session detail + /v1/plan
+# ---------------------------------------------------------------------------
+
+
+def test_detail_and_plan_require_the_bearer_token(tmp_path):
+    SentinelService(tmp_path)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    detail = "/v1/session?client=claude-code&session_id=x"
+    assert client.get(detail).status_code == 401
+    assert client.get("/v1/plan").status_code == 401
+    no_token = TestClient(create_local_api_app(store_dir=tmp_path))
+    assert no_token.get(detail, headers=AUTH).status_code == 503
+    assert no_token.get("/v1/plan", headers=AUTH).status_code == 503
+
+
+def test_detail_404_for_an_unknown_session(tmp_path):
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="root-a", tokens=100, updated_at=time.time() - 60)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    response = client.get("/v1/session", headers=AUTH,
+                          params={"client": "claude-code", "session_id": "nope"})
+    assert response.status_code == 404
+
+
+def test_detail_steps_carry_tui_grade_depth(tmp_path):
+    """The bar the owner set: per-step status/kind/title/summary/timestamps
+    plus the machine checks with their results — everything the TUI detail
+    screen shows, on the wire."""
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, session_id="root-a", tokens=1000, updated_at=now - 900)
+    _record_section(service, session_id="root-a", status="started", title="build the thing",
+                    created_at=now - 800, section_id="s1", kind="implementation",
+                    summary="working on it")
+    _record_check(service, session_id="root-a", section_id="s1", result="passed",
+                  created_at=now - 700)
+    _record_section(service, session_id="root-a", status="completed", title="build the thing",
+                    created_at=now - 600, section_id="s1", kind="implementation")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    detail = client.get("/v1/session", headers=AUTH,
+                        params={"client": "claude-code", "session_id": "root-a"}).json()
+    assert detail["schema"] == "agentacct.v1-session-detail.v1"
+    assert detail["session"]["client_session_id"] == "root-a"
+    assert "is_root" not in detail["session"] and "fold_top" not in detail["session"]
+    steps = detail["steps"]
+    assert len(steps) == 1
+    step = steps[0]
+    assert step["section_id"] == "s1"
+    assert step["latest_status"] == "completed"
+    assert step["kind"] == "implementation"
+    assert step["title"] == "build the thing"
+    assert step["started_at"] is not None and step["updated_at"] is not None
+    assert isinstance(step["models"], list)
+    assert step["evidence_status"] == "strong"
+    checks = step["checks"]
+    assert len(checks) == 1
+    assert checks[0]["evidence_type"] == "test"
+    assert checks[0]["result"] == "passed"
+    assert checks[0]["summary"] == "suite green"
+    assert checks[0]["exit_code"] == 0
+    # The raw command never rides this wire — only the redacted variant key.
+    assert "pytest -q --token secret" not in str(checks[0].get("command") or "")
+
+
+def test_detail_descendants_and_plan_block(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    _record_usage(service, session_id="root-a", tokens=10_000_000, updated_at=now - 600)
+    _record_usage(service, session_id="22222222-aaaa-bbbb-cccc-333333333333",
+                  tokens=5_000_000, updated_at=now - 300,
+                  session_kind="child", parent_session_id="root-a")
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    detail = client.get("/v1/session", headers=AUTH,
+                        params={"client": "claude-code", "session_id": "root-a"}).json()
+    scale = detail["plan"]["scale"]
+    assert detail["plan"]["confidence"] == "calibrated"
+    assert abs(detail["plan"]["pct_own"] - 10.0 * opus * scale) < 1e-6
+    assert abs(detail["plan"]["pct_children"] - 5.0 * opus * scale) < 1e-6
+    assert abs(detail["plan"]["pct"] - 15.0 * opus * scale) < 1e-6
+    by_model = {entry["model"]: entry for entry in detail["plan"]["by_model"]}
+    assert abs(by_model["claude-opus-4-8"]["pct"] - 10.0 * opus * scale) < 1e-6
+    descendants = detail["descendants"]
+    assert len(descendants) == 1
+    child = descendants[0]
+    assert child["client_session_id"] == "22222222-aaaa-bbbb-cccc-333333333333"
+    assert abs(child["plan_pct"] - 5.0 * opus * scale) < 1e-6
+
+
+def test_step_models_join_unit():
+    """The attribution join, in isolation: tokens come from the attribution
+    rows, unknown usage events are skipped, lanes sort by tokens."""
+
+    from agentacct.v1_sessions import _step_models
+
+    attributions = {
+        "w1": [
+            {"usage_event_id": "u1", "usage_tokens": 100},
+            {"usage_event_id": "u2", "usage_tokens": 900},
+            {"usage_event_id": "missing", "usage_tokens": 50},
+        ]
+    }
+    models = {
+        "u1": ("claude-opus-4-8", "claude-code"),
+        "u2": ("claude-fable-5", "claude-code"),
+    }
+    lanes = _step_models("w1", attributions, models)
+    assert [lane["model"] for lane in lanes] == ["claude-fable-5", "claude-opus-4-8"]
+    assert lanes[0]["total_tokens"] == 900
+    assert _step_models("unknown", attributions, models) == []
+
+
+def test_plan_endpoint_uncalibrated_carries_states_not_numbers(tmp_path):
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="root-a", tokens=1_000_000, updated_at=time.time() - 60)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = client.get("/v1/plan", headers=AUTH).json()
+    assert payload["schema"] == "agentacct.v1-plan.v1"
+    clients = {entry["client"]: entry for entry in payload["clients"]}
+    assert clients["claude-code"]["calibration_state"] == "calibrating"
+    assert clients["claude-code"]["window_pcts"] is None
+    assert clients["claude-code"]["daily"] is None
+    assert clients["codex"]["calibration_state"] == "never"
+    assert clients["codex"]["by_model"] is None
+
+
+def test_plan_endpoint_calibrated_aggregates_agree(tmp_path):
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _calibrate_claude(service, now=now)
+    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    _record_usage(service, session_id="root-a", tokens=10_000_000, updated_at=now - 60)
+
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    payload = client.get("/v1/plan", headers=AUTH, params={"days": 14}).json()
+    entry = {row["client"]: row for row in payload["clients"]}["claude-code"]
+    assert entry["confidence"] == "calibrated"
+    scale = entry["scale"]
+    # All calibration usage (400M) + root-a (10M) landed within 7 days. The
+    # calibration hours can straddle local midnight (a test running at 1am),
+    # so "today" is only bounded, not pinned: it must include at least
+    # root-a's just-now share and never exceed the window total.
+    expected_total = 410.0 * opus * scale
+    assert abs(entry["window_pcts"]["7d"] - expected_total) < 1e-6
+    assert 10.0 * opus * scale - 1e-6 <= entry["window_pcts"]["today"] <= expected_total + 1e-6
+    daily = entry["daily"]
+    assert len(daily) == 14  # trailing days incl. empty ones
+    assert abs(sum(day["pct"] for day in daily) - expected_total) < 1e-6
+    by_model = {row["model"]: row for row in entry["by_model"]}
+    assert abs(by_model["claude-opus-4-8"]["pct"] - expected_total) < 1e-6
+    # Cache: an unchanged store serves the same build (same generated_at).
+    again = client.get("/v1/plan", headers=AUTH, params={"days": 14}).json()
+    assert again["generated_at"] == payload["generated_at"]

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -774,8 +774,12 @@ def test_detail_steps_carry_tui_grade_depth(tmp_path):
     assert checks[0]["result"] == "passed"
     assert checks[0]["summary"] == "suite green"
     assert checks[0]["exit_code"] == 0
-    # The raw command never rides this wire — only the redacted variant key.
-    assert "pytest -q --token secret" not in str(checks[0].get("command") or "")
+    # No raw command exists on this wire at all — only the boolean disclosure
+    # that one was recorded (the ledger's evidence projection never carries
+    # the string). Regression for the booleans-under-string-keys finding.
+    assert "command" not in checks[0]
+    assert checks[0]["command_redacted"] is True
+    assert "pytest -q --token secret" not in str(checks[0])
 
 
 def test_detail_descendants_and_plan_block(tmp_path):
@@ -807,7 +811,9 @@ def test_detail_descendants_and_plan_block(tmp_path):
 
 def test_step_models_join_unit():
     """The attribution join, in isolation: tokens come from the attribution
-    rows, unknown usage events are skipped, lanes sort by tokens."""
+    rows, dangling usage events are skipped, a KNOWN event without a model
+    keeps a null lane (lane sums must reconcile with the step total), lanes
+    sort by tokens."""
 
     from agentacct.v1_sessions import _step_models
 
@@ -815,17 +821,67 @@ def test_step_models_join_unit():
         "w1": [
             {"usage_event_id": "u1", "usage_tokens": 100},
             {"usage_event_id": "u2", "usage_tokens": 900},
+            {"usage_event_id": "u3", "usage_tokens": 400},
             {"usage_event_id": "missing", "usage_tokens": 50},
         ]
     }
     models = {
         "u1": ("claude-opus-4-8", "claude-code"),
         "u2": ("claude-fable-5", "claude-code"),
+        "u3": (None, "codex"),
     }
     lanes = _step_models("w1", attributions, models)
-    assert [lane["model"] for lane in lanes] == ["claude-fable-5", "claude-opus-4-8"]
+    assert [lane["model"] for lane in lanes] == ["claude-fable-5", None, "claude-opus-4-8"]
     assert lanes[0]["total_tokens"] == 900
+    assert lanes[1]["total_tokens"] == 400  # model-less lane kept, not dropped
     assert _step_models("unknown", attributions, models) == []
+
+
+def test_step_cost_is_none_when_nothing_priced():
+    """estimated_cost_usd on the wire means None-never-$0 when nothing was
+    priced — the ledger's internal 0.0 default must not leak as a measured
+    zero (adversarial-review finding)."""
+
+    from agentacct.v1_sessions import _project_step
+
+    unpriced = _project_step(
+        {"work_id": "w", "estimated_cost_total": 0.0, "priced_usage_records": 0,
+         "unpriced_usage_records": 2, "work": {}},
+        [],
+    )
+    assert unpriced["usage"]["estimated_cost_usd"] is None
+    priced = _project_step(
+        {"work_id": "w", "estimated_cost_total": 1.25, "priced_usage_records": 2,
+         "unpriced_usage_records": 0, "work": {}},
+        [],
+    )
+    assert priced["usage"]["estimated_cost_usd"] == 1.25
+
+
+def test_detail_reuses_the_cached_fit_no_per_request_usage_view(tmp_path, monkeypatch):
+    """A polling detail screen must not pay a full usage-view rebuild per
+    request: everything plan-shaped comes from the cached view's own fit
+    (which also keeps the payload self-consistent)."""
+
+    import agentacct.usage_snapshot as usage_snapshot_module
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="root-a", tokens=1000, updated_at=time.time() - 60)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    assert client.get("/v1/sessions", headers=AUTH).status_code == 200  # warm the view
+
+    calls = {"count": 0}
+    real = usage_snapshot_module.usage_records
+
+    def _counting(*args, **kwargs):
+        calls["count"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(usage_snapshot_module, "usage_records", _counting)
+    detail = client.get("/v1/session", headers=AUTH,
+                        params={"client": "claude-code", "session_id": "root-a"})
+    assert detail.status_code == 200
+    assert calls["count"] == 0  # pure cache lookups, no usage-view rebuild
 
 
 def test_plan_endpoint_uncalibrated_carries_states_not_numbers(tmp_path):


### PR DESCRIPTION
PR-D2 — the second daemon half of the app-v3 plan (D3 session-detail depth + D4 plan aggregates). Consumes nothing new from the store; both endpoints are additive on the /v1 bearer lane.

## GET /v1/session?client=&session_id=

The one-session deep view the full-window detail page renders (the TUI detail screen sets the bar):

- the list row (same projection as /v1/sessions, plan trio included);
- **steps** — every work item of the session, newest first: status/kind/title/summary/timestamps/files/blocker/next_step, per-step usage + estimated cost, join confidence + explanation, the 4-state evidence enum, and the machine checks (curated projection; command/artifact fields are the REDACTED variants only);
- **per-step model lanes** via the ledger's attribution join — tokens come from the attribution rows, never re-guessed; an unattributed step shows `[]` (live coverage is ~6% of usage events / 177 of 1027 work items — session-cumulative rows mostly cannot be pinned to one section, so shells fall back to the session-level `usage.model_lanes` for context);
- **descendants** — every row whose fold fixpoint is this session (the exact accounting behind the list row's `plan_pct_children`, so the two can never disagree);
- **plan block** — three-state calibration + basis/scale disclosure + a by-model split of the session's own share (calibrated-or-nothing).

404 for unknown sessions — never an empty fabrication.

## GET /v1/plan?days=N

Per-client attributed plan aggregates for the Dashboard (calibrated-or-nothing): today/7d/30d window shares, a **daily series that mirrors the usage cube's calendar semantics** (local days, trailing range ending today, a session-lane's tokens land on its latest-update day) so the plan chart and the /usage/summary cost chart align column-for-column; a by-model split ("which model eats the weekly plan"); and an `unknown_time_pct` disclosure for tokens whose timestamps fail the guard. Uncalibrated clients carry explicit `None` aggregates next to their three-state status. The account-wide provider 7d truth stays in glance `limits[]` — a different quantity, deliberately not duplicated.

## Plumbing

- `/v1/version` advertises `session_detail_schema` + `plan_schema` (additive).
- Both routes bearer-gated; detail reuses the ledger + view caches; plan cached per (fingerprint × days), TTL 30s.
- View rows carry a new internal `fold_top` (stripped from the wire alongside `is_root`).

## Tests

9 new (auth/503 parity incl. param-shaped routes, 404, TUI-grade step depth incl. check redaction, descendants + plan-block arithmetic, attribution-join unit, uncalibrated None-not-numbers, calibrated aggregate agreement incl. midnight-straddle tolerance, plan cache identity). Full suite: 2902 passed, exit 0.
