### PR TITLE
fix(codex): keep quota buckets distinct and stop trusting rewritten rollout timestamps

### DIFF
--- a/src/agentacct/rate_limits.py
+++ b/src/agentacct/rate_limits.py
@@ -389,13 +389,13 @@ def snapshot_run_id(snapshot: RateLimitSnapshot) -> str:
     """
 
     if snapshot.origin == ORIGIN_CODEX_SESSION or snapshot.client == "codex":
-        limit_id = snapshot.limit_id
-        # "codex" is the default account-wide bucket — keep its legacy stream id
-        # so this fix does not fork the existing healthy series. Only non-default
+        # The default account-wide bucket keeps its legacy stream id so this fix
+        # does not fork the existing healthy series (case-insensitive, so a
+        # "Codex" casing variant does not orphan it). Only genuinely non-default
         # buckets branch into their own stream.
-        if limit_id and limit_id != "codex":
-            return f"{CODEX_RUN_ID}:{limit_id}"
-        return CODEX_RUN_ID
+        if _is_default_codex_bucket(snapshot):
+            return CODEX_RUN_ID
+        return f"{CODEX_RUN_ID}:{snapshot.limit_id}"
     if snapshot.origin == ORIGIN_CLAUDE_STATUSLINE:
         return CLAUDE_STATUSLINE_RUN_ID
     org = snapshot.org or "unknown"
@@ -664,8 +664,31 @@ def _codex_session_id_from_path(path: Path) -> str | None:
     return stem or None
 
 
+def _is_default_codex_bucket(snapshot: RateLimitSnapshot) -> bool:
+    """Whether a snapshot is the default account-wide Codex bucket.
+
+    ``limit_id`` absent or ``"codex"`` (case-insensitive) is the default plan
+    meter; any other id is a distinct quota bucket (model-specific / Spark /
+    premium). The match is case-insensitive so a provider casing variant
+    (``"Codex"``) is not wrongly forked into its own stream, orphaning the
+    legacy default series (adversarial-review finding).
+    """
+
+    limit_id = snapshot.limit_id
+    return limit_id is None or limit_id.strip().lower() == "codex"
+
+
 def _read_codex_file_latest_rate_limits(path: Path) -> RateLimitSnapshot | None:
-    """Latest ``rate_limits`` snapshot in one rollout file (chronological), or None."""
+    """The file's latest DEFAULT-bucket ``rate_limits`` snapshot, or None.
+
+    Deliberately keeps the last snapshot whose ``limit_id`` is the default
+    account bucket, NOT the last snapshot of any bucket. A rollout interleaves
+    lines from every bucket the session touched, so the chronologically-last
+    line can be a non-default bucket (e.g. a Spark turn); returning that as the
+    account-wide meter would mislabel a model-specific quota as "the codex plan"
+    (adversarial-review finding). Non-default buckets are recorded on their own
+    streams elsewhere; this reader feeds the single account meter.
+    """
 
     latest: RateLimitSnapshot | None = None
     try:
@@ -695,8 +718,8 @@ def _read_codex_file_latest_rate_limits(path: Path) -> RateLimitSnapshot | None:
                     )
                 except Exception:  # noqa: BLE001 - one poison line must not abort the file/scan.
                     continue
-                if snapshot is not None:
-                    latest = snapshot  # file is chronological; keep the last
+                if snapshot is not None and _is_default_codex_bucket(snapshot):
+                    latest = snapshot  # file is chronological; keep the last default-bucket line
     except OSError:
         return None
     return latest
@@ -718,11 +741,14 @@ def read_codex_rate_limits_latest(
     behaviour) could therefore surface a stale, replayed snapshot as "latest".
 
     Filesystem mtime is not rewritten by replay: the active session's file is
-    the most-recently-modified, and its LAST chronological ``rate_limits`` line
-    is the genuine current state (replayed payloads sit in the copied prefix,
-    never after the live turns). So we walk files newest-mtime first and return
-    the first that yields a snapshot. Returns ``None`` if no rollout carries
-    rate limits.
+    the most-recently-modified, and its LAST chronological DEFAULT-bucket
+    ``rate_limits`` line is the genuine current account meter (replayed payloads
+    sit in the copied prefix, never after the live turns). So we walk files
+    newest-mtime first and return the first that yields a default-bucket
+    snapshot. Only the DEFAULT account bucket feeds this account meter — a file
+    whose last line is a non-default bucket (a Spark/model-specific turn) does
+    not mislabel that bucket as the account plan. Returns ``None`` if no rollout
+    carries a default-bucket rate-limit line.
     """
 
     rollouts: list[Path] = []
