### PR TITLE
feat(app): semantic theme tokens — adaptive precision-instrument light + Tokyo dark

### DIFF
--- a/apps/agentacct/Scripts/build-app.sh
+++ b/apps/agentacct/Scripts/build-app.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 # Build agentacct.app from the SwiftPM executable (no Xcode project needed).
-# Output: apps/AgentacctBar/.build/AgentacctBar.app — unsigned; drag it to
-# /Applications or run it in place. LSUIElement makes it menu-bar-only.
+# Output: apps/agentacct/.build/agentacct.app — unsigned; run in place, or
+# pass --install to copy it to /Applications and relaunch (so Spotlight and
+# login items always point at the newest build). LSUIElement = menu-bar-only.
 set -euo pipefail
+
+INSTALL=false
+if [[ "${1:-}" == "--install" ]]; then INSTALL=true; fi
 
 cd "$(dirname "$0")/.."
 swift build -c release
@@ -31,3 +35,13 @@ PLIST
 
 echo "built: $PWD/$APP"
 echo "run:   open $PWD/$APP"
+
+if $INSTALL; then
+    # The Swift app only (the python daemon is a separate process and is
+    # never touched here). ditto preserves the bundle; relaunch so the menu
+    # bar runs the newest build.
+    killall agentacct 2>/dev/null || true
+    ditto --rsrc "$APP" /Applications/agentacct.app
+    open /Applications/agentacct.app
+    echo "installed: /Applications/agentacct.app (relaunched)"
+fi

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
-// The full window, committed to the brand: a dark Tokyo Night surface with
-// custom chrome (no system sidebar), like the TUI is. The menu bar is the
-// glance; this is where details live.
+// The full window: a precision instrument on warm paper (light) or the Tokyo
+// Night storm (dark), following the system appearance — every color is a
+// Theme token with both values. Custom chrome (no system sidebar), like the
+// TUI. The menu bar is the glance; this is where details live.
 
 struct MainWindow: View {
     @EnvironmentObject var dashboard: DashboardStore
@@ -23,7 +24,6 @@ struct MainWindow: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(Theme.bg)
-        .preferredColorScheme(.dark)
         .frame(minWidth: 960, minHeight: 560)
         .task { await dashboard.refresh() }
     }
