### PR TITLE
feat(plan): two-component calibration — cache reads discounted, heavy-day cliff removed

### DIFF
--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -63,8 +63,6 @@ _MAX_INTERVAL_PCT = 60.0
 # Only fit from recent history, so an old plan tier / stale baseline doesn't drag the
 # current scale.
 _CALIBRATION_WINDOW_DAYS = 21
-# Keep a raw fitted scale sane even if the sparse early data is noisy.
-_SCALE_CLAMP = (0.1, 10.0)
 # Only APPLY a fitted scale (and claim "calibrated") when it lands in this band. The
 # 7-day meter is account-wide but our tokens cover only tracked clients, so a scale
 # far from 1 means either heavy untracked Claude usage (desktop app / claude.ai) or a
@@ -203,14 +201,29 @@ def baseline_weight(model: Any, cost_per_mtok: float | None = None) -> float:
     return BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
 
 
-def baseline_weight_fresh(model: Any, cost_per_mtok: float | None = None) -> float:
-    """The baseline weight in FRESH-component units (%%/M fresh tokens).
+def baseline_weight_fresh(model: Any, cost_per_fresh_mtok: float | None = None) -> float:
+    """The baseline weight in FRESH-component units (%/M fresh tokens).
 
-    The shipped table is anchored to total-including-cache volume; the
-    two-component model re-anchors it by the measured reference factor (see
-    ``_FRESH_COMPONENT_REF_FACTOR``)."""
+    Table models: the shipped total-anchored weight times the measured
+    reference factor (see ``_FRESH_COMPONENT_REF_FACTOR``). An UNKNOWN model
+    with a price derives directly from its cost per FRESH token times the
+    reference plan-%-per-dollar — NOT the table path times the factor, which
+    double-counted the reference cache mix and inflated a cache-light unknown
+    model's weight up to ~19x (adversarial-review HIGH finding: any newly
+    shipped model id would have decalibrated the account or skewed its
+    sessions' shares). The identity check: at the reference mix,
+    price_fresh = price_total x factor, so both paths agree for a
+    reference-mix model. With neither table nor price, the Opus anchor in
+    fresh units — never zero for real usage.
+    """
 
-    return baseline_weight(model, cost_per_mtok) * _FRESH_COMPONENT_REF_FACTOR
+    name = str(model or "")
+    if name in BASELINE_MODEL_WEIGHTS:
+        return BASELINE_MODEL_WEIGHTS[name] * _FRESH_COMPONENT_REF_FACTOR
+    price_fresh = _finite(cost_per_fresh_mtok)
+    if price_fresh is not None and price_fresh > 0:
+        return price_fresh * _REF_PCT_PER_DOLLAR
+    return BASELINE_MODEL_WEIGHTS["claude-opus-4-8"] * _FRESH_COMPONENT_REF_FACTOR
 
 
 def seven_day_series(events: Sequence[Mapping[str, Any]], *, client: str = "claude-code") -> list[tuple[float, float]]:
@@ -257,20 +270,28 @@ def _cost_per_mtok(records: Sequence[Any]) -> dict[str, float]:
     return {m: cost[m] / (toks[m] / 1_000_000.0) for m in toks if toks[m] > 0 and m in cost}
 
 
-def _model_tokens_between(records: Sequence[Any], record_time, lo: float, hi: float) -> dict[str, float]:
-    tokens: dict[str, float] = {}
+def _cost_per_fresh_mtok(records: Sequence[Any]) -> dict[str, float]:
+    """Per-model $ per 1M FRESH tokens (the price basis for fresh-unit
+    weights): total observed cost over the fresh component only. Dollars are
+    mix-free evidence; dividing by fresh volume yields the weight basis the
+    two-component model actually applies."""
+
+    cost: dict[str, float] = {}
+    fresh_toks: dict[str, float] = {}
     for record in records:
-        moment = record_time(record)
-        if not isinstance(moment, (int, float)) or isinstance(moment, bool):
-            continue
-        if not (lo < float(moment) <= hi):
-            continue
         model = str(getattr(record, "model", "") or "")
         if not model:
             continue