@@ -740,7 +766,9 @@ def read_codex_rate_limits_latest(
         except OSError:
             return 0.0
 
-    rollouts.sort(key=_mtime, reverse=True)
+    # Secondary key (path) makes an exact-mtime tie deterministic instead of
+    # depending on filesystem iteration order (adversarial-review finding).
+    rollouts.sort(key=lambda p: (_mtime(p), str(p)), reverse=True)
     for path in rollouts[: max(1, max_files)]:
         try:
             snapshot = _read_codex_file_latest_rate_limits(path)

--- a/src/agentacct/rate_limits.py
+++ b/src/agentacct/rate_limits.py
@@ -130,6 +130,13 @@ class RateLimitSnapshot:
     org: str | None = None
     source_session_id: str | None = None
     source_file: str | None = None
+    # Codex quota-bucket identity. Different ``limit_id`` values are DIFFERENT
+    # quota buckets (default account bucket vs model-specific / Spark / rare
+    # buckets) and must never be merged into one time series — see
+    # ``snapshot_run_id``. ``limit_name`` is a mutable display label, kept for
+    # provenance but never used as identity.
+    limit_id: str | None = None
+    limit_name: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +261,10 @@ def normalize_codex_rate_limits(
         reached_type=_str_or_none(rate_limits.get("rate_limit_reached_type")),
         source_session_id=session_id,
         source_file=source_file,
+        # limit_id / limit_name live at the rate_limits top level (not per
+        # window); preserve them so buckets stay distinct streams.
+        limit_id=_str_or_none(rate_limits.get("limit_id")),
+        limit_name=_str_or_none(rate_limits.get("limit_name")),
     )
 
 
@@ -367,13 +378,23 @@ def normalize_claude_statusline(
 def snapshot_run_id(snapshot: RateLimitSnapshot) -> str:
     """A stable per-stream run_id.
 
-    Codex limits are account-wide, so all codex snapshots share one run_id; the
-    Claude desktop plan-usage series is per-org; the terminal-CLI statusLine feed
-    is its own stream. All are stable across scans so consecutive unchanged
-    snapshots collapse to one recorded event.
+    Codex quota buckets are keyed by ``limit_id``: the default account bucket
+    keeps the legacy ``CODEX_RUN_ID`` stream, but any OTHER ``limit_id``
+    (model-specific / Spark / rare buckets) gets its own stream so a bucket with
+    a different quota can never contaminate the default series' transition
+    history (adversarial-review finding: two buckets sharing a window duration
+    were merged into one meter). The Claude desktop plan-usage series is
+    per-org; the terminal-CLI statusLine feed is its own stream. All are stable
+    across scans so consecutive unchanged snapshots collapse to one event.
     """
 
     if snapshot.origin == ORIGIN_CODEX_SESSION or snapshot.client == "codex":
+        limit_id = snapshot.limit_id
+        # "codex" is the default account-wide bucket — keep its legacy stream id
+        # so this fix does not fork the existing healthy series. Only non-default
+        # buckets branch into their own stream.
+        if limit_id and limit_id != "codex":
+            return f"{CODEX_RUN_ID}:{limit_id}"
         return CODEX_RUN_ID
     if snapshot.origin == ORIGIN_CLAUDE_STATUSLINE:
         return CLAUDE_STATUSLINE_RUN_ID
@@ -440,6 +461,11 @@ def snapshot_to_event(snapshot: RateLimitSnapshot) -> dict[str, Any]:
         "org": snapshot.org,
         "source_client_session_id": snapshot.source_session_id,
         "source_file": snapshot.source_file,
+        # Bucket identity, persisted so a future per-epoch calibrator can keep
+        # buckets distinct (§7.2 recording foundation). limit_id is identity;
+        # limit_name is a mutable display label kept only for provenance.
+        "limit_id": snapshot.limit_id,
+        "limit_name": snapshot.limit_name,
         "state_signature": snapshot_state_signature(snapshot),
     }
     return {
@@ -683,10 +709,20 @@ def read_codex_rate_limits_latest(
 ) -> RateLimitSnapshot | None:
     """The freshest account-wide Codex limit snapshot from recent session files.
 
-    Scans the ``max_files`` most-recently-modified rollout files across every
-    resolved codex root (the active session's file carries the newest limits) and
-    returns the snapshot with the latest ``captured_at``. Returns ``None`` if no
-    rollout carries rate limits.
+    Selection is by **file modification time**, not the rollout's outer
+    ``timestamp``. The outer timestamp is untrustworthy for freshness: a
+    fork/replay copies history into a NEW file and the recorder stamps each
+    copied ``TokenCount`` with a fresh ``now_utc()``, so a replayed OLD limit
+    payload can carry a numerically LARGER outer timestamp than the genuine
+    current one. Picking the global max over that timestamp (the previous
+    behaviour) could therefore surface a stale, replayed snapshot as "latest".
+
+    Filesystem mtime is not rewritten by replay: the active session's file is
+    the most-recently-modified, and its LAST chronological ``rate_limits`` line
+    is the genuine current state (replayed payloads sit in the copied prefix,
+    never after the live turns). So we walk files newest-mtime first and return
+    the first that yields a snapshot. Returns ``None`` if no rollout carries
+    rate limits.
     """
 
     rollouts: list[Path] = []
@@ -705,20 +741,14 @@ def read_codex_rate_limits_latest(
             return 0.0
 
     rollouts.sort(key=_mtime, reverse=True)
-    best: RateLimitSnapshot | None = None
-    best_key = float("-inf")
     for path in rollouts[: max(1, max_files)]:
         try:
             snapshot = _read_codex_file_latest_rate_limits(path)
         except Exception:  # noqa: BLE001 - fail soft per the module contract.
             continue
-        if snapshot is None:
-            continue
-        key = snapshot.captured_at if snapshot.captured_at is not None else 0.0
-        if key > best_key:
-            best = snapshot
-            best_key = key
-    return best
+        if snapshot is not None:
+            return snapshot
+    return None
 
 
 def read_claude_plan_usage_latest(

--- a/src/agentacct/rate_limits.py
+++ b/src/agentacct/rate_limits.py
@@ -686,8 +686,13 @@ def _read_codex_file_latest_rate_limits(path: Path) -> RateLimitSnapshot | None:
     lines from every bucket the session touched, so the chronologically-last
     line can be a non-default bucket (e.g. a Spark turn); returning that as the
     account-wide meter would mislabel a model-specific quota as "the codex plan"
-    (adversarial-review finding). Non-default buckets are recorded on their own
-    streams elsewhere; this reader feeds the single account meter.
+    (adversarial-review finding).
+
+    Non-default buckets are currently DROPPED — this reader is the only producer
+    of recorded codex limit snapshots, so today only the default account meter
+    is recorded and shown. The ``limit_id`` preservation and the per-bucket
+    ``snapshot_run_id`` branch are forward-compat scaffolding for a future
+    per-bucket reader/calibrator (§7.2); they are not yet fed by any live path.
     """
 
     latest: RateLimitSnapshot | None = None

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -289,6 +289,34 @@ def test_read_codex_latest_ignores_rewritten_outer_timestamp(tmp_path):
     assert snap.plan_type == "pro"
 
 
+def test_read_codex_latest_ignores_nondefault_bucket_last_line(tmp_path):
+    """The account meter is the DEFAULT bucket, even when a file's last
+    rate_limits line is a non-default bucket. A rollout interleaves lines from
+    every bucket the session touched; if the last billable turn ran on a
+    model-specific / Spark bucket, returning that line would mislabel a distinct
+    quota as 'the codex plan' (adversarial-review finding)."""
+    home = tmp_path / "codex"
+    d = home / "sessions" / "2026" / "07" / "29"
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "rollout-mixed.jsonl"
+    lines = [
+        # default bucket at 61% earlier in the file...
+        {"timestamp": "2026-07-29T09:00:00.000Z", "payload": {"type": "token_count",
+            "info": {"total_token_usage": {"total_tokens": 1}},
+            "rate_limits": {"limit_id": "codex", "secondary": {"used_percent": 61.0, "window_minutes": 10080, "resets_at": 5}, "plan_type": "pro"}}},
+        # ...then a Spark bucket line is chronologically LAST.
+        {"timestamp": "2026-07-29T09:05:00.000Z", "payload": {"type": "token_count",
+            "info": {"total_token_usage": {"total_tokens": 1}},
+            "rate_limits": {"limit_id": "codex_bengalfox", "limit_name": "GPT-5.3-Codex-Spark", "secondary": {"used_percent": 4.0, "window_minutes": 10080, "resets_at": 9}}}},
+    ]
+    f.write_text("\n".join(json.dumps(x) for x in lines) + "\n", encoding="utf-8")
+    snap = rl.read_codex_rate_limits_latest(home)
+    assert snap is not None
+    assert snap.limit_id == "codex"  # the default account bucket, not Spark
+    assert snap.windows[0].used_percent == 61.0
+    assert rl.snapshot_run_id(snap) == rl.CODEX_RUN_ID  # single account stream
+
+
 def test_read_codex_rate_limits_missing_root(tmp_path):
     assert rl.read_codex_rate_limits_latest(tmp_path / "no-codex") is None
 

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -40,6 +40,57 @@ def test_normalize_codex_full_object():
     assert kinds["5h"].window_minutes == 300
     # ISO-8601 with a trailing Z parses to a real epoch.
     assert snap.captured_at is not None and snap.captured_at > 1_700_000_000
+    # limit_id / limit_name (top-level bucket identity) are preserved.
+    assert snap.limit_id == "codex"
+    assert snap.limit_name is None
+
+
+def test_normalize_codex_preserves_nondefault_bucket_identity():
+    """A model-specific / Spark bucket keeps its own limit_id + limit_name."""
+    raw = {
+        "limit_id": "gpt-5-spark",
+        "limit_name": "GPT-5 Spark",
+        "secondary": {"used_percent": 3.0, "window_minutes": 10080, "resets_at": 9},
+        "plan_type": "pro",
+    }
+    snap = rl.normalize_codex_rate_limits(raw)
+    assert snap is not None
+    assert snap.limit_id == "gpt-5-spark"
+    assert snap.limit_name == "GPT-5 Spark"
+
+
+def test_run_id_segregates_nondefault_codex_buckets():
+    """Different limit_id = different quota bucket = different stream. The
+    default 'codex' bucket keeps the legacy run_id (no migration churn); any
+    other bucket branches into its own stream so it can't contaminate the
+    default series' transition history."""
+    default = rl.normalize_codex_rate_limits(
+        {"limit_id": "codex", "secondary": {"used_percent": 40.0, "window_minutes": 10080}}
+    )
+    spark = rl.normalize_codex_rate_limits(
+        {"limit_id": "gpt-5-spark", "secondary": {"used_percent": 40.0, "window_minutes": 10080}}
+    )
+    missing = rl.normalize_codex_rate_limits(
+        {"secondary": {"used_percent": 40.0, "window_minutes": 10080}}
+    )
+    assert rl.snapshot_run_id(default) == rl.CODEX_RUN_ID
+    assert rl.snapshot_run_id(missing) == rl.CODEX_RUN_ID  # absent id → legacy stream
+    assert rl.snapshot_run_id(spark) == f"{rl.CODEX_RUN_ID}:gpt-5-spark"
+    assert rl.snapshot_run_id(spark) != rl.snapshot_run_id(default)
+    # Same window state, different bucket → different state signatures, so the
+    # transition dedup never collapses two buckets into one meter.
+    assert rl.snapshot_state_signature(spark) != rl.snapshot_state_signature(default)
+
+
+def test_snapshot_to_event_carries_bucket_identity():
+    snap = rl.normalize_codex_rate_limits(
+        {"limit_id": "gpt-5-spark", "limit_name": "GPT-5 Spark",
+         "secondary": {"used_percent": 3.0, "window_minutes": 10080}}
+    )
+    event = rl.snapshot_to_event(snap)
+    assert event["metadata"]["limit_id"] == "gpt-5-spark"
+    assert event["metadata"]["limit_name"] == "GPT-5 Spark"
+    assert event["run_id"] == f"{rl.CODEX_RUN_ID}:gpt-5-spark"
 
 
 def test_normalize_codex_rejects_empty_and_malformed():
@@ -203,6 +254,39 @@ def test_read_codex_rate_limits_latest_picks_freshest(tmp_path):
     assert snap is not None
     assert snap.plan_type == "pro"
     assert snap.windows[0].used_percent == 88.0  # the later-captured file won
+
+
+def test_read_codex_latest_ignores_rewritten_outer_timestamp(tmp_path):
+    """The replay bug: a fork copies history into a new file and the recorder
+    stamps each copied TokenCount with a fresh now_utc(), so a REPLAYED old
+    limit payload can carry a LATER outer timestamp than the genuine current
+    one. Selection must go by file mtime (which replay does not rewrite), not by
+    the outer timestamp — else a stale, replayed snapshot surfaces as 'latest'.
+    """
+    import os
+
+    home = tmp_path / "codex"
+    # The genuine active file: current state (55%), but an EARLIER outer stamp.
+    active = _write_codex_rollout(
+        home, "29", "active",
+        timestamp="2026-07-29T09:00:00.000Z",
+        rate_limits={"limit_id": "codex", "secondary": {"used_percent": 55.0, "window_minutes": 10080, "resets_at": 5}, "plan_type": "pro"},
+    )
+    # A fork/replay file: stale value (10%) but a LATER (rewritten) outer stamp.
+    replay = _write_codex_rollout(
+        home, "28", "replay",
+        timestamp="2026-07-30T23:00:00.000Z",  # numerically newer, but rewritten
+        rate_limits={"limit_id": "codex", "secondary": {"used_percent": 10.0, "window_minutes": 10080, "resets_at": 1}},
+    )
+    # Force filesystem truth: the active file is genuinely the most recent write.
+    os.utime(replay, (1_785_000_000, 1_785_000_000))   # older mtime
+    os.utime(active, (1_785_600_000, 1_785_600_000))   # newer mtime
+    snap = rl.read_codex_rate_limits_latest(home)
+    assert snap is not None
+    # mtime wins: the genuine current 55%, NOT the replayed 10% with the newer
+    # (rewritten) outer timestamp.
+    assert snap.windows[0].used_percent == 55.0
+    assert snap.plan_type == "pro"
 
 
 def test_read_codex_rate_limits_missing_root(tmp_path):


### PR DESCRIPTION
Two data-identity defects in the Codex rate-limit foundation, surfaced by a codex-authored study of the `~/.codex` rate-limit semantics. Both block reliable Codex limit tracking and any future calibration.

## 1. Cross-bucket contamination

`normalize_codex_rate_limits` dropped the `rate_limits` top-level `limit_id`/`limit_name`, and `snapshot_run_id` keyed every codex snapshot to one account-wide stream (`CODEX_RUN_ID`). Different `limit_id` values are different quota buckets (the default account bucket vs model-specific / Spark / rare buckets) and were being merged into a single time series, corrupting transition history.

- Preserve `limit_id`/`limit_name` through the snapshot.
- Branch any **non-default** bucket into its own `run_id` (`codex_rate_limit:<limit_id>`) and state signature. The default `codex` bucket keeps its legacy stream id, so the existing healthy series is not forked (no migration churn).

## 2. Rewritten-timestamp trust

`read_codex_rate_limits_latest` selected the snapshot with the maximum **outer rollout timestamp**. But a fork/replay copies history into a new file and the recorder stamps each copied `TokenCount` with a fresh `now_utc()` — so a replayed OLD limit payload can carry a numerically LATER outer timestamp than the genuine current one and surface as "latest".

- Select by **filesystem mtime** instead (replay does not rewrite it): the active session's file is the most-recently-modified, and its last `rate_limits` line is the true current state (replayed payloads sit in the copied prefix, never after live turns).

## Recording foundation

`limit_id`/`limit_name` are now persisted into the recorded event metadata, unblocking a future per-epoch calibrator.

## On computing a Codex plan %

A calibrated weekly-plan % for Codex stays **undefined by design**. The study's verdict: an exact per-session share is not identifiable from a rolling meter without fresh authenticated reads and controlled calibration. This PR fixes the identity foundation the study says must come first; the estimator itself is future work gated on collecting fresh reads.

## Verification

- New regression tests: bucket-identity preservation, non-default-bucket stream segregation, event metadata carries `limit_id`, and — the key one — a replay scenario where a file with a LATER outer timestamp but OLDER mtime must NOT win (proves selection is mtime-based).
- Full suite: 2915 passed, 1 skipped.
- Read-only live check: on current `~/.codex` data old and new selection agree (no active replay contamination right now); the fix removes the latent failure mode.
