### PR TITLE
fix(sessions): complete a session's model list from usage when instrumentation is thin

### DIFF
--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -151,6 +151,47 @@ def _fold_parent_key(
     return None
 
 
+def _observed_models_with_usage_fallback(
+    instrumented: Any, usage: Any
+) -> list[str] | None:
+    """The session's model list, completed from usage when instrumentation is
+    thin.
+
+    ``observed_models`` is sourced from the recording hook's section metadata,
+    which is often empty even when the session demonstrably used models. The
+    usage records are the authoritative token source and always carry the model
+    (``identity_models`` / ``model_lanes``). Union the two — instrumentation
+    order first, then any usage model not already listed — so a multi-model
+    session (e.g. one that switched models mid-run) shows every model it used at
+    the row level instead of a blank. Returns ``None`` when neither source has a
+    model, so the wire stays null-not-empty.
+    """
+
+    models: list[str] = []
+    seen: set[str] = set()
+
+    def _add(name: Any) -> None:
+        text = str(name or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            models.append(text)
+
+    if isinstance(instrumented, list):
+        for name in instrumented:
+            _add(name)
+    if isinstance(usage, dict):
+        identity = usage.get("identity_models")
+        if isinstance(identity, list):
+            for name in identity:
+                _add(name)
+        lanes = usage.get("model_lanes")
+        if isinstance(lanes, list):
+            for lane in lanes:
+                if isinstance(lane, dict):
+                    _add(lane.get("model"))
+    return models or None
+
+
 def _project_entry(entry: dict[str, Any]) -> dict[str, Any]:
     """The curated wire row for one rollup entry (plan fields joined later).
 
@@ -196,7 +237,9 @@ def _project_entry(entry: dict[str, Any]) -> dict[str, Any]:
         "instrumentation_state": entry.get("instrumentation_state"),
         "instrumentation_state_basis": entry.get("instrumentation_state_basis"),
         "instrumentation_installed_at": entry.get("instrumentation_installed_at"),
-        "observed_models": entry.get("observed_models"),
+        "observed_models": _observed_models_with_usage_fallback(
+            entry.get("observed_models"), entry.get("usage")
+        ),
         "usage": entry.get("usage"),
         "usage_note": entry.get("usage_note"),
         "join": entry.get("join"),

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -902,6 +902,34 @@ def test_detail_descendants_and_plan_block(tmp_path):
     assert abs(child["plan_pct"] - 5.0 * opus * scale) < 1e-6
 
 
+def test_observed_models_falls_back_and_unions_with_usage():
+    """A session's model list is completed from the authoritative usage records
+    when the instrumentation-sourced observed_models is thin — so a multi-model
+    (e.g. mid-run model switch) session never shows a blank at the row level."""
+
+    from agentacct.v1_sessions import _observed_models_with_usage_fallback
+
+    usage = {
+        "identity_models": ["claude-opus-4-8", "claude-fable-5"],
+        "model_lanes": [
+            {"model": "claude-fable-5"},
+            {"model": "claude-opus-4-8"},
+            {"model": "claude-haiku-4-5-20251001"},
+        ],
+    }
+    # Empty instrumentation → the models come entirely from usage.
+    got = _observed_models_with_usage_fallback([], usage)
+    assert got == ["claude-opus-4-8", "claude-fable-5", "claude-haiku-4-5-20251001"]
+
+    # Instrumentation order is preserved first; usage adds only what's missing.
+    got2 = _observed_models_with_usage_fallback(["claude-fable-5"], usage)
+    assert got2 == ["claude-fable-5", "claude-opus-4-8", "claude-haiku-4-5-20251001"]
+
+    # No models anywhere → null-not-empty on the wire.
+    assert _observed_models_with_usage_fallback(None, None) is None
+    assert _observed_models_with_usage_fallback([], {"identity_models": []}) is None
+
+
 def test_step_models_join_unit():
     """The attribution join, in isolation: tokens come from the attribution
     rows, dangling usage events are skipped, a KNOWN event without a model


### PR DESCRIPTION
The session row's `observed_models` is sourced only from the recording hook's section metadata, which is frequently empty even when the session demonstrably used models. The app renders a per-row model chip from this field (`SessionsPane.swift`), so it showed nothing — most visibly for multi-model sessions.

Surfaced while investigating mid-session model-switch accuracy: the plan/cost accounting is per-record-model and correct (a session that went fable-5 → opus-4.8 shows both models in `by_model` and `usage.model_lanes` with correct splits), but the row's `observed_models` label was blank because it ignored the authoritative usage models.

## Change

`observed_models` is now the union of the instrumentation-sourced list and the usage records' models (`identity_models` / `model_lanes`), instrumentation order first. Null-not-empty when neither source has a model. Display-only — `observed_models` never feeds plan/cost math.

## Verification

- Unit test covers empty-instrumentation fallback, order-preserving union, and the null-not-empty edge.
- Full suite: 2912 passed, 1 skipped.