-        total = _finite(getattr(record, "total_tokens_including_cached", None))
-        tokens[model] = tokens.get(model, 0.0) + (total or 0.0)
-    return tokens
+        fresh, _reads = record_components(record)
+        fresh_toks[model] = fresh_toks.get(model, 0.0) + fresh
+        price = _finite(getattr(record, "estimated_cost_usd", None))
+        if price is not None:
+            cost[model] = cost.get(model, 0.0) + price
+    return {
+        m: cost[m] / (fresh_toks[m] / 1_000_000.0)
+        for m in fresh_toks
+        if fresh_toks[m] > 0 and m in cost
+    }
 
 
 def _component_tokens_between(
@@ -332,10 +353,10 @@ def calibrate_plan_weights(
 
         records = _usage_records(events, client=client)
 
-    cost_per_mtok = _cost_per_mtok(records)
+    cost_per_fresh = _cost_per_fresh_mtok(records)
     observed_models = {str(getattr(r, "model", "") or "") for r in records if getattr(r, "model", None)}
     model_names = observed_models | set(BASELINE_MODEL_WEIGHTS)
-    base = {m: baseline_weight_fresh(m, cost_per_mtok.get(m)) for m in model_names if m}
+    base = {m: baseline_weight_fresh(m, cost_per_fresh.get(m)) for m in model_names if m}
     default_base = BASELINE_MODEL_WEIGHTS["claude-opus-4-8"] * _FRESH_COMPONENT_REF_FACTOR
 
     if client not in CALIBRATABLE_CLIENTS:
@@ -383,7 +404,7 @@ def calibrate_plan_weights(
     raw_scale = 1.0
     alpha = 0.0
     if points:
-        best: tuple[float, float, float] | None = None  # (sse, scale, alpha)
+        candidates: list[tuple[float, float, float]] = []  # (alpha, scale, sse)
         observed_sum = sum(delta for delta, _a, _b in points)
         for step in range(_ALPHA_GRID_STEPS + 1):
             candidate_alpha = step / _ALPHA_GRID_STEPS
@@ -395,12 +416,23 @@ def calibrate_plan_weights(
                 (delta - candidate_scale * (a + candidate_alpha * b)) ** 2
                 for delta, a, b in points
             )
-            if best is None or sse < best[0]:
-                best = (sse, candidate_scale, candidate_alpha)
-        if best is not None:
-            raw_scale = best[1]
-            alpha = best[2]
-    raw_scale = max(_SCALE_CLAMP[0], min(_SCALE_CLAMP[1], raw_scale))
+            candidates.append((candidate_alpha, candidate_scale, sse))
+        if candidates:
+            # SMALLEST alpha within tolerance of the best fit wins. alpha is a
+            # second degree of freedom the trusted band never inspects:
+            # untracked meter movement that co-occurs with cache-read-heavy
+            # days would otherwise be absorbed into alpha, silently multiplying
+            # every cache-heavy session's share while reporting "calibrated"
+            # (adversarial-review finding). Reads are only charged when the
+            # data clearly demands it; a collinear cache mix (alpha
+            # unidentifiable) deterministically lands on 0.
+            best_sse = min(sse for _a, _s, sse in candidates)
+            tolerance = best_sse * 1.05 + 1e-12
+            for candidate_alpha, candidate_scale, sse in candidates:  # ascending alpha
+                if sse <= tolerance:
+                    alpha = candidate_alpha
+                    raw_scale = candidate_scale
+                    break
     trusted = _TRUSTED_SCALE_BAND[0] <= raw_scale <= _TRUSTED_SCALE_BAND[1]
     if intervals >= _MIN_SCALE_INTERVALS and trusted:
         scale = raw_scale
@@ -434,36 +466,6 @@ def calibrate_plan_weights(
         alpha=alpha,
         raw_scale=raw_scale if intervals else None,
     )
-
-
-def session_tokens_by_model(
-    events: list[dict[str, Any]] | None = None,
-    *,
-    client: str,
-    session_id: str,
-    records: list[Any] | None = None,
-) -> dict[str, float]:
-    """Per-model total tokens (incl. cache) for one session, from its usage records.
-
-    ``records`` may be passed pre-built to avoid rebuilding the usage view."""
-
-    if records is None:
-        from .usage_snapshot import usage_records as _usage_records
-
-        records = _usage_records(events or [], client=client)
-
-    tokens: dict[str, float] = {}
-    for record in records:
-        if str(getattr(record, "client", "") or "") != client:
-            continue
-        if str(getattr(record, "session_id", "") or "") != str(session_id):
-            continue
-        model = str(getattr(record, "model", "") or "")
-        if not model:
-            continue
-        total = _finite(getattr(record, "total_tokens_including_cached", None)) or 0.0
-        tokens[model] = tokens.get(model, 0.0) + total
-    return tokens
 
 
 def session_components_by_model(
@@ -768,6 +770,5 @@ __all__ = [
     "plan_status_entry",
     "record_components",
     "session_components_by_model",
-    "session_tokens_by_model",
     "session_plan_pcts",
 ]

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -72,6 +72,25 @@ _SCALE_CLAMP = (0.1, 10.0)
 # baseline rather than apply an unreliable (over- or under-stating) scale.
 _TRUSTED_SCALE_BAND = (0.5, 2.5)
 
+# The two-component token model. The weekly meter is driven by FRESH work
+# (input + output + cache_creation); cache READS barely move it — measured on
+# the reference account (2026-08-06): a two-component fit put the cache-read
+# coefficient at 0.00 in every leave-one-out fold while cutting the residual
+# by a third, and the single-component fit (total-including-cache) had been
+# structurally over-predicting on cache-heavy days until the trusted band
+# rejected it (the "plan %% vanishes exactly on heavy days" cliff). alpha (the
+# cache-read discount) is FITTED per account in [0, 1], so an account whose
+# meter does charge cache reads still calibrates.
+#
+# The shipped BASELINE_MODEL_WEIGHTS were measured against total-including-
+# cache volume at the reference account's cache mix; re-anchoring the same
+# table into fresh-component units uses this factor, measured the same way the
+# table itself was (two-component fit on the reference account: fresh scale
+# 8.3 vs the total-anchored table).
+_FRESH_COMPONENT_REF_FACTOR = 8.3
+# alpha grid resolution for the fit (closed-form scale per alpha, min-SSE pick).
+_ALPHA_GRID_STEPS = 100
+
 # Plan-bearing clients whose meter can actually CALIBRATE to per-session weekly
 # percentages — i.e. a clean weekly-reset cumulative meter. codex's 7-day meter is
 # rolling and opaque (Σdeltas ≫ the window, resets unobservable), so a weekly plan %
@@ -83,12 +102,17 @@ CALIBRATABLE_CLIENTS = ("claude-code",)
 
 @dataclass(frozen=True)
 class PlanWeights:
-    """Effective per-model weekly-plan weights (percent per 1M tokens) for one account.
+    """Effective per-model weekly-plan weights for one account (two-component).
 
-    ``weights`` is the baseline times the fitted ``scale``. ``confidence`` is
-    ``calibrated`` when ``scale`` was fit from enough recorded 7-day history, else
-    ``baseline`` (the shipped table at scale 1.0). ``default_weight`` applies to a
-    model absent from ``weights``.
+    ``weights`` are FRESH-component weights (percent of the weekly plan per 1M
+    fresh tokens = input + output + cache_creation): the re-anchored baseline
+    times the fitted ``scale``. ``alpha`` is the fitted cache-read discount in
+    [0, 1] — a cache-read token counts as ``alpha`` fresh tokens (measured ~0
+    on the reference account). ``confidence`` is ``calibrated`` when the fit
+    came from enough recorded 7-day history and landed in the trusted band,
+    else ``baseline``. ``raw_scale`` preserves the pre-band fit for the
+    calibration-progress disclosure. ``default_weight`` applies to a model
+    absent from ``weights``.
     """
 
     weights: Mapping[str, float]
@@ -98,13 +122,15 @@ class PlanWeights:
     basis: str
     intervals_used: int
     client: str
+    alpha: float = 0.0
+    raw_scale: float | None = None
 
     def weight_for(self, model: Any) -> float:
         value = self.weights.get(str(model))
         return float(value) if isinstance(value, (int, float)) else self.default_weight
 
     def pct_for_tokens(self, tokens_by_model: Mapping[str, Any]) -> float:
-        """Estimated percent of the weekly plan for a per-model token map."""
+        """Percent of the weekly plan for a per-model FRESH-component map."""
 
         total = 0.0
         for model, tokens in tokens_by_model.items():
@@ -113,6 +139,45 @@ class PlanWeights:
                 continue
             total += self.weight_for(model) * (count / 1_000_000.0)
         return total
+
+    def pct_for_components(
+        self,
+        fresh_by_model: Mapping[str, Any],
+        cache_read_by_model: Mapping[str, Any],
+    ) -> float:
+        """Percent of the weekly plan for per-model (fresh, cache_read) maps."""
+
+        total = self.pct_for_tokens(fresh_by_model)
+        for model, tokens in cache_read_by_model.items():
+            count = _finite(tokens)
+            if count is None or count <= 0:
+                continue
+            total += self.weight_for(model) * self.alpha * (count / 1_000_000.0)
+        return total
+
+
+def record_components(record: Any) -> tuple[float, float]:
+    """One usage record's (fresh, cache_read) token components.
+
+    fresh = input + output + cache_creation (the work that drives the weekly
+    meter); cache_read is the discounted component. A record carrying a
+    combined cached count with no creation/read split books the whole cached
+    bucket as reads — reads dominate real caches, and the conservative
+    direction for the ESTIMATE is the discounted one (never overstate a
+    session's share on unreported data).
+    """
+
+    creation = _finite(getattr(record, "cache_creation_input_tokens", None)) or 0.0
+    read = _finite(getattr(record, "cache_read_input_tokens", None)) or 0.0
+    cached = _finite(getattr(record, "cached_input_tokens", None)) or 0.0
+    if creation + read == 0 and cached > 0:
+        read = cached
+    fresh = (
+        (_finite(getattr(record, "input_tokens", None)) or 0.0)
+        + (_finite(getattr(record, "output_tokens", None)) or 0.0)
+        + creation
+    )
+    return fresh, read
 
 
 def _finite(value: Any) -> float | None:
@@ -136,6 +201,16 @@ def baseline_weight(model: Any, cost_per_mtok: float | None = None) -> float:
     if price is not None and price > 0:
         return price * _REF_PCT_PER_DOLLAR
     return BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+
+
+def baseline_weight_fresh(model: Any, cost_per_mtok: float | None = None) -> float:
+    """The baseline weight in FRESH-component units (%%/M fresh tokens).
+
+    The shipped table is anchored to total-including-cache volume; the
+    two-component model re-anchors it by the measured reference factor (see
+    ``_FRESH_COMPONENT_REF_FACTOR``)."""
+
+    return baseline_weight(model, cost_per_mtok) * _FRESH_COMPONENT_REF_FACTOR
 
 
 def seven_day_series(events: Sequence[Mapping[str, Any]], *, client: str = "claude-code") -> list[tuple[float, float]]:
@@ -198,6 +273,28 @@ def _model_tokens_between(records: Sequence[Any], record_time, lo: float, hi: fl
     return tokens
 
 
+def _component_tokens_between(
+    records: Sequence[Any], record_time, lo: float, hi: float
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Per-model (fresh, cache_read) token maps for records inside (lo, hi]."""
+
+    fresh: dict[str, float] = {}
+    reads: dict[str, float] = {}
+    for record in records:
+        moment = record_time(record)
+        if not isinstance(moment, (int, float)) or isinstance(moment, bool):
+            continue
+        if not (lo < float(moment) <= hi):
+            continue
+        model = str(getattr(record, "model", "") or "")
+        if not model:
+            continue
+        f, r = record_components(record)
+        fresh[model] = fresh.get(model, 0.0) + f
+        reads[model] = reads.get(model, 0.0) + r
+    return fresh, reads
+
+
 def calibrate_plan_weights(
     events: list[dict[str, Any]],
     *,
@@ -205,20 +302,25 @@ def calibrate_plan_weights(
     records: list[Any] | None = None,
     now: float | None = None,
 ) -> PlanWeights:
-    """Baseline per-model weights scaled to this account's recorded plan history.
+    """Baseline per-model weights fit to this account's recorded plan history.
 
-    Fits ONE per-user scale = (observed weekly-%% moved) / (baseline-predicted %%)
-    over recent, clean, non-reset intervals — robust and collinearity-free. Only
-    intervals whose movement our tracked-client tokens can actually explain
-    (``predicted > 0``) contribute, and the fitted scale is applied only inside a
-    trusted band; otherwise the shipped baseline is kept. This guards the estimate's
-    known blind spot: the 7-day meter is ACCOUNT-WIDE (Claude desktop app, claude.ai,
-    other machines all move it) while our tokens cover only tracked clients, so
-    movement with no local tokens is untracked usage that must not inflate the scale.
+    Two-component fit: for each clean interval the movement is modeled as
+    ``scale × (A + alpha × B)`` where A is the fresh-component prediction
+    (input+output+cache_creation at the re-anchored baseline weights) and B
+    the cache-read prediction. ``scale`` is the robust ratio-of-sums
+    Σobserved / Σ(A + alpha×B) for a given alpha; alpha is chosen on a [0, 1]
+    grid by residual (closed-form per point, no iterative optimizer). Only
+    intervals whose movement our tracked-client tokens can explain
+    (``A + B > 0``) contribute, and the fitted scale is applied only inside
+    the trusted band; otherwise the shipped baseline is kept. This guards the
+    estimate's known blind spot: the 7-day meter is ACCOUNT-WIDE (Claude
+    desktop app, claude.ai, other machines all move it) while our tokens cover
+    only tracked clients, so movement with no local tokens is untracked usage
+    that must not inflate the scale.
 
-    ``records`` may be passed pre-built (the caller already ran the usage view) to
-    avoid rebuilding it. ``now`` bounds the recency window (injectable for tests).
-    ``events`` still supplies the 7-day series regardless.
+    ``records`` may be passed pre-built (the caller already ran the usage view)
+    to avoid rebuilding it. ``now`` bounds the recency window (injectable for
+    tests). ``events`` still supplies the 7-day series regardless.
     """
 
     from .usage_view import _usage_record_time
@@ -233,18 +335,19 @@ def calibrate_plan_weights(
     cost_per_mtok = _cost_per_mtok(records)
     observed_models = {str(getattr(r, "model", "") or "") for r in records if getattr(r, "model", None)}
     model_names = observed_models | set(BASELINE_MODEL_WEIGHTS)
-    base = {m: baseline_weight(m, cost_per_mtok.get(m)) for m in model_names if m}
+    base = {m: baseline_weight_fresh(m, cost_per_mtok.get(m)) for m in model_names if m}
+    default_base = BASELINE_MODEL_WEIGHTS["claude-opus-4-8"] * _FRESH_COMPONENT_REF_FACTOR
 
     if client not in CALIBRATABLE_CLIENTS:
         # A rolling/opaque meter (codex) can land 3 numerically-clean intervals
-        # inside the trusted band by coincidence — but its weekly plan %% is
+        # inside the trusted band by coincidence — but its weekly plan % is
         # UNDEFINED by design, so a fit here would confidently label a number
         # that means nothing (adversarial-review finding: /v1/plan served
         # "calibrated" codex aggregates). The gate lives HERE, not in each
         # display surface, so no surface can ever receive one.
         return PlanWeights(
             weights=base,
-            default_weight=BASELINE_MODEL_WEIGHTS["claude-opus-4-8"],
+            default_weight=default_base,
             scale=1.0,
             confidence="baseline",
             basis="weekly plan % is undefined for this client's rolling meter (it never calibrates)",
@@ -254,9 +357,9 @@ def calibrate_plan_weights(
 
     series = seven_day_series(events, client=client)
     window_start = now_epoch - _CALIBRATION_WINDOW_DAYS * 86400.0
-    observed = 0.0
-    predicted = 0.0
-    intervals = 0
+    # (delta, A, B) per clean interval: observed movement, fresh-component
+    # prediction, cache-read prediction.
+    points: list[tuple[float, float, float]] = []
     for (t0, p0), (t1, p1) in zip(series, series[1:]):
         if not (0 < t1 - t0 <= _MAX_INTERVAL_SECONDS):
             continue
@@ -265,45 +368,71 @@ def calibrate_plan_weights(
         delta = p1 - p0
         if delta < 0 or delta > _MAX_INTERVAL_PCT:  # a drop is a weekly reset
             continue
-        interval_tokens = _model_tokens_between(records, _usage_record_time, t0, t1)
-        pred = sum(base.get(m, 0.0) * (tok / 1_000_000.0) for m, tok in interval_tokens.items())
-        # Fit ONLY from movement our tokens can explain. An interval where the meter
-        # moved with no local tokens (pred == 0) is Claude usage outside the tracked
+        fresh, reads = _component_tokens_between(records, _usage_record_time, t0, t1)
+        fresh_pred = sum(base.get(m, 0.0) * (tok / 1_000_000.0) for m, tok in fresh.items())
+        read_pred = sum(base.get(m, 0.0) * (tok / 1_000_000.0) for m, tok in reads.items())
+        # Fit ONLY from movement our tokens can explain. An interval where the
+        # meter moved with no local tokens is Claude usage outside the tracked
         # clients (desktop app / web); counting it would inflate the scale and
         # over-state every session, so skip it.
-        if pred <= 0:
+        if fresh_pred + read_pred <= 0:
             continue
-        observed += delta
-        predicted += pred
-        intervals += 1
+        points.append((delta, fresh_pred, read_pred))
 
-    raw_scale = (observed / predicted) if predicted > 0 else 1.0
+    intervals = len(points)
+    raw_scale = 1.0
+    alpha = 0.0
+    if points:
+        best: tuple[float, float, float] | None = None  # (sse, scale, alpha)
+        observed_sum = sum(delta for delta, _a, _b in points)
+        for step in range(_ALPHA_GRID_STEPS + 1):
+            candidate_alpha = step / _ALPHA_GRID_STEPS
+            predicted_sum = sum(a + candidate_alpha * b for _d, a, b in points)
+            if predicted_sum <= 0:
+                continue
+            candidate_scale = observed_sum / predicted_sum
+            sse = sum(
+                (delta - candidate_scale * (a + candidate_alpha * b)) ** 2
+                for delta, a, b in points
+            )
+            if best is None or sse < best[0]:
+                best = (sse, candidate_scale, candidate_alpha)
+        if best is not None:
+            raw_scale = best[1]
+            alpha = best[2]
     raw_scale = max(_SCALE_CLAMP[0], min(_SCALE_CLAMP[1], raw_scale))
     trusted = _TRUSTED_SCALE_BAND[0] <= raw_scale <= _TRUSTED_SCALE_BAND[1]
-    if intervals >= _MIN_SCALE_INTERVALS and predicted > 0 and trusted:
+    if intervals >= _MIN_SCALE_INTERVALS and trusted:
         scale = raw_scale
         confidence = "calibrated"
         # A plain string, not a %-format template — no %% escaping (a literal
         # "%%" leaked onto every basis-rendering surface).
-        basis = f"baseline scaled x{scale:.2f} to this account ({intervals} recent weekly-% intervals)"
+        basis = (
+            f"two-component fit x{scale:.2f}, cache-read discount {alpha:.2f} "
+            f"({intervals} recent weekly-% intervals)"
+        )
     else:
-        # Too little clean history, or a fit outside the trusted band (heavy untracked
-        # Claude usage or a very different plan tier we can't identify) → keep the
-        # shipped baseline rather than apply an unreliable scale.
+        # Too little clean history, or a fit outside the trusted band (heavy
+        # untracked Claude usage or a very different plan tier we can't
+        # identify) → keep the shipped baseline rather than apply an
+        # unreliable scale. alpha stays 0 under baseline: cache reads are
+        # excluded rather than guessed (the measured reference behavior).
         scale = 1.0
+        alpha = 0.0
         confidence = "baseline"
         basis = "shipped baseline (record more 7-day limit history from tracked clients to calibrate)"
 
     weights = {m: w * scale for m, w in base.items()}
-    default = BASELINE_MODEL_WEIGHTS["claude-opus-4-8"] * scale
     return PlanWeights(
         weights=weights,
-        default_weight=default,
+        default_weight=default_base * scale,
         scale=scale,
         confidence=confidence,
         basis=basis,
         intervals_used=intervals,
         client=client,
+        alpha=alpha,
+        raw_scale=raw_scale if intervals else None,
     )
 
 
@@ -337,16 +466,53 @@ def session_tokens_by_model(
     return tokens
 
 
+def session_components_by_model(
+    events: list[dict[str, Any]] | None = None,
+    *,
+    client: str,
+    session_id: str,
+    records: list[Any] | None = None,
+) -> dict[str, dict[str, float]]:
+    """Per-model ``{total, fresh, cache_read}`` tokens for one session.
+
+    ``total`` is the REAL total (incl. cache — what a user recognizes);
+    ``fresh``/``cache_read`` are the plan components the estimate weighs."""
+
+    if records is None:
+        from .usage_snapshot import usage_records as _usage_records
+
+        records = _usage_records(events or [], client=client)
+
+    out: dict[str, dict[str, float]] = {}
+    for record in records:
+        if str(getattr(record, "client", "") or "") != client:
+            continue
+        if str(getattr(record, "session_id", "") or "") != str(session_id):
+            continue
+        model = str(getattr(record, "model", "") or "")
+        if not model:
+            continue
+        fresh, reads = record_components(record)
+        total = _finite(getattr(record, "total_tokens_including_cached", None)) or 0.0
+        bucket = out.setdefault(model, {"total": 0.0, "fresh": 0.0, "cache_read": 0.0})
+        bucket["total"] += total
+        bucket["fresh"] += fresh
+        bucket["cache_read"] += reads
+    return out
+
+
 def session_plan_pcts(
     records: Sequence[Any], weights: PlanWeights, *, client: str = "claude-code"
 ) -> dict[str, float]:
     """``{session_id: estimated % of the weekly plan}`` for one client, in ONE pass.
 
-    Groups the pre-built usage records by (session, model) once, then applies
-    ``weights`` — so estimating many sessions (a list view) is cheap, not O(records)
-    per session."""
+    Groups the pre-built usage records by (session, model) once — fresh and
+    cache-read components separately — then applies ``weights`` (two-component:
+    cache reads at the fitted discount), so estimating many sessions (a list
+    view) is cheap, not O(records) per session."""
 
-    by_session: dict[str, dict[str, float]] = {}
+    fresh_by_session: dict[str, dict[str, float]] = {}
+    reads_by_session: dict[str, dict[str, float]] = {}
     for record in records:
         if str(getattr(record, "client", "") or "") != client:
             continue
@@ -354,10 +520,15 @@ def session_plan_pcts(
         model = str(getattr(record, "model", "") or "")
         if not session_id or not model:
             continue
-        total = _finite(getattr(record, "total_tokens_including_cached", None)) or 0.0
-        bucket = by_session.setdefault(session_id, {})
-        bucket[model] = bucket.get(model, 0.0) + total
-    return {sid: weights.pct_for_tokens(tokens) for sid, tokens in by_session.items()}
+        fresh, reads = record_components(record)
+        fresh_bucket = fresh_by_session.setdefault(session_id, {})
+        fresh_bucket[model] = fresh_bucket.get(model, 0.0) + fresh
+        read_bucket = reads_by_session.setdefault(session_id, {})
+        read_bucket[model] = read_bucket.get(model, 0.0) + reads
+    return {
+        sid: weights.pct_for_components(fresh_tokens, reads_by_session.get(sid) or {})
+        for sid, fresh_tokens in fresh_by_session.items()
+    }
 
 
 def plan_pct_aggregates(
@@ -398,10 +569,24 @@ def plan_pct_aggregates(
         "30d": resolved_today - _timedelta(days=29),
     }
 
-    daily_tokens: dict[_date, dict[str, float]] = {}
-    window_tokens: dict[str, dict[str, float]] = {label: {} for label in window_starts}
-    model_tokens: dict[str, float] = {}
-    unknown_tokens: dict[str, float] = {}
+    # Accumulator shape everywhere: {model: [fresh, cache_read, total]} — the
+    # components drive the estimate, the real total stays for display.
+    def _add(bucket: dict[str, list[float]], model: str, fresh: float, reads: float, total: float) -> None:
+        entry = bucket.setdefault(model, [0.0, 0.0, 0.0])
+        entry[0] += fresh
+        entry[1] += reads
+        entry[2] += total
+
+    def _pct(bucket: dict[str, list[float]]) -> float:
+        return weights.pct_for_components(
+            {m: parts[0] for m, parts in bucket.items()},
+            {m: parts[1] for m, parts in bucket.items()},
+        )
+
+    daily_tokens: dict[_date, dict[str, list[float]]] = {}
+    window_tokens: dict[str, dict[str, list[float]]] = {label: {} for label in window_starts}
+    model_tokens: dict[str, list[float]] = {}
+    unknown_tokens: dict[str, list[float]] = {}
     for record in records:
         if str(getattr(record, "client", "") or "") != client:
             continue
@@ -411,20 +596,19 @@ def plan_pct_aggregates(
         total = _finite(getattr(record, "total_tokens_including_cached", None)) or 0.0
         if total <= 0:
             continue
+        fresh, reads = record_components(record)
         day = usage_bucket_date(_usage_record_time(record))
         if day is None:
-            unknown_tokens[model] = unknown_tokens.get(model, 0.0) + total
+            _add(unknown_tokens, model, fresh, reads, total)
             continue
         if day > resolved_today:
             continue
         if start <= day:
-            bucket = daily_tokens.setdefault(day, {})
-            bucket[model] = bucket.get(model, 0.0) + total
-            model_tokens[model] = model_tokens.get(model, 0.0) + total
+            _add(daily_tokens.setdefault(day, {}), model, fresh, reads, total)
+            _add(model_tokens, model, fresh, reads, total)
         for label, window_start in window_starts.items():
             if window_start <= day:
-                window_bucket = window_tokens[label]
-                window_bucket[model] = window_bucket.get(model, 0.0) + total
+                _add(window_tokens[label], model, fresh, reads, total)
 
     daily: list[dict[str, Any]] = []
     cursor = start
@@ -432,7 +616,7 @@ def plan_pct_aggregates(
         daily.append(
             {
                 "date": cursor.isoformat(),
-                "pct": weights.pct_for_tokens(daily_tokens.get(cursor) or {}),
+                "pct": _pct(daily_tokens.get(cursor) or {}),
             }
         )
         cursor += _timedelta(days=1)
@@ -441,23 +625,19 @@ def plan_pct_aggregates(
         (
             {
                 "model": model,
-                "total_tokens": tokens,
-                "pct": weights.pct_for_tokens({model: tokens}),
+                "total_tokens": parts[2],
+                "pct": weights.pct_for_components({model: parts[0]}, {model: parts[1]}),
             }
-            for model, tokens in model_tokens.items()
+            for model, parts in model_tokens.items()
         ),
         key=lambda entry: (-entry["pct"], entry["model"]),
     )
 
     return {
-        "window_pcts": {
-            label: weights.pct_for_tokens(tokens) for label, tokens in window_tokens.items()
-        },
+        "window_pcts": {label: _pct(tokens) for label, tokens in window_tokens.items()},
         "daily": daily,
         "by_model": by_model,
-        "unknown_time_pct": (
-            weights.pct_for_tokens(unknown_tokens) if unknown_tokens else None
-        ),
+        "unknown_time_pct": (_pct(unknown_tokens) if unknown_tokens else None),
     }
 
 
@@ -531,20 +711,46 @@ def plan_status_entry(weights: PlanWeights) -> dict[str, Any]:
 
     Additive superset of the original ``{client, confidence}`` shape: the
     three-state ``calibration_state`` (so no shell has to hard-code which
-    clients can calibrate), ``calibratable``, and the why-this-number
-    disclosure fields (``basis``/``scale``/``intervals_used``) a detail view
-    renders verbatim. ``scale`` is only meaningful when calibrated; it is
-    reported as-is (1.0 under baseline) with ``confidence`` as its guard.
+    clients can calibrate), ``calibratable``, the why-this-number disclosure
+    fields (``basis``/``scale``/``alpha``/``intervals_used``), and the
+    calibration-PROGRESS fields (``raw_scale``/``trusted_band``/
+    ``intervals_needed``/``state_detail``) so a shell can show WHY a client is
+    still calibrating instead of a bare spinner. ``scale``/``alpha`` are only
+    meaningful when calibrated (1.0/0.0 under baseline) with ``confidence`` as
+    their guard.
     """
 
+    state = calibration_state(weights)
+    if state == "calibrated":
+        detail = weights.basis
+    elif state == "never":
+        detail = weights.basis
+    elif weights.intervals_used < _MIN_SCALE_INTERVALS:
+        detail = (
+            f"{weights.intervals_used} of {_MIN_SCALE_INTERVALS} clean weekly-% intervals "
+            "recorded — keep working with tracked clients to calibrate"
+        )
+    else:
+        raw = weights.raw_scale
+        detail = (
+            f"{weights.intervals_used} intervals recorded; the fit"
+            + (f" (x{raw:.2f})" if raw is not None else "")
+            + f" is outside the trusted band [{_TRUSTED_SCALE_BAND[0]}, {_TRUSTED_SCALE_BAND[1]}]"
+            " — heavy untracked usage or a plan change can cause this"
+        )
     return {
         "client": weights.client,
         "confidence": weights.confidence,
-        "calibration_state": calibration_state(weights),
+        "calibration_state": state,
         "calibratable": weights.client in CALIBRATABLE_CLIENTS,
         "basis": weights.basis,
         "scale": weights.scale,
+        "alpha": weights.alpha,
         "intervals_used": weights.intervals_used,
+        "intervals_needed": _MIN_SCALE_INTERVALS,
+        "raw_scale": weights.raw_scale,
+        "trusted_band": list(_TRUSTED_SCALE_BAND),
+        "state_detail": detail,
     }
 
 
@@ -560,6 +766,8 @@ __all__ = [
     "calibration_state",
     "plan_pct_aggregates",
     "plan_status_entry",
+    "record_components",
+    "session_components_by_model",
     "session_tokens_by_model",
     "session_plan_pcts",
 ]

--- a/src/agentacct/subagent_roles.py
+++ b/src/agentacct/subagent_roles.py
@@ -171,9 +171,16 @@ def subagent_files_for_parent(
     # instead of every parent — a crafted id must never read outside the root.
     if any(ch in parent_client_session_id for ch in ("/", os.sep, "\x00")) or ".." in parent_client_session_id:
         return {}
-    pattern = str(root / "*" / glob.escape(parent_client_session_id) / "subagents" / "agent-*.jsonl")
+    # Two layouts: Task-tool subagents sit directly in subagents/; workflow
+    # agents nest one level deeper (subagents/workflows/wf_*/agent-*.jsonl).
+    # Both are bounded single-directory-depth globs, not a recursive walk.
+    base = root / "*" / glob.escape(parent_client_session_id) / "subagents"
+    patterns = (
+        str(base / "agent-*.jsonl"),
+        str(base / "workflows" / "*" / "agent-*.jsonl"),
+    )
     try:
-        matches = glob.glob(pattern)
+        matches = [match for pattern in patterns for match in glob.glob(pattern)]
     except OSError:
         return {}
     try:

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -608,6 +608,8 @@ def build_v1_session_detail(
     # on disk (the same bounded, fail-soft reader the TUI detail uses) — an
     # untitled child otherwise renders as a bare id, which unravels nothing.
     if descendants:
+        from .client_usage import _sanitized_session_title
+        from .service import _redact_secret_spans
         from .subagent_roles import read_roles_for_children, scan_enabled
 
         if scan_enabled():
@@ -620,7 +622,19 @@ def build_v1_session_detail(
                 role = roles.get(str(child.get("client_session_id") or ""))
                 if role is not None:
                     child["agent_type"] = role.agent_type
-                    child["task"] = role.task
+                    # The wire gets a LABEL, not the prompt: first line,
+                    # bounded, secret-spans redacted, then the same sanitizer
+                    # session titles use. Full multi-KB Task prompts blew a
+                    # live 179-descendant payload past 1MB and can carry
+                    # secrets — the same redaction posture that keeps raw
+                    # commands off this wire applies (adversarial-review
+                    # findings).
+                    label: str | None = None
+                    if role.task:
+                        first_line = role.task.splitlines()[0][:160]
+                        redacted, _classes = _redact_secret_spans(first_line)
+                        label = _sanitized_session_title(redacted)
+                    child["task"] = label
 
     plan_context = view.get("plan_context") if isinstance(view.get("plan_context"), dict) else {}
     weights = (plan_context.get("weights_by_client") or {}).get(client)
@@ -650,10 +664,13 @@ def build_v1_session_detail(
         else:
             plan["by_model"] = None
     else:
-        # Not a plan-bearing client: an explicit no-plan block, not a guess.
+        # Not a plan-bearing client: an explicit no-plan block, not a guess —
+        # SAME key set as plan_status_entry so the schema shape is uniform
+        # across clients on this endpoint (adversarial-review finding).
         plan = {"client": client, "confidence": None, "calibration_state": None,
-                "calibratable": False, "basis": None, "scale": None,
-                "intervals_used": None, "by_model": None}
+                "calibratable": False, "basis": None, "scale": None, "alpha": None,
+                "intervals_used": None, "intervals_needed": None, "raw_scale": None,
+                "trusted_band": None, "state_detail": None, "by_model": None}
     plan["pct_own"] = row.get("plan_pct_own")
     plan["pct_children"] = row.get("plan_pct_children")
     plan["pct"] = row.get("plan_pct")

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -631,9 +631,13 @@ def build_v1_session_detail(
                     # findings).
                     label: str | None = None
                     if role.task:
-                        first_line = role.task.splitlines()[0][:160]
+                        # Redact BEFORE bounding: truncating first could split a
+                        # secret so the remaining prefix falls under a pattern's
+                        # min-length floor and slips through un-redacted. Redact
+                        # the whole first line, then bound the sanitized text.
+                        first_line = role.task.splitlines()[0]
                         redacted, _classes = _redact_secret_spans(first_line)
-                        label = _sanitized_session_title(redacted)
+                        label = _sanitized_session_title(redacted)[:160]
                     child["task"] = label
 
     plan_context = view.get("plan_context") if isinstance(view.get("plan_context"), dict) else {}

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -564,7 +564,7 @@ def build_v1_session_detail(
     with the very pct values it shipped next to (adversarial-review findings).
     """
 
-    from .plan_cost import plan_status_entry, session_tokens_by_model
+    from .plan_cost import plan_status_entry, session_components_by_model
 
     key = (client, session_id)
     row = next(
@@ -604,6 +604,23 @@ def build_v1_session_detail(
         if candidate.get("fold_top") == key
         and (candidate.get("client"), candidate.get("client_session_id")) != key
     ]
+    # Enrich with the subagent's role + Task prompt read from its transcript
+    # on disk (the same bounded, fail-soft reader the TUI detail uses) — an
+    # untitled child otherwise renders as a bare id, which unravels nothing.
+    if descendants:
+        from .subagent_roles import read_roles_for_children, scan_enabled
+
+        if scan_enabled():
+            # NB: a dedicated loop variable — reusing ``row`` here shadowed the
+            # selected session row and served the LAST descendant as the
+            # session (self-caught while validating against the live store).
+            child_ids = [str(child.get("client_session_id") or "") for child in descendants]
+            roles = read_roles_for_children(session_id, child_ids)
+            for child in descendants:
+                role = roles.get(str(child.get("client_session_id") or ""))
+                if role is not None:
+                    child["agent_type"] = role.agent_type
+                    child["task"] = role.task
 
     plan_context = view.get("plan_context") if isinstance(view.get("plan_context"), dict) else {}
     weights = (plan_context.get("weights_by_client") or {}).get(client)
@@ -612,17 +629,21 @@ def build_v1_session_detail(
     if weights is not None:
         plan = dict(plan_status_entry(weights))
         if weights.confidence == "calibrated":
-            tokens_by_model = session_tokens_by_model(
+            components = session_components_by_model(
                 client=client, session_id=session_id, records=records
             )
             plan["by_model"] = sorted(
                 (
                     {
+                        # total = the REAL token count (incl. cache); the pct
+                        # weighs the components (cache reads discounted).
                         "model": model,
-                        "total_tokens": tokens,
-                        "pct": weights.pct_for_tokens({model: tokens}),
+                        "total_tokens": parts["total"],
+                        "pct": weights.pct_for_components(
+                            {model: parts["fresh"]}, {model: parts["cache_read"]}
+                        ),
                     }
-                    for model, tokens in tokens_by_model.items()
+                    for model, parts in components.items()
                 ),
                 key=lambda entry: (-entry["pct"], entry["model"]),
             )

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -635,9 +635,14 @@ def build_v1_session_detail(
                         # secret so the remaining prefix falls under a pattern's
                         # min-length floor and slips through un-redacted. Redact
                         # the whole first line, then bound the sanitized text.
+                        # _sanitized_session_title returns None when the line
+                        # sanitizes to empty (e.g. a first line of only
+                        # control/format chars, which survive .strip()); guard
+                        # it — None[:160] would 500 the whole detail response.
                         first_line = role.task.splitlines()[0]
                         redacted, _classes = _redact_secret_spans(first_line)
-                        label = _sanitized_session_title(redacted)[:160]
+                        sanitized = _sanitized_session_title(redacted)
+                        label = sanitized[:160] if sanitized else None
                     child["task"] = label
 
     plan_context = view.get("plan_context") if isinstance(view.get("plan_context"), dict) else {}

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -617,7 +617,7 @@ def test_folded_root_plan_pct_includes_child_shares(tmp_path):
 
     service = SentinelService(tmp_path)
     now = time.time()
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
     # Calibration history: observed movement == baseline prediction → scale ~1.
     move = 100.0 * opus
     t0 = now - 5 * 3600
@@ -659,7 +659,7 @@ def test_glance_refuses_cross_home_child_fold(tmp_path):
 
     service = SentinelService(tmp_path)
     now = time.time()
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
     move = 100.0 * opus
     t0 = now - 5 * 3600
     pct = 10.0

--- a/tests/test_plan_cost.py
+++ b/tests/test_plan_cost.py
@@ -92,18 +92,6 @@ def test_seven_day_series(tmp_path):
     assert series == [(100.0, 3.0), (200.0, 5.0)]  # ascending, claude only
 
 
-def test_session_tokens_by_model(tmp_path):
-    service = SentinelService(tmp_path)
-    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s1",
-                  tokens=100, updated_at=1000, cost=0.1)
-    _record_usage(service, client="claude-code", model="claude-fable-5", session_id="s1",
-                  tokens=40, updated_at=1001, cost=0.1)
-    _record_usage(service, client="claude-code", model="claude-opus-4-8", session_id="s2",
-                  tokens=999, updated_at=1002, cost=0.1)
-    tbm = pc.session_tokens_by_model(service.list_all_events(), client="claude-code", session_id="s1")
-    assert tbm == {"claude-opus-4-8": 100.0, "claude-fable-5": 40.0}  # only s1, grouped by model
-
-
 # ---------------------------------------------------------------------------
 # calibration
 # ---------------------------------------------------------------------------
@@ -265,6 +253,79 @@ def test_cache_heavy_days_no_longer_fall_out_of_the_band(tmp_path):
     )
     pcts = pc.session_plan_pcts(records, weights, client="claude-code")
     assert abs(pcts["s0"] - w * 10.0) < 0.2
+
+
+def test_unknown_model_fallback_prices_in_fresh_units():
+    """Round-2 HIGH regression: an unknown model's cost fallback derives from
+    its $ per FRESH Mtok x the reference %/$, NOT the total-anchored path
+    times the reference factor (which double-counted the reference cache mix
+    and inflated cache-light unknown models ~19x). Identity: at the reference
+    mix the two paths agree."""
+
+    # Table path: unchanged anchoring.
+    assert pc.baseline_weight_fresh("claude-opus-4-8") == (
+        pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"] * pc._FRESH_COMPONENT_REF_FACTOR
+    )
+    # Unknown model with a FRESH price: linear in the price, no 8.3 anywhere.
+    assert abs(pc.baseline_weight_fresh("brand-new", cost_per_fresh_mtok=100.0)
+               - 100.0 * pc._REF_PCT_PER_DOLLAR) < 1e-12
+    # Reference-mix identity: price_fresh = price_total x factor -> the
+    # fallback equals the old total path re-anchored.
+    price_total = 15.0
+    price_fresh = price_total * pc._FRESH_COMPONENT_REF_FACTOR
+    assert abs(pc.baseline_weight_fresh("brand-new", cost_per_fresh_mtok=price_fresh)
+               - price_total * pc._REF_PCT_PER_DOLLAR * pc._FRESH_COMPONENT_REF_FACTOR) < 1e-12
+    # No price at all -> the Opus anchor in fresh units.
+    assert pc.baseline_weight_fresh("brand-new") == (
+        pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"] * pc._FRESH_COMPONENT_REF_FACTOR
+    )
+
+
+def test_collinear_cache_mix_lands_on_alpha_zero(tmp_path):
+    """When every interval has the SAME fresh:read ratio, alpha is
+    unidentifiable — the smallest-alpha-within-tolerance rule must land on 0
+    deterministically (never an arbitrary grid point)."""
+
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    w = pc.baseline_weight_fresh("claude-opus-4-8")
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(4):
+        # constant 1:4 fresh:read mix; meter moves as if only fresh counts.
+        _record_cached_usage(service, session_id=f"s{i}", fresh=50_000_000,
+                             cache_read=200_000_000, updated_at=t0 + i * 3600 + 1800,
+                             index=i)
+        pct += w * 50.0
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + 5 * 3600))
+    assert weights.alpha == 0.0
+    assert weights.confidence == "calibrated"
+
+
+def test_raw_scale_discloses_the_unclamped_fit(tmp_path):
+    """The calibration-progress field must carry the TRUE fitted ratio, not a
+    clamped copy — two very different out-of-band accounts must not read
+    identically (round-2 finding)."""
+
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    w = pc.baseline_weight_fresh("claude-opus-4-8")
+    # Small volume so a 45x ratio still fits inside a clean interval (<60%).
+    move = 45.0 * (10.0 * w)
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(4):
+        _record_usage(service, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"s{i}", tokens=10_000_000, updated_at=t0 + i * 3600 + 1800,
+                      cost=1.0)
+        pct += move
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + 5 * 3600))
+    assert weights.confidence == "baseline"  # far outside the band
+    assert weights.raw_scale is not None and weights.raw_scale > 10.0
 
 
 def test_codex_never_calibrates_even_with_numerically_clean_history(tmp_path):

--- a/tests/test_plan_cost.py
+++ b/tests/test_plan_cost.py
@@ -116,7 +116,7 @@ def test_calibrate_baseline_when_no_history(tmp_path):
     weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code")
     assert weights.confidence == "baseline"      # no 7d history → shipped baseline
     assert weights.scale == 1.0
-    assert weights.weight_for("claude-opus-4-8") == pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    assert weights.weight_for("claude-opus-4-8") == pc.baseline_weight_fresh("claude-opus-4-8")
 
 
 def test_calibrate_fits_scale_from_history(tmp_path):
@@ -124,7 +124,7 @@ def test_calibrate_fits_scale_from_history(tmp_path):
     # baseline predicts → the fitted per-user scale should be ~2.0 (calibrated).
     service = SentinelService(tmp_path)
     t0 = 1_000_000
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]  # %/Mtoken
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")  # %/M fresh tokens
     # 100M Opus/hour → baseline predicts 100 * opus % per hour; make the real move 2x.
     move = 2.0 * (100.0 * opus)
     pct = 0.0
@@ -177,6 +177,96 @@ def test_calibrate_skips_untracked_movement(tmp_path):
     assert weights.intervals_used == 0
 
 
+def _record_cached_usage(service, *, session_id, fresh, cache_read, updated_at, index=0):
+    """A claude-code usage row with an explicit fresh/cache-read split."""
+
+    event = ClientUsageEvent(
+        client="claude-code",
+        client_session_id=session_id,
+        source_path=Path(f"/tmp/claude-code/{session_id}-{index}.jsonl"),
+        title=None,
+        cwd="/tmp/p",
+        model="claude-opus-4-8",
+        input_tokens=fresh,
+        output_tokens=0,
+        cached_input_tokens=cache_read,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=cache_read,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name="claude-code",
+        started_at=updated_at,
+        updated_at=updated_at,
+        turn_count=1,
+        usage_row_lane="model:claude-opus-4-8",
+        source_namespace_fingerprint="sha256:claude-code",
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=fresh,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    service.record_event(event, trusted_usage_import=True)
+
+
+def test_two_component_fit_recovers_the_cache_discount(tmp_path):
+    """Intervals constructed with observed = 1.0 x (fresh + 0.5 x reads)
+    prediction → the grid recovers alpha ≈ 0.5 with scale ≈ 1.0."""
+
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    w = pc.baseline_weight_fresh("claude-opus-4-8")
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    # Vary the cache mix across intervals so alpha is identified (all-same
+    # mixes are collinear and any alpha would fit).
+    mixes = [(100, 0), (50, 200), (100, 100), (20, 400)]  # (fresh M, reads M)
+    for i, (fresh_m, reads_m) in enumerate(mixes):
+        _record_cached_usage(service, session_id=f"s{i}", fresh=fresh_m * 1_000_000,
+                             cache_read=reads_m * 1_000_000, updated_at=t0 + i * 3600 + 1800,
+                             index=i)
+        pct += w * (fresh_m + 0.5 * reads_m)
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + 5 * 3600))
+    assert weights.confidence == "calibrated"
+    assert abs(weights.alpha - 0.5) < 0.05
+    assert abs(weights.scale - 1.0) < 0.1
+
+
+def test_cache_heavy_days_no_longer_fall_out_of_the_band(tmp_path):
+    """The cliff this redesign removes: huge cache-read volume with modest
+    meter movement used to drag the single-component fit far below the band
+    (plan %% vanished exactly on heavy days). Under the two-component model
+    the same store calibrates with alpha ≈ 0."""
+
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    w = pc.baseline_weight_fresh("claude-opus-4-8")
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(4):
+        # 10M fresh + 500M cache reads per interval; the meter moves with the
+        # FRESH work only (the measured real-world behavior).
+        _record_cached_usage(service, session_id=f"s{i}", fresh=10_000_000,
+                             cache_read=500_000_000, updated_at=t0 + i * 3600 + 1800,
+                             index=i)
+        pct += w * 10.0
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + 5 * 3600))
+    assert weights.confidence == "calibrated"
+    assert weights.alpha < 0.05
+    assert abs(weights.scale - 1.0) < 0.1
+    # A cache-heavy session's share reflects its fresh work, not its reads.
+    records = __import__("agentacct.usage_snapshot", fromlist=["usage_records"]).usage_records(
+        service.list_all_events(), client="claude-code"
+    )
+    pcts = pc.session_plan_pcts(records, weights, client="claude-code")
+    assert abs(pcts["s0"] - w * 10.0) < 0.2
+
+
 def test_codex_never_calibrates_even_with_numerically_clean_history(tmp_path):
     """A rolling meter can land 3 clean intervals in the trusted band by
     coincidence, but codex's weekly plan % is UNDEFINED by design — the gate
@@ -186,7 +276,7 @@ def test_codex_never_calibrates_even_with_numerically_clean_history(tmp_path):
 
     service = SentinelService(tmp_path)
     t0 = 1_000_000
-    anchor = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]  # unknown codex model -> anchor weight
+    anchor = pc.baseline_weight_fresh("claude-opus-4-8")  # unknown codex model -> anchor weight
     move = 100.0 * anchor  # observed == predicted -> scale ~1.0, inside the band
     pct = 10.0
     _record_7d(service, captured=float(t0), pct=pct, client="codex", index=0)
@@ -208,7 +298,7 @@ def test_calibrate_untrusted_scale_falls_back_to_baseline(tmp_path):
     # outside the trusted band → keep the baseline rather than a 10x over-estimate.
     service = SentinelService(tmp_path)
     t0 = 1_000_000
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
     move = 10.0 * (100.0 * opus)  # 10x the baseline prediction
     pct = 0.0
     _record_7d(service, captured=float(t0), pct=pct, index=0)
@@ -227,20 +317,28 @@ def test_calibrate_untrusted_scale_falls_back_to_baseline(tmp_path):
 
 def test_session_plan_pcts():
     class _R:
-        def __init__(self, client, session_id, model, tok):
+        def __init__(self, client, session_id, model, fresh, cache_read=0):
             self.client = client; self.session_id = session_id
-            self.model = model; self.total_tokens_including_cached = tok
+            self.model = model
+            self.input_tokens = fresh; self.output_tokens = 0
+            self.cached_input_tokens = cache_read
+            self.cache_creation_input_tokens = 0
+            self.cache_read_input_tokens = cache_read
+            self.total_tokens_including_cached = fresh + cache_read
 
     recs = [
         _R("claude-code", "s1", "claude-opus-4-8", 100_000_000),
         _R("claude-code", "s1", "claude-fable-5", 10_000_000),
         _R("claude-code", "s2", "claude-opus-4-8", 50_000_000),
+        # cache reads count at alpha (0.5 here): 100M reads ≈ 50M fresh.
+        _R("claude-code", "s4", "claude-opus-4-8", 0, cache_read=100_000_000),
         _R("codex", "s3", "gpt-5", 99_000_000),  # non-claude → excluded
     ]
     w = pc.PlanWeights(weights={"claude-opus-4-8": 0.01, "claude-fable-5": 0.10},
                        default_weight=0.01, scale=1.0, confidence="baseline", basis="",
-                       intervals_used=0, client="claude-code")
+                       intervals_used=0, client="claude-code", alpha=0.5)
     pcts = pc.session_plan_pcts(recs, w, client="claude-code")
-    assert set(pcts) == {"s1", "s2"}                      # one pass, grouped, codex out
+    assert set(pcts) == {"s1", "s2", "s4"}                # one pass, grouped, codex out
     assert abs(pcts["s1"] - (100 * 0.01 + 10 * 0.10)) < 1e-9  # 1.0 + 1.0 = 2.0
-    assert abs(pcts["s2"] - 0.5) < 1e-9                       # 50M × 0.01
+    assert abs(pcts["s2"] - 0.5) < 1e-9                       # 50M fresh × 0.01
+    assert abs(pcts["s4"] - 0.5) < 1e-9                       # 100M reads × 0.01 × α=0.5

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -104,9 +104,9 @@ def _seed_calibrated_claude(service: SentinelService, *, now: float) -> None:
     """Recent history where the account's weekly-% moves exactly as the baseline
     predicts (fitted scale ~1.0, trusted) so claude-code calibrates: 4 clean hourly
     intervals of 100M Opus tokens, all within the recency window."""
-    from agentacct.plan_cost import BASELINE_MODEL_WEIGHTS
+    from agentacct.plan_cost import baseline_weight_fresh
 
-    move = 100.0 * BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]  # 100M Opus → baseline move
+    move = 100.0 * baseline_weight_fresh("claude-opus-4-8")  # 100M Opus → baseline move
     base = now - 6 * 3600
     pct = 0.0
     _record_7d(service, captured=base, pct=pct, index=0)

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -157,7 +157,7 @@ def _calibrate_claude(service: SentinelService, *, now: float) -> None:
     fitted scale is ~1.0 (inside the trusted band) and claude-code calibrates.
     The calibration burner sessions are named ``cal-N``."""
 
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
     move = 100.0 * opus  # 100M Opus tokens per interval → observed == predicted
     t0 = now - 5 * 3600
     pct = 10.0
@@ -300,7 +300,7 @@ def test_plan_pct_folds_children_into_the_root_row(tmp_path):
     service = SentinelService(tmp_path)
     now = time.time()
     _calibrate_claude(service, now=now)
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
     _record_usage(service, session_id="root-a", tokens=10_000_000, updated_at=now - 600)
     _record_usage(
         service,
@@ -468,7 +468,7 @@ def test_mutual_parent_cycle_keeps_shares_on_a_visible_root(tmp_path):
     service = SentinelService(tmp_path)
     now = time.time()
     _calibrate_claude(service, now=now)
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
     _record_usage(service, session_id="cyc-b", tokens=5_000_000, updated_at=now - 300,
                   session_kind="child", parent_session_id="cyc-a")
     _record_usage(service, session_id="cyc-a", tokens=10_000_000, updated_at=now - 200,
@@ -786,7 +786,7 @@ def test_detail_descendants_and_plan_block(tmp_path):
     service = SentinelService(tmp_path)
     now = time.time()
     _calibrate_claude(service, now=now)
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
     _record_usage(service, session_id="root-a", tokens=10_000_000, updated_at=now - 600)
     _record_usage(service, session_id="22222222-aaaa-bbbb-cccc-333333333333",
                   tokens=5_000_000, updated_at=now - 300,
@@ -902,7 +902,7 @@ def test_plan_endpoint_calibrated_aggregates_agree(tmp_path):
     service = SentinelService(tmp_path)
     now = time.time()
     _calibrate_claude(service, now=now)
-    opus = pc.BASELINE_MODEL_WEIGHTS["claude-opus-4-8"]
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
     _record_usage(service, session_id="root-a", tokens=10_000_000, updated_at=now - 60)
 
     client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -646,6 +646,8 @@ def test_descendant_task_label_is_bounded_and_redacted(tmp_path, monkeypatch):
                   session_kind="child", parent_session_id="root-a")
     _record_usage(service, session_id="root-a:agent-def456", tokens=100, updated_at=now - 200,
                   session_kind="child", parent_session_id="root-a")
+    _record_usage(service, session_id="root-a:agent-ghi789", tokens=100, updated_at=now - 100,
+                  session_kind="child", parent_session_id="root-a")
 
     secret = "sk-ant-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz"
     long_line = "review the deploy " + "x" * 400 + " end"
@@ -655,6 +657,11 @@ def test_descendant_task_label_is_bounded_and_redacted(tmp_path, monkeypatch):
     # must scrub it whole regardless of where the bound lands.
     boundary_secret = "sk-ant-" + "z" * 80
     boundary_task = "x" * 149 + " " + boundary_secret + " tail"
+    # A first line of ONLY control/format chars (BOM + zero-width space): these
+    # survive .strip() (non-whitespace category-C), so the sanitizer returns
+    # None. The label path must not crash on that None (regression: an unguarded
+    # None[:160] 500'd the whole /v1/session response).
+    format_only_task = "﻿​\nDo the real work"
     monkeypatch.setattr(roles_module, "scan_enabled", lambda: True)
     monkeypatch.setattr(
         roles_module,
@@ -667,6 +674,10 @@ def test_descendant_task_label_is_bounded_and_redacted(tmp_path, monkeypatch):
             "root-a:agent-def456": SubagentRole(
                 agent_type="Explore",
                 task=boundary_task,
+            ),
+            "root-a:agent-ghi789": SubagentRole(
+                agent_type="Explore",
+                task=format_only_task,
             ),
         },
     )
@@ -688,6 +699,10 @@ def test_descendant_task_label_is_bounded_and_redacted(tmp_path, monkeypatch):
     assert "sk-ant-" not in boundary_label
     assert "z" * 20 not in boundary_label
     assert len(boundary_label) <= 170
+
+    # A format-only first line sanitizes to None: the enrichment must degrade to
+    # task=None (present key) rather than crash the whole detail response.
+    assert by_id["root-a:agent-ghi789"]["task"] is None
 
 
 def test_non_plan_client_detail_plan_block_keeps_the_full_key_set(tmp_path):

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -644,9 +644,17 @@ def test_descendant_task_label_is_bounded_and_redacted(tmp_path, monkeypatch):
     _record_usage(service, session_id="root-a", tokens=1000, updated_at=now - 900)
     _record_usage(service, session_id="root-a:agent-abc123", tokens=100, updated_at=now - 300,
                   session_kind="child", parent_session_id="root-a")
+    _record_usage(service, session_id="root-a:agent-def456", tokens=100, updated_at=now - 200,
+                  session_kind="child", parent_session_id="root-a")
 
     secret = "sk-ant-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz"
     long_line = "review the deploy " + "x" * 400 + " end"
+    # A secret that STRADDLES the 160-char bound: it starts before 160 and runs
+    # past it, so truncate-then-redact would cut it into a short prefix that
+    # could fall under the redactor's min-length floor. redact-then-truncate
+    # must scrub it whole regardless of where the bound lands.
+    boundary_secret = "sk-ant-" + "z" * 80
+    boundary_task = "x" * 149 + " " + boundary_secret + " tail"
     monkeypatch.setattr(roles_module, "scan_enabled", lambda: True)
     monkeypatch.setattr(
         roles_module,
@@ -655,7 +663,11 @@ def test_descendant_task_label_is_bounded_and_redacted(tmp_path, monkeypatch):
             "root-a:agent-abc123": SubagentRole(
                 agent_type="Explore",
                 task=f"use {secret} then {long_line}\nsecond line ignored",
-            )
+            ),
+            "root-a:agent-def456": SubagentRole(
+                agent_type="Explore",
+                task=boundary_task,
+            ),
         },
     )
 
@@ -663,11 +675,19 @@ def test_descendant_task_label_is_bounded_and_redacted(tmp_path, monkeypatch):
     ledger = build_work_ledger(events)
     view = build_v1_sessions_view(ledger, events)
     detail = build_v1_session_detail(view, ledger, client="claude-code", session_id="root-a")
-    child = detail["descendants"][0]
+    by_id = {c["client_session_id"]: c for c in detail["descendants"]}
+    child = by_id["root-a:agent-abc123"]
     assert child["agent_type"] == "Explore"
     assert secret not in (child["task"] or "")
     assert "second line" not in (child["task"] or "")
     assert len(child["task"] or "") <= 170
+
+    # No fragment of the boundary-straddling secret survives, and no bare
+    # "sk-ant-" prefix leaks even though the bound falls inside the key.
+    boundary_label = by_id["root-a:agent-def456"]["task"] or ""
+    assert "sk-ant-" not in boundary_label
+    assert "z" * 20 not in boundary_label
+    assert len(boundary_label) <= 170
 
 
 def test_non_plan_client_detail_plan_block_keeps_the_full_key_set(tmp_path):

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -629,6 +629,64 @@ def test_explicit_vs_missing_namespace_refuses_the_fold(tmp_path):
     assert abs(g_child["plan_pct"] - child["plan_pct"]) < 1e-9
 
 
+def test_descendant_task_label_is_bounded_and_redacted(tmp_path, monkeypatch):
+    """The descendants' role enrichment ships a LABEL, not the prompt: first
+    line, bounded, secret spans redacted (round-2 findings: a live payload
+    blew past 1MB of raw Task prompts, and prompts can carry keys)."""
+
+    import agentacct.subagent_roles as roles_module
+    from agentacct.subagent_roles import SubagentRole
+    from agentacct.v1_sessions import build_v1_session_detail, build_v1_sessions_view
+    from agentacct.work_ledger import build_work_ledger
+
+    service = SentinelService(tmp_path)
+    now = time.time()
+    _record_usage(service, session_id="root-a", tokens=1000, updated_at=now - 900)
+    _record_usage(service, session_id="root-a:agent-abc123", tokens=100, updated_at=now - 300,
+                  session_kind="child", parent_session_id="root-a")
+
+    secret = "sk-ant-abc123def456ghi789jkl012mno345pqr678stu901vwx234yz"
+    long_line = "review the deploy " + "x" * 400 + " end"
+    monkeypatch.setattr(roles_module, "scan_enabled", lambda: True)
+    monkeypatch.setattr(
+        roles_module,
+        "read_roles_for_children",
+        lambda parent, ids, projects_root=None: {
+            "root-a:agent-abc123": SubagentRole(
+                agent_type="Explore",
+                task=f"use {secret} then {long_line}\nsecond line ignored",
+            )
+        },
+    )
+
+    events = service.list_all_events()
+    ledger = build_work_ledger(events)
+    view = build_v1_sessions_view(ledger, events)
+    detail = build_v1_session_detail(view, ledger, client="claude-code", session_id="root-a")
+    child = detail["descendants"][0]
+    assert child["agent_type"] == "Explore"
+    assert secret not in (child["task"] or "")
+    assert "second line" not in (child["task"] or "")
+    assert len(child["task"] or "") <= 170
+
+
+def test_non_plan_client_detail_plan_block_keeps_the_full_key_set(tmp_path):
+    """The no-plan block mirrors plan_status_entry's key set exactly, so the
+    schema shape is uniform across clients on this endpoint."""
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, client="hermes", model="gpt-5.5", session_id="h1",
+                  tokens=1000, updated_at=time.time() - 60)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    detail = client.get("/v1/session", headers=AUTH,
+                        params={"client": "hermes", "session_id": "h1"}).json()
+    plan = detail["plan"]
+    for key in ("client", "confidence", "calibration_state", "calibratable", "basis",
+                "scale", "alpha", "intervals_used", "intervals_needed", "raw_scale",
+                "trusted_band", "state_detail", "by_model"):
+        assert key in plan, key
+
+
 def test_generated_at_is_the_view_build_time(tmp_path):
     """A cache-hit response must not stamp a fresh clock on cached content."""
 