@@ -38,7 +38,7 @@ struct TopBar: View {
     var body: some View {
         HStack(spacing: 14) {
             HStack(spacing: 7) {
-                Circle().fill(Theme.blue.gradient).frame(width: 9, height: 9)
+                Circle().fill(Theme.accent.gradient).frame(width: 9, height: 9)
                 Text("agentacct")
                     .font(.system(size: 13, weight: .semibold, design: .rounded))
                     .foregroundStyle(Theme.text)
@@ -115,23 +115,6 @@ extension MainPane {
         case .usage: return "chart.bar.fill"
         case .limits: return "gauge.with.needle.fill"
         }
-    }
-}
-
-// MARK: - Shared dark card
-
-struct DarkCard<Content: View>: View {
-    var padding: CGFloat = 12
-    @ViewBuilder let content: () -> Content
-
-    var body: some View {
-        content()
-            .padding(padding)
-            .background(Theme.surface, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .strokeBorder(Theme.border, lineWidth: 1)
-            )
     }
 }
 
@@ -263,7 +246,7 @@ struct SessionRow: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(selected ? Theme.blue.opacity(0.45) : .clear, lineWidth: 1)
+                .strokeBorder(selected ? Theme.accent.opacity(0.45) : .clear, lineWidth: 1)
         )
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
@@ -295,12 +278,12 @@ struct SessionDetail: View {
 
                 if let usage = entry.usage {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4), spacing: 8) {
-                        DarkStatTile(label: "cost", value: usage.costText,
+                        PanelTile(label: "cost", value: usage.costText,
                                      detail: usage.costConfidence?.replacingOccurrences(of: "_", with: " "),
                                      accent: Theme.blue)
-                        DarkStatTile(label: "fresh", value: usage.freshTokens.map(UsageTotals.compact) ?? "—")
-                        DarkStatTile(label: "cache read", value: usage.cacheReadTokens.map(UsageTotals.compact) ?? "—")
-                        DarkStatTile(label: "turns", value: usage.turnsTotal.map(String.init) ?? "—")
+                        PanelTile(label: "fresh", value: usage.freshTokens.map(UsageTotals.compact) ?? "—")
+                        PanelTile(label: "cache read", value: usage.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                        PanelTile(label: "turns", value: usage.turnsTotal.map(String.init) ?? "—")
                     }
                 }
 
@@ -312,8 +295,8 @@ struct SessionDetail: View {
 
                 if let items = entry.work?.items, !items.isEmpty {
                     VStack(alignment: .leading, spacing: 8) {
-                        DarkSectionCaption(text: "Work")
-                        DarkCard(padding: 4) {
+                        SectionCaption(tone: Theme.textMuted, text: "Work")
+                        Card(padding: 4) {
                             VStack(alignment: .leading, spacing: 0) {
                                 ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                                     HStack(spacing: 9) {
@@ -325,7 +308,7 @@ struct SessionDetail: View {
                                         Spacer(minLength: 8)
                                         if let evidence = item.evidenceStatus {
                                             Chip(text: evidence.replacingOccurrences(of: "_", with: " "),
-                                                 tint: evidence.contains("verified") ? Theme.green : Theme.textMuted)
+                                                 tint: evidenceTint(evidence))
                                         }
                                     }
                                     .padding(.horizontal, 9)
@@ -341,7 +324,7 @@ struct SessionDetail: View {
 
                 if let join = entry.join {
                     VStack(alignment: .leading, spacing: 8) {
-                        DarkSectionCaption(text: "Attribution")
+                        SectionCaption(tone: Theme.textMuted, text: "Attribution")
                         HStack(alignment: .firstTextBaseline, spacing: 8) {
                             Chip(text: join.state ?? "unknown", tint: joinTint(join.state))
                             if let reason = join.reason {
@@ -354,7 +337,7 @@ struct SessionDetail: View {
                 }
 
                 if let related = entry.related, (related.childSessionCount ?? 0) > 0 {
-                    DarkCard {
+                    Card {
                         HStack(spacing: 8) {
                             Image(systemName: "point.3.connected.trianglepath.dotted")
                                 .foregroundStyle(Theme.textMuted)
@@ -376,6 +359,19 @@ struct SessionDetail: View {
         }
     }
 
+    /// The evidence four-state enum, in the product's confidence colors —
+    /// strong proof green, failure red, weak amber, nothing muted. This chip
+    /// IS the product (what did the agent prove?), so it never renders as an
+    /// undifferentiated gray.
+    private func evidenceTint(_ status: String) -> Color {
+        switch status {
+        case "strong": return Theme.green
+        case "failed": return Theme.red
+        case "weak": return Theme.orange
+        default: return Theme.textMuted
+        }
+    }
+
     private func joinTint(_ state: String?) -> Color {
         switch state {
         case "attributed": return Theme.green
@@ -394,50 +390,6 @@ struct SessionDetail: View {
     }
 }
 
-/// Dark-surface stat tile (window variant of StatTile).
-struct DarkStatTile: View {
-    let label: String
-    let value: String
-    var detail: String? = nil
-    var accent: Color = Theme.text
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            Text(label.uppercased())
-                .font(.system(size: 9, weight: .semibold))
-                .tracking(0.7)
-                .foregroundStyle(Theme.textFaint)
-            Text(value)
-                .font(.system(size: 18, weight: .semibold, design: .rounded))
-                .monospacedDigit()
-                .foregroundStyle(accent)
-            if let detail {
-                Text(detail)
-                    .font(.system(size: 9.5))
-                    .foregroundStyle(Theme.textFaint)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(11)
-        .background(Theme.surface, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                .strokeBorder(Theme.border, lineWidth: 1)
-        )
-    }
-}
-
-struct DarkSectionCaption: View {
-    let text: String
-
-    var body: some View {
-        Text(text.uppercased())
-            .font(.system(size: 10, weight: .semibold))
-            .tracking(0.9)
-            .foregroundStyle(Theme.textFaint)
-    }
-}
-
 // MARK: - Usage
 
 struct UsagePane: View {
@@ -449,12 +401,12 @@ struct UsagePane: View {
                 if let usage = dashboard.usage {
                     if let totals = usage.totals {
                         HStack(spacing: 8) {
-                            DarkStatTile(label: "30d cost", value: totals.costText, accent: Theme.blue)
-                            DarkStatTile(label: "30d fresh tokens",
+                            PanelTile(label: "30d cost", value: totals.costText, accent: Theme.blue)
+                            PanelTile(label: "30d fresh tokens",
                                          value: totals.freshTokens.map(UsageTotals.compact) ?? "—")
-                            DarkStatTile(label: "cache read",
+                            PanelTile(label: "cache read",
                                          value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—")
-                            DarkStatTile(label: "sessions",
+                            PanelTile(label: "sessions",
                                          value: totals.sessions.map(String.init) ?? "—")
                         }
                     }
@@ -491,8 +443,8 @@ struct UsagePane: View {
         let sorted = buckets.sorted { ($0.freshTokens ?? 0) > ($1.freshTokens ?? 0) }
         let maxFresh = Double(sorted.first?.freshTokens ?? 1)
         return VStack(alignment: .leading, spacing: 8) {
-            DarkSectionCaption(text: title + " · last 30 days")
-            DarkCard(padding: 6) {
+            SectionCaption(tone: Theme.textMuted, text: title + " · last 30 days")
+            Card(padding: 6) {
                 VStack(spacing: 0) {
                     ForEach(Array(sorted.enumerated()), id: \.element.id) { index, bucket in
                         let (name, tint) = nameOf(bucket)
@@ -549,7 +501,7 @@ struct DailyChart: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 10) {
-                DarkSectionCaption(text: "Daily fresh tokens")
+                SectionCaption(tone: Theme.textMuted, text: "Daily fresh tokens")
                 Spacer()
                 ForEach(clients, id: \.self) { client in
                     HStack(spacing: 4) {
@@ -560,7 +512,7 @@ struct DailyChart: View {
                     }
                 }
             }
-            DarkCard(padding: 12) {
+            Card(padding: 12) {
                 VStack(spacing: 6) {
                     HStack(alignment: .bottom, spacing: 3) {
                         ForEach(periods) { period in
@@ -608,7 +560,7 @@ struct LimitsPane: View {
         ScrollBox {
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
-                    DarkSectionCaption(text: "Provider limits")
+                    SectionCaption(tone: Theme.textMuted, text: "Provider limits")
                     Spacer()
                     Toggle("Show stale accounts", isOn: $showStale)
                         .toggleStyle(.checkbox)
@@ -636,7 +588,7 @@ struct LimitsPane: View {
     }
 
     private func limitCard(_ limit: LimitEntry) -> some View {
-        DarkCard {
+        Card {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 7) {
                     StatusDot(color: Theme.clientColor(limit.client))

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -241,7 +241,10 @@ struct SessionRow: View {
         .padding(.horizontal, 11)
         .padding(.vertical, 8)
         .background(
-            selected ? AnyShapeStyle(Theme.cardAlt) : (hovering ? AnyShapeStyle(Theme.surface) : AnyShapeStyle(.clear)),
+            // Hover must be VISIBLE on paper: surface-on-bg was a ~1% value
+            // difference in light mode (review polish note) — cardAlt at half
+            // opacity reads as a real highlight in both schemes.
+            selected ? AnyShapeStyle(Theme.cardAlt) : (hovering ? AnyShapeStyle(Theme.cardAlt.opacity(0.5)) : AnyShapeStyle(.clear)),
             in: RoundedRectangle(cornerRadius: 8, style: .continuous)
         )
         .overlay(

--- a/apps/agentacct/Sources/agentacct/MenuContent.swift
+++ b/apps/agentacct/Sources/agentacct/MenuContent.swift
@@ -194,7 +194,7 @@ struct MenuContent: View {
                     .font(.system(size: 11.5, weight: .medium))
             }
             .buttonStyle(.plain)
-            .foregroundStyle(Theme.blue)
+            .foregroundStyle(Theme.accent)
             Spacer()
             Button {
                 state.refreshNow()

--- a/apps/agentacct/Sources/agentacct/SnapshotRunner.swift
+++ b/apps/agentacct/Sources/agentacct/SnapshotRunner.swift
@@ -24,24 +24,37 @@ enum SnapshotRunner {
                 let selection = AppSelection()
                 selection.sessionId = dashboard.sessions.first?.id
 
-                for pane in MainPane.allCases {
-                    selection.pane = pane
-                    let window = MainWindow()
+                // Light AND dark of every surface: the theme is adaptive, so
+                // a design pass must see both. SnapshotScheme pins the Theme
+                // tokens; the environment pins the system styles.
+                for scheme in [ColorScheme.light, ColorScheme.dark] {
+                    SnapshotScheme.override = scheme
+                    let suffix = scheme == .dark ? "dark" : "light"
+
+                    for pane in MainPane.allCases {
+                        selection.pane = pane
+                        let window = MainWindow()
+                            .environmentObject(glance)
+                            .environmentObject(dashboard)
+                            .environmentObject(selection)
+                            .frame(width: 1120, height: 680)
+                            .environment(\.colorScheme, scheme)
+                        try render(
+                            window,
+                            to: out.appendingPathComponent("window-\(pane.rawValue.lowercased())-\(suffix).png")
+                        )
+                    }
+
+                    let menu = MenuContent()
                         .environmentObject(glance)
                         .environmentObject(dashboard)
                         .environmentObject(selection)
-                        .frame(width: 1120, height: 680)
-                    try render(window, to: out.appendingPathComponent("window-\(pane.rawValue.lowercased()).png"))
+                        .background(scheme == .dark ? Color(white: 0.13) : Color(white: 0.97))
+                        .frame(width: 360)
+                        .environment(\.colorScheme, scheme)
+                    try render(menu, to: out.appendingPathComponent("menu-\(suffix).png"))
                 }
-
-                let menu = MenuContent()
-                    .environmentObject(glance)
-                    .environmentObject(dashboard)
-                    .environmentObject(selection)
-                    .background(.regularMaterial)
-                    .frame(width: 360)
-                    .preferredColorScheme(.dark)
-                try render(menu, to: out.appendingPathComponent("menu.png"))
+                SnapshotScheme.override = nil
                 print("snapshots written to \(out.path)")
             } catch {
                 FileHandle.standardError.write(Data("snapshot failed: \(error)\n".utf8))

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -1,8 +1,20 @@
+import AppKit
 import SwiftUI
 
-// The agentacct visual system — the native sibling of the TUI's Tokyo Night
-// theme. Accents carry the brand; surfaces stay adaptive (light/dark) via
-// system materials so the app always looks native.
+// The agentacct visual system — semantic tokens with a light and a dark value
+// each, resolved live from the system appearance. The identity is a precision
+// instrument: warm paper surfaces, ink text, one restrained indigo accent,
+// hairline borders, monospaced digits everywhere a number lives. Dark mode is
+// the Tokyo Night storm variant (shared identity with `agentacct tui`), not a
+// separate design.
+//
+// Rules of the road:
+// * Views never hard-code a color or a font size — they use Theme/Type tokens
+//   so a retune touches ONE file.
+// * Numbers always render in monospaced digits (Type.metric*), so columns of
+//   money and tokens align like a meter, not a paragraph.
+// * No `.preferredColorScheme` locks anywhere: the app follows the system,
+//   and snapshots pin the scheme explicitly via `SnapshotScheme`.
 
 enum Fmt {
     static let usd: NumberFormatter = {
@@ -20,25 +32,62 @@ enum Fmt {
     }
 }
 
-enum Theme {
-    // The committed dark surface system (Tokyo Night storm): the window owns
-    // its identity like the TUI does, instead of dressing up system chrome.
-    static let bg = Color(red: 0.086, green: 0.086, blue: 0.118)        // #16161e
-    static let surface = Color(red: 0.102, green: 0.106, blue: 0.149)   // #1a1b26
-    static let card = Color(red: 0.122, green: 0.137, blue: 0.208)      // #1f2335
-    static let cardAlt = Color(red: 0.141, green: 0.157, blue: 0.231)   // #24283b
-    static let border = Color(red: 0.161, green: 0.180, blue: 0.259)    // #292e42
-    static let text = Color(red: 0.753, green: 0.792, blue: 0.961)      // #c0caf5
-    static let textMuted = Color(red: 0.471, green: 0.487, blue: 0.600) // #787c99
-    static let textFaint = Color(red: 0.337, green: 0.371, blue: 0.537) // #565f89
+/// Snapshot-only scheme pin: offscreen ImageRenderer resolves dynamic NSColors
+/// against whatever appearance the process has, so deterministic light/dark
+/// renders set this override alongside `.environment(\.colorScheme, ...)`.
+/// The live app leaves it nil and follows the system.
+enum SnapshotScheme {
+    nonisolated(unsafe) static var override: ColorScheme? = nil
+}
 
-    // Tokyo Night accents (shared identity with `agentacct tui`).
-    static let blue = Color(red: 0.478, green: 0.635, blue: 0.969)     // #7aa2f7
-    static let purple = Color(red: 0.733, green: 0.604, blue: 0.969)   // #bb9af7
-    static let green = Color(red: 0.620, green: 0.808, blue: 0.416)    // #9ece6a
-    static let orange = Color(red: 0.878, green: 0.686, blue: 0.408)   // #e0af68
-    static let red = Color(red: 0.969, green: 0.463, blue: 0.557)      // #f7768e
-    static let cyan = Color(red: 0.490, green: 0.812, blue: 1.0)       // #7dcfff
+enum Theme {
+    // MARK: dynamic resolution
+
+    private static func rgb(_ hex: UInt32, _ alpha: CGFloat = 1) -> NSColor {
+        NSColor(
+            srgbRed: CGFloat((hex >> 16) & 0xFF) / 255,
+            green: CGFloat((hex >> 8) & 0xFF) / 255,
+            blue: CGFloat(hex & 0xFF) / 255,
+            alpha: alpha
+        )
+    }
+
+    /// A semantic color with a light and a dark value. Resolves per-draw via
+    /// the appearance (live app) or the snapshot override (offscreen).
+    static func dynamic(light: UInt32, dark: UInt32) -> Color {
+        Color(nsColor: NSColor(name: nil) { appearance in
+            if let pinned = SnapshotScheme.override {
+                return pinned == .dark ? rgb(dark) : rgb(light)
+            }
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            return isDark ? rgb(dark) : rgb(light)
+        })
+    }
+
+    // MARK: surfaces (light: warm paper + white panels · dark: Tokyo storm)
+
+    static let bg = dynamic(light: 0xF7F5F1, dark: 0x16161E)
+    static let surface = dynamic(light: 0xFDFCFA, dark: 0x1A1B26)
+    static let card = dynamic(light: 0xFFFFFF, dark: 0x1F2335)
+    static let cardAlt = dynamic(light: 0xEEEBE4, dark: 0x24283B)
+    static let border = dynamic(light: 0xE3DFD6, dark: 0x292E42)
+
+    // MARK: text (ink on paper · Tokyo foreground)
+
+    static let text = dynamic(light: 0x201E1B, dark: 0xC0CAF5)
+    static let textMuted = dynamic(light: 0x6E6960, dark: 0x787C99)
+    static let textFaint = dynamic(light: 0xA39D91, dark: 0x565F89)
+
+    // MARK: accents — one restrained indigo carries the brand; the client
+    // palette keeps the TUI's hue identities, darkened for paper.
+
+    static let accent = dynamic(light: 0x3B5BDB, dark: 0x7AA2F7)
+    static let blue = dynamic(light: 0x3B5BDB, dark: 0x7AA2F7)
+    static let purple = dynamic(light: 0x7048B6, dark: 0xBB9AF7)
+    static let green = dynamic(light: 0x2F7D46, dark: 0x9ECE6A)
+    static let orange = dynamic(light: 0xB26A00, dark: 0xE0AF68)
+    static let red = dynamic(light: 0xC03050, dark: 0xF7768E)
+    static let cyan = dynamic(light: 0x0E7490, dark: 0x7DCFFF)
 
     static func clientColor(_ client: String?) -> Color {
         switch client {
@@ -82,9 +131,45 @@ enum Theme {
     }
 }
 
+// MARK: - Typography tokens
+
+/// The type ramp. Metrics are rounded + monospaced-digit (instrument dials);
+/// labels are compact tracked caps; body copy is the system face.
+enum Type {
+    /// The one big number (menu hero).
+    static let hero = Font.system(size: 30, weight: .bold, design: .rounded).monospacedDigit()
+    /// Panel-leading metric (stat tiles).
+    static let metric = Font.system(size: 18, weight: .semibold, design: .rounded).monospacedDigit()
+    /// Row-trailing metric (list money/token cells).
+    static let metricS = Font.system(size: 12, weight: .semibold, design: .rounded).monospacedDigit()
+    /// Inline numeric text (meters, percentages).
+    static let numeric = Font.system(size: 11.5, weight: .semibold).monospacedDigit()
+    /// Row titles.
+    static let rowTitle = Font.system(size: 12.5, weight: .medium)
+    /// Body copy.
+    static let body = Font.system(size: 12)
+    /// Secondary copy.
+    static let small = Font.system(size: 10.5)
+    /// Footnotes / axis labels.
+    static let tiny = Font.system(size: 9.5)
+    /// Tracked caps caption (see SectionCaption).
+    static let caption = Font.system(size: 10, weight: .semibold)
+    /// Small tracked caps label inside tiles.
+    static let tileLabel = Font.system(size: 9.5, weight: .semibold)
+}
+
+/// The spacing scale. Padding and gaps come from here, not magic numbers.
+enum Space {
+    static let xs: CGFloat = 4
+    static let s: CGFloat = 8
+    static let m: CGFloat = 12
+    static let l: CGFloat = 16
+    static let xl: CGFloat = 24
+}
+
 // MARK: - Reusable components
 
-/// A caption + big monospaced value, on a soft card.
+/// A caption + big monospaced value, on a soft adaptive card (menu variant).
 struct StatTile: View {
     let label: String
     let value: String
@@ -94,12 +179,11 @@ struct StatTile: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             Text(label.uppercased())
-                .font(.system(size: 9.5, weight: .semibold))
+                .font(Type.tileLabel)
                 .tracking(0.6)
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(.system(size: 17, weight: .semibold, design: .rounded))
-                .monospacedDigit()
+                .font(Font.system(size: 17, weight: .semibold, design: .rounded).monospacedDigit())
                 .foregroundStyle(accent)
             if let detail {
                 Text(detail)
@@ -110,6 +194,54 @@ struct StatTile: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(10)
         .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+    }
+}
+
+/// The window's stat tile: white/storm panel, hairline border, big dial.
+struct PanelTile: View {
+    let label: String
+    let value: String
+    var detail: String? = nil
+    var accent: Color = Theme.text
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label.uppercased())
+                .font(Type.tileLabel)
+                .tracking(0.7)
+                .foregroundStyle(Theme.textFaint)
+            Text(value)
+                .font(Type.metric)
+                .foregroundStyle(accent)
+            if let detail {
+                Text(detail)
+                    .font(Type.tiny)
+                    .foregroundStyle(Theme.textFaint)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(11)
+        .background(Theme.card, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .strokeBorder(Theme.border, lineWidth: 1)
+        )
+    }
+}
+
+/// The window's panel card: content on card surface with a hairline border.
+struct Card<Content: View>: View {
+    var padding: CGFloat = Space.m
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        content()
+            .padding(padding)
+            .background(Theme.card, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(Theme.border, lineWidth: 1)
+            )
     }
 }
 
@@ -142,12 +274,12 @@ struct Chip: View {
             .font(.system(size: 10, weight: .medium))
             .padding(.horizontal, 7)
             .padding(.vertical, 2.5)
-            .background(tint.opacity(0.16), in: Capsule())
+            .background(tint.opacity(0.14), in: Capsule())
             .foregroundStyle(tint)
     }
 }
 
-/// A colored status dot.
+/// A colored status dot (soft glow kept subtle so paper stays clean).
 struct StatusDot: View {
     let color: Color
     var size: CGFloat = 7
@@ -156,19 +288,22 @@ struct StatusDot: View {
         Circle()
             .fill(color)
             .frame(width: size, height: size)
-            .shadow(color: color.opacity(0.5), radius: 2)
+            .shadow(color: color.opacity(0.35), radius: 1.5)
     }
 }
 
-/// Section header caption used across the dropdown and window.
+/// Section header caption used across the dropdown and window. ``tone``
+/// precedes ``text`` so the memberwise init reads ``(tone:text:)`` at window
+/// call sites while menu calls stay ``(text:)``.
 struct SectionCaption: View {
+    var tone: Color? = nil
     let text: String
 
     var body: some View {
         Text(text.uppercased())
-            .font(.system(size: 10, weight: .semibold))
+            .font(Type.caption)
             .tracking(0.8)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(tone ?? Color.secondary)
     }
 }
 

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -76,7 +76,7 @@ enum Theme {
 
     static let text = dynamic(light: 0x201E1B, dark: 0xC0CAF5)
     static let textMuted = dynamic(light: 0x6E6960, dark: 0x787C99)
-    static let textFaint = dynamic(light: 0xA39D91, dark: 0x565F89)
+    static let textFaint = dynamic(light: 0x8F8878, dark: 0x565F89)
 
     // MARK: accents — one restrained indigo carries the brand; the client
     // palette keeps the TUI's hue identities, darkened for paper.


### PR DESCRIPTION
PR-T — the app-side design foundation of the v3 plan. Swift only; no daemon changes.

## What

**Semantic token system.** `Theme.swift` now defines every color as a light+dark pair resolved live from the system appearance (`NSColor(name:dynamicProvider:)`). The light identity is a precision instrument: warm paper surfaces, ink text, one restrained indigo accent, hairline borders, monospaced digits everywhere a number lives. Dark is the Tokyo Night storm (shared identity with `agentacct tui`) — one design with two values, not two designs. All `.preferredColorScheme(.dark)` locks removed; the app follows the system.

**Type ramp + spacing scale.** `Type` (hero/metric/metricS/numeric/rowTitle/body/small/tiny/captions — rounded + `monospacedDigit` for every metric) and `Space` tokens replace the worst inline magic numbers. The `Dark*` window components fold into shared token components (`Card`, `PanelTile`, `SectionCaption(tone:)`) — darkness is no longer baked into component identity.

**Evidence chips in confidence colors.** The four-state evidence enum now renders strong=green / failed=red / weak=amber / none=muted. The old tint keyed on `contains("verified")` — a value that never occurs — so every chip rendered the same gray. This chip is the product ("what did the agent prove?"); it must never be undifferentiated.

**Snapshot pairs + install flow.** `agentacct --snapshot <dir>` now renders light AND dark of every surface (8 PNGs; `SnapshotScheme` pins the theme tokens deterministically while `.environment(\.colorScheme,)` pins system styles). `Scripts/build-app.sh --install` copies the bundle to /Applications and relaunches, so Spotlight/login items always point at the newest build.

## Verification

`swift build` clean; live-data snapshot pass over both schemes (sessions/usage/limits window + menu dropdown) reviewed visually — light reads as paper instrument, dark is pixel-faithful to the previous Tokyo look.
