### PR TITLE
feat(app): usage pane defaults to 7d with one range control across both lanes

### DIFF
--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -23,9 +23,11 @@ final class DashboardStore: ObservableObject {
     @Published private(set) var isLoadingMore = false
     @Published private(set) var lastUpdated: Date?
 
-    /// The cost-chart range (7/30/90 trailing days); the plan lane stays on
-    /// its own fixed windows.
-    @Published private(set) var usageDays = 30
+    /// The usage-pane range (7/30/90 trailing days). Defaults to 7 so the
+    /// per-model plan breakdown lines up with the 7d headline out of the box
+    /// (a 30-day accumulation reads as >100% of a weekly plan and confuses);
+    /// the today/7d headline windows are fixed regardless of this.
+    @Published private(set) var usageDays = 7
 
     /// Monotonic token so rapid range switches can't land out of order and a
     /// failed fetch can't leave the old data labeled with the new range.
@@ -46,7 +48,11 @@ final class DashboardStore: ObservableObject {
             let payload: V1SessionsPayload = try await client.getAuthed(
                 "/v1/sessions?limit=\(limit)&offset=0"
             )
-            let plan: V1PlanPayload = try await client.getAuthed("/v1/plan?days=30")
+            // Both the plan lane and the cost cube follow the pane range so the
+            // per-model breakdown, the daily bars, and the $ view all describe
+            // the same window. The today/7d headline windows are fixed inside
+            // the plan payload regardless of this days param.
+            let plan: V1PlanPayload = try await client.getAuthed("/v1/plan?days=\(usageDays)")
             let summary: UsageSummary = try await client.getLocal("/usage/summary?days=\(usageDays)")
             sessions = payload.sessions
             totalSessions = payload.totalSessions
@@ -121,17 +127,20 @@ final class DashboardStore: ObservableObject {
         planStatuses.first { $0.client == clientName }
     }
 
-    /// Switch the cost-chart range and refetch just the usage cube. The range
-    /// label only flips once the matching payload has landed, and only the
+    /// Switch the pane range and refetch BOTH the plan lane and the cost cube
+    /// so the plan breakdown, the daily bars, and the $ view stay on one window.
+    /// The range label only flips once both payloads have landed, and only the
     /// newest in-flight switch is allowed to write.
     func setUsageDays(_ days: Int) async {
         guard days != usageDays else { return }
         usageDaysGeneration += 1
         let generation = usageDaysGeneration
         do {
+            let plan: V1PlanPayload = try await client.getAuthed("/v1/plan?days=\(days)")
             let summary: UsageSummary = try await client.getLocal("/usage/summary?days=\(days)")
             guard generation == usageDaysGeneration else { return }
             usageDays = days
+            planClients = plan.clients
             usage = summary
         } catch {
             guard generation == usageDaysGeneration else { return }

--- a/apps/agentacct/Sources/agentacct/UsagePane.swift
+++ b/apps/agentacct/Sources/agentacct/UsagePane.swift
@@ -30,16 +30,27 @@ struct UsagePane: View {
     var body: some View {
         ScrollBox {
             VStack(alignment: .leading, spacing: Space.l) {
-                HStack {
+                HStack(spacing: 10) {
                     SectionCaption(tone: Theme.textMuted, text: "Usage · last \(dashboard.usageDays) days")
                     Spacer()
+                    // One range control for the whole pane: it drives the daily
+                    // bars AND the per-model breakdown depth. The today/7d
+                    // headline windows stay fixed regardless.
+                    Picker("", selection: Binding(get: { dashboard.usageDays },
+                                                  set: { days in Task { await dashboard.setUsageDays(days) } })) {
+                        Text("7d").tag(7)
+                        Text("30d").tag(30)
+                        Text("90d").tag(90)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 130)
                     Picker("", selection: Binding(get: { mode }, set: { chosenMode = $0 })) {
                         ForEach(UsageMode.allCases) { mode in
                             Text(mode.rawValue).tag(mode)
                         }
                     }
                     .pickerStyle(.segmented)
-                    .frame(width: 140)
+                    .frame(width: 110)
                 }
                 if mode == .plan {
                     planView
@@ -114,7 +125,16 @@ struct UsagePane: View {
     private func modelShares(_ shares: [V1PlanModelShare]) -> some View {
         let maxPct = shares.compactMap(\.pct).max() ?? 1
         return VStack(alignment: .leading, spacing: Space.s) {
-            SectionCaption(tone: Theme.textMuted, text: "Which model eats the plan")
+            HStack(spacing: 6) {
+                SectionCaption(tone: Theme.textMuted, text: "Which model eats the plan")
+                Spacer()
+                // Disclose that these are estimates AND the window they sum over,
+                // so a 30/90-day breakdown reading >100% of a weekly plan is
+                // clearly a multi-week accumulation, not a broken number.
+                Text("estimated · last \(dashboard.usageDays)d")
+                    .font(Type.tiny)
+                    .foregroundStyle(Theme.textFaint)
+            }
             Card(padding: 6) {
                 VStack(spacing: 0) {
                     ForEach(Array(shares.enumerated()), id: \.element.id) { index, share in
@@ -164,11 +184,8 @@ struct UsagePane: View {
                 }
             }
             if let periods = usage.byPeriod, periods.count > 1 {
-                DailyChart(
-                    periods: periods,
-                    selectedDays: dashboard.usageDays,
-                    onSelectDays: { days in Task { await dashboard.setUsageDays(days) } }
-                )
+                // Range lives in the pane header now; the chart shows no picker.
+                DailyChart(periods: periods)
             }
             bucketSection(title: "By agent", buckets: usage.byClient) { bucket in
                 (bucket.client ?? "?", Theme.clientColor(bucket.client))
@@ -239,6 +256,8 @@ struct PlanDailyChart: View {
     let days: [V1PlanDay]
     var tint: Color
 
+    @State private var hovered: V1PlanDay?
+
     private var maxPct: Double {
         max(days.map(\.pct).max() ?? 0.0001, 0.0001)
     }
@@ -252,9 +271,19 @@ struct PlanDailyChart: View {
                             .fill(day.pct > 0 ? AnyShapeStyle(tint.gradient) : AnyShapeStyle(Theme.border.opacity(0.5)))
                             .frame(height: day.pct > 0 ? max(2, 110 * day.pct / maxPct) : 1.5)
                             .frame(maxWidth: .infinity, alignment: .bottom)
+                            .contentShape(Rectangle())
+                            .opacity(hovered == nil || hovered?.id == day.id ? 1 : 0.55)
+                            .onHover { inside in
+                                if inside { hovered = day } else if hovered?.id == day.id { hovered = nil }
+                            }
                     }
                 }
                 .frame(height: 112, alignment: .bottom)
+                .overlay(alignment: .topLeading) {
+                    if let hovered {
+                        PlanDayTooltip(day: hovered)
+                    }
+                }
                 HStack {
                     Text(shortDate(days.first?.date))
                     Spacer()
@@ -271,6 +300,29 @@ struct PlanDailyChart: View {
     private func shortDate(_ iso: String?) -> String {
         guard let iso, iso.count >= 10 else { return "" }
         return String(iso.dropFirst(5))  // YYYY-MM-DD -> MM-DD
+    }
+}
+
+/// Hover card for the plan-share chart: one day's date + estimated plan %.
+struct PlanDayTooltip: View {
+    let day: V1PlanDay
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(day.date.count >= 10 ? String(day.date.dropFirst(5)) : day.date)
+                .font(Type.tiny.weight(.semibold))
+                .foregroundStyle(Theme.text)
+            Text(Fmt.planPct(day.pct) ?? "≈0%")
+                .font(Type.tiny.monospacedDigit())
+                .foregroundStyle(Theme.accent)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(Theme.card, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .strokeBorder(Theme.border, lineWidth: 1))
+        .padding(4)
+        .fixedSize()
     }
 }
 


### PR DESCRIPTION
The usage pane's per-model plan breakdown was fed by `/v1/plan?days=30` while its headline showed the fixed 7-day window, so a single model read as ~141% "of the weekly plan" — a 30-day accumulation under a weekly-plan label, with no window cue.

## Changes

- **Default to 7 days.** The per-model breakdown now sums to the 7d headline (~39.5%) out of the box instead of a >100% multi-week figure. The today/7d headline windows are fixed and unaffected.
- **One range control for the whole pane.** A single 7/30/90 picker in the pane header reloads BOTH the plan lane (`/v1/plan?days=N`) and the cost cube (`/usage/summary?days=N`) under the existing generation guard, so the daily bars, the per-model breakdown, and the $ view always describe the same window. Removed the chart-local range picker (it only moved the $ view).
- **Disclose the window.** The breakdown carries an `estimated · last Nd` caption, so a 30/90-day view reading >100% is clearly a multi-week accumulation, not a broken number.
- **Plan-share chart hover.** The plan% daily chart gains a hover tooltip (date + estimated plan %), matching the cost chart.

## Verification

- `swift build` clean (arm64).
- `--snapshot` re-rendered: at the 7d default the breakdown is fable-5 ≈30.2% / opus-4.8 ≈6.1% / opus-5 ≈3.3% / haiku <0.1% = ~39.6%, matching the 7d headline; header reads "last 7 days"; the estimated-window caption is present.