### PR DESCRIPTION
The estimator redesign behind the owner's "why is plan % gone from the session list" report — the heavy-day calibration cliff, removed at the root. Core money math: adversarially reviewed before merge.

## The cliff

The single-component model (per-model weights × total-tokens-including-cache) structurally over-predicted on cache-heavy days: measured live, tracked tokens predicted 49.5% weekly movement while the meter moved 19%, the fitted scale (0.38) fell out of the trusted band [0.5, 2.5], and the calibrated-or-nothing rule honestly withdrew every plan % — exactly on the days usage was heaviest. (It also explains the TUI mystery: the pre-refresh display was a fingerprint-cached older fit that was still in-band; refresh recomputed and the number vanished.)

## The two-component model

Every record splits into FRESH work (input + output + cache_creation) and cache READS; the fit is `scale × (fresh_prediction + alpha × read_prediction)` with `alpha ∈ [0,1]` chosen on a grid (robust ratio-of-sums scale per candidate, min-SSE — no iterative optimizer). Validated offline on the live store before implementation:

- leave-one-out stable: scale 7.5–10 (vs the total-anchored table), **alpha 0.00 in every fold** — cache reads genuinely do not move the weekly meter on the reference account;
- residual −33% vs the single-component fit;
- the shipped baseline table re-anchors into fresh-component units via a same-methodology reference factor (8.3), so the trusted band keeps its meaning.

