### PR TITLE
feat(app): Dashboard home + /v1 lane everywhere — plan-first work intelligence

### DIFF
--- a/apps/agentacct/Sources/agentacct/DashboardModel.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardModel.swift
@@ -87,6 +87,23 @@ struct SessionJoin: Decodable {
 
 struct SessionWork: Decodable {
     let items: [WorkItem]?
+    let counts: WorkCounts?
+    let evidence: EvidenceCounts?
+}
+
+struct WorkCounts: Decodable {
+    let total: Int?
+    let completed: Int?
+    let resolved: Int?
+    let active: Int?
+    let blocked: Int?
+}
+
+struct EvidenceCounts: Decodable {
+    let strong: Int?
+    let weak: Int?
+    let failed: Int?
+    let none: Int?
 }
 
 struct WorkItem: Decodable, Identifiable {

--- a/apps/agentacct/Sources/agentacct/DashboardModel.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardModel.swift
@@ -1,53 +1,11 @@
 import Foundation
 
-// Models for the full window: the /sessions rollup and /usage/summary cube.
-// Same decoding stance as the glance: tolerant, selective, never inventing a
-// number an absent field does not carry.
-
-struct SessionsPayload: Decodable {
-    let sessions: [SessionEntry]
-    let totalSessions: Int?
-
-    enum CodingKeys: String, CodingKey {
-        case sessions
-        case totalSessions = "total_sessions"
-    }
-}
-
-struct SessionEntry: Decodable, Identifiable {
-    let client: String
-    let clientSessionId: String
-    let shortId: String?
-    let title: String?
-    let sessionKind: String?
-    let project: String?
-    let durationSeconds: Double?
-    let lastActivityAt: Double?
-    let usage: SessionUsage?
-    let join: SessionJoin?
-    let work: SessionWork?
-    let related: SessionRelated?
-    let usageNote: String?
-    let observedModels: [String]?
-
-    var id: String { "\(client)::\(clientSessionId)" }
-    var isRoot: Bool { (related?.parent ?? nil) == nil }
-    var displayTitle: String { title ?? "\(client) · \(shortId ?? String(clientSessionId.prefix(8)))" }
-
-    enum CodingKeys: String, CodingKey {
-        case client
-        case clientSessionId = "client_session_id"
-        case shortId = "client_session_id_short"
-        case title = "client_session_title"
-        case sessionKind = "session_kind"
-        case project
-        case durationSeconds = "duration_seconds"
-        case lastActivityAt = "last_activity_at"
-        case usage, join, work, related
-        case usageNote = "usage_note"
-        case observedModels = "observed_models"
-    }
-}
+// Shared decodables for the daemon's session sub-blocks (usage/join/work/
+// related — embedded verbatim in /v1/sessions rows, see V1Model.swift) and
+// the /usage/summary cube that feeds the cost charts. Same decoding stance
+// as the glance: tolerant, selective, never inventing a number an absent
+// field does not carry. (The legacy /sessions list decoders left with the
+// /v1 migration.)
 
 struct SessionUsage: Decodable {
     let rows: Int?

--- a/apps/agentacct/Sources/agentacct/DashboardPane.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardPane.swift
@@ -1,0 +1,323 @@
+import SwiftUI
+
+// The home: "how is my week going" answered in one screen, plan-first.
+//
+// Two DIFFERENT plan quantities, always labeled apart (the product plan's
+// core honesty rule):
+// * the ACCOUNT truth — the provider-reported 7d used %, account-wide,
+//   includes untracked usage (glance limits[]); this is the hero ring;
+// * the ATTRIBUTED estimate — calibrated-or-nothing per-session shares and
+//   window aggregates (/v1/plan); shown as "tracked ≈X%" beside the truth,
+//   never merged with it.
+// Below: today, the 30-day rhythm, live sessions, and what needs attention —
+// the work-intelligence strip (blocked sessions, failed evidence), because
+// this product unravels what agents DID, not just what they cost.
+
+struct DashboardPane: View {
+    @EnvironmentObject var dashboard: DashboardStore
+    @EnvironmentObject var glance: GlanceState
+    @EnvironmentObject var selection: AppSelection
+
+    var body: some View {
+        ScrollBox {
+            VStack(alignment: .leading, spacing: Space.l) {
+                planHeroRow
+                todayRow
+                if let periods = dashboard.usage?.byPeriod, periods.count > 1 {
+                    DailyChart(periods: periods)
+                }
+                activeSessions
+                attentionStrip
+            }
+            .padding(Space.l)
+        }
+        .overlay(alignment: .bottom) {
+            if let error = dashboard.errorText {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(Theme.red)
+                    .padding(Space.s)
+                    .background(Theme.card, in: RoundedRectangle(cornerRadius: 8))
+                    .padding(.bottom, 10)
+            }
+        }
+    }
+
+    // MARK: plan hero
+
+    private var liveLimits: [LimitEntry] {
+        guard case .connected(let snapshot) = glance.phase else { return [] }
+        return snapshot.glance.limits.filter { $0.stale != true }
+    }
+
+    @ViewBuilder
+    private var planHeroRow: some View {
+        if liveLimits.isEmpty {
+            Card {
+                Text("No live provider limit readings — the weekly plan hero appears once a tracked client reports one.")
+                    .font(Type.small)
+                    .foregroundStyle(Theme.textMuted)
+            }
+        } else {
+            HStack(spacing: Space.s) {
+                ForEach(Array(liveLimits.enumerated()), id: \.offset) { _, limit in
+                    PlanHeroCard(
+                        limit: limit,
+                        planClient: dashboard.planClients.first { $0.client == limit.client }
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: today
+
+    private var todayRow: some View {
+        let windows: [String: UsageTotals] = {
+            guard case .connected(let snapshot) = glance.phase else { return [:] }
+            return Dictionary(uniqueKeysWithValues: snapshot.glance.usage.windows.map { ($0.label, $0.totals) })
+        }()
+        let todayPlan = dashboard.planClients
+            .compactMap { client -> Double? in
+                guard client.calibrationState == "calibrated" else { return nil }
+                return client.windowPcts?["today"] ?? nil
+            }
+            .reduce(nil as Double?) { partial, pct in (partial ?? 0) + pct }
+        return HStack(spacing: Space.s) {
+            PanelTile(
+                label: "today · tracked plan",
+                value: Fmt.planPct(todayPlan) ?? "—",
+                detail: todayPlan == nil ? "calibration pending" : "attributed estimate",
+                accent: Theme.accent
+            )
+            PanelTile(
+                label: "today · cost",
+                value: windows["today"]?.costText ?? "—",
+                detail: "reference"
+            )
+            PanelTile(
+                label: "today · fresh tokens",
+                value: windows["today"]?.tokensText ?? "—"
+            )
+            PanelTile(
+                label: "root sessions",
+                value: dashboard.totalRootSessions.map(String.init) ?? "—",
+                detail: dashboard.totalSessions.map { "\($0) with subagents" }
+            )
+        }
+    }
+
+    // MARK: active sessions
+
+    @ViewBuilder
+    private var activeSessions: some View {
+        if case .connected(let snapshot) = glance.phase, !snapshot.glance.recentSessions.isEmpty {
+            VStack(alignment: .leading, spacing: Space.s) {
+                SectionCaption(tone: Theme.textMuted, text: "Active sessions")
+                Card(padding: 4) {
+                    VStack(spacing: 0) {
+                        let rows = Array(snapshot.glance.recentSessions.prefix(6))
+                        ForEach(Array(rows.enumerated()), id: \.offset) { index, session in
+                            Button {
+                                selection.pane = .sessions
+                                selection.sessionId = "\(session.client)::\(session.sessionId)"
+                            } label: {
+                                HStack(spacing: 9) {
+                                    StatusDot(color: Theme.statusColor(session.status))
+                                    Text(session.title ?? "\(session.client) · \(session.shortSessionId)")
+                                        .font(Type.body)
+                                        .foregroundStyle(Theme.text)
+                                        .lineLimit(1)
+                                    Spacer(minLength: 8)
+                                    if let pct = session.planPctText {
+                                        Text(pct)
+                                            .font(Type.numeric)
+                                            .foregroundStyle(Theme.accent)
+                                    }
+                                    Text(session.client)
+                                        .font(Type.tiny)
+                                        .foregroundStyle(Theme.clientColor(session.client))
+                                }
+                                .padding(.horizontal, 9)
+                                .padding(.vertical, 7)
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            if index < rows.count - 1 {
+                                Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: needs attention
+
+    private var attentionRows: [V1SessionRow] {
+        dashboard.sessions.filter { row in
+            row.status == "blocked" || (row.work?.evidence?.failed ?? 0) > 0
+        }
+    }
+
+    @ViewBuilder
+    private var attentionStrip: some View {
+        VStack(alignment: .leading, spacing: Space.s) {
+            SectionCaption(tone: Theme.textMuted, text: "Needs attention")
+            if attentionRows.isEmpty {
+                HStack(spacing: 7) {
+                    Image(systemName: "checkmark.circle")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.green)
+                    Text("Nothing blocked, no failed checks in the loaded sessions.")
+                        .font(Type.small)
+                        .foregroundStyle(Theme.textMuted)
+                }
+            } else {
+                Card(padding: 4) {
+                    VStack(spacing: 0) {
+                        ForEach(Array(attentionRows.prefix(5).enumerated()), id: \.element.id) { index, row in
+                            Button {
+                                selection.pane = .sessions
+                                selection.sessionId = row.id
+                            } label: {
+                                HStack(spacing: 9) {
+                                    Image(systemName: row.status == "blocked"
+                                          ? "hand.raised.fill" : "xmark.octagon.fill")
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(row.status == "blocked" ? Theme.orange : Theme.red)
+                                    Text(row.displayTitle)
+                                        .font(Type.body)
+                                        .foregroundStyle(Theme.text)
+                                        .lineLimit(1)
+                                    Spacer(minLength: 8)
+                                    if row.status == "blocked" {
+                                        Chip(text: "blocked", tint: Theme.orange)
+                                    }
+                                    if let failed = row.work?.evidence?.failed, failed > 0 {
+                                        Chip(text: "\(failed) failed check\(failed == 1 ? "" : "s")", tint: Theme.red)
+                                    }
+                                }
+                                .padding(.horizontal, 9)
+                                .padding(.vertical, 7)
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            if index < min(attentionRows.count, 5) - 1 {
+                                Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - The plan hero card (one per live limit account)
+
+/// Account truth front and center (the provider's own 7d %), the attributed
+/// estimate beside it — different quantities, labeled apart, never merged.
+struct PlanHeroCard: View {
+    let limit: LimitEntry
+    let planClient: V1PlanClient?
+
+    private var sevenDay: LimitWindow? {
+        (limit.windows ?? []).first { $0.kind == "7d" }
+    }
+    private var fiveHour: LimitWindow? {
+        (limit.windows ?? []).first { $0.kind == "5h" }
+    }
+
+    var body: some View {
+        Card {
+            HStack(spacing: Space.m) {
+                if let used = sevenDay?.usedPercent {
+                    PlanRing(fraction: used / 100.0, tint: Theme.limitColor(usedPercent: used))
+                        .frame(width: 74, height: 74)
+                        .overlay(
+                            VStack(spacing: 0) {
+                                Text(String(format: "%.0f%%", used))
+                                    .font(Font.system(size: 17, weight: .bold, design: .rounded).monospacedDigit())
+                                    .foregroundStyle(Theme.text)
+                                Text("7d")
+                                    .font(Type.tiny)
+                                    .foregroundStyle(Theme.textFaint)
+                            }
+                        )
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        StatusDot(color: Theme.clientColor(limit.client), size: 6)
+                        Text(limit.client ?? "?")
+                            .font(.system(size: 12.5, weight: .semibold))
+                            .foregroundStyle(Theme.text)
+                        if let plan = limit.planType {
+                            Chip(text: plan, tint: Theme.clientColor(limit.client))
+                        }
+                    }
+                    Text("account truth · provider-reported")
+                        .font(Type.tiny)
+                        .foregroundStyle(Theme.textFaint)
+                    if let resets = Theme.resetsIn(sevenDay?.resetsAt) {
+                        Text("resets in \(resets)")
+                            .font(Type.small)
+                            .foregroundStyle(Theme.textMuted)
+                    }
+                    if let tracked = trackedLine {
+                        Text(tracked)
+                            .font(Type.small)
+                            .foregroundStyle(Theme.accent)
+                    } else if planClient?.calibrationState == "calibrating" {
+                        Text("tracked share calibrating from your own limit history")
+                            .font(Type.tiny)
+                            .foregroundStyle(Theme.textFaint)
+                    }
+                    if let five = fiveHour?.usedPercent {
+                        HStack(spacing: 6) {
+                            Text("5h")
+                                .font(Type.tiny)
+                                .foregroundStyle(Theme.textFaint)
+                            MeterBar(fraction: five / 100.0,
+                                     tint: Theme.limitColor(usedPercent: five), height: 4)
+                                .frame(width: 90)
+                            Text(String(format: "%.0f%%", five))
+                                .font(Type.tiny.monospacedDigit())
+                                .foregroundStyle(Theme.textMuted)
+                        }
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// "tracked ≈X% of this week" — the attributed estimate, only when the
+    /// daemon says it is calibrated (calibrated-or-nothing).
+    private var trackedLine: String? {
+        guard planClient?.calibrationState == "calibrated",
+              let pct = planClient?.windowPcts?["7d"] ?? nil,
+              let text = Fmt.planPct(pct)
+        else { return nil }
+        return "tracked \(text) of this week"
+    }
+}
+
+/// A thin ring gauge (the 7d dial).
+struct PlanRing: View {
+    let fraction: Double
+    var tint: Color
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Theme.border, lineWidth: 7)
+            Circle()
+                .trim(from: 0, to: min(max(fraction, 0), 1))
+                .stroke(tint.gradient, style: StrokeStyle(lineWidth: 7, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+    }
+}

--- a/apps/agentacct/Sources/agentacct/DashboardPane.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardPane.swift
@@ -77,15 +77,16 @@ struct DashboardPane: View {
             guard case .connected(let snapshot) = glance.phase else { return [:] }
             return Dictionary(uniqueKeysWithValues: snapshot.glance.usage.windows.map { ($0.label, $0.totals) })
         }()
-        let todayPlan = dashboard.planClients
-            .compactMap { client -> Double? in
-                guard client.calibrationState == "calibrated" else { return nil }
-                return client.windowPcts?["today"] ?? nil
-            }
-            .reduce(nil as Double?) { partial, pct in (partial ?? 0) + pct }
+        // ONE client's share, never a sum: percentages of different plans have
+        // different denominators, so a cross-client total is meaningless
+        // (review finding — latent while only claude-code can calibrate).
+        let todayClient = dashboard.planClients.first {
+            $0.calibrationState == "calibrated" && ($0.windowPcts?["today"] ?? nil) != nil
+        }
+        let todayPlan = todayClient.flatMap { $0.windowPcts?["today"] ?? nil }
         return HStack(spacing: Space.s) {
             PanelTile(
-                label: "today · tracked plan",
+                label: todayClient.map { "today · tracked plan · \($0.client)" } ?? "today · tracked plan",
                 value: Fmt.planPct(todayPlan) ?? "—",
                 detail: todayPlan == nil ? "calibration pending" : "attributed estimate",
                 accent: Theme.accent

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -1,66 +1,101 @@
 import Foundation
 import SwiftUI
 
-// Data for the full window: the /sessions rollup and the /usage/summary cube.
-// These are the daemon's machine-local JSON surfaces (localhost-guarded, no
-// bearer); the port comes from the same discovery file the glance uses.
+// Data for the full window, all on the authenticated /v1 lane:
+// /v1/sessions (server-side roots + pagination + plan shares),
+// /v1/session (the one-session deep view), /v1/plan (attributed aggregates).
+// The legacy /usage/summary cube still feeds the cost charts (no /v1 twin
+// yet). Honesty rides the payloads; the store never re-derives a number.
 
 @MainActor
 final class DashboardStore: ObservableObject {
-    @Published private(set) var sessions: [SessionEntry] = []
+    @Published private(set) var sessions: [V1SessionRow] = []
     @Published private(set) var totalSessions: Int?
+    @Published private(set) var totalRootSessions: Int?
+    @Published private(set) var truncated = false
+    @Published private(set) var planStatuses: [V1PlanStatus] = []
+    @Published private(set) var planClients: [V1PlanClient] = []
     @Published private(set) var usage: UsageSummary?
+    @Published private(set) var detail: V1SessionDetail?
+    @Published private(set) var detailError: String?
     @Published private(set) var errorText: String?
     @Published private(set) var isRefreshing = false
+    @Published private(set) var isLoadingMore = false
     @Published private(set) var lastUpdated: Date?
 
-    private let session: URLSession
-
-    init() {
-        let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = 30
-        session = URLSession(configuration: config)
-    }
+    private let client = GlanceClient()
+    private let pageSize = 60
 
     func refresh() async {
         guard !isRefreshing else { return }
         isRefreshing = true
         defer { isRefreshing = false }
         do {
-            guard let data = try? Data(contentsOf: GlanceClient.discoveryPath()),
-                  let discovery = try? JSONDecoder().decode(Discovery.self, from: data)
-            else {
-                errorText = "daemon not running (no discovery file) — start it with `agentacct start`"
-                return
-            }
-            let host = discovery.host ?? "127.0.0.1"
-            let base = "http://\(host):\(discovery.port)"
-            let payload: SessionsPayload = try await get("\(base)/sessions?limit=300")
-            let summary: UsageSummary = try await get("\(base)/usage/summary?days=30")
-            // Root sessions only, newest first: the rollup lists child lanes as
-            // their own entries (related.parent set); the window folds them —
-            // a child's usage is already summarized under its root.
+            let payload: V1SessionsPayload = try await client.getAuthed(
+                "/v1/sessions?limit=\(pageSize)&offset=0"
+            )
+            let plan: V1PlanPayload = try await client.getAuthed("/v1/plan?days=30")
+            let summary: UsageSummary = try await client.getLocal("/usage/summary?days=30")
             sessions = payload.sessions
-                .filter(\.isRoot)
-                .sorted { ($0.lastActivityAt ?? 0) > ($1.lastActivityAt ?? 0) }
             totalSessions = payload.totalSessions
+            totalRootSessions = payload.totalRootSessions
+            truncated = payload.truncated ?? false
+            planStatuses = payload.plan ?? []
+            planClients = plan.clients
             usage = summary
             errorText = nil
             lastUpdated = Date()
+        } catch GlanceClientError.noDiscovery(_) {
+            errorText = "daemon not running (no discovery file) — start it with `agentacct start`"
         } catch {
             errorText = "daemon fetch failed: \(error.localizedDescription)"
         }
     }
 
-    private func get<T: Decodable>(_ urlString: String) async throws -> T {
-        guard let url = URL(string: urlString) else {
-            throw GlanceClientError.transport("bad URL")
+    /// The next page of the recency-ordered roots walk (server-side slice;
+    /// `truncated` from the envelope says whether more rows exist).
+    func loadMore() async {
+        guard truncated, !isLoadingMore else { return }
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+        do {
+            let payload: V1SessionsPayload = try await client.getAuthed(
+                "/v1/sessions?limit=\(pageSize)&offset=\(sessions.count)"
+            )
+            // A session landing between pages shifts the window by one; the
+            // id-keyed de-dup keeps the walk honest instead of double-listing.
+            let known = Set(sessions.map(\.id))
+            sessions += payload.sessions.filter { !known.contains($0.id) }
+            truncated = payload.truncated ?? false
+            totalSessions = payload.totalSessions
+            totalRootSessions = payload.totalRootSessions
+        } catch {
+            errorText = "load more failed: \(error.localizedDescription)"
         }
-        let (data, response) = try await session.data(from: url)
-        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-            throw GlanceClientError.http((response as? HTTPURLResponse)?.statusCode ?? -1)
+    }
+
+    /// The deep view for one session. 404 (session aged out / unknown) is a
+    /// first-class message, never a silent empty screen.
+    func fetchDetail(client clientName: String, sessionId: String) async {
+        detail = nil
+        detailError = nil
+        do {
+            let encodedClient = clientName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? clientName
+            let encodedSession = sessionId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sessionId
+            let payload: V1SessionDetail = try await client.getAuthed(
+                "/v1/session?client=\(encodedClient)&session_id=\(encodedSession)"
+            )
+            detail = payload
+        } catch GlanceClientError.http(404) {
+            detailError = "this session is not in the store (it may have been recorded elsewhere)"
+        } catch {
+            detailError = "detail fetch failed: \(error.localizedDescription)"
         }
-        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    /// The plan status for one client (three-state honesty), if known.
+    func planStatus(for clientName: String) -> V1PlanStatus? {
+        planStatuses.first { $0.client == clientName }
     }
 }
 
@@ -68,10 +103,11 @@ final class DashboardStore: ObservableObject {
 @MainActor
 final class AppSelection: ObservableObject {
     @Published var sessionId: String?
-    @Published var pane: MainPane = .sessions
+    @Published var pane: MainPane = .dashboard
 }
 
 enum MainPane: String, CaseIterable, Identifiable {
+    case dashboard = "Dashboard"
     case sessions = "Sessions"
     case usage = "Usage"
     case limits = "Limits"

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -31,8 +31,12 @@ final class DashboardStore: ObservableObject {
         isRefreshing = true
         defer { isRefreshing = false }
         do {
+            // Preserve the paginated depth across auto-refreshes: replacing a
+            // Load-more'd list with page 1 collapsed the walk and blanked an
+            // open detail mid-read (review finding).
+            let limit = max(pageSize, min(sessions.count, 500))
             let payload: V1SessionsPayload = try await client.getAuthed(
-                "/v1/sessions?limit=\(pageSize)&offset=0"
+                "/v1/sessions?limit=\(limit)&offset=0"
             )
             let plan: V1PlanPayload = try await client.getAuthed("/v1/plan?days=30")
             let summary: UsageSummary = try await client.getLocal("/usage/summary?days=30")
@@ -75,7 +79,10 @@ final class DashboardStore: ObservableObject {
     }
 
     /// The deep view for one session. 404 (session aged out / unknown) is a
-    /// first-class message, never a silent empty screen.
+    /// first-class message, never a silent empty screen. A CANCELLED fetch
+    /// (the user clicked another row) writes nothing: its error used to land
+    /// after the new row's fetch had already started and masked the freshly
+    /// loaded steps (review finding).
     func fetchDetail(client clientName: String, sessionId: String) async {
         detail = nil
         detailError = nil
@@ -85,10 +92,18 @@ final class DashboardStore: ObservableObject {
             let payload: V1SessionDetail = try await client.getAuthed(
                 "/v1/session?client=\(encodedClient)&session_id=\(encodedSession)"
             )
+            guard !Task.isCancelled else { return }
             detail = payload
+            detailError = nil
+        } catch is CancellationError {
+            return
+        } catch let error as URLError where error.code == .cancelled {
+            return
         } catch GlanceClientError.http(404) {
+            guard !Task.isCancelled else { return }
             detailError = "this session is not in the store (it may have been recorded elsewhere)"
         } catch {
+            guard !Task.isCancelled else { return }
             detailError = "detail fetch failed: \(error.localizedDescription)"
         }
     }

--- a/apps/agentacct/Sources/agentacct/GlanceClient.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceClient.swift
@@ -101,6 +101,32 @@ final class GlanceClient {
         return GlanceSnapshot(glance: glance, daemonVersion: version.version)
     }
 
+    /// A bearer-authed GET on the /v1 lane with the standard 401 retry
+    /// (daemon restarted → re-read the discovery file once). The window's
+    /// data lanes use this so ALL app traffic rides the authenticated lane.
+    func getAuthed<T: Decodable>(_ path: String) async throws -> T {
+        do {
+            return try await get(path, discovery: loadDiscovery())
+        } catch GlanceClientError.http(401) {
+            return try await get(path, discovery: loadDiscovery())
+        }
+    }
+
+    /// A localhost GET on the legacy machine-local JSON surfaces (no bearer —
+    /// e.g. /usage/summary, which has no /v1 twin yet).
+    func getLocal<T: Decodable>(_ path: String) async throws -> T {
+        let discovery = try loadDiscovery()
+        let host = discovery.host ?? "127.0.0.1"
+        guard let url = URL(string: "http://\(host):\(discovery.port)\(path)") else {
+            throw GlanceClientError.transport("bad daemon URL")
+        }
+        let (data, response) = try await session.data(from: url)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw GlanceClientError.http((response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
     private func get<T: Decodable>(_ path: String, discovery: Discovery) async throws -> T {
         let host = discovery.host ?? "127.0.0.1"
         guard let url = URL(string: "http://\(host):\(discovery.port)\(path)") else {

--- a/apps/agentacct/Sources/agentacct/GlanceModel.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceModel.swift
@@ -149,12 +149,9 @@ struct RecentSession: Decodable {
 
     /// TUI-parity plan share formatting: one decimal with the approximation
     /// marker, a "<0.1%" band instead of a fake exact zero, nothing when the
-    /// estimate is withheld (uncalibrated).
-    var planPctText: String? {
-        guard let pct = planPct else { return nil }
-        if pct > 0 && pct < 0.1 { return "≈<0.1%" }
-        return String(format: "≈%.1f%%", pct)
-    }
+    /// estimate is withheld (uncalibrated). One shared rule with the window
+    /// (Fmt.planPct) so the two surfaces can never disagree on a zero share.
+    var planPctText: String? { Fmt.planPct(planPct) }
 
     var statusGlyph: String {
         switch status {

--- a/apps/agentacct/Sources/agentacct/GlanceState.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceState.swift
@@ -66,18 +66,37 @@ final class GlanceState: ObservableObject {
         }
     }
 
-    /// Menu bar label: today's cost when connected (the number a glance is
-    /// for), a quiet marker otherwise — never a fabricated figure.
+    /// Menu bar label: the weekly plan meter (the subscription user's real
+    /// question), account truth from the provider's own 7d reading —
+    /// claude-code's when live, else the hottest live 7d window. Falls back
+    /// to today's cost when no limit reading exists; a quiet marker when the
+    /// daemon is down — never a fabricated figure.
     var menuBarTitle: String {
         switch phase {
         case .connected(let snapshot):
+            if let used = Self.sevenDayUsedPercent(snapshot.glance) {
+                return "⏺ \(Int(used.rounded()))%"
+            }
             let today = snapshot.glance.usage.windows.first { $0.label == "today" }
-            let cost = today?.totals.costText ?? "—"
-            return "⏺ \(cost)"
+            return "⏺ \(today?.totals.costText ?? "—")"
         case .connecting:
             return "⏺ …"
         case .disconnected, .incompatible:
             return "⏺ ∅"
         }
+    }
+
+    /// The provider-reported 7d used %% for the label + dropdown hero:
+    /// claude-code's live reading first (the primary plan), else the hottest
+    /// live 7d window across accounts. nil when nothing live reports one.
+    static func sevenDayUsedPercent(_ glance: Glance, client: String = "claude-code") -> Double? {
+        let live = glance.limits.filter { $0.stale != true }
+        let sevenDay: (LimitEntry) -> Double? = { entry in
+            (entry.windows ?? []).first { $0.kind == "7d" }?.usedPercent
+        }
+        if let primary = live.first(where: { $0.client == client }), let used = sevenDay(primary) {
+            return used
+        }
+        return live.compactMap(sevenDay).max()
     }
 }

--- a/apps/agentacct/Sources/agentacct/LimitsPane.swift
+++ b/apps/agentacct/Sources/agentacct/LimitsPane.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+// Limits: per-account provider meters plus the calibration ledger — the
+// three-state honesty (calibrated / calibrating / never) with the
+// why-this-number basis, straight from the daemon.
+
+struct LimitsPane: View {
+    @EnvironmentObject var glance: GlanceState
+    @EnvironmentObject var dashboard: DashboardStore
+    @State private var showStale = false
+
+    var body: some View {
+        ScrollBox {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    SectionCaption(tone: Theme.textMuted, text: "Provider limits")
+                    Spacer()
+                    Toggle("Show stale accounts", isOn: $showStale)
+                        .toggleStyle(.checkbox)
+                        .font(.system(size: 11))
+                        .foregroundStyle(Theme.textMuted)
+                }
+                if case .connected(let snapshot) = glance.phase {
+                    let limits = snapshot.glance.limits.filter { showStale || $0.stale != true }
+                    if limits.isEmpty {
+                        Text("No live limit readings.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Theme.textMuted)
+                    }
+                    ForEach(Array(limits.enumerated()), id: \.offset) { _, limit in
+                        limitCard(limit)
+                    }
+                } else {
+                    Text("Daemon not connected.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.textMuted)
+                }
+                calibrationSection
+            }
+            .padding(16)
+        }
+    }
+
+    private func limitCard(_ limit: LimitEntry) -> some View {
+        Card {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 7) {
+                    StatusDot(color: Theme.clientColor(limit.client))
+                    Text(limit.client ?? "?")
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(Theme.text)
+                    if let plan = limit.planType {
+                        Chip(text: plan, tint: Theme.clientColor(limit.client))
+                    }
+                    if limit.stale == true {
+                        Chip(text: "stale", tint: Theme.textMuted)
+                    }
+                    Spacer()
+                }
+                ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
+                    if let used = window.usedPercent {
+                        HStack(spacing: 10) {
+                            Text(window.kind ?? "")
+                                .font(.system(size: 11))
+                                .foregroundStyle(Theme.textMuted)
+                                .frame(width: 26, alignment: .leading)
+                            MeterBar(fraction: used / 100.0,
+                                     tint: Theme.limitColor(usedPercent: used), height: 8)
+                            Text(String(format: "%.0f%%", used))
+                                .font(Type.numeric)
+                                .foregroundStyle(Theme.text)
+                                .frame(width: 36, alignment: .trailing)
+                            Text(Theme.resetsIn(window.resetsAt).map { "resets in \($0)" } ?? "")
+                                .font(.system(size: 10))
+                                .foregroundStyle(Theme.textFaint)
+                                .frame(width: 100, alignment: .trailing)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// The plan-estimate calibration ledger: what state each plan-bearing
+    /// client is in and why — the "why this number" disclosure surfaced.
+    @ViewBuilder
+    private var calibrationSection: some View {
+        if !dashboard.planClients.isEmpty {
+            VStack(alignment: .leading, spacing: Space.s) {
+                SectionCaption(tone: Theme.textMuted, text: "Plan estimate calibration")
+                Card(padding: 4) {
+                    VStack(spacing: 0) {
+                        ForEach(Array(dashboard.planClients.enumerated()), id: \.element.id) { index, client in
+                            HStack(alignment: .firstTextBaseline, spacing: 9) {
+                                StatusDot(color: Theme.clientColor(client.client), size: 6)
+                                Text(client.client)
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundStyle(Theme.text)
+                                    .frame(width: 110, alignment: .leading)
+                                Chip(text: client.calibrationState ?? "unknown",
+                                     tint: calibrationTint(client.calibrationState))
+                                if let basis = client.basis {
+                                    Text(basis)
+                                        .font(Type.tiny)
+                                        .foregroundStyle(Theme.textFaint)
+                                        .lineLimit(2)
+                                }
+                                Spacer(minLength: 0)
+                            }
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 7)
+                            if index < dashboard.planClients.count - 1 {
+                                Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func calibrationTint(_ state: String?) -> Color {
+        switch state {
+        case "calibrated": return Theme.green
+        case "calibrating": return Theme.orange
+        default: return Theme.textMuted
+        }
+    }
+}

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -1,9 +1,13 @@
+import AppKit
 import SwiftUI
 
 // The full window: a precision instrument on warm paper (light) or the Tokyo
 // Night storm (dark), following the system appearance — every color is a
 // Theme token with both values. Custom chrome (no system sidebar), like the
 // TUI. The menu bar is the glance; this is where details live.
+//
+// Panes live in their own files: DashboardPane (the home), SessionsPane,
+// UsagePane, LimitsPane.
 
 struct MainWindow: View {
     @EnvironmentObject var dashboard: DashboardStore
@@ -16,6 +20,7 @@ struct MainWindow: View {
             Rectangle().fill(Theme.border).frame(height: 1)
             Group {
                 switch selection.pane {
+                case .dashboard: DashboardPane()
                 case .sessions: SessionsPane()
                 case .usage: UsagePane()
                 case .limits: LimitsPane()
@@ -25,7 +30,30 @@ struct MainWindow: View {
         }
         .background(Theme.bg)
         .frame(minWidth: 960, minHeight: 560)
-        .task { await dashboard.refresh() }
+        .task {
+            await dashboard.refresh()
+            // The window is a live instrument: refresh while it stays open
+            // (the daemon caches by fingerprint, so a quiet minute is one
+            // store read + a hash for it, not a rebuild).
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                guard !Task.isCancelled else { break }
+                await dashboard.refresh()
+            }
+        }
+        .onAppear {
+            // A menu-bar app (LSUIElement) has no Dock presence; while the
+            // full window is open it should behave like a real app — Dock
+            // icon, Cmd-Tab entry — and drop back to accessory on close.
+            // NSApp is nil in the offscreen snapshot process (no NSApplication).
+            guard !SnapshotMode.enabled, let app = NSApp else { return }
+            app.setActivationPolicy(.regular)
+            app.activate(ignoringOtherApps: true)
+        }
+        .onDisappear {
+            guard !SnapshotMode.enabled, let app = NSApp else { return }
+            app.setActivationPolicy(.accessory)
+        }
     }
 }
 
@@ -111,6 +139,7 @@ struct PaneTab: View {
 extension MainPane {
     var icon: String {
         switch self {
+        case .dashboard: return "gauge.with.dots.needle.50percent"
         case .sessions: return "rectangle.stack.fill"
         case .usage: return "chart.bar.fill"
         case .limits: return "gauge.with.needle.fill"
@@ -118,516 +147,45 @@ extension MainPane {
     }
 }
 
-// MARK: - Sessions
+// MARK: - Shared bits used by several panes
 
-struct SessionsPane: View {
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var selection: AppSelection
-
-    var body: some View {
-        HStack(spacing: 0) {
-            VStack(spacing: 0) {
-                ScrollBox {
-                    VStack(spacing: 2) {
-                        ForEach(dashboard.sessions) { entry in
-                            SessionRow(entry: entry, selected: selection.sessionId == entry.id)
-                                .onTapGesture { selection.sessionId = entry.id }
-                        }
-                    }
-                    .padding(10)
-                }
-                if let total = dashboard.totalSessions {
-                    Rectangle().fill(Theme.border).frame(height: 1)
-                    Text("\(dashboard.sessions.count) root sessions · \(total) total in the store")
-                        .font(.system(size: 10))
-                        .foregroundStyle(Theme.textFaint)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 7)
-                }
-            }
-            .frame(width: 430)
-            Rectangle().fill(Theme.border).frame(width: 1)
-            detail
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Theme.surface.opacity(0.4))
-        }
-        .overlay(alignment: .bottom) {
-            if let error = dashboard.errorText {
-                Label(error, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(Theme.red)
-                    .padding(8)
-                    .background(Theme.card, in: RoundedRectangle(cornerRadius: 8))
-                    .padding(.bottom, 10)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var detail: some View {
-        if let id = selection.sessionId,
-           let entry = dashboard.sessions.first(where: { $0.id == id }) {
-            SessionDetail(entry: entry)
-        } else {
-            VStack(spacing: 10) {
-                Image(systemName: "rectangle.stack")
-                    .font(.system(size: 34, weight: .light))
-                    .foregroundStyle(Theme.textFaint)
-                Text("Select a session")
-                    .font(.system(size: 13))
-                    .foregroundStyle(Theme.textMuted)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
+/// The evidence four-state enum, in the product's confidence colors — strong
+/// proof green, failure red, weak amber, nothing muted. This chip IS the
+/// product (what did the agent prove?), so it never renders as an
+/// undifferentiated gray.
+func evidenceTint(_ status: String?) -> Color {
+    switch status {
+    case "strong": return Theme.green
+    case "failed": return Theme.red
+    case "weak": return Theme.orange
+    default: return Theme.textMuted
     }
 }
 
-struct SessionRow: View {
-    let entry: SessionEntry
-    let selected: Bool
-    @State private var hovering = false
-
-    private var workStatus: String? {
-        let statuses = Set((entry.work?.items ?? []).compactMap(\.latestStatus))
-        if statuses.contains("blocked") { return "blocked" }
-        if statuses.contains("handed_off") { return "handed_off" }
-        if !statuses.isDisjoint(with: ["started", "checkpoint"]) { return "in_progress" }
-        if statuses.contains("completed") { return "completed" }
-        return nil
-    }
-
-    var body: some View {
-        HStack(spacing: 10) {
-            StatusDot(color: Theme.statusColor(workStatus), size: 7)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(entry.displayTitle)
-                    .font(.system(size: 12.5, weight: .medium))
-                    .foregroundStyle(Theme.text)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                HStack(spacing: 6) {
-                    Text(entry.client)
-                        .font(.system(size: 9.5, weight: .semibold))
-                        .foregroundStyle(Theme.clientColor(entry.client))
-                    if let project = entry.project {
-                        Text(project)
-                            .font(.system(size: 10))
-                            .foregroundStyle(Theme.textFaint)
-                    }
-                }
-            }
-            Spacer(minLength: 10)
-            VStack(alignment: .trailing, spacing: 3) {
-                Text(entry.usage?.costText ?? "—")
-                    .font(.system(size: 12, weight: .semibold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundStyle(Theme.text)
-                HStack(spacing: 5) {
-                    if let tokens = entry.usage?.freshTokens {
-                        Text(UsageTotals.compact(tokens))
-                            .font(.system(size: 9.5))
-                            .monospacedDigit()
-                            .foregroundStyle(Theme.textFaint)
-                    }
-                    if let ts = entry.lastActivityAt {
-                        Text(Date(timeIntervalSince1970: ts), style: .relative)
-                            .font(.system(size: 9.5))
-                            .foregroundStyle(Theme.textFaint)
-                    }
-                }
-            }
-        }
-        .padding(.horizontal, 11)
-        .padding(.vertical, 8)
-        .background(
-            // Hover must be VISIBLE on paper: surface-on-bg was a ~1% value
-            // difference in light mode (review polish note) — cardAlt at half
-            // opacity reads as a real highlight in both schemes.
-            selected ? AnyShapeStyle(Theme.cardAlt) : (hovering ? AnyShapeStyle(Theme.cardAlt.opacity(0.5)) : AnyShapeStyle(.clear)),
-            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(selected ? Theme.accent.opacity(0.45) : .clear, lineWidth: 1)
-        )
-        .contentShape(Rectangle())
-        .onHover { hovering = $0 }
+func joinTint(_ state: String?) -> Color {
+    switch state {
+    case "attributed": return Theme.green
+    case "ambiguous": return Theme.orange
+    case "sections_only": return Theme.blue
+    default: return Theme.textMuted
     }
 }
 
-struct SessionDetail: View {
-    let entry: SessionEntry
-
-    var body: some View {
-        ScrollBox {
-            VStack(alignment: .leading, spacing: 16) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(entry.displayTitle)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(Theme.text)
-                        .lineLimit(3)
-                    HStack(spacing: 6) {
-                        Chip(text: entry.client, tint: Theme.clientColor(entry.client))
-                        if let project = entry.project { Chip(text: project, tint: Theme.textMuted) }
-                        if let duration = entry.durationSeconds {
-                            Chip(text: SessionDetail.duration(duration), tint: Theme.textMuted)
-                        }
-                        if let models = entry.observedModels, !models.isEmpty {
-                            Chip(text: models.joined(separator: " · "), tint: Theme.purple)
-                        }
-                    }
-                }
-
-                if let usage = entry.usage {
-                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4), spacing: 8) {
-                        PanelTile(label: "cost", value: usage.costText,
-                                     detail: usage.costConfidence?.replacingOccurrences(of: "_", with: " "),
-                                     accent: Theme.blue)
-                        PanelTile(label: "fresh", value: usage.freshTokens.map(UsageTotals.compact) ?? "—")
-                        PanelTile(label: "cache read", value: usage.cacheReadTokens.map(UsageTotals.compact) ?? "—")
-                        PanelTile(label: "turns", value: usage.turnsTotal.map(String.init) ?? "—")
-                    }
-                }
-
-                if let note = entry.usageNote {
-                    Text(note)
-                        .font(.system(size: 10.5))
-                        .foregroundStyle(Theme.textFaint)
-                }
-
-                if let items = entry.work?.items, !items.isEmpty {
-                    VStack(alignment: .leading, spacing: 8) {
-                        SectionCaption(tone: Theme.textMuted, text: "Work")
-                        Card(padding: 4) {
-                            VStack(alignment: .leading, spacing: 0) {
-                                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-                                    HStack(spacing: 9) {
-                                        StatusDot(color: Theme.statusColor(item.latestStatus))
-                                        Text(item.title ?? item.sectionId ?? "untitled")
-                                            .font(.system(size: 12))
-                                            .foregroundStyle(Theme.text)
-                                            .lineLimit(2)
-                                        Spacer(minLength: 8)
-                                        if let evidence = item.evidenceStatus {
-                                            Chip(text: evidence.replacingOccurrences(of: "_", with: " "),
-                                                 tint: evidenceTint(evidence))
-                                        }
-                                    }
-                                    .padding(.horizontal, 9)
-                                    .padding(.vertical, 7)
-                                    if index < items.count - 1 {
-                                        Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if let join = entry.join {
-                    VStack(alignment: .leading, spacing: 8) {
-                        SectionCaption(tone: Theme.textMuted, text: "Attribution")
-                        HStack(alignment: .firstTextBaseline, spacing: 8) {
-                            Chip(text: join.state ?? "unknown", tint: joinTint(join.state))
-                            if let reason = join.reason {
-                                Text(reason)
-                                    .font(.system(size: 10.5))
-                                    .foregroundStyle(Theme.textMuted)
-                            }
-                        }
-                    }
-                }
-
-                if let related = entry.related, (related.childSessionCount ?? 0) > 0 {
-                    Card {
-                        HStack(spacing: 8) {
-                            Image(systemName: "point.3.connected.trianglepath.dotted")
-                                .foregroundStyle(Theme.textMuted)
-                            Text("\(related.childSessionCount ?? 0) subagent sessions")
-                                .font(.system(size: 11.5))
-                                .foregroundStyle(Theme.text)
-                            Spacer()
-                            if let fresh = related.childrenUsage?.freshTokens {
-                                Text("\(UsageTotals.compact(fresh)) fresh tok")
-                                    .font(.system(size: 11))
-                                    .monospacedDigit()
-                                    .foregroundStyle(Theme.textMuted)
-                            }
-                        }
-                    }
-                }
-            }
-            .padding(16)
-        }
-    }
-
-    /// The evidence four-state enum, in the product's confidence colors —
-    /// strong proof green, failure red, weak amber, nothing muted. This chip
-    /// IS the product (what did the agent prove?), so it never renders as an
-    /// undifferentiated gray.
-    private func evidenceTint(_ status: String) -> Color {
-        switch status {
-        case "strong": return Theme.green
-        case "failed": return Theme.red
-        case "weak": return Theme.orange
-        default: return Theme.textMuted
-        }
-    }
-
-    private func joinTint(_ state: String?) -> Color {
-        switch state {
-        case "attributed": return Theme.green
-        case "ambiguous": return Theme.orange
-        case "sections_only": return Theme.blue
-        default: return Theme.textMuted
-        }
-    }
-
-    static func duration(_ seconds: Double) -> String {
-        let total = Int(seconds)
-        let hours = total / 3600
-        let minutes = (total % 3600) / 60
-        if hours > 0 { return "\(hours)h \(minutes)m" }
-        return "\(minutes)m"
-    }
+func durationText(_ seconds: Double) -> String {
+    let total = Int(seconds)
+    let hours = total / 3600
+    let minutes = (total % 3600) / 60
+    if hours > 0 { return "\(hours)h \(minutes)m" }
+    return "\(minutes)m"
 }
 
-// MARK: - Usage
-
-struct UsagePane: View {
-    @EnvironmentObject var dashboard: DashboardStore
-
-    var body: some View {
-        ScrollBox {
-            VStack(alignment: .leading, spacing: 16) {
-                if let usage = dashboard.usage {
-                    if let totals = usage.totals {
-                        HStack(spacing: 8) {
-                            PanelTile(label: "30d cost", value: totals.costText, accent: Theme.blue)
-                            PanelTile(label: "30d fresh tokens",
-                                         value: totals.freshTokens.map(UsageTotals.compact) ?? "—")
-                            PanelTile(label: "cache read",
-                                         value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—")
-                            PanelTile(label: "sessions",
-                                         value: totals.sessions.map(String.init) ?? "—")
-                        }
-                    }
-                    if let periods = usage.byPeriod, periods.count > 1 {
-                        DailyChart(periods: periods)
-                    }
-                    bucketSection(title: "By agent", buckets: usage.byClient) { bucket in
-                        (bucket.client ?? "?", Theme.clientColor(bucket.client))
-                    }
-                    bucketSection(title: "By model", buckets: usage.byModel) { bucket in
-                        (bucket.model ?? "?", Theme.clientColor(bucket.client))
-                    }
-                } else {
-                    VStack(spacing: 10) {
-                        Image(systemName: "chart.bar.xaxis")
-                            .font(.system(size: 32, weight: .light))
-                            .foregroundStyle(Theme.textFaint)
-                        Text("No usage loaded")
-                            .foregroundStyle(Theme.textMuted)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, 90)
-                }
-            }
-            .padding(16)
-        }
-    }
-
-    private func bucketSection(
-        title: String,
-        buckets: [UsageBucket],
-        nameOf: @escaping (UsageBucket) -> (String, Color)
-    ) -> some View {
-        let sorted = buckets.sorted { ($0.freshTokens ?? 0) > ($1.freshTokens ?? 0) }
-        let maxFresh = Double(sorted.first?.freshTokens ?? 1)
-        return VStack(alignment: .leading, spacing: 8) {
-            SectionCaption(tone: Theme.textMuted, text: title + " · last 30 days")
-            Card(padding: 6) {
-                VStack(spacing: 0) {
-                    ForEach(Array(sorted.enumerated()), id: \.element.id) { index, bucket in
-                        let (name, tint) = nameOf(bucket)
-                        HStack(spacing: 10) {
-                            StatusDot(color: tint, size: 6)
-                            Text(name)
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(Theme.text)
-                                .lineLimit(1)
-                                .frame(width: 168, alignment: .leading)
-                            MeterBar(fraction: Double(bucket.freshTokens ?? 0) / max(maxFresh, 1),
-                                     tint: tint, height: 7)
-                            Text(bucket.freshTokens.map(UsageTotals.compact) ?? "—")
-                                .font(.system(size: 11.5))
-                                .monospacedDigit()
-                                .foregroundStyle(Theme.textMuted)
-                                .frame(width: 58, alignment: .trailing)
-                            Text(bucket.costText)
-                                .font(.system(size: 11.5, weight: .semibold, design: .rounded))
-                                .monospacedDigit()
-                                .foregroundStyle(Theme.text)
-                                .frame(width: 82, alignment: .trailing)
-                        }
-                        .padding(.horizontal, 9)
-                        .padding(.vertical, 7)
-                        if index < sorted.count - 1 {
-                            Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// The 30-day stacked daily bars, client-colored — the dashboard's centerpiece.
-struct DailyChart: View {
-    let periods: [PeriodBucket]
-
-    private var clients: [String] {
-        var seen: [String] = []
-        for period in periods {
-            for client in (period.byClient ?? [:]).keys where !seen.contains(client) {
-                seen.append(client)
-            }
-        }
-        return seen.sorted()
-    }
-
-    private var maxTokens: Double {
-        max(Double(periods.compactMap(\.freshTokens).max() ?? 1), 1)
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 10) {
-                SectionCaption(tone: Theme.textMuted, text: "Daily fresh tokens")
-                Spacer()
-                ForEach(clients, id: \.self) { client in
-                    HStack(spacing: 4) {
-                        StatusDot(color: Theme.clientColor(client), size: 5)
-                        Text(client)
-                            .font(.system(size: 9.5))
-                            .foregroundStyle(Theme.textMuted)
-                    }
-                }
-            }
-            Card(padding: 12) {
-                VStack(spacing: 6) {
-                    HStack(alignment: .bottom, spacing: 3) {
-                        ForEach(periods) { period in
-                            VStack(spacing: 0) {
-                                let total = Double(period.freshTokens ?? 0)
-                                let height = 110 * total / maxTokens
-                                VStack(spacing: 0.5) {
-                                    ForEach(clients, id: \.self) { client in
-                                        let slice = Double(period.byClient?[client]?.freshTokens ?? 0)
-                                        if slice > 0, total > 0 {
-                                            RoundedRectangle(cornerRadius: 1)
-                                                .fill(Theme.clientColor(client).gradient)
-                                                .frame(height: max(1.5, height * slice / total))
-                                        }
-                                    }
-                                }
-                                .frame(maxWidth: .infinity)
-                            }
-                            .frame(maxWidth: .infinity, alignment: .bottom)
-                        }
-                    }
-                    .frame(height: 112, alignment: .bottom)
-                    HStack {
-                        Text(periods.first?.shortLabel ?? "")
-                        Spacer()
-                        Text(periods[periods.count / 2].shortLabel)
-                        Spacer()
-                        Text(periods.last?.shortLabel ?? "")
-                    }
-                    .font(.system(size: 9))
-                    .foregroundStyle(Theme.textFaint)
-                }
-            }
-        }
-    }
-}
-
-// MARK: - Limits
-
-struct LimitsPane: View {
-    @EnvironmentObject var glance: GlanceState
-    @State private var showStale = false
-
-    var body: some View {
-        ScrollBox {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack {
-                    SectionCaption(tone: Theme.textMuted, text: "Provider limits")
-                    Spacer()
-                    Toggle("Show stale accounts", isOn: $showStale)
-                        .toggleStyle(.checkbox)
-                        .font(.system(size: 11))
-                        .foregroundStyle(Theme.textMuted)
-                }
-                if case .connected(let snapshot) = glance.phase {
-                    let limits = snapshot.glance.limits.filter { showStale || $0.stale != true }
-                    if limits.isEmpty {
-                        Text("No live limit readings.")
-                            .font(.system(size: 12))
-                            .foregroundStyle(Theme.textMuted)
-                    }
-                    ForEach(Array(limits.enumerated()), id: \.offset) { _, limit in
-                        limitCard(limit)
-                    }
-                } else {
-                    Text("Daemon not connected.")
-                        .font(.system(size: 12))
-                        .foregroundStyle(Theme.textMuted)
-                }
-            }
-            .padding(16)
-        }
-    }
-
-    private func limitCard(_ limit: LimitEntry) -> some View {
-        Card {
-            VStack(alignment: .leading, spacing: 10) {
-                HStack(spacing: 7) {
-                    StatusDot(color: Theme.clientColor(limit.client))
-                    Text(limit.client ?? "?")
-                        .font(.system(size: 12.5, weight: .semibold))
-                        .foregroundStyle(Theme.text)
-                    if let plan = limit.planType {
-                        Chip(text: plan, tint: Theme.clientColor(limit.client))
-                    }
-                    if limit.stale == true {
-                        Chip(text: "stale", tint: Theme.textMuted)
-                    }
-                    Spacer()
-                }
-                ForEach(Array((limit.windows ?? []).enumerated()), id: \.offset) { _, window in
-                    if let used = window.usedPercent {
-                        HStack(spacing: 10) {
-                            Text(window.kind ?? "")
-                                .font(.system(size: 11))
-                                .foregroundStyle(Theme.textMuted)
-                                .frame(width: 26, alignment: .leading)
-                            MeterBar(fraction: used / 100.0,
-                                     tint: Theme.limitColor(usedPercent: used), height: 8)
-                            Text(String(format: "%.0f%%", used))
-                                .font(.system(size: 11.5, weight: .semibold))
-                                .monospacedDigit()
-                                .foregroundStyle(Theme.text)
-                                .frame(width: 36, alignment: .trailing)
-                            Text(Theme.resetsIn(window.resetsAt).map { "resets in \($0)" } ?? "")
-                                .font(.system(size: 10))
-                                .foregroundStyle(Theme.textFaint)
-                                .frame(width: 100, alignment: .trailing)
-                        }
-                    }
-                }
-            }
-        }
-    }
+func agoText(_ epoch: Double?) -> String? {
+    guard let epoch, epoch > 0 else { return nil }
+    let delta = Date().timeIntervalSince1970 - epoch
+    guard delta >= 0 else { return nil }
+    let total = Int(delta)
+    if total < 60 { return "\(total)s ago" }
+    if total < 3600 { return "\(total / 60)m ago" }
+    if total < 86400 { return "\(total / 3600)h ago" }
+    return "\(total / 86400)d ago"
 }

--- a/apps/agentacct/Sources/agentacct/MenuContent.swift
+++ b/apps/agentacct/Sources/agentacct/MenuContent.swift
@@ -1,8 +1,10 @@
+import ServiceManagement
 import SwiftUI
 
-// The dropdown: a glance, not a workspace. A today hero, compact window
-// stats, live limit meters, and root sessions — click anything deep to open
-// the full window. Honesty rules carried from the TUI: costs are complete-$ /
+// The dropdown: a glance, not a workspace. The weekly-plan hero (account
+// truth, the subscription user's real question), today's cost as reference,
+// live limit meters, and root sessions — click anything deep to open the
+// full window. Honesty rules carried from the TUI: costs are complete-$ /
 // partial-~$ / em-dash (never a fabricated $0), plan shares only when
 // calibrated, statuses use the server-side reduction. Stale limit accounts
 // are hidden here (the full window has the toggle).
@@ -68,11 +70,13 @@ struct MenuContent: View {
     private func connectedView(snapshot: GlanceSnapshot) -> some View {
         let glance = snapshot.glance
         let windows = Dictionary(uniqueKeysWithValues: glance.usage.windows.map { ($0.label, $0.totals) })
+        let sevenDay = GlanceState.sevenDayUsedPercent(glance)
 
-        // Hero: today.
+        // Hero: the weekly plan (account truth). Falls back to today's cost
+        // when no provider reading exists — never a fabricated %.
         VStack(alignment: .leading, spacing: 2) {
             HStack(alignment: .firstTextBaseline) {
-                Text("TODAY")
+                Text(sevenDay != nil ? "WEEKLY PLAN · 7D" : "TODAY")
                     .font(.system(size: 10, weight: .semibold))
                     .tracking(0.8)
                     .foregroundStyle(.secondary)
@@ -85,12 +89,23 @@ struct MenuContent: View {
                         .foregroundStyle(.tertiary)
                 }
             }
-            Text(windows["today"]?.costText ?? "—")
-                .font(.system(size: 30, weight: .bold, design: .rounded))
-                .monospacedDigit()
-            Text("\(windows["today"]?.tokensText ?? "—") fresh tokens")
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
+            if let used = sevenDay {
+                Text("\(Int(used.rounded()))%")
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                MeterBar(fraction: used / 100.0, tint: Theme.limitColor(usedPercent: used), height: 6)
+                    .padding(.vertical, 2)
+                Text("today \(windows["today"]?.costText ?? "—") · \(windows["today"]?.tokensText ?? "—") fresh tok")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(windows["today"]?.costText ?? "—")
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                Text("\(windows["today"]?.tokensText ?? "—") fresh tokens")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
         }
 
         HStack(spacing: 8) {
@@ -196,6 +211,7 @@ struct MenuContent: View {
             .buttonStyle(.plain)
             .foregroundStyle(Theme.accent)
             Spacer()
+            LaunchAtLoginToggle()
             Button {
                 state.refreshNow()
             } label: {
@@ -226,6 +242,41 @@ struct MenuContent: View {
         openWindow(id: "main")
         NSApp.activate(ignoringOtherApps: true)
         Task { await dashboard.refresh() }
+    }
+}
+
+/// "Launch at Login" via SMAppService — the app registers ITSELF (the OS
+/// shows it in System Settings › Login Items under this app's name; no
+/// hidden helpers, nothing system-wide). State reads back from the service
+/// so the toggle always reflects reality, including changes made in System
+/// Settings.
+struct LaunchAtLoginToggle: View {
+    @State private var enabled = SMAppService.mainApp.status == .enabled
+
+    var body: some View {
+        Toggle(isOn: Binding(
+            get: { enabled },
+            set: { wanted in
+                do {
+                    if wanted {
+                        try SMAppService.mainApp.register()
+                    } else {
+                        try SMAppService.mainApp.unregister()
+                    }
+                } catch {
+                    // Registration can fail for an unsigned dev build moved
+                    // mid-run; reflect reality rather than pretending.
+                }
+                enabled = SMAppService.mainApp.status == .enabled
+            }
+        )) {
+            Text("Login")
+                .font(.system(size: 10.5))
+                .foregroundStyle(.secondary)
+        }
+        .toggleStyle(.checkbox)
+        .controlSize(.small)
+        .help("Launch agentacct at login")
     }
 }
 

--- a/apps/agentacct/Sources/agentacct/SessionsPane.swift
+++ b/apps/agentacct/Sources/agentacct/SessionsPane.swift
@@ -1,0 +1,501 @@
+import SwiftUI
+
+// Sessions: the server-paginated roots list (plan share first, cost as the
+// reference) and the one-session deep view — expandable steps with their
+// machine checks, the evidence enum in confidence colors, attributed model
+// lanes, descendants, and the plan why-this-number block. The daemon's
+// honesty semantics render verbatim; nothing is re-derived here.
+
+struct SessionsPane: View {
+    @EnvironmentObject var dashboard: DashboardStore
+    @EnvironmentObject var selection: AppSelection
+
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                ScrollBox {
+                    VStack(spacing: 2) {
+                        // Offscreen renders have no scrolling: cap the list so
+                        // the snapshot shows the top of it plus the detail.
+                        let rows = SnapshotMode.enabled ? Array(dashboard.sessions.prefix(9)) : dashboard.sessions
+                        ForEach(rows) { row in
+                            SessionRow(row: row, selected: selection.sessionId == row.id)
+                                .onTapGesture { selection.sessionId = row.id }
+                        }
+                        if dashboard.truncated {
+                            Button {
+                                Task { await dashboard.loadMore() }
+                            } label: {
+                                HStack(spacing: 6) {
+                                    if dashboard.isLoadingMore {
+                                        ProgressView().controlSize(.small)
+                                    } else {
+                                        Image(systemName: "arrow.down.circle")
+                                            .font(.system(size: 11))
+                                    }
+                                    Text("Load more")
+                                        .font(Type.body)
+                                }
+                                .foregroundStyle(Theme.accent)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(10)
+                }
+                Rectangle().fill(Theme.border).frame(height: 1)
+                Text(footerText)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.textFaint)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+            }
+            .frame(width: 430)
+            Rectangle().fill(Theme.border).frame(width: 1)
+            detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Theme.surface.opacity(0.4))
+        }
+        .overlay(alignment: .bottom) {
+            if let error = dashboard.errorText {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(Theme.red)
+                    .padding(8)
+                    .background(Theme.card, in: RoundedRectangle(cornerRadius: 8))
+                    .padding(.bottom, 10)
+            }
+        }
+    }
+
+    private var footerText: String {
+        let shown = dashboard.sessions.count
+        let roots = dashboard.totalRootSessions.map(String.init) ?? "?"
+        let total = dashboard.totalSessions.map(String.init) ?? "?"
+        return "\(shown) of \(roots) root sessions · \(total) total in the store"
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if let id = selection.sessionId,
+           let row = dashboard.sessions.first(where: { $0.id == id }) {
+            SessionDetail(row: row)
+                .id(row.id)  // re-fetch when the selection changes
+        } else {
+            VStack(spacing: 10) {
+                Image(systemName: "rectangle.stack")
+                    .font(.system(size: 34, weight: .light))
+                    .foregroundStyle(Theme.textFaint)
+                Text("Select a session")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Theme.textMuted)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+// MARK: - List row (plan share first, cost as the reference)
+
+struct SessionRow: View {
+    let row: V1SessionRow
+    let selected: Bool
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            StatusDot(color: Theme.statusColor(row.status), size: 7)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(row.displayTitle)
+                    .font(Type.rowTitle)
+                    .foregroundStyle(Theme.text)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                HStack(spacing: 6) {
+                    Text(row.client)
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .foregroundStyle(Theme.clientColor(row.client))
+                    if let project = row.project {
+                        Text(project)
+                            .font(.system(size: 10))
+                            .foregroundStyle(Theme.textFaint)
+                    }
+                    if let count = row.related?.childSessionCount, count > 0 {
+                        Text("×\(count) sub")
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(Theme.textFaint)
+                    }
+                }
+            }
+            Spacer(minLength: 10)
+            VStack(alignment: .trailing, spacing: 3) {
+                if let pct = Fmt.planPct(row.planPct) {
+                    Text(pct)
+                        .font(Type.metricS)
+                        .foregroundStyle(Theme.accent)
+                    Text(row.usage?.costText ?? "—")
+                        .font(.system(size: 9.5))
+                        .monospacedDigit()
+                        .foregroundStyle(Theme.textFaint)
+                } else {
+                    Text(row.usage?.costText ?? "—")
+                        .font(Type.metricS)
+                        .foregroundStyle(Theme.text)
+                    if let ts = row.lastActivityAt, let ago = agoText(ts) {
+                        Text(ago)
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(Theme.textFaint)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 8)
+        .background(
+            selected ? AnyShapeStyle(Theme.cardAlt) : (hovering ? AnyShapeStyle(Theme.cardAlt.opacity(0.5)) : AnyShapeStyle(.clear)),
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(selected ? Theme.accent.opacity(0.45) : .clear, lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+    }
+}
+
+// MARK: - Deep detail (/v1/session)
+
+struct SessionDetail: View {
+    let row: V1SessionRow
+    @EnvironmentObject var dashboard: DashboardStore
+
+    var body: some View {
+        ScrollBox {
+            VStack(alignment: .leading, spacing: Space.l) {
+                header
+                statGrid
+                planBlock
+                stepsSection
+                descendantsSection
+                attributionSection
+            }
+            .padding(Space.l)
+        }
+        .task(id: row.id) {
+            await dashboard.fetchDetail(client: row.client, sessionId: row.clientSessionId)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(row.displayTitle)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(Theme.text)
+                .lineLimit(3)
+            HStack(spacing: 6) {
+                Chip(text: row.client, tint: Theme.clientColor(row.client))
+                if let project = row.project { Chip(text: project, tint: Theme.textMuted) }
+                if let duration = row.durationSeconds {
+                    Chip(text: durationText(duration), tint: Theme.textMuted)
+                }
+                if let models = row.observedModels, !models.isEmpty {
+                    Chip(text: models.joined(separator: " · "), tint: Theme.purple)
+                }
+                if row.instrumentationState == "pre_instrumentation" {
+                    Chip(text: "pre-instrumentation", tint: Theme.textFaint)
+                }
+            }
+            if let note = row.usageNote {
+                Text(note)
+                    .font(Type.small)
+                    .foregroundStyle(Theme.textFaint)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statGrid: some View {
+        if let usage = row.usage {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4), spacing: 8) {
+                if let pct = Fmt.planPct(row.planPct) {
+                    PanelTile(label: "weekly plan", value: pct,
+                              detail: planSplitDetail, accent: Theme.accent)
+                    PanelTile(label: "cost", value: usage.costText,
+                              detail: usage.costConfidence?.replacingOccurrences(of: "_", with: " "))
+                } else {
+                    PanelTile(label: "cost", value: usage.costText,
+                              detail: usage.costConfidence?.replacingOccurrences(of: "_", with: " "),
+                              accent: Theme.blue)
+                    PanelTile(label: "fresh", value: usage.freshTokens.map(UsageTotals.compact) ?? "—")
+                }
+                PanelTile(label: "cache read", value: usage.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                PanelTile(label: "turns", value: usage.turnsTotal.map(String.init) ?? "—")
+            }
+        }
+    }
+
+    private var planSplitDetail: String? {
+        guard let own = Fmt.planPct(row.planPctOwn) else { return nil }
+        if let children = Fmt.planPct(row.planPctChildren) {
+            return "own \(own) · subagents \(children)"
+        }
+        return "own \(own)"
+    }
+
+    @ViewBuilder
+    private var planBlock: some View {
+        if let basis = dashboard.detail?.plan?.basis {
+            Text("plan estimate: \(basis)")
+                .font(Type.tiny)
+                .foregroundStyle(Theme.textFaint)
+        }
+    }
+
+    // MARK: steps
+
+    @ViewBuilder
+    private var stepsSection: some View {
+        if let error = dashboard.detailError {
+            Text(error)
+                .font(Type.small)
+                .foregroundStyle(Theme.orange)
+        } else if let detail = dashboard.detail {
+            if !detail.steps.isEmpty {
+                VStack(alignment: .leading, spacing: Space.s) {
+                    SectionCaption(tone: Theme.textMuted, text: "Steps · \(detail.steps.count)")
+                    VStack(spacing: 6) {
+                        ForEach(detail.steps) { step in
+                            StepCard(step: step)
+                        }
+                    }
+                }
+            }
+        } else {
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("loading steps…")
+                    .font(Type.small)
+                    .foregroundStyle(Theme.textFaint)
+            }
+        }
+    }
+
+    // MARK: descendants
+
+    @ViewBuilder
+    private var descendantsSection: some View {
+        if let descendants = dashboard.detail?.descendants, !descendants.isEmpty {
+            VStack(alignment: .leading, spacing: Space.s) {
+                SectionCaption(tone: Theme.textMuted, text: "Subagent sessions · \(descendants.count)")
+                Card(padding: 4) {
+                    VStack(spacing: 0) {
+                        let shown = Array(descendants.prefix(8))
+                        ForEach(Array(shown.enumerated()), id: \.element.id) { index, child in
+                            HStack(spacing: 9) {
+                                StatusDot(color: Theme.statusColor(child.status), size: 6)
+                                Text(child.title ?? child.clientSessionIdShort ?? child.clientSessionId ?? "?")
+                                    .font(Type.body)
+                                    .foregroundStyle(Theme.text)
+                                    .lineLimit(1)
+                                Spacer(minLength: 8)
+                                if let pct = Fmt.planPct(child.planPct) {
+                                    Text(pct)
+                                        .font(Type.numeric)
+                                        .foregroundStyle(Theme.accent)
+                                }
+                                if let tokens = child.usage?.freshTokens {
+                                    Text(UsageTotals.compact(Int(tokens)))
+                                        .font(Type.tiny.monospacedDigit())
+                                        .foregroundStyle(Theme.textFaint)
+                                        .frame(width: 48, alignment: .trailing)
+                                }
+                            }
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 6)
+                            if index < shown.count - 1 {
+                                Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
+                            }
+                        }
+                        if descendants.count > 8 {
+                            Text("+ \(descendants.count - 8) more")
+                                .font(Type.tiny)
+                                .foregroundStyle(Theme.textFaint)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 9)
+                                .padding(.vertical, 6)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var attributionSection: some View {
+        if let join = row.join {
+            VStack(alignment: .leading, spacing: Space.s) {
+                SectionCaption(tone: Theme.textMuted, text: "Attribution")
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Chip(text: join.state ?? "unknown", tint: joinTint(join.state))
+                    if let reason = join.reason {
+                        Text(reason)
+                            .font(Type.small)
+                            .foregroundStyle(Theme.textMuted)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - One expandable step
+
+struct StepCard: View {
+    let step: V1Step
+    @State private var expanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) { expanded.toggle() }
+            } label: {
+                HStack(spacing: 9) {
+                    Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(Theme.textFaint)
+                        .frame(width: 10)
+                    StatusDot(color: Theme.statusColor(step.latestStatus))
+                    Text(step.title ?? step.sectionId ?? "untitled")
+                        .font(Type.body)
+                        .foregroundStyle(Theme.text)
+                        .lineLimit(expanded ? 3 : 1)
+                    Spacer(minLength: 8)
+                    if let kind = step.kind, kind != "unknown" {
+                        Chip(text: kind, tint: Theme.textMuted)
+                    }
+                    if let checks = step.checks, !checks.isEmpty {
+                        Text("\(checks.count) check\(checks.count == 1 ? "" : "s")")
+                            .font(Type.tiny)
+                            .foregroundStyle(Theme.textFaint)
+                    }
+                    if let evidence = step.evidenceStatus {
+                        Chip(text: evidence, tint: evidenceTint(evidence))
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if expanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        if let status = step.latestStatus {
+                            Chip(text: status.replacingOccurrences(of: "_", with: " "),
+                                 tint: Theme.statusColor(step.latestStatus))
+                        }
+                        if let ago = agoText(step.updatedAt) {
+                            Text("updated \(ago)")
+                                .font(Type.tiny)
+                                .foregroundStyle(Theme.textFaint)
+                        }
+                        if let usage = step.usage, let tokens = usage.totalTokens, tokens > 0 {
+                            Text("\(UsageTotals.compact(Int(tokens))) tok · \(usage.costText)")
+                                .font(Type.tiny.monospacedDigit())
+                                .foregroundStyle(Theme.textMuted)
+                        }
+                        if let models = step.models, !models.isEmpty {
+                            Text(models.compactMap { $0.model ?? "unknown model" }.joined(separator: " · "))
+                                .font(Type.tiny)
+                                .foregroundStyle(Theme.purple)
+                        }
+                    }
+                    if let summary = step.summary, !summary.isEmpty {
+                        Text(summary)
+                            .font(Type.small)
+                            .foregroundStyle(Theme.textMuted)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if let checks = step.checks, !checks.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(checks) { check in
+                                CheckRow(check: check)
+                            }
+                        }
+                    }
+                    if let blocker = step.blocker, !blocker.isEmpty {
+                        Label(blocker, systemImage: "hand.raised.fill")
+                            .font(Type.small)
+                            .foregroundStyle(Theme.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if let next = step.nextStep, !next.isEmpty {
+                        Label(next, systemImage: "arrow.turn.down.right")
+                            .font(Type.small)
+                            .foregroundStyle(Theme.textMuted)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    if let files = step.files, !files.isEmpty {
+                        Text("\(files.count) file\(files.count == 1 ? "" : "s"): \(files.prefix(4).joined(separator: ", "))\(files.count > 4 ? " …" : "")")
+                            .font(Type.tiny)
+                            .foregroundStyle(Theme.textFaint)
+                            .lineLimit(2)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 10)
+                .padding(.leading, 18)
+            }
+        }
+        .background(Theme.card, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .strokeBorder(Theme.border, lineWidth: 1)
+        )
+    }
+}
+
+/// One machine check: the TUI's ✓/✗/»/• marks with type, summary, exit code.
+struct CheckRow: View {
+    let check: V1Check
+
+    private var mark: (String, Color) {
+        switch check.result {
+        case "passed": return ("checkmark", Theme.green)
+        case "failed", "error": return ("xmark", Theme.red)
+        case "skipped": return ("chevron.right.2", Theme.orange)
+        default: return ("circle.fill", Theme.textFaint)
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Image(systemName: mark.0)
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(mark.1)
+                .frame(width: 12)
+            Text(check.evidenceType ?? "check")
+                .font(Type.tiny.weight(.semibold))
+                .foregroundStyle(Theme.textMuted)
+            Text(check.summary ?? "")
+                .font(Type.tiny)
+                .foregroundStyle(Theme.textMuted)
+                .lineLimit(2)
+            if let exit = check.exitCode {
+                Text("(exit \(exit))")
+                    .font(Type.tiny.monospacedDigit())
+                    .foregroundStyle(Theme.textFaint)
+            }
+            if check.supersessionState == "superseded" {
+                Chip(text: "superseded", tint: Theme.textFaint)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}

--- a/apps/agentacct/Sources/agentacct/SessionsPane.swift
+++ b/apps/agentacct/Sources/agentacct/SessionsPane.swift
@@ -81,8 +81,7 @@ struct SessionsPane: View {
 
     @ViewBuilder
     private var detail: some View {
-        if let id = selection.sessionId,
-           let row = dashboard.sessions.first(where: { $0.id == id }) {
+        if let id = selection.sessionId, let row = selectedRow(id) {
             SessionDetail(row: row)
                 .id(row.id)  // re-fetch when the selection changes
         } else {
@@ -96,6 +95,14 @@ struct SessionsPane: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    /// The selected row from the list — or from the loaded detail when a
+    /// refresh dropped it off the current page (an open detail must never
+    /// blank mid-read; review finding).
+    private func selectedRow(_ id: String) -> V1SessionRow? {
+        dashboard.sessions.first { $0.id == id }
+            ?? (dashboard.detail?.session.id == id ? dashboard.detail?.session : nil)
     }
 }
 
@@ -247,9 +254,17 @@ struct SessionDetail: View {
         return "own \(own)"
     }
 
+    /// The store-global detail, only when it belongs to THIS row — a stale
+    /// payload from the previously selected row must never flash under the
+    /// new header (review finding).
+    private var loadedDetail: V1SessionDetail? {
+        guard let detail = dashboard.detail, detail.session.id == row.id else { return nil }
+        return detail
+    }
+
     @ViewBuilder
     private var planBlock: some View {
-        if let basis = dashboard.detail?.plan?.basis {
+        if let basis = loadedDetail?.plan?.basis {
             Text("plan estimate: \(basis)")
                 .font(Type.tiny)
                 .foregroundStyle(Theme.textFaint)
@@ -264,7 +279,7 @@ struct SessionDetail: View {
             Text(error)
                 .font(Type.small)
                 .foregroundStyle(Theme.orange)
-        } else if let detail = dashboard.detail {
+        } else if let detail = loadedDetail {
             if !detail.steps.isEmpty {
                 VStack(alignment: .leading, spacing: Space.s) {
                     SectionCaption(tone: Theme.textMuted, text: "Steps · \(detail.steps.count)")
@@ -289,7 +304,7 @@ struct SessionDetail: View {
 
     @ViewBuilder
     private var descendantsSection: some View {
-        if let descendants = dashboard.detail?.descendants, !descendants.isEmpty {
+        if let descendants = loadedDetail?.descendants, !descendants.isEmpty {
             VStack(alignment: .leading, spacing: Space.s) {
                 SectionCaption(tone: Theme.textMuted, text: "Subagent sessions · \(descendants.count)")
                 Card(padding: 4) {

--- a/apps/agentacct/Sources/agentacct/SnapshotRunner.swift
+++ b/apps/agentacct/Sources/agentacct/SnapshotRunner.swift
@@ -22,7 +22,12 @@ enum SnapshotRunner {
                 let dashboard = DashboardStore()
                 await dashboard.refresh()
                 let selection = AppSelection()
-                selection.sessionId = dashboard.sessions.first?.id
+                if let first = dashboard.sessions.first {
+                    selection.sessionId = first.id
+                    // The deep view loads async in the live app; a snapshot
+                    // must render the loaded state, not the spinner.
+                    await dashboard.fetchDetail(client: first.client, sessionId: first.clientSessionId)
+                }
 
                 // Light AND dark of every surface: the theme is adaptive, so
                 // a design pass must see both. SnapshotScheme pins the Theme

--- a/apps/agentacct/Sources/agentacct/UsagePane.swift
+++ b/apps/agentacct/Sources/agentacct/UsagePane.swift
@@ -1,0 +1,337 @@
+import SwiftUI
+
+// Usage: plan-share view first (the subscription user's real question),
+// dollars as the reference view — a toggle, not a merge. The plan view only
+// exists when the daemon says the client is calibrated (calibrated-or-
+// nothing); otherwise the pane opens on the cost view with an honest note.
+
+struct UsagePane: View {
+    @EnvironmentObject var dashboard: DashboardStore
+    @State private var mode: UsageMode = .plan
+
+    enum UsageMode: String, CaseIterable, Identifiable {
+        case plan = "plan %"
+        case dollars = "$"
+        var id: String { rawValue }
+    }
+
+    private var calibratedClients: [V1PlanClient] {
+        dashboard.planClients.filter { $0.calibrationState == "calibrated" }
+    }
+
+    var body: some View {
+        ScrollBox {
+            VStack(alignment: .leading, spacing: Space.l) {
+                HStack {
+                    SectionCaption(tone: Theme.textMuted, text: "Usage · last 30 days")
+                    Spacer()
+                    Picker("", selection: $mode) {
+                        ForEach(UsageMode.allCases) { mode in
+                            Text(mode.rawValue).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 140)
+                }
+                if mode == .plan {
+                    planView
+                } else {
+                    dollarsView
+                }
+            }
+            .padding(Space.l)
+        }
+        .onAppear {
+            if calibratedClients.isEmpty { mode = .dollars }
+        }
+    }
+
+    // MARK: plan view
+
+    @ViewBuilder
+    private var planView: some View {
+        if calibratedClients.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("No calibrated plan estimate yet.")
+                    .font(Type.body)
+                    .foregroundStyle(Theme.textMuted)
+                ForEach(dashboard.planClients) { client in
+                    if client.calibrationState == "calibrating" {
+                        Text("\(client.client): calibrating from your own limit history")
+                            .font(Type.small)
+                            .foregroundStyle(Theme.textFaint)
+                    } else if client.calibrationState == "never" {
+                        Text("\(client.client): a weekly plan % is undefined for this client's rolling meter")
+                            .font(Type.small)
+                            .foregroundStyle(Theme.textFaint)
+                    }
+                }
+            }
+        } else {
+            ForEach(calibratedClients) { client in
+                VStack(alignment: .leading, spacing: Space.s) {
+                    HStack(spacing: 8) {
+                        StatusDot(color: Theme.clientColor(client.client), size: 6)
+                        SectionCaption(tone: Theme.textMuted, text: "\(client.client) · % of the weekly plan")
+                        Spacer()
+                        if let today = Fmt.planPct(client.windowPcts?["today"] ?? nil) {
+                            Text("today \(today)")
+                                .font(Type.numeric)
+                                .foregroundStyle(Theme.accent)
+                        }
+                        if let week = Fmt.planPct(client.windowPcts?["7d"] ?? nil) {
+                            Text("7d \(week)")
+                                .font(Type.numeric)
+                                .foregroundStyle(Theme.textMuted)
+                        }
+                    }
+                    if let daily = client.daily, daily.count > 1 {
+                        PlanDailyChart(days: daily, tint: Theme.clientColor(client.client))
+                    }
+                    if let byModel = client.byModel, !byModel.isEmpty {
+                        modelShares(byModel)
+                    }
+                    if let unknown = Fmt.planPct(client.unknownTimePct) {
+                        Text("+ \(unknown) from rows with unusable timestamps (outside the daily bars)")
+                            .font(Type.tiny)
+                            .foregroundStyle(Theme.textFaint)
+                    }
+                    if let basis = client.basis {
+                        Text("estimate basis: \(basis)")
+                            .font(Type.tiny)
+                            .foregroundStyle(Theme.textFaint)
+                    }
+                }
+            }
+        }
+    }
+
+    private func modelShares(_ shares: [V1PlanModelShare]) -> some View {
+        let maxPct = shares.compactMap(\.pct).max() ?? 1
+        return VStack(alignment: .leading, spacing: Space.s) {
+            SectionCaption(tone: Theme.textMuted, text: "Which model eats the plan")
+            Card(padding: 6) {
+                VStack(spacing: 0) {
+                    ForEach(Array(shares.enumerated()), id: \.element.id) { index, share in
+                        HStack(spacing: 10) {
+                            Text(share.model ?? "unknown")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(Theme.text)
+                                .lineLimit(1)
+                                .frame(width: 168, alignment: .leading)
+                            MeterBar(fraction: (share.pct ?? 0) / max(maxPct, 0.0001),
+                                     tint: Theme.accent, height: 7)
+                            Text(Fmt.planPct(share.pct) ?? "—")
+                                .font(Type.numeric)
+                                .foregroundStyle(Theme.text)
+                                .frame(width: 64, alignment: .trailing)
+                            Text(share.totalTokens.map { UsageTotals.compact(Int($0)) } ?? "—")
+                                .font(.system(size: 11))
+                                .monospacedDigit()
+                                .foregroundStyle(Theme.textMuted)
+                                .frame(width: 58, alignment: .trailing)
+                        }
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 7)
+                        if index < shares.count - 1 {
+                            Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: dollars view (the previous pane, unchanged semantics)
+
+    @ViewBuilder
+    private var dollarsView: some View {
+        if let usage = dashboard.usage {
+            if let totals = usage.totals {
+                HStack(spacing: 8) {
+                    PanelTile(label: "30d cost", value: totals.costText, accent: Theme.blue)
+                    PanelTile(label: "30d fresh tokens",
+                              value: totals.freshTokens.map(UsageTotals.compact) ?? "—")
+                    PanelTile(label: "cache read",
+                              value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                    PanelTile(label: "sessions",
+                              value: totals.sessions.map(String.init) ?? "—")
+                }
+            }
+            if let periods = usage.byPeriod, periods.count > 1 {
+                DailyChart(periods: periods)
+            }
+            bucketSection(title: "By agent", buckets: usage.byClient) { bucket in
+                (bucket.client ?? "?", Theme.clientColor(bucket.client))
+            }
+            bucketSection(title: "By model", buckets: usage.byModel) { bucket in
+                (bucket.model ?? "?", Theme.clientColor(bucket.client))
+            }
+        } else {
+            VStack(spacing: 10) {
+                Image(systemName: "chart.bar.xaxis")
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundStyle(Theme.textFaint)
+                Text("No usage loaded")
+                    .foregroundStyle(Theme.textMuted)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 90)
+        }
+    }
+
+    private func bucketSection(
+        title: String,
+        buckets: [UsageBucket],
+        nameOf: @escaping (UsageBucket) -> (String, Color)
+    ) -> some View {
+        let sorted = buckets.sorted { ($0.freshTokens ?? 0) > ($1.freshTokens ?? 0) }
+        let maxFresh = Double(sorted.first?.freshTokens ?? 1)
+        return VStack(alignment: .leading, spacing: 8) {
+            SectionCaption(tone: Theme.textMuted, text: title + " · last 30 days")
+            Card(padding: 6) {
+                VStack(spacing: 0) {
+                    ForEach(Array(sorted.enumerated()), id: \.element.id) { index, bucket in
+                        let (name, tint) = nameOf(bucket)
+                        HStack(spacing: 10) {
+                            StatusDot(color: tint, size: 6)
+                            Text(name)
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(Theme.text)
+                                .lineLimit(1)
+                                .frame(width: 168, alignment: .leading)
+                            MeterBar(fraction: Double(bucket.freshTokens ?? 0) / max(maxFresh, 1),
+                                     tint: tint, height: 7)
+                            Text(bucket.freshTokens.map(UsageTotals.compact) ?? "—")
+                                .font(.system(size: 11.5))
+                                .monospacedDigit()
+                                .foregroundStyle(Theme.textMuted)
+                                .frame(width: 58, alignment: .trailing)
+                            Text(bucket.costText)
+                                .font(Type.metricS)
+                                .foregroundStyle(Theme.text)
+                                .frame(width: 82, alignment: .trailing)
+                        }
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 7)
+                        if index < sorted.count - 1 {
+                            Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The daily plan-share bars for one calibrated client (aligned to the same
+/// local calendar days as the cost chart).
+struct PlanDailyChart: View {
+    let days: [V1PlanDay]
+    var tint: Color
+
+    private var maxPct: Double {
+        max(days.map(\.pct).max() ?? 0.0001, 0.0001)
+    }
+
+    var body: some View {
+        Card(padding: 12) {
+            VStack(spacing: 6) {
+                HStack(alignment: .bottom, spacing: 3) {
+                    ForEach(days) { day in
+                        RoundedRectangle(cornerRadius: 1)
+                            .fill(day.pct > 0 ? AnyShapeStyle(tint.gradient) : AnyShapeStyle(Theme.border.opacity(0.5)))
+                            .frame(height: day.pct > 0 ? max(2, 110 * day.pct / maxPct) : 1.5)
+                            .frame(maxWidth: .infinity, alignment: .bottom)
+                    }
+                }
+                .frame(height: 112, alignment: .bottom)
+                HStack {
+                    Text(shortDate(days.first?.date))
+                    Spacer()
+                    Text(shortDate(days[days.count / 2].date))
+                    Spacer()
+                    Text(shortDate(days.last?.date))
+                }
+                .font(.system(size: 9))
+                .foregroundStyle(Theme.textFaint)
+            }
+        }
+    }
+
+    private func shortDate(_ iso: String?) -> String {
+        guard let iso, iso.count >= 10 else { return "" }
+        return String(iso.dropFirst(5))  // YYYY-MM-DD -> MM-DD
+    }
+}
+
+/// The 30-day stacked daily bars, client-colored (cost/tokens view + the
+/// dashboard's rhythm strip).
+struct DailyChart: View {
+    let periods: [PeriodBucket]
+
+    private var clients: [String] {
+        var seen: [String] = []
+        for period in periods {
+            for client in (period.byClient ?? [:]).keys where !seen.contains(client) {
+                seen.append(client)
+            }
+        }
+        return seen.sorted()
+    }
+
+    private var maxTokens: Double {
+        max(Double(periods.compactMap(\.freshTokens).max() ?? 1), 1)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                SectionCaption(tone: Theme.textMuted, text: "Daily fresh tokens")
+                Spacer()
+                ForEach(clients, id: \.self) { client in
+                    HStack(spacing: 4) {
+                        StatusDot(color: Theme.clientColor(client), size: 5)
+                        Text(client)
+                            .font(.system(size: 9.5))
+                            .foregroundStyle(Theme.textMuted)
+                    }
+                }
+            }
+            Card(padding: 12) {
+                VStack(spacing: 6) {
+                    HStack(alignment: .bottom, spacing: 3) {
+                        ForEach(periods) { period in
+                            VStack(spacing: 0) {
+                                let total = Double(period.freshTokens ?? 0)
+                                let height = 110 * total / maxTokens
+                                VStack(spacing: 0.5) {
+                                    ForEach(clients, id: \.self) { client in
+                                        let slice = Double(period.byClient?[client]?.freshTokens ?? 0)
+                                        if slice > 0, total > 0 {
+                                            RoundedRectangle(cornerRadius: 1)
+                                                .fill(Theme.clientColor(client).gradient)
+                                                .frame(height: max(1.5, height * slice / total))
+                                        }
+                                    }
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .bottom)
+                        }
+                    }
+                    .frame(height: 112, alignment: .bottom)
+                    HStack {
+                        Text(periods.first?.shortLabel ?? "")
+                        Spacer()
+                        Text(periods[periods.count / 2].shortLabel)
+                        Spacer()
+                        Text(periods.last?.shortLabel ?? "")
+                    }
+                    .font(.system(size: 9))
+                    .foregroundStyle(Theme.textFaint)
+                }
+            }
+        }
+    }
+}

--- a/apps/agentacct/Sources/agentacct/UsagePane.swift
+++ b/apps/agentacct/Sources/agentacct/UsagePane.swift
@@ -7,7 +7,11 @@ import SwiftUI
 
 struct UsagePane: View {
     @EnvironmentObject var dashboard: DashboardStore
-    @State private var mode: UsageMode = .plan
+    // nil = no explicit user choice: the default follows the DATA (plan view
+    // when a calibrated client exists) and re-evaluates as /v1/plan loads —
+    // pinning a default in onAppear froze the pane on $ when it rendered
+    // before the first plan response (review finding).
+    @State private var chosenMode: UsageMode?
 
     enum UsageMode: String, CaseIterable, Identifiable {
         case plan = "plan %"
@@ -19,13 +23,17 @@ struct UsagePane: View {
         dashboard.planClients.filter { $0.calibrationState == "calibrated" }
     }
 
+    private var mode: UsageMode {
+        chosenMode ?? (calibratedClients.isEmpty ? .dollars : .plan)
+    }
+
     var body: some View {
         ScrollBox {
             VStack(alignment: .leading, spacing: Space.l) {
                 HStack {
                     SectionCaption(tone: Theme.textMuted, text: "Usage · last 30 days")
                     Spacer()
-                    Picker("", selection: $mode) {
+                    Picker("", selection: Binding(get: { mode }, set: { chosenMode = $0 })) {
                         ForEach(UsageMode.allCases) { mode in
                             Text(mode.rawValue).tag(mode)
                         }
@@ -40,9 +48,6 @@ struct UsagePane: View {
                 }
             }
             .padding(Space.l)
-        }
-        .onAppear {
-            if calibratedClients.isEmpty { mode = .dollars }
         }
     }
 

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -1,0 +1,350 @@
+import Foundation
+
+// Decodables for the /v1 native-shell lane beyond the glance:
+// /v1/sessions (paginated roots list), /v1/session (one-session deep view),
+// /v1/plan (attributed plan aggregates). Contract: additive-only schemas —
+// every struct tolerates unknown keys, every field the daemon may omit is
+// Optional, and honesty semantics ride the payload (calibrated-or-nothing
+// plan numbers, None-never-$0 costs) rather than being re-derived here.
+
+struct V1SessionsPayload: Decodable {
+    let schema: String
+    let generatedAt: Double?
+    let totalSessions: Int?
+    let totalRootSessions: Int?
+    let filteredTotal: Int?
+    let offset: Int?
+    let limit: Int?
+    let returned: Int?
+    let truncated: Bool?
+    let plan: [V1PlanStatus]?
+    let sessions: [V1SessionRow]
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case generatedAt = "generated_at"
+        case totalSessions = "total_sessions"
+        case totalRootSessions = "total_root_sessions"
+        case filteredTotal = "filtered_total"
+        case offset, limit, returned, truncated, plan, sessions
+    }
+}
+
+struct V1PlanStatus: Decodable {
+    let client: String
+    let confidence: String?
+    let calibrationState: String?
+    let calibratable: Bool?
+    let basis: String?
+    let scale: Double?
+    let intervalsUsed: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case client, confidence, calibratable, basis, scale
+        case calibrationState = "calibration_state"
+        case intervalsUsed = "intervals_used"
+    }
+}
+
+struct V1SessionRow: Decodable, Identifiable {
+    let sessionKey: String?
+    let client: String
+    let clientSessionId: String
+    let clientSessionIdShort: String?
+    let sessionKind: String?
+    let title: String?
+    let project: String?
+    let status: String?
+    let firstActivityAt: Double?
+    let lastActivityAt: Double?
+    let durationSeconds: Double?
+    let instrumentationState: String?
+    let observedModels: [String]?
+    let usage: SessionUsage?
+    let usageNote: String?
+    let join: SessionJoin?
+    let work: SessionWork?
+    let related: SessionRelated?
+    let planPctOwn: Double?
+    let planPctChildren: Double?
+    let planPct: Double?
+
+    var id: String { sessionKey ?? "\(client)::\(clientSessionId)" }
+
+    var displayTitle: String {
+        if let title, !title.isEmpty { return title }
+        return "\(client) · \(clientSessionIdShort ?? String(clientSessionId.prefix(8)))"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case client, title, project, status, usage, join, work, related
+        case sessionKey = "session_key"
+        case clientSessionId = "client_session_id"
+        case clientSessionIdShort = "client_session_id_short"
+        case sessionKind = "session_kind"
+        case firstActivityAt = "first_activity_at"
+        case lastActivityAt = "last_activity_at"
+        case durationSeconds = "duration_seconds"
+        case instrumentationState = "instrumentation_state"
+        case observedModels = "observed_models"
+        case usageNote = "usage_note"
+        case planPctOwn = "plan_pct_own"
+        case planPctChildren = "plan_pct_children"
+        case planPct = "plan_pct"
+    }
+}
+
+// MARK: - /v1/session detail
+
+struct V1SessionDetail: Decodable {
+    let schema: String
+    let generatedAt: Double?
+    let session: V1SessionRow
+    let steps: [V1Step]
+    let descendants: [V1Descendant]
+    let plan: V1SessionPlan?
+
+    enum CodingKeys: String, CodingKey {
+        case schema, session, steps, descendants, plan
+        case generatedAt = "generated_at"
+    }
+}
+
+struct V1Step: Decodable, Identifiable {
+    let workId: String?
+    let sectionId: String?
+    let title: String?
+    let latestStatus: String?
+    let kind: String?
+    let phase: String?
+    let startedAt: Double?
+    let updatedAt: Double?
+    let summary: String?
+    let files: [String]?
+    let blocker: String?
+    let nextStep: String?
+    let usage: V1StepUsage?
+    let joinConfidence: String?
+    let evidenceStatus: String?
+    let models: [V1ModelLane]?
+    let checks: [V1Check]?
+
+    var id: String { workId ?? sectionId ?? UUID().uuidString }
+
+    enum CodingKeys: String, CodingKey {
+        case title, kind, phase, summary, files, blocker, usage, models, checks
+        case workId = "work_id"
+        case sectionId = "section_id"
+        case latestStatus = "latest_status"
+        case startedAt = "started_at"
+        case updatedAt = "updated_at"
+        case nextStep = "next_step"
+        case joinConfidence = "join_confidence"
+        case evidenceStatus = "evidence_status"
+    }
+}
+
+struct V1StepUsage: Decodable {
+    let totalTokens: Double?
+    let freshTokens: Double?
+    let cacheReadTokens: Double?
+    let cacheCreationTokens: Double?
+    let estimatedCostUsd: Double?
+    let linkedUsageRecords: Int?
+    let pricedUsageRecords: Int?
+    let unpricedUsageRecords: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case totalTokens = "total_tokens"
+        case freshTokens = "fresh_tokens"
+        case cacheReadTokens = "cache_read_tokens"
+        case cacheCreationTokens = "cache_creation_tokens"
+        case estimatedCostUsd = "estimated_cost_usd"
+        case linkedUsageRecords = "linked_usage_records"
+        case pricedUsageRecords = "priced_usage_records"
+        case unpricedUsageRecords = "unpriced_usage_records"
+    }
+
+    /// The shared cost honesty rule: None-never-$0; a value with unpriced
+    /// rows alongside is a partial subtotal (~$).
+    var costText: String {
+        guard let cost = estimatedCostUsd else { return "—" }
+        let partial = (unpricedUsageRecords ?? 0) > 0
+        return Fmt.dollars(cost, prefix: partial ? "~$" : "$")
+    }
+}
+
+struct V1ModelLane: Decodable, Identifiable {
+    let model: String?
+    let provider: String?
+    let totalTokens: Double?
+
+    var id: String { "\(provider ?? "?")/\(model ?? "unknown")" }
+
+    enum CodingKeys: String, CodingKey {
+        case model, provider
+        case totalTokens = "total_tokens"
+    }
+}
+
+struct V1Check: Decodable, Identifiable {
+    let eventId: String?
+    let createdAt: Double?
+    let evidenceType: String?
+    let result: String?
+    let summary: String?
+    let exitCode: Int?
+    let checkIdentity: String?
+    let supersessionState: String?
+    let resolutionScope: String?
+    let resolutionSummary: String?
+    let files: [String]?
+    let artifactRef: String?
+    let artifactPath: String?
+    let artifactUrl: String?
+    let commandRedacted: Bool?
+
+    var id: String { eventId ?? UUID().uuidString }
+
+    enum CodingKeys: String, CodingKey {
+        case summary, files
+        case eventId = "event_id"
+        case createdAt = "created_at"
+        case evidenceType = "evidence_type"
+        case result
+        case exitCode = "exit_code"
+        case checkIdentity = "check_identity"
+        case supersessionState = "supersession_state"
+        case resolutionScope = "resolution_scope"
+        case resolutionSummary = "resolution_summary"
+        case artifactRef = "artifact_ref"
+        case artifactPath = "artifact_path"
+        case artifactUrl = "artifact_url"
+        case commandRedacted = "command_redacted"
+    }
+}
+
+struct V1Descendant: Decodable, Identifiable {
+    let client: String?
+    let clientSessionId: String?
+    let clientSessionIdShort: String?
+    let title: String?
+    let status: String?
+    let lastActivityAt: Double?
+    let usage: V1DescendantUsage?
+    let planPct: Double?
+
+    var id: String { "\(client ?? "?")::\(clientSessionId ?? UUID().uuidString)" }
+
+    enum CodingKeys: String, CodingKey {
+        case client, title, status, usage
+        case clientSessionId = "client_session_id"
+        case clientSessionIdShort = "client_session_id_short"
+        case lastActivityAt = "last_activity_at"
+        case planPct = "plan_pct"
+    }
+}
+
+struct V1DescendantUsage: Decodable {
+    let totalTokens: Double?
+    let freshTokens: Double?
+    let estimatedCostUsd: Double?
+    let costConfidence: String?
+
+    enum CodingKeys: String, CodingKey {
+        case totalTokens = "total_tokens"
+        case freshTokens = "fresh_tokens"
+        case estimatedCostUsd = "estimated_cost_usd"
+        case costConfidence = "cost_confidence"
+    }
+}
+
+struct V1SessionPlan: Decodable {
+    let client: String?
+    let confidence: String?
+    let calibrationState: String?
+    let basis: String?
+    let scale: Double?
+    let pctOwn: Double?
+    let pctChildren: Double?
+    let pct: Double?
+    let byModel: [V1PlanModelShare]?
+
+    enum CodingKeys: String, CodingKey {
+        case client, confidence, basis, scale, pct
+        case calibrationState = "calibration_state"
+        case pctOwn = "pct_own"
+        case pctChildren = "pct_children"
+        case byModel = "by_model"
+    }
+}
+
+struct V1PlanModelShare: Decodable, Identifiable {
+    let model: String?
+    let totalTokens: Double?
+    let pct: Double?
+
+    var id: String { model ?? "unknown" }
+
+    enum CodingKeys: String, CodingKey {
+        case model, pct
+        case totalTokens = "total_tokens"
+    }
+}
+
+// MARK: - /v1/plan
+
+struct V1PlanPayload: Decodable {
+    let schema: String
+    let generatedAt: Double?
+    let days: Int?
+    let clients: [V1PlanClient]
+
+    enum CodingKeys: String, CodingKey {
+        case schema, days, clients
+        case generatedAt = "generated_at"
+    }
+}
+
+struct V1PlanClient: Decodable, Identifiable {
+    let client: String
+    let confidence: String?
+    let calibrationState: String?
+    let calibratable: Bool?
+    let basis: String?
+    let scale: Double?
+    let intervalsUsed: Int?
+    let windowPcts: [String: Double?]?
+    let daily: [V1PlanDay]?
+    let byModel: [V1PlanModelShare]?
+    let unknownTimePct: Double?
+
+    var id: String { client }
+
+    enum CodingKeys: String, CodingKey {
+        case client, confidence, calibratable, basis, scale, daily
+        case calibrationState = "calibration_state"
+        case intervalsUsed = "intervals_used"
+        case windowPcts = "window_pcts"
+        case byModel = "by_model"
+        case unknownTimePct = "unknown_time_pct"
+    }
+}
+
+struct V1PlanDay: Decodable, Identifiable {
+    let date: String
+    let pct: Double
+
+    var id: String { date }
+}
+
+// MARK: - shared plan formatting
+
+extension Fmt {
+    /// The TUI's plan-share rule: ≈X.X% with a <0.1% band, never a claimed
+    /// exact zero for a nonzero share. nil in → nil out (calibrated-or-nothing).
+    static func planPct(_ pct: Double?) -> String? {
+        guard let pct, pct > 0 else { return nil }
+        return pct >= 0.1 ? String(format: "≈%.1f%%", pct) : "≈<0.1%"
+    }
+}

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -247,7 +247,7 @@ def calibrate_plan_weights(
             default_weight=BASELINE_MODEL_WEIGHTS["claude-opus-4-8"],
             scale=1.0,
             confidence="baseline",
-            basis="weekly plan %% is undefined for this client's rolling meter (it never calibrates)",
+            basis="weekly plan % is undefined for this client's rolling meter (it never calibrates)",
             intervals_used=0,
             client=client,
         )
@@ -283,7 +283,9 @@ def calibrate_plan_weights(
     if intervals >= _MIN_SCALE_INTERVALS and predicted > 0 and trusted:
         scale = raw_scale
         confidence = "calibrated"
-        basis = f"baseline scaled x{scale:.2f} to this account ({intervals} recent weekly-%% intervals)"
+        # A plain string, not a %-format template — no %% escaping (a literal
+        # "%%" leaked onto every basis-rendering surface).
+        basis = f"baseline scaled x{scale:.2f} to this account ({intervals} recent weekly-% intervals)"
     else:
         # Too little clean history, or a fit outside the trusted band (heavy untracked
         # Claude usage or a very different plan tier we can't identify) → keep the


### PR DESCRIPTION
PR-F — the app feature layer of the v3 plan, built on the /v1 lane (#66/#67) and the token system (#68). Swift only.

## Dashboard (new, the default pane)

"How is my week going" in one screen, plan-first, with the two plan quantities always labeled apart:

- **Weekly-plan hero rings** per live limit account — the ACCOUNT TRUTH (provider-reported 7d %, includes untracked usage) with resets countdown and a 5h mini-meter; the ATTRIBUTED tracked share (`tracked ≈X% of this week`) beside it when calibrated, an honest "calibrating" line when not.
- **Today tiles**: tracked plan (calibrated-or-nothing) / cost as reference / fresh tokens / root-session count.
- The 30d rhythm chart, the active-sessions strip (click-through), and **Needs attention** — blocked sessions and failed checks surfaced on the front door (the unravel-the-blackbox steer).

## Sessions on the /v1 lane

- Server-side roots + pagination (`Load more`, honest totals footer: "N of R roots · T total").
- Plan share is the leading number on a row when calibrated; cost beneath as reference. `×N sub` badges.
- **Detail = /v1/session**: expandable steps (kind chip, status, updated-ago, per-step tokens+cost, attributed model lanes, machine checks with the TUI's ✓/✗/»/• marks + exit codes + superseded chips, blocker/next-step/files), descendants with their own plan shares, the plan why-this-number basis line, pre-instrumentation chip, 404 as a first-class message.

## Usage: plan % first

- New plan view (default when any client is calibrated): per-client daily plan bars on the same local-calendar buckets as the cost chart, "which model eats the plan" shares, unknown-time disclosure, basis footnote. Dollars view is one toggle away and unchanged.
- Limits gains the calibration ledger (three-state chip + basis per client).

## Menu bar

- Label becomes the weekly plan meter: `⏺ 84%` (provider-reported 7d; claude-code first, hottest live window otherwise; falls back to today's cost when nothing reports — never a fabricated %).
- Dropdown hero follows suit (big %, meter bar, today cost + tokens subline).
- **Launch at Login** checkbox (SMAppService self-registration only — shows under this app's name in System Settings).
- The window now enters the Dock while open (activation policy switch, guarded for the snapshot process where NSApp is nil).

## Plumbing

- All window traffic moves to the authenticated /v1 lane (bearer + 401 re-read retry); `/usage/summary` stays on the localhost lane (no /v1 twin yet).
- 60s auto-refresh while the window is open (cheap: the daemon caches by fingerprint).
- Snapshot runner prefetches the session detail and caps the offscreen list so renders show the loaded state, not spinners.

## Verification

`swift build` clean; live-data snapshots of all 4 panes × light/dark reviewed visually (dashboard hero rings, steps expansion data, plan honesty states all rendering real daemon data).
