### PR TITLE
feat(app): full-depth session detail, subagent roles, session search/sort, interactive usage charts

### DIFF
--- a/apps/agentacct/Sources/agentacct/AgentacctApp.swift
+++ b/apps/agentacct/Sources/agentacct/AgentacctApp.swift
@@ -18,7 +18,11 @@ struct AgentacctApp: App {
                 .environmentObject(dashboard)
                 .environmentObject(selection)
         } label: {
-            Text(glance.menuBarTitle)
+            // A quiet placeholder icon (a proper brand mark is future work).
+            // The weekly-plan % lives in the dropdown and the window — the
+            // menu BAR shows no number (the provider's own menu already does).
+            Label("agentacct", systemImage: glance.menuBarSymbol)
+                .labelStyle(.iconOnly)
         }
         .menuBarExtraStyle(.window)
 

--- a/apps/agentacct/Sources/agentacct/DashboardModel.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardModel.swift
@@ -41,6 +41,42 @@ struct SessionUsage: Decodable {
 struct SessionJoin: Decodable {
     let state: String?
     let reason: String?
+    /// Per-row join outcome counts (attributed / ambiguous /
+    /// context_matched_unallocated / unjoined) + veto count.
+    let rowStates: [String: Int]?
+    let vetoedRows: Int?
+    let attributedFreshTokens: Int?
+    let attributedTotalTokens: Int?
+    let attributedWork: [AttributedWork]?
+    let ambiguousCandidateWorkIds: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case state, reason
+        case rowStates = "row_states"
+        case vetoedRows = "vetoed_rows"
+        case attributedFreshTokens = "attributed_fresh_tokens"
+        case attributedTotalTokens = "attributed_total_tokens"
+        case attributedWork = "attributed_work"
+        case ambiguousCandidateWorkIds = "ambiguous_candidate_work_ids"
+    }
+}
+
+struct AttributedWork: Decodable, Identifiable {
+    let workId: String?
+    let sectionId: String?
+    let title: String?
+    let joinStrategy: String?
+    let joinConfidence: String?
+
+    var id: String { workId ?? sectionId ?? UUID().uuidString }
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case workId = "work_id"
+        case sectionId = "section_id"
+        case joinStrategy = "join_strategy"
+        case joinConfidence = "join_confidence"
+    }
 }
 
 struct SessionWork: Decodable {
@@ -152,6 +188,12 @@ struct PeriodBucket: Decodable, Identifiable {
     var shortLabel: String {
         guard let period, period.count >= 10 else { return period ?? "" }
         return String(period.dropFirst(5))
+    }
+
+    /// The shared cost honesty rule (complete-$ / partial-~$ / em-dash).
+    var costText: String {
+        guard let cost = estimatedCostUsd else { return "—" }
+        return Fmt.dollars(cost, prefix: costComplete == true ? "$" : "~$")
     }
 
     enum CodingKeys: String, CodingKey {

--- a/apps/agentacct/Sources/agentacct/DashboardPane.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardPane.swift
@@ -266,14 +266,18 @@ struct PlanHeroCard: View {
                             .font(Type.small)
                             .foregroundStyle(Theme.textMuted)
                     }
-                    if let tracked = trackedLine {
+    if let tracked = trackedLine {
                         Text(tracked)
                             .font(Type.small)
                             .foregroundStyle(Theme.accent)
                     } else if planClient?.calibrationState == "calibrating" {
-                        Text("tracked share calibrating from your own limit history")
+                        // The daemon's calibration-progress sentence (why the
+                        // number is withheld), not a bare spinner.
+                        Text(planClient?.stateDetail ?? "tracked share calibrating from your own limit history")
                             .font(Type.tiny)
                             .foregroundStyle(Theme.textFaint)
+                            .lineLimit(3)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     if let five = fiveHour?.usedPercent {
                         HStack(spacing: 6) {

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -23,6 +23,10 @@ final class DashboardStore: ObservableObject {
     @Published private(set) var isLoadingMore = false
     @Published private(set) var lastUpdated: Date?
 
+    /// The cost-chart range (7/30/90 trailing days); the plan lane stays on
+    /// its own fixed windows.
+    @Published private(set) var usageDays = 30
+
     private let client = GlanceClient()
     private let pageSize = 60
 
@@ -39,7 +43,7 @@ final class DashboardStore: ObservableObject {
                 "/v1/sessions?limit=\(limit)&offset=0"
             )
             let plan: V1PlanPayload = try await client.getAuthed("/v1/plan?days=30")
-            let summary: UsageSummary = try await client.getLocal("/usage/summary?days=30")
+            let summary: UsageSummary = try await client.getLocal("/usage/summary?days=\(usageDays)")
             sessions = payload.sessions
             totalSessions = payload.totalSessions
             totalRootSessions = payload.totalRootSessions
@@ -111,6 +115,18 @@ final class DashboardStore: ObservableObject {
     /// The plan status for one client (three-state honesty), if known.
     func planStatus(for clientName: String) -> V1PlanStatus? {
         planStatuses.first { $0.client == clientName }
+    }
+
+    /// Switch the cost-chart range and refetch just the usage cube.
+    func setUsageDays(_ days: Int) async {
+        guard days != usageDays else { return }
+        usageDays = days
+        do {
+            let summary: UsageSummary = try await client.getLocal("/usage/summary?days=\(days)")
+            usage = summary
+        } catch {
+            errorText = "usage range fetch failed: \(error.localizedDescription)"
+        }
     }
 }
 

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -27,6 +27,10 @@ final class DashboardStore: ObservableObject {
     /// its own fixed windows.
     @Published private(set) var usageDays = 30
 
+    /// Monotonic token so rapid range switches can't land out of order and a
+    /// failed fetch can't leave the old data labeled with the new range.
+    private var usageDaysGeneration = 0
+
     private let client = GlanceClient()
     private let pageSize = 60
 
@@ -117,14 +121,20 @@ final class DashboardStore: ObservableObject {
         planStatuses.first { $0.client == clientName }
     }
 
-    /// Switch the cost-chart range and refetch just the usage cube.
+    /// Switch the cost-chart range and refetch just the usage cube. The range
+    /// label only flips once the matching payload has landed, and only the
+    /// newest in-flight switch is allowed to write.
     func setUsageDays(_ days: Int) async {
         guard days != usageDays else { return }
-        usageDays = days
+        usageDaysGeneration += 1
+        let generation = usageDaysGeneration
         do {
             let summary: UsageSummary = try await client.getLocal("/usage/summary?days=\(days)")
+            guard generation == usageDaysGeneration else { return }
+            usageDays = days
             usage = summary
         } catch {
+            guard generation == usageDaysGeneration else { return }
             errorText = "usage range fetch failed: \(error.localizedDescription)"
         }
     }

--- a/apps/agentacct/Sources/agentacct/GlanceState.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceState.swift
@@ -66,23 +66,16 @@ final class GlanceState: ObservableObject {
         }
     }
 
-    /// Menu bar label: the weekly plan meter (the subscription user's real
-    /// question), account truth from the provider's own 7d reading —
-    /// claude-code's when live, else the hottest live 7d window. Falls back
-    /// to today's cost when no limit reading exists; a quiet marker when the
-    /// daemon is down — never a fabricated figure.
-    var menuBarTitle: String {
+    /// Menu bar icon (placeholder until a brand mark exists): a steady gauge
+    /// when connected, a slashed one when the daemon is down/incompatible.
+    /// No number in the bar — the provider's own menu already shows the plan
+    /// meter; ours lives one click away in the dropdown.
+    var menuBarSymbol: String {
         switch phase {
-        case .connected(let snapshot):
-            if let used = Self.sevenDayUsedPercent(snapshot.glance) {
-                return "⏺ \(Int(used.rounded()))%"
-            }
-            let today = snapshot.glance.usage.windows.first { $0.label == "today" }
-            return "⏺ \(today?.totals.costText ?? "—")"
-        case .connecting:
-            return "⏺ …"
+        case .connected, .connecting:
+            return "gauge.with.dots.needle.50percent"
         case .disconnected, .incompatible:
-            return "⏺ ∅"
+            return "gauge.badge.minus"
         }
     }
 

--- a/apps/agentacct/Sources/agentacct/LimitsPane.swift
+++ b/apps/agentacct/Sources/agentacct/LimitsPane.swift
@@ -99,11 +99,14 @@ struct LimitsPane: View {
                                     .frame(width: 110, alignment: .leading)
                                 Chip(text: client.calibrationState ?? "unknown",
                                      tint: calibrationTint(client.calibrationState))
-                                if let basis = client.basis {
-                                    Text(basis)
+                                // The progress/why sentence beats the raw
+                                // basis: "48 intervals recorded; the fit
+                                // (x0.38) is outside the trusted band…"
+                                if let detail = client.stateDetail ?? client.basis {
+                                    Text(detail)
                                         .font(Type.tiny)
                                         .foregroundStyle(Theme.textFaint)
-                                        .lineLimit(2)
+                                        .fixedSize(horizontal: false, vertical: true)
                                 }
                                 Spacer(minLength: 0)
                             }

--- a/apps/agentacct/Sources/agentacct/SessionsPane.swift
+++ b/apps/agentacct/Sources/agentacct/SessionsPane.swift
@@ -508,7 +508,10 @@ struct SessionDetail: View {
                 }
                 if let attributed = join.attributedWork, !attributed.isEmpty {
                     VStack(alignment: .leading, spacing: 3) {
-                        ForEach(attributed) { work in
+                        // Position-keyed: a malformed row with no work_id/section_id
+                        // must keep stable identity across renders (an id that
+                        // minted a fresh UUID each access churned the list).
+                        ForEach(Array(attributed.enumerated()), id: \.offset) { _, work in
                             HStack(spacing: 6) {
                                 Image(systemName: "arrow.right")
                                     .font(.system(size: 8))

--- a/apps/agentacct/Sources/agentacct/SessionsPane.swift
+++ b/apps/agentacct/Sources/agentacct/SessionsPane.swift
@@ -9,15 +9,61 @@ import SwiftUI
 struct SessionsPane: View {
     @EnvironmentObject var dashboard: DashboardStore
     @EnvironmentObject var selection: AppSelection
+    @State private var query = ""
+    @State private var clientFilter: String?
+    @State private var sort: SessionSort = .latest
+
+    enum SessionSort: String, CaseIterable, Identifiable {
+        case latest = "latest"
+        case plan = "plan %"
+        case cost = "cost"
+        var id: String { rawValue }
+    }
+
+    /// The loaded rows through the toolbar: search (title/project/id),
+    /// client filter, sort. Client-side over the paginated walk — the footer
+    /// still discloses how much of the store is loaded.
+    private var visibleRows: [V1SessionRow] {
+        var rows = dashboard.sessions
+        if let clientFilter {
+            rows = rows.filter { $0.client == clientFilter }
+        }
+        if !query.isEmpty {
+            let needle = query.lowercased()
+            rows = rows.filter { row in
+                row.displayTitle.lowercased().contains(needle)
+                    || (row.project ?? "").lowercased().contains(needle)
+                    || row.clientSessionId.lowercased().contains(needle)
+            }
+        }
+        switch sort {
+        case .latest:
+            return rows  // server order: recency
+        case .plan:
+            return rows.sorted { ($0.planPct ?? -1) > ($1.planPct ?? -1) }
+        case .cost:
+            return rows.sorted { ($0.usage?.estimatedCostUsd ?? -1) > ($1.usage?.estimatedCostUsd ?? -1) }
+        }
+    }
+
+    private var loadedClients: [String] {
+        var seen: [String] = []
+        for row in dashboard.sessions where !seen.contains(row.client) {
+            seen.append(row.client)
+        }
+        return seen.sorted()
+    }
 
     var body: some View {
         HStack(spacing: 0) {
             VStack(spacing: 0) {
+                toolbar
+                Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
                 ScrollBox {
                     VStack(spacing: 2) {
                         // Offscreen renders have no scrolling: cap the list so
                         // the snapshot shows the top of it plus the detail.
-                        let rows = SnapshotMode.enabled ? Array(dashboard.sessions.prefix(9)) : dashboard.sessions
+                        let rows = SnapshotMode.enabled ? Array(visibleRows.prefix(8)) : visibleRows
                         ForEach(rows) { row in
                             SessionRow(row: row, selected: selection.sessionId == row.id)
                                 .onTapGesture { selection.sessionId = row.id }
@@ -72,11 +118,59 @@ struct SessionsPane: View {
         }
     }
 
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 5) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.textFaint)
+                TextField("Search title · project · id", text: $query)
+                    .textFieldStyle(.plain)
+                    .font(Type.body)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(Theme.card, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .strokeBorder(Theme.border, lineWidth: 1))
+
+            Menu {
+                Button("All agents") { clientFilter = nil }
+                Divider()
+                ForEach(loadedClients, id: \.self) { client in
+                    Button(client) { clientFilter = client }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    StatusDot(color: clientFilter.map { Theme.clientColor($0) } ?? Theme.textFaint, size: 5)
+                    Text(clientFilter ?? "all")
+                        .font(Type.small)
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+
+            Picker("", selection: $sort) {
+                ForEach(SessionSort.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            .pickerStyle(.menu)
+            .fixedSize()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+    }
+
     private var footerText: String {
-        let shown = dashboard.sessions.count
+        let shown = visibleRows.count
+        let loaded = dashboard.sessions.count
         let roots = dashboard.totalRootSessions.map(String.init) ?? "?"
         let total = dashboard.totalSessions.map(String.init) ?? "?"
-        return "\(shown) of \(roots) root sessions · \(total) total in the store"
+        if shown != loaded {
+            return "\(shown) shown of \(loaded) loaded · \(roots) roots · \(total) total in the store"
+        }
+        return "\(loaded) of \(roots) root sessions · \(total) total in the store"
     }
 
     @ViewBuilder
@@ -113,6 +207,21 @@ struct SessionRow: View {
     let selected: Bool
     @State private var hovering = false
 
+    /// The TUI's steps cell: "6 · 4✓ 1▶ 1⚠" from the work counts.
+    private var stepsSummary: String? {
+        guard let counts = row.work?.counts, let total = counts.total, total > 0 else { return nil }
+        var parts: [String] = []
+        let done = (counts.completed ?? 0) + (counts.resolved ?? 0)
+        if done > 0 { parts.append("\(done)✓") }
+        if let active = counts.active, active > 0 { parts.append("\(active)▶") }
+        if let blocked = counts.blocked, blocked > 0 { parts.append("\(blocked)⚠") }
+        return "\(total) step\(total == 1 ? "" : "s")\(parts.isEmpty ? "" : " · " + parts.joined(separator: " "))"
+    }
+
+    private var statusWord: String? {
+        row.status?.replacingOccurrences(of: "_", with: " ")
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             StatusDot(color: Theme.statusColor(row.status), size: 7)
@@ -122,21 +231,43 @@ struct SessionRow: View {
                     .foregroundStyle(Theme.text)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                // One metadata line: the load-bearing bits (client, status,
+                // steps, sub count) never wrap; the project name is the one
+                // that yields, truncating in the middle.
                 HStack(spacing: 6) {
                     Text(row.client)
                         .font(.system(size: 9.5, weight: .semibold))
                         .foregroundStyle(Theme.clientColor(row.client))
+                        .fixedSize()
+                    if let statusWord {
+                        Text(statusWord)
+                            .font(.system(size: 9.5, weight: .medium))
+                            .foregroundStyle(Theme.statusColor(row.status))
+                            .fixedSize()
+                    }
+                    if let stepsSummary {
+                        Text(stepsSummary)
+                            .font(.system(size: 9.5))
+                            .monospacedDigit()
+                            .foregroundStyle(Theme.textMuted)
+                            .fixedSize()
+                    }
                     if let project = row.project {
                         Text(project)
                             .font(.system(size: 10))
                             .foregroundStyle(Theme.textFaint)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .layoutPriority(-1)
                     }
                     if let count = row.related?.childSessionCount, count > 0 {
                         Text("×\(count) sub")
                             .font(.system(size: 9.5))
                             .foregroundStyle(Theme.textFaint)
+                            .fixedSize()
                     }
                 }
+                .lineLimit(1)
             }
             Spacer(minLength: 10)
             VStack(alignment: .trailing, spacing: 3) {
@@ -180,6 +311,7 @@ struct SessionRow: View {
 struct SessionDetail: View {
     let row: V1SessionRow
     @EnvironmentObject var dashboard: DashboardStore
+    @State private var showAllDescendants = false
 
     var body: some View {
         ScrollBox {
@@ -309,40 +441,28 @@ struct SessionDetail: View {
                 SectionCaption(tone: Theme.textMuted, text: "Subagent sessions · \(descendants.count)")
                 Card(padding: 4) {
                     VStack(spacing: 0) {
-                        let shown = Array(descendants.prefix(8))
+                        let shown = showAllDescendants ? descendants : Array(descendants.prefix(8))
                         ForEach(Array(shown.enumerated()), id: \.element.id) { index, child in
-                            HStack(spacing: 9) {
-                                StatusDot(color: Theme.statusColor(child.status), size: 6)
-                                Text(child.title ?? child.clientSessionIdShort ?? child.clientSessionId ?? "?")
-                                    .font(Type.body)
-                                    .foregroundStyle(Theme.text)
-                                    .lineLimit(1)
-                                Spacer(minLength: 8)
-                                if let pct = Fmt.planPct(child.planPct) {
-                                    Text(pct)
-                                        .font(Type.numeric)
-                                        .foregroundStyle(Theme.accent)
-                                }
-                                if let tokens = child.usage?.freshTokens {
-                                    Text(UsageTotals.compact(Int(tokens)))
-                                        .font(Type.tiny.monospacedDigit())
-                                        .foregroundStyle(Theme.textFaint)
-                                        .frame(width: 48, alignment: .trailing)
-                                }
-                            }
-                            .padding(.horizontal, 9)
-                            .padding(.vertical, 6)
+                            DescendantRow(child: child)
                             if index < shown.count - 1 {
                                 Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
                             }
                         }
                         if descendants.count > 8 {
-                            Text("+ \(descendants.count - 8) more")
-                                .font(Type.tiny)
-                                .foregroundStyle(Theme.textFaint)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, 9)
-                                .padding(.vertical, 6)
+                            Button {
+                                withAnimation(.easeInOut(duration: 0.15)) { showAllDescendants.toggle() }
+                            } label: {
+                                Text(showAllDescendants
+                                     ? "Show fewer"
+                                     : "Show all \(descendants.count)")
+                                    .font(Type.small)
+                                    .foregroundStyle(Theme.accent)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, 9)
+                                    .padding(.vertical, 6)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
                         }
                     }
                 }
@@ -355,16 +475,93 @@ struct SessionDetail: View {
         if let join = row.join {
             VStack(alignment: .leading, spacing: Space.s) {
                 SectionCaption(tone: Theme.textMuted, text: "Attribution")
+                // Attribution ≠ evidence: this answers "which recorded work
+                // does this session's USAGE belong to" (the money↔work join);
+                // evidence lives on each step (what the machine checks prove).
+                Text("how this session's usage maps onto its recorded work — separate from each step's evidence")
+                    .font(Type.tiny)
+                    .foregroundStyle(Theme.textFaint)
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Chip(text: join.state ?? "unknown", tint: joinTint(join.state))
                     if let reason = join.reason {
                         Text(reason)
                             .font(Type.small)
                             .foregroundStyle(Theme.textMuted)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                if let rows = join.rowStates, !rows.isEmpty {
+                    HStack(spacing: 8) {
+                        ForEach(rows.sorted(by: { $0.key < $1.key }), id: \.key) { state, count in
+                            if count > 0 {
+                                Text("\(state.replacingOccurrences(of: "_", with: " ")): \(count)")
+                                    .font(Type.tiny.monospacedDigit())
+                                    .foregroundStyle(Theme.textMuted)
+                            }
+                        }
+                        if let vetoed = join.vetoedRows, vetoed > 0 {
+                            Text("vetoed: \(vetoed)")
+                                .font(Type.tiny.monospacedDigit())
+                                .foregroundStyle(Theme.orange)
+                        }
+                    }
+                }
+                if let attributed = join.attributedWork, !attributed.isEmpty {
+                    VStack(alignment: .leading, spacing: 3) {
+                        ForEach(attributed) { work in
+                            HStack(spacing: 6) {
+                                Image(systemName: "arrow.right")
+                                    .font(.system(size: 8))
+                                    .foregroundStyle(Theme.textFaint)
+                                Text(work.title ?? work.sectionId ?? "?")
+                                    .font(Type.tiny)
+                                    .foregroundStyle(Theme.textMuted)
+                                    .lineLimit(1)
+                                if let confidence = work.joinConfidence {
+                                    Chip(text: confidence.replacingOccurrences(of: "_", with: " "),
+                                         tint: Theme.textFaint)
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
+    }
+}
+
+/// One subagent row: role-aware label (Task first line > title > agent type),
+/// an agent-type chip, plan share and fresh tokens.
+struct DescendantRow: View {
+    let child: V1Descendant
+
+    var body: some View {
+        HStack(spacing: 9) {
+            StatusDot(color: Theme.statusColor(child.status), size: 6)
+            Text(child.displayTitle)
+                .font(Type.body)
+                .foregroundStyle(Theme.text)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if let agentType = child.agentType {
+                Chip(text: agentType, tint: Theme.purple)
+            }
+            Spacer(minLength: 8)
+            if let pct = Fmt.planPct(child.planPct) {
+                Text(pct)
+                    .font(Type.numeric)
+                    .foregroundStyle(Theme.accent)
+            }
+            if let tokens = child.usage?.freshTokens {
+                Text(UsageTotals.compact(Int(tokens)))
+                    .font(Type.tiny.monospacedDigit())
+                    .foregroundStyle(Theme.textFaint)
+                    .frame(width: 48, alignment: .trailing)
+            }
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 6)
+        .help(child.task ?? child.displayTitle)
     }
 }
 
@@ -373,6 +570,34 @@ struct SessionDetail: View {
 struct StepCard: View {
     let step: V1Step
     @State private var expanded = false
+
+    /// WHY this confidence level — mirrors the daemon's evidence_status
+    /// derivation (failed: any live failing check; strong: any pass; weak:
+    /// claims without a pass; none: nothing recorded) using the same inputs
+    /// it used, so the label never needs to be taken on faith.
+    private var evidenceExplanation: String? {
+        guard let status = step.evidenceStatus else { return nil }
+        let checks = step.checks ?? []
+        let live = checks.filter { $0.supersessionState != "superseded" }
+        let passed = live.filter { $0.result == "passed" }.count
+        let failed = live.filter { $0.result == "failed" || $0.result == "error" }.count
+        let files = step.files?.count ?? 0
+        switch status {
+        case "failed":
+            return "failed — \(failed) failing check\(failed == 1 ? "" : "s") with no later pass superseding \(failed == 1 ? "it" : "them")"
+        case "strong":
+            return "strong — \(passed) passing machine check\(passed == 1 ? "" : "s") recorded"
+        case "weak":
+            if checks.isEmpty && files > 0 {
+                return "weak — \(files) file\(files == 1 ? "" : "s") claimed, but no machine check proves the work"
+            }
+            return "weak — checks were recorded but none passed"
+        case "none":
+            return "none — no machine checks and no file claims were recorded for this step"
+        default:
+            return nil
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -388,7 +613,8 @@ struct StepCard: View {
                     Text(step.title ?? step.sectionId ?? "untitled")
                         .font(Type.body)
                         .foregroundStyle(Theme.text)
-                        .lineLimit(expanded ? 3 : 1)
+                        .lineLimit(expanded ? nil : 1)
+                        .fixedSize(horizontal: false, vertical: expanded)
                     Spacer(minLength: 8)
                     if let kind = step.kind, kind != "unknown" {
                         Chip(text: kind, tint: Theme.textMuted)
@@ -409,6 +635,8 @@ struct StepCard: View {
             .buttonStyle(.plain)
 
             if expanded {
+                // The expanded step is the DETAILED view: nothing here is
+                // truncated — the user opened it to see everything.
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 8) {
                         if let status = step.latestStatus {
@@ -431,11 +659,18 @@ struct StepCard: View {
                                 .foregroundStyle(Theme.purple)
                         }
                     }
+                    if let why = evidenceExplanation {
+                        Text(why)
+                            .font(Type.tiny)
+                            .foregroundStyle(evidenceTint(step.evidenceStatus))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                     if let summary = step.summary, !summary.isEmpty {
                         Text(summary)
                             .font(Type.small)
                             .foregroundStyle(Theme.textMuted)
                             .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
                     }
                     if let checks = step.checks, !checks.isEmpty {
                         VStack(alignment: .leading, spacing: 4) {
@@ -449,18 +684,28 @@ struct StepCard: View {
                             .font(Type.small)
                             .foregroundStyle(Theme.orange)
                             .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
                     }
                     if let next = step.nextStep, !next.isEmpty {
                         Label(next, systemImage: "arrow.turn.down.right")
                             .font(Type.small)
                             .foregroundStyle(Theme.textMuted)
                             .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
                     }
                     if let files = step.files, !files.isEmpty {
-                        Text("\(files.count) file\(files.count == 1 ? "" : "s"): \(files.prefix(4).joined(separator: ", "))\(files.count > 4 ? " …" : "")")
-                            .font(Type.tiny)
-                            .foregroundStyle(Theme.textFaint)
-                            .lineLimit(2)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("\(files.count) file\(files.count == 1 ? "" : "s")")
+                                .font(Type.tiny.weight(.semibold))
+                                .foregroundStyle(Theme.textFaint)
+                            ForEach(files, id: \.self) { file in
+                                Text(file)
+                                    .font(Type.tiny.monospaced())
+                                    .foregroundStyle(Theme.textFaint)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .textSelection(.enabled)
+                            }
+                        }
                     }
                 }
                 .padding(.horizontal, 12)

--- a/apps/agentacct/Sources/agentacct/UsagePane.swift
+++ b/apps/agentacct/Sources/agentacct/UsagePane.swift
@@ -372,7 +372,11 @@ struct DailyChart: View {
                     .frame(height: 112, alignment: .bottom)
                     .overlay(alignment: .topLeading) {
                         if let hovered {
-                            DayTooltip(period: hovered, clients: visibleClients)
+                            // Cost has no per-client breakdown, so a day cost is
+                            // only honest when nothing is hidden; otherwise the
+                            // header would out-total the rows it sits above.
+                            DayTooltip(period: hovered, clients: visibleClients,
+                                       dayCostText: hidden.isEmpty ? hovered.costText : nil)
                         }
                     }
                     HStack {
@@ -390,10 +394,18 @@ struct DailyChart: View {
     }
 }
 
-/// The hover card: one day's totals and per-client split.
+/// The hover card: one day's totals and per-client split. The header total is
+/// summed over the VISIBLE clients so it always equals the stacked bar and the
+/// rows below it; the day cost is only shown when the caller vouches it covers
+/// the same (unfiltered) set.
 struct DayTooltip: View {
     let period: PeriodBucket
     let clients: [String]
+    var dayCostText: String? = nil
+
+    private var visibleFresh: Int {
+        clients.reduce(0) { $0 + (period.byClient?[$1]?.freshTokens ?? 0) }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -401,12 +413,14 @@ struct DayTooltip: View {
                 Text(period.shortLabel)
                     .font(Type.tiny.weight(.semibold))
                     .foregroundStyle(Theme.text)
-                Text(period.freshTokens.map(UsageTotals.compact) ?? "—")
+                Text(UsageTotals.compact(visibleFresh))
                     .font(Type.tiny.monospacedDigit())
                     .foregroundStyle(Theme.textMuted)
-                Text(period.costText)
-                    .font(Type.tiny.monospacedDigit())
-                    .foregroundStyle(Theme.textMuted)
+                if let dayCostText {
+                    Text(dayCostText)
+                        .font(Type.tiny.monospacedDigit())
+                        .foregroundStyle(Theme.textMuted)
+                }
             }
             ForEach(clients, id: \.self) { client in
                 if let slice = period.byClient?[client], let fresh = slice.freshTokens, fresh > 0 {

--- a/apps/agentacct/Sources/agentacct/UsagePane.swift
+++ b/apps/agentacct/Sources/agentacct/UsagePane.swift
@@ -31,7 +31,7 @@ struct UsagePane: View {
         ScrollBox {
             VStack(alignment: .leading, spacing: Space.l) {
                 HStack {
-                    SectionCaption(tone: Theme.textMuted, text: "Usage · last 30 days")
+                    SectionCaption(tone: Theme.textMuted, text: "Usage · last \(dashboard.usageDays) days")
                     Spacer()
                     Picker("", selection: Binding(get: { mode }, set: { chosenMode = $0 })) {
                         ForEach(UsageMode.allCases) { mode in
@@ -154,8 +154,8 @@ struct UsagePane: View {
         if let usage = dashboard.usage {
             if let totals = usage.totals {
                 HStack(spacing: 8) {
-                    PanelTile(label: "30d cost", value: totals.costText, accent: Theme.blue)
-                    PanelTile(label: "30d fresh tokens",
+                    PanelTile(label: "\(dashboard.usageDays)d cost", value: totals.costText, accent: Theme.blue)
+                    PanelTile(label: "\(dashboard.usageDays)d fresh tokens",
                               value: totals.freshTokens.map(UsageTotals.compact) ?? "—")
                     PanelTile(label: "cache read",
                               value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—")
@@ -164,7 +164,11 @@ struct UsagePane: View {
                 }
             }
             if let periods = usage.byPeriod, periods.count > 1 {
-                DailyChart(periods: periods)
+                DailyChart(
+                    periods: periods,
+                    selectedDays: dashboard.usageDays,
+                    onSelectDays: { days in Task { await dashboard.setUsageDays(days) } }
+                )
             }
             bucketSection(title: "By agent", buckets: usage.byClient) { bucket in
                 (bucket.client ?? "?", Theme.clientColor(bucket.client))
@@ -193,7 +197,7 @@ struct UsagePane: View {
         let sorted = buckets.sorted { ($0.freshTokens ?? 0) > ($1.freshTokens ?? 0) }
         let maxFresh = Double(sorted.first?.freshTokens ?? 1)
         return VStack(alignment: .leading, spacing: 8) {
-            SectionCaption(tone: Theme.textMuted, text: title + " · last 30 days")
+            SectionCaption(tone: Theme.textMuted, text: title + " · last \(dashboard.usageDays) days")
             Card(padding: 6) {
                 VStack(spacing: 0) {
                     ForEach(Array(sorted.enumerated()), id: \.element.id) { index, bucket in
@@ -270,10 +274,18 @@ struct PlanDailyChart: View {
     }
 }
 
-/// The 30-day stacked daily bars, client-colored (cost/tokens view + the
-/// dashboard's rhythm strip).
+/// The stacked daily bars, client-colored (cost/tokens view + the dashboard's
+/// rhythm strip). Interactive: hover a bar for the day's per-client split,
+/// click a legend entry to hide/show that agent's slices, and (when wired)
+/// switch the trailing-days range.
 struct DailyChart: View {
     let periods: [PeriodBucket]
+    /// Present → the range switcher renders (7/30/90) and calls back.
+    var selectedDays: Int? = nil
+    var onSelectDays: ((Int) -> Void)? = nil
+
+    @State private var hovered: PeriodBucket?
+    @State private var hidden: Set<String> = []
 
     private var clients: [String] {
         var seen: [String] = []
@@ -285,47 +297,84 @@ struct DailyChart: View {
         return seen.sorted()
     }
 
+    private var visibleClients: [String] {
+        clients.filter { !hidden.contains($0) }
+    }
+
+    private func visibleTotal(_ period: PeriodBucket) -> Double {
+        visibleClients.reduce(0.0) { partial, client in
+            partial + Double(period.byClient?[client]?.freshTokens ?? 0)
+        }
+    }
+
     private var maxTokens: Double {
-        max(Double(periods.compactMap(\.freshTokens).max() ?? 1), 1)
+        max(periods.map(visibleTotal).max() ?? 1, 1)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 10) {
                 SectionCaption(tone: Theme.textMuted, text: "Daily fresh tokens")
+                if let selectedDays, let onSelectDays {
+                    Picker("", selection: Binding(get: { selectedDays }, set: onSelectDays)) {
+                        Text("7d").tag(7)
+                        Text("30d").tag(30)
+                        Text("90d").tag(90)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 130)
+                }
                 Spacer()
                 ForEach(clients, id: \.self) { client in
-                    HStack(spacing: 4) {
-                        StatusDot(color: Theme.clientColor(client), size: 5)
-                        Text(client)
-                            .font(.system(size: 9.5))
-                            .foregroundStyle(Theme.textMuted)
+                    Button {
+                        if hidden.contains(client) { hidden.remove(client) } else { hidden.insert(client) }
+                    } label: {
+                        HStack(spacing: 4) {
+                            StatusDot(color: hidden.contains(client)
+                                      ? Theme.textFaint.opacity(0.4)
+                                      : Theme.clientColor(client), size: 5)
+                            Text(client)
+                                .font(.system(size: 9.5))
+                                .foregroundStyle(hidden.contains(client) ? Theme.textFaint : Theme.textMuted)
+                                .strikethrough(hidden.contains(client))
+                        }
+                        .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
+                    .help(hidden.contains(client) ? "Show \(client)" : "Hide \(client)")
                 }
             }
             Card(padding: 12) {
                 VStack(spacing: 6) {
                     HStack(alignment: .bottom, spacing: 3) {
                         ForEach(periods) { period in
-                            VStack(spacing: 0) {
-                                let total = Double(period.freshTokens ?? 0)
-                                let height = 110 * total / maxTokens
-                                VStack(spacing: 0.5) {
-                                    ForEach(clients, id: \.self) { client in
-                                        let slice = Double(period.byClient?[client]?.freshTokens ?? 0)
-                                        if slice > 0, total > 0 {
-                                            RoundedRectangle(cornerRadius: 1)
-                                                .fill(Theme.clientColor(client).gradient)
-                                                .frame(height: max(1.5, height * slice / total))
-                                        }
+                            let total = visibleTotal(period)
+                            let height = 110 * total / maxTokens
+                            VStack(spacing: 0.5) {
+                                ForEach(visibleClients, id: \.self) { client in
+                                    let slice = Double(period.byClient?[client]?.freshTokens ?? 0)
+                                    if slice > 0, total > 0 {
+                                        RoundedRectangle(cornerRadius: 1)
+                                            .fill(Theme.clientColor(client).gradient)
+                                            .frame(height: max(1.5, height * slice / total))
                                     }
                                 }
-                                .frame(maxWidth: .infinity)
                             }
                             .frame(maxWidth: .infinity, alignment: .bottom)
+                            .frame(maxHeight: .infinity, alignment: .bottom)
+                            .contentShape(Rectangle())
+                            .opacity(hovered == nil || hovered?.id == period.id ? 1 : 0.55)
+                            .onHover { inside in
+                                if inside { hovered = period } else if hovered?.id == period.id { hovered = nil }
+                            }
                         }
                     }
                     .frame(height: 112, alignment: .bottom)
+                    .overlay(alignment: .topLeading) {
+                        if let hovered {
+                            DayTooltip(period: hovered, clients: visibleClients)
+                        }
+                    }
                     HStack {
                         Text(periods.first?.shortLabel ?? "")
                         Spacer()
@@ -338,5 +387,49 @@ struct DailyChart: View {
                 }
             }
         }
+    }
+}
+
+/// The hover card: one day's totals and per-client split.
+struct DayTooltip: View {
+    let period: PeriodBucket
+    let clients: [String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(period.shortLabel)
+                    .font(Type.tiny.weight(.semibold))
+                    .foregroundStyle(Theme.text)
+                Text(period.freshTokens.map(UsageTotals.compact) ?? "—")
+                    .font(Type.tiny.monospacedDigit())
+                    .foregroundStyle(Theme.textMuted)
+                Text(period.costText)
+                    .font(Type.tiny.monospacedDigit())
+                    .foregroundStyle(Theme.textMuted)
+            }
+            ForEach(clients, id: \.self) { client in
+                if let slice = period.byClient?[client], let fresh = slice.freshTokens, fresh > 0 {
+                    HStack(spacing: 5) {
+                        StatusDot(color: Theme.clientColor(client), size: 4)
+                        Text(client)
+                            .font(Type.tiny)
+                            .foregroundStyle(Theme.textMuted)
+                        Spacer(minLength: 6)
+                        Text(UsageTotals.compact(fresh))
+                            .font(Type.tiny.monospacedDigit())
+                            .foregroundStyle(Theme.text)
+                    }
+                }
+            }
+        }
+        .padding(8)
+        .frame(minWidth: 140, alignment: .leading)
+        .background(Theme.card, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .strokeBorder(Theme.border, lineWidth: 1))
+        .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
+        .padding(4)
+        .allowsHitTesting(false)
     }
 }

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -37,12 +37,19 @@ struct V1PlanStatus: Decodable {
     let calibratable: Bool?
     let basis: String?
     let scale: Double?
+    let alpha: Double?
     let intervalsUsed: Int?
+    let intervalsNeeded: Int?
+    let rawScale: Double?
+    let stateDetail: String?
 
     enum CodingKeys: String, CodingKey {
-        case client, confidence, calibratable, basis, scale
+        case client, confidence, calibratable, basis, scale, alpha
         case calibrationState = "calibration_state"
         case intervalsUsed = "intervals_used"
+        case intervalsNeeded = "intervals_needed"
+        case rawScale = "raw_scale"
+        case stateDetail = "state_detail"
     }
 }
 
@@ -233,15 +240,31 @@ struct V1Descendant: Decodable, Identifiable {
     let lastActivityAt: Double?
     let usage: V1DescendantUsage?
     let planPct: Double?
+    /// Subagent role read from its transcript (daemon-enriched): the agent
+    /// type (Explore / Plan / workflow-subagent / …) and its Task prompt.
+    let agentType: String?
+    let task: String?
 
     var id: String { "\(client ?? "?")::\(clientSessionId ?? UUID().uuidString)" }
 
+    /// The best human label: Task prompt first line > recorded title >
+    /// agent type > short id.
+    var displayTitle: String {
+        if let task, let first = task.split(separator: "\n").first, !first.isEmpty {
+            return String(first)
+        }
+        if let title, !title.isEmpty { return title }
+        if let agentType, !agentType.isEmpty { return agentType }
+        return clientSessionIdShort ?? clientSessionId ?? "?"
+    }
+
     enum CodingKeys: String, CodingKey {
-        case client, title, status, usage
+        case client, title, status, usage, task
         case clientSessionId = "client_session_id"
         case clientSessionIdShort = "client_session_id_short"
         case lastActivityAt = "last_activity_at"
         case planPct = "plan_pct"
+        case agentType = "agent_type"
     }
 }
 
@@ -313,7 +336,11 @@ struct V1PlanClient: Decodable, Identifiable {
     let calibratable: Bool?
     let basis: String?
     let scale: Double?
+    let alpha: Double?
     let intervalsUsed: Int?
+    let intervalsNeeded: Int?
+    let rawScale: Double?
+    let stateDetail: String?
     let windowPcts: [String: Double?]?
     let daily: [V1PlanDay]?
     let byModel: [V1PlanModelShare]?
@@ -322,9 +349,12 @@ struct V1PlanClient: Decodable, Identifiable {
     var id: String { client }
 
     enum CodingKeys: String, CodingKey {
-        case client, confidence, calibratable, basis, scale, daily
+        case client, confidence, calibratable, basis, scale, alpha, daily
         case calibrationState = "calibration_state"
         case intervalsUsed = "intervals_used"
+        case intervalsNeeded = "intervals_needed"
+        case rawScale = "raw_scale"
+        case stateDetail = "state_detail"
         case windowPcts = "window_pcts"
         case byModel = "by_model"
         case unknownTimePct = "unknown_time_pct"


### PR DESCRIPTION
Additive Swift UI work on the `/v1` native-shell lane. No daemon behavior changes; every new decoder field is Optional and unknown keys are tolerated, so the app degrades cleanly against an older daemon.

## Session detail

- Full-depth step content: expanded `StepCard` renders the complete summary, blocker, and next-step with text selection enabled, instead of a truncated one-line preview.
- Descendant (subagent) list shows every child with a `Show all N` expander past the first 8, each row carrying the child's agent type and a bounded, redacted task label from `/v1/session`.
- Attribution and evidence are presented as distinct concepts: an attribution block explains the usage↔work join (records linked, confidence basis), and each evidence row explains why a step reads as strong / weak / none.

## Session list

- Each row shows step count and work-status word, matching the TUI, plus the calibrated weekly plan share (`≈x.x%`, shown only once the client's own history has calibrated).
- Toolbar adds free-text search, per-client filter, and sort by latest activity or cost. Filtering operates over the loaded page and the footer states "N shown of M loaded" so the scope is never overclaimed.

## Usage charts

- Per-day hover tooltips, legend series hide/show, and a 7 / 30 / 90-day range picker. Captions and tiles are range-aware.
- Chart scaling guards against empty/all-hidden series and zero-token days (no NaN or divide-by-zero).

## Menu bar

- Placeholder gauge icon replaces the numeric percentage in the status item; the 7-day summary moves into the menu content alongside a launch-at-login toggle.

## Dashboard / Limits

- Calibration progress (`state_detail`, x/N intervals) is surfaced; single-client accounts get a focused "today" tile.

## Verification

- `swift build` clean (arm64).
- Light and dark `--snapshot` renders regenerated for all four panes.
- Decoders verified against the live daemon on the 180-root store.