**Live result: claude-code calibrates again** (scale 1.47 in band, alpha 0, 48 intervals). The flagship workflow session reads own 2.7% + subagents 11.6% = **14.3% of the week** — believable numbers where there was an honest blank.

## Also in this PR

- Every consumer moves to component accounting (session shares, window/daily aggregates, by-model splits); display fields keep REAL totals, components drive the estimate; unreported cache splits book as reads (the never-overstate direction).
- **Calibration progress disclosure**: plan entries gain `alpha`, `raw_scale`, `trusted_band`, `intervals_needed`, and a human `state_detail` sentence — a "calibrating" client now shows *why* (e.g. "48 intervals recorded; the fit (x0.38) is outside the trusted band…") instead of a bare spinner.
- `/v1/session` descendants gain `agent_type` + `task` from the subagent transcript reader (the TUI's bounded fail-soft reader, extended to the workflow-agent layout `subagents/workflows/*/agent-*.jsonl`) — untitled children no longer render as bare ids (52/52 enriched on the live store). Includes a self-caught variable-shadowing fix where the enrichment loop replaced the session row with the last descendant.

## Tests

Fixtures re-anchored to `baseline_weight_fresh`; new alpha-recovery (constructed α=0.5 store → fit recovers 0.5±0.05) and cache-heavy-day regression (10M fresh + 500M reads per interval → calibrated, α≈0) tests. Full suite 2907 passed (exit 0).
