### PR TITLE
feat(app): self-contained installer app — frozen CLI + one-click onboard

### DIFF
--- a/apps/agentacct/Scripts/build-app.sh
+++ b/apps/agentacct/Scripts/build-app.sh
@@ -16,6 +16,19 @@ rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS"
 cp ".build/release/agentacct" "$APP/Contents/MacOS/agentacct"
 
+# Embed the frozen standalone CLI when it has been built (packaging/freeze-cli.sh
+# writes packaging/dist/agentacct/). This is what lets a machine with no Python
+# run the MCP server + daemon: the app installs this into ~/.local/share on
+# first setup. Dev builds skip it (fast); the DMG build always freezes first.
+FROZEN_CLI="$(cd ../.. && pwd)/packaging/dist/agentacct"
+if [[ -d "$FROZEN_CLI" ]]; then
+    mkdir -p "$APP/Contents/Resources"
+    ditto "$FROZEN_CLI" "$APP/Contents/Resources/cli"
+    echo "embedded frozen CLI: Contents/Resources/cli ($(du -sh "$APP/Contents/Resources/cli" | awk '{print $1}'))"
+else
+    echo "note: no frozen CLI at $FROZEN_CLI — app built without the embedded installer (run packaging/freeze-cli.sh for a distributable build)"
+fi
+
 cat > "$APP/Contents/Info.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -13,10 +13,12 @@ struct MainWindow: View {
     @EnvironmentObject var dashboard: DashboardStore
     @EnvironmentObject var glance: GlanceState
     @EnvironmentObject var selection: AppSelection
+    @StateObject private var setup = SetupModel()
+    @State private var showSetup = false
 
     var body: some View {
         VStack(spacing: 0) {
-            TopBar()
+            TopBar(canSetUp: setup.bundledCLIDir != nil) { showSetup = true }
             Rectangle().fill(Theme.border).frame(height: 1)
             Group {
                 switch selection.pane {
@@ -30,7 +32,14 @@ struct MainWindow: View {
         }
         .background(Theme.bg)
         .frame(minWidth: 960, minHeight: 560)
+        .sheet(isPresented: $showSetup) {
+            SetupSheet(setup: setup) { showSetup = false }
+        }
         .task {
+            // First-run: a packaged build whose recorder isn't installed yet
+            // offers setup once, automatically. A dev build (no embedded CLI)
+            // never prompts.
+            if !SnapshotMode.enabled, setup.shouldOfferSetup { showSetup = true }
             await dashboard.refresh()
             // The window is a live instrument: refresh while it stays open
             // (the daemon caches by fingerprint, so a quiet minute is one
@@ -62,6 +71,9 @@ struct MainWindow: View {
 struct TopBar: View {
     @EnvironmentObject var dashboard: DashboardStore
     @EnvironmentObject var selection: AppSelection
+    /// Packaged build → show the "Set up recording" entry point.
+    var canSetUp: Bool = false
+    var onSetUp: () -> Void = {}
 
     var body: some View {
         HStack(spacing: 14) {
@@ -85,6 +97,17 @@ struct TopBar: View {
 
             Spacer()
 
+            if canSetUp {
+                Button(action: onSetUp) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "sparkles")
+                        Text("Set up recording").font(.system(size: 11, weight: .medium))
+                    }
+                    .foregroundStyle(Theme.accent)
+                }
+                .buttonStyle(.plain)
+                .help("Install the recorder and configure your coding agents")
+            }
             if let updated = dashboard.lastUpdated {
                 Text(updated, style: .relative)
                     .font(.system(size: 10.5))

--- a/apps/agentacct/Sources/agentacct/SetupModel.swift
+++ b/apps/agentacct/Sources/agentacct/SetupModel.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+// The one-click "Set up recording" flow for the packaged app: install the
+// embedded standalone CLI to a stable location and run its `onboard` so a
+// machine with no Python gets the MCP servers, hooks, and standing instructions
+// configured for its coding agents. This is the exact CLI install flow
+// (`agentacct onboard`) the docs describe — the app just drives it for a user
+// who never opens a terminal. Idempotent: re-running is safe.
+//
+// Layout (matches the validated install simulation):
+//   ~/.local/share/agentacct/cli/     <- the onedir CLI (binary + _internal)
+//   ~/.local/bin/agentacct            <- a wrapper on PATH -> the real binary
+// onboard, run from the installed binary, writes that stable installed path
+// into every hook/MCP config, so an app upgrade that replaces the CLI in place
+// keeps every registration valid.
+
+@MainActor
+final class SetupModel: ObservableObject {
+    enum Phase: Equatable {
+        case idle
+        case working(String)   // a short status line
+        case done
+        case failed(String)
+    }
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var log: [String] = []
+
+    private let fm = FileManager.default
+
+    // MARK: locations
+
+    /// The CLI embedded in the app bundle (Contents/Resources/cli), if this is
+    /// a packaged build. nil for a dev app built without the frozen CLI.
+    var bundledCLIDir: URL? {
+        guard let res = Bundle.main.resourceURL else { return nil }
+        let dir = res.appendingPathComponent("cli", isDirectory: true)
+        return fm.fileExists(atPath: dir.appendingPathComponent("agentacct").path) ? dir : nil
+    }
+
+    private var home: URL { fm.homeDirectoryForCurrentUser }
+    private var installedCLIDir: URL { home.appendingPathComponent(".local/share/agentacct/cli", isDirectory: true) }
+    private var installedBinary: URL { installedCLIDir.appendingPathComponent("agentacct") }
+    private var binDir: URL { home.appendingPathComponent(".local/bin", isDirectory: true) }
+    private var wrapper: URL { binDir.appendingPathComponent("agentacct") }
+
+    /// True once the CLI has been installed to the stable location by this app.
+    var isCLIInstalled: Bool { fm.isExecutableFile(atPath: installedBinary.path) }
+
+    /// Show the first-run setup prompt only when we CAN install (packaged
+    /// build) and haven't yet. A dev build (no embedded CLI) never prompts.
+    var shouldOfferSetup: Bool { bundledCLIDir != nil && !isCLIInstalled }
+
+    // MARK: run
+
+    func setUp() async {
+        guard case .idle = phase else { return }
+        log = []
+        do {
+            try installCLI()
+            try await runOnboard()
+            phase = .done
+        } catch {
+            phase = .failed(error.localizedDescription)
+            append("error: \(error.localizedDescription)")
+        }
+    }
+
+    func reset() { phase = .idle }
+
+    // MARK: steps
+
+    private func installCLI() throws {
+        guard let bundled = bundledCLIDir else {
+            throw SetupError.noEmbeddedCLI
+        }
+        phase = .working("Installing the recorder…")
+        append("Installing CLI to ~/.local/share/agentacct/cli")
+        try fm.createDirectory(at: installedCLIDir.deletingLastPathComponent(),
+                               withIntermediateDirectories: true)
+        if fm.fileExists(atPath: installedCLIDir.path) {
+            try fm.removeItem(at: installedCLIDir)  // replace in place on upgrade
+        }
+        try fm.copyItem(at: bundled, to: installedCLIDir)
+
+        // Wrapper on PATH so the user can run `agentacct` in a terminal too. A
+        // script (not a symlink) is bulletproof for a onedir PyInstaller binary,
+        // which resolves its _internal/ next to the real executable.
+        try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let script = "#!/bin/sh\nexec \"\(installedBinary.path)\" \"$@\"\n"
+        try script.write(to: wrapper, atomically: true, encoding: .utf8)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wrapper.path)
+        append("Wrote ~/.local/bin/agentacct")
+    }
+
+    private func runOnboard() async throws {
+        phase = .working("Configuring your coding agents…")
+        append("Running: agentacct onboard --agent auto --yes")
+        // Run from the INSTALLED binary so onboard stamps the stable installed
+        // path into every hook/MCP config (verified end-to-end).
+        let stream = try ProcessRunner.run(
+            executable: installedBinary,
+            arguments: ["onboard", "--agent", "auto", "--yes"]
+        )
+        for await line in stream {
+            append(line)
+        }
+    }
+
+    private func append(_ line: String) {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        log.append(trimmed)
+        if log.count > 200 { log.removeFirst(log.count - 200) }
+    }
+
+    enum SetupError: LocalizedError {
+        case noEmbeddedCLI
+        var errorDescription: String? {
+            switch self {
+            case .noEmbeddedCLI:
+                return "This build has no embedded CLI. Install agentacct with `pipx install agentacct` instead."
+            }
+        }
+    }
+}
+
+// MARK: - subprocess helper
+
+enum ProcessRunner {
+    /// Launch a process and yield its merged stdout+stderr line by line. The
+    /// AsyncStream finishes when the process exits.
+    static func run(executable: URL, arguments: [String]) throws -> AsyncStream<String> {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        // A frozen binary resolves its own paths; keep the user's environment
+        // (HOME, PATH) so onboard writes to the real ~/.claude, ~/.codex.
+        process.environment = ProcessInfo.processInfo.environment
+
+        return AsyncStream<String> { continuation in
+            let handle = pipe.fileHandleForReading
+            var buffer = Data()
+            handle.readabilityHandler = { fh in
+                let chunk = fh.availableData
+                if chunk.isEmpty {
+                    if !buffer.isEmpty, let tail = String(data: buffer, encoding: .utf8) {
+                        continuation.yield(tail)
+                    }
+                    return
+                }
+                buffer.append(chunk)
+                while let nl = buffer.firstIndex(of: 0x0A) {
+                    let lineData = buffer.subdata(in: buffer.startIndex..<nl)
+                    buffer.removeSubrange(buffer.startIndex...nl)
+                    if let line = String(data: lineData, encoding: .utf8) {
+                        continuation.yield(line)
+                    }
+                }
+            }
+            process.terminationHandler = { _ in
+                handle.readabilityHandler = nil
+                continuation.finish()
+            }
+            do {
+                try process.run()
+            } catch {
+                continuation.yield("failed to launch: \(error.localizedDescription)")
+                continuation.finish()
+            }
+        }
+    }
+}

--- a/apps/agentacct/Sources/agentacct/SetupModel.swift
+++ b/apps/agentacct/Sources/agentacct/SetupModel.swift
@@ -144,12 +144,20 @@ enum ProcessRunner {
         return AsyncStream<String> { continuation in
             let handle = pipe.fileHandleForReading
             var buffer = Data()
+            let drainTail: () -> Void = {
+                if !buffer.isEmpty, let tail = String(data: buffer, encoding: .utf8) {
+                    continuation.yield(tail)
+                }
+                buffer.removeAll()
+            }
             handle.readabilityHandler = { fh in
                 let chunk = fh.availableData
                 if chunk.isEmpty {
-                    if !buffer.isEmpty, let tail = String(data: buffer, encoding: .utf8) {
-                        continuation.yield(tail)
-                    }
+                    // EOF: yield any unterminated tail once and STOP — leaving the
+                    // handler installed would busy-spin on repeated empty reads and
+                    // re-yield the same tail every tick.
+                    drainTail()
+                    fh.readabilityHandler = nil
                     return
                 }
                 buffer.append(chunk)
@@ -162,6 +170,10 @@ enum ProcessRunner {
                 }
             }
             process.terminationHandler = { _ in
+                // Finish the stream. `buffer` is deliberately NOT touched here —
+                // it is owned by the readability queue, and the EOF read above
+                // drains the final tail; racing it from this queue would be a
+                // data race for a log-only line. Post-finish yields are ignored.
                 handle.readabilityHandler = nil
                 continuation.finish()
             }

--- a/apps/agentacct/Sources/agentacct/SetupSheet.swift
+++ b/apps/agentacct/Sources/agentacct/SetupSheet.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+// The one-click setup surface. Non-developers download the app and press one
+// button; this installs the embedded recorder and configures their coding
+// agents (MCP servers, hooks, standing instructions) — the same `agentacct
+// onboard` the CLI docs describe, driven from a window instead of a terminal.
+
+struct SetupSheet: View {
+    @ObservedObject var setup: SetupModel
+    var onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Space.l) {
+            HStack(spacing: 9) {
+                Circle().fill(Theme.accent.gradient).frame(width: 10, height: 10)
+                Text("Set up recording")
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    .foregroundStyle(Theme.text)
+                Spacer()
+            }
+
+            Text("agentacct records what your coding agents actually do — the work, not just tokens — for this local dashboard. This installs the recorder and configures the agents you have.")
+                .font(Type.body)
+                .foregroundStyle(Theme.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                SetupBullet(text: "Installs a self-contained recorder to ~/.local (no Python needed).")
+                SetupBullet(text: "Registers agentacct with Claude Code, Codex, and other MCP agents.")
+                SetupBullet(text: "Adds the recording hooks and a short \u{201C}record your work\u{201D} instruction. Your own settings are never overwritten.")
+                SetupBullet(text: "Everything stays on this machine. No API keys, no uploads.")
+            }
+
+            if !setup.log.isEmpty {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(Array(setup.log.enumerated()), id: \.offset) { i, line in
+                                Text(line)
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundStyle(Theme.textMuted)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .id(i)
+                            }
+                        }
+                        .padding(8)
+                    }
+                    .frame(height: 150)
+                    .background(Theme.surface, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(Theme.border, lineWidth: 1))
+                    .onChange(of: setup.log.count) {
+                        withAnimation { proxy.scrollTo(setup.log.count - 1, anchor: .bottom) }
+                    }
+                }
+            }
+
+            footer
+        }
+        .padding(Space.l)
+        .frame(width: 460)
+        .background(Theme.bg)
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        switch setup.phase {
+        case .idle:
+            HStack {
+                Button("Not now", action: onClose).buttonStyle(.plain).foregroundStyle(Theme.textMuted)
+                Spacer()
+                Button {
+                    Task { await setup.setUp() }
+                } label: {
+                    Text("Set up recording").fontWeight(.semibold)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+            }
+        case .working(let status):
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text(status).font(Type.small).foregroundStyle(Theme.textMuted)
+                Spacer()
+            }
+        case .done:
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 7) {
+                    Image(systemName: "checkmark.circle.fill").foregroundStyle(Theme.green)
+                    Text("Recording is configured.").font(Type.body.weight(.medium)).foregroundStyle(Theme.text)
+                }
+                Text("Open a NEW agent session (in any project) so it picks up the tools and hooks — the session that ran setup can't see them yet.")
+                    .font(Type.small).foregroundStyle(Theme.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack { Spacer(); Button("Done", action: onClose).buttonStyle(.borderedProminent).tint(Theme.accent) }
+            }
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 7) {
+                    Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(Theme.orange)
+                    Text("Setup didn't finish").font(Type.body.weight(.medium)).foregroundStyle(Theme.text)
+                }
+                Text(message).font(Type.small).foregroundStyle(Theme.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack {
+                    Button("Close", action: onClose).buttonStyle(.plain).foregroundStyle(Theme.textMuted)
+                    Spacer()
+                    Button("Try again") { setup.reset(); Task { await setup.setUp() } }
+                        .buttonStyle(.borderedProminent).tint(Theme.accent)
+                }
+            }
+        }
+    }
+}
+
+private struct SetupBullet: View {
+    let text: String
+    var body: some View {
+        HStack(alignment: .top, spacing: 7) {
+            Circle().fill(Theme.accent.opacity(0.7)).frame(width: 4, height: 4).padding(.top, 6)
+            Text(text).font(Type.small).foregroundStyle(Theme.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -1,0 +1,6 @@
+# Freeze build artifacts — never committed (rebuilt by freeze-cli.sh).
+.buildvenv/
+build/
+dist/
+*.spec
+release/

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,75 @@
+# Packaging — distributable app for non-developers
+
+This directory builds a self-contained `agentacct.app` + DMG that a
+non-developer can install without Python, pipx, or a terminal. The app embeds a
+**frozen standalone CLI** and drives the normal `agentacct onboard` from a
+one-click screen.
+
+## Why a frozen CLI
+
+The app is a GUI over the daemon; it cannot replace the CLI. The MCP servers the
+coding agents connect to (`agentacct mcp serve`), the daemon (`agentacct serve`),
+and the recording hooks are all the Python CLI. So a machine with no Python
+needs the CLI as a standalone binary. PyInstaller freezes it (interpreter and
+all) into one directory; the app ships that directory and installs it on first
+setup.
+
+The frozen binary is a drop-in for a pip/pipx `agentacct` — including the two
+Python-interpreter forms the Claude Code hooks invoke it with
+(`<cli> -m agentacct.statusline_hook`, `<cli> <hook>.py`), handled by the
+interpreter-emulation entry in `pyinstaller_entry.py`.
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `freeze-cli.sh` | Freeze the CLI to `packaging/dist/agentacct/` (onedir). Isolated build venv; smoke-tests `mcp serve` / `serve` / `onboard`. |
+| `build-dmg.sh` | Full release: freeze → build the app (embeds the CLI) → sign (if configured) → DMG → notarize (if configured). Output in `packaging/release/`. |
+| `pyinstaller_entry.py` | The frozen binary's entry point (CLI + hook-interpreter emulation). |
+| `entitlements.plist` | Hardened-runtime entitlements the embedded PyInstaller binary needs to run notarized. |
+
+`apps/agentacct/Scripts/build-app.sh` embeds `packaging/dist/agentacct/` into
+`agentacct.app/Contents/Resources/cli/` when it exists (dev builds skip it).
+
+## What the app's setup does
+
+`SetupModel` / `SetupSheet` (in the app) drive:
+
+1. Copy the embedded CLI → `~/.local/share/agentacct/cli/` (stable location; an
+   app upgrade replaces it in place, so every registration stays valid).
+2. Write a wrapper at `~/.local/bin/agentacct` (on PATH for terminal use).
+3. Run `agentacct onboard --agent auto --yes` from the installed binary — which
+   registers the MCP servers, hooks, and standing instructions and stamps the
+   stable installed path into every config.
+
+## Build a DMG now (unsigned)
+
+```bash
+bash packaging/build-dmg.sh
+# -> packaging/release/agentacct-<version>.dmg  (unsigned)
+```
+
+An unsigned DMG installs, but first launch needs right-click → Open to get past
+Gatekeeper. Fine for testing and local use.
+
+## Sign + notarize (once a Developer ID exists)
+
+No code changes — the same `build-dmg.sh` signs and notarizes when the
+environment is set:
+
+```bash
+# one-time: store notarytool credentials in the keychain
+xcrun notarytool store-credentials agentacct-notary \
+  --apple-id you@example.com --team-id TEAMID --password <app-specific-password>
+
+export DEVELOPER_ID="Developer ID Application: Your Name (TEAMID)"
+export NOTARY_PROFILE="agentacct-notary"
+bash packaging/build-dmg.sh
+# -> signed, notarized, stapled DMG that opens with a normal double-click
+```
+
+Signing is inside-out: every dylib/.so and the binary in the embedded CLI, then
+the `.app`, all with the hardened runtime + `entitlements.plist` (a frozen
+Python binary needs `disable-library-validation`, `allow-jit`, and
+`allow-unsigned-executable-memory`). Notarization eliminates the ~15s first-run
+Gatekeeper scan an unsigned binary otherwise pays.

--- a/packaging/build-dmg.sh
+++ b/packaging/build-dmg.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Build a distributable agentacct.app + DMG: freeze the CLI, build the Swift app
+# with the CLI embedded, (optionally) sign + notarize, then package a DMG.
+#
+# Signing/notarization are ENV-GATED so this same script produces:
+#   - an UNSIGNED DMG today (DEVELOPER_ID unset) — installable with a
+#     right-click-Open past Gatekeeper, fine for local/testing;
+#   - a SIGNED + NOTARIZED DMG once an Apple Developer ID exists, by exporting
+#     DEVELOPER_ID (and the notarytool creds) and re-running — no code changes.
+#
+# Required to sign+notarize (all from the Apple Developer account):
+#   export DEVELOPER_ID="Developer ID Application: Your Name (TEAMID)"
+#   export NOTARY_PROFILE="agentacct-notary"   # a stored `notarytool` keychain profile
+# (create the profile once: xcrun notarytool store-credentials agentacct-notary \
+#   --apple-id you@example.com --team-id TEAMID --password <app-specific-password>)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+APP_SRC="$REPO_ROOT/apps/agentacct/.build/agentacct.app"
+OUT_DIR="$HERE/release"
+DMG_STAGE="$OUT_DIR/dmg-stage"
+
+echo "==> [1/5] freezing the CLI"
+bash "$HERE/freeze-cli.sh"
+
+echo "==> [2/5] building the app (embeds the frozen CLI)"
+bash "$REPO_ROOT/apps/agentacct/Scripts/build-app.sh"
+[[ -d "$APP_SRC/Contents/Resources/cli" ]] || { echo "ERROR: CLI was not embedded"; exit 1; }
+
+VERSION="$("$APP_SRC/Contents/Resources/cli/agentacct" --version | awk '{print $2}')"
+echo "==> packaging agentacct $VERSION"
+
+rm -rf "$OUT_DIR"; mkdir -p "$DMG_STAGE"
+ditto "$APP_SRC" "$DMG_STAGE/agentacct.app"
+
+# ---- [3/5] sign (env-gated) ------------------------------------------------
+if [[ -n "${DEVELOPER_ID:-}" ]]; then
+    echo "==> [3/5] signing with: $DEVELOPER_ID"
+    ENTITLEMENTS="$HERE/entitlements.plist"
+    # Sign inside-out: the embedded CLI (binary + every dylib/so in _internal)
+    # first, then the .app. Hardened runtime is REQUIRED for notarization; the
+    # CLI needs the disable-library-validation + allow-jit entitlements because
+    # a PyInstaller binary loads unsigned-at-build .so files and Python JITs.
+    find "$DMG_STAGE/agentacct.app/Contents/Resources/cli" \
+        -type f \( -name "*.so" -o -name "*.dylib" -o -perm +111 \) \
+        -exec codesign --force --timestamp --options runtime \
+        --entitlements "$ENTITLEMENTS" --sign "$DEVELOPER_ID" {} + 2>/dev/null || true
+    codesign --force --timestamp --options runtime \
+        --entitlements "$ENTITLEMENTS" --sign "$DEVELOPER_ID" \
+        "$DMG_STAGE/agentacct.app/Contents/Resources/cli/agentacct"
+    codesign --force --deep --timestamp --options runtime \
+        --entitlements "$ENTITLEMENTS" --sign "$DEVELOPER_ID" \
+        "$DMG_STAGE/agentacct.app"
+    codesign --verify --deep --strict "$DMG_STAGE/agentacct.app" && echo "    signature verified"
+else
+    echo "==> [3/5] SKIP signing (DEVELOPER_ID unset) — producing an UNSIGNED build"
+fi
+
+# ---- [4/5] DMG -------------------------------------------------------------
+echo "==> [4/5] building DMG"
+ln -s /Applications "$DMG_STAGE/Applications"
+DMG="$OUT_DIR/agentacct-$VERSION.dmg"
+hdiutil create -volname "agentacct $VERSION" -srcfolder "$DMG_STAGE" \
+    -ov -format UDZO "$DMG" >/dev/null
+echo "    $DMG"
+
+# ---- [5/5] notarize (env-gated) -------------------------------------------
+if [[ -n "${DEVELOPER_ID:-}" && -n "${NOTARY_PROFILE:-}" ]]; then
+    echo "==> [5/5] notarizing (submit + wait + staple)"
+    xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+    xcrun stapler staple "$DMG"
+    xcrun stapler staple "$DMG_STAGE/agentacct.app"  # staple the app too
+    echo "    notarized + stapled"
+else
+    echo "==> [5/5] SKIP notarization (need DEVELOPER_ID + NOTARY_PROFILE)"
+    echo "    Unsigned DMG: first launch needs right-click -> Open (Gatekeeper)."
+fi
+
+echo "==> done: $OUT_DIR"

--- a/packaging/build-dmg.sh
+++ b/packaging/build-dmg.sh
@@ -42,10 +42,12 @@ if [[ -n "${DEVELOPER_ID:-}" ]]; then
     # first, then the .app. Hardened runtime is REQUIRED for notarization; the
     # CLI needs the disable-library-validation + allow-jit entitlements because
     # a PyInstaller binary loads unsigned-at-build .so files and Python JITs.
+    # Sign every Mach-O in the embedded CLI. Failures are NOT swallowed — a lib
+    # that won't sign must surface here, not silently fail notarization later.
     find "$DMG_STAGE/agentacct.app/Contents/Resources/cli" \
         -type f \( -name "*.so" -o -name "*.dylib" -o -perm +111 \) \
         -exec codesign --force --timestamp --options runtime \
-        --entitlements "$ENTITLEMENTS" --sign "$DEVELOPER_ID" {} + 2>/dev/null || true
+        --entitlements "$ENTITLEMENTS" --sign "$DEVELOPER_ID" {} +
     codesign --force --timestamp --options runtime \
         --entitlements "$ENTITLEMENTS" --sign "$DEVELOPER_ID" \
         "$DMG_STAGE/agentacct.app/Contents/Resources/cli/agentacct"
@@ -70,7 +72,6 @@ if [[ -n "${DEVELOPER_ID:-}" && -n "${NOTARY_PROFILE:-}" ]]; then
     echo "==> [5/5] notarizing (submit + wait + staple)"
     xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
     xcrun stapler staple "$DMG"
-    xcrun stapler staple "$DMG_STAGE/agentacct.app"  # staple the app too
     echo "    notarized + stapled"
 else
     echo "==> [5/5] SKIP notarization (need DEVELOPER_ID + NOTARY_PROFILE)"

--- a/packaging/entitlements.plist
+++ b/packaging/entitlements.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Hardened-runtime entitlements for the embedded PyInstaller CLI. A
+         frozen Python binary loads .so/.dylib files that were not signed at
+         build time and the interpreter allocates executable memory, both of
+         which the default hardened runtime blocks. These three are the standard
+         set that lets a notarized PyInstaller app run. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/freeze-cli.sh
+++ b/packaging/freeze-cli.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Freeze the agentacct Python CLI into a standalone, no-Python-required binary.
+#
+# Output: packaging/dist/agentacct/  (PyInstaller *onedir* bundle — the
+# executable plus its _internal/ libs). onedir over onefile on purpose: onefile
+# re-extracts ~24MB to a temp dir on EVERY launch (seconds of latency), and this
+# binary is launched constantly — by every MCP connection, every hook, the
+# daemon. onedir starts in ~0.5s warm.
+#
+# The frozen binary is a drop-in for a pip/pipx `agentacct`: it runs the CLI, the
+# `serve` daemon (uvicorn/fastapi), the `mcp serve` stdio server, `onboard`, AND
+# — via the interpreter-emulation entry (packaging/pyinstaller_entry.py) — the
+# Claude Code hooks that invoke it as `<cli> -m agentacct.statusline_hook` and
+# `<cli> <script>.py`.
+#
+# This does NOT sign or notarize. The app-bundle build (build-app.sh) embeds the
+# output; signing/notarization happen at DMG time once a Developer ID is set up.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+BUILD_VENV="$HERE/.buildvenv"
+DIST_DIR="$HERE/dist"
+WORK_DIR="$HERE/build"
+
+echo "==> agentacct CLI freeze (PyInstaller onedir)"
+cd "$REPO_ROOT"
+
+# Isolated build venv so the freeze never touches the dev/live environment.
+if [[ ! -x "$BUILD_VENV/bin/pyinstaller" ]]; then
+    echo "==> creating build venv + installing package + pyinstaller"
+    python3 -m venv "$BUILD_VENV"
+    "$BUILD_VENV/bin/pip" install --quiet --upgrade pip
+    "$BUILD_VENV/bin/pip" install --quiet . pyinstaller
+else
+    # Refresh the package so the frozen binary tracks the current source.
+    echo "==> refreshing package in existing build venv"
+    "$BUILD_VENV/bin/pip" install --quiet --upgrade . >/dev/null
+fi
+
+VERSION="$("$BUILD_VENV/bin/agentacct" --version | awk '{print $2}')"
+echo "==> freezing agentacct $VERSION"
+
+rm -rf "$DIST_DIR" "$WORK_DIR" "$HERE"/*.spec
+
+# --collect-all for packages with dynamic imports / data files PyInstaller's
+# static analysis misses: agentacct (package-data: INSTALL.md, example JSON),
+# uvicorn (loop/protocol autodiscovery), textual (CSS assets). pydantic submods
+# + the uvicorn auto hidden-imports cover the runtime dispatch tables.
+"$BUILD_VENV/bin/pyinstaller" --noconfirm --onedir --name agentacct \
+    --distpath "$DIST_DIR" --workpath "$WORK_DIR" --specpath "$HERE" \
+    --collect-all agentacct \
+    --collect-all uvicorn \
+    --collect-all textual \
+    --collect-submodules pydantic \
+    --hidden-import=agentacct.statusline_hook \
+    --hidden-import=uvicorn.loops.auto \
+    --hidden-import=uvicorn.protocols.http.auto \
+    --hidden-import=uvicorn.protocols.websockets.auto \
+    --hidden-import=uvicorn.lifespan.on \
+    "$HERE/pyinstaller_entry.py"
+
+BIN="$DIST_DIR/agentacct/agentacct"
+echo "==> smoke-testing the frozen binary"
+"$BIN" --version
+"$BIN" mcp serve --help >/dev/null && echo "    mcp serve: ok"
+"$BIN" serve --help >/dev/null && echo "    serve: ok"
+"$BIN" onboard --help >/dev/null && echo "    onboard: ok"
+
+echo "==> done: $DIST_DIR/agentacct  ($(du -sh "$DIST_DIR/agentacct" | awk '{print $1}'))"

--- a/packaging/pyinstaller_entry.py
+++ b/packaging/pyinstaller_entry.py
@@ -1,0 +1,61 @@
+"""PyInstaller entry point for the standalone agentacct CLI.
+
+A frozen build has no console_scripts shim and is NOT a Python interpreter, yet
+the recording hooks agentacct installs invoke their command as if it were one:
+Claude Code's ``settings.json`` runs ``<cli> -m agentacct.statusline_hook`` and
+``<cli> <hooks>/claude_pre_tool_use.py`` (onboard fills ``<cli>`` from
+``sys.executable`` — a real ``python`` for a pip/pipx install, but the frozen
+binary itself here). So this entry emulates the two interpreter forms the hooks
+rely on, then falls through to the normal Typer CLI for everything else:
+
+  agentacct -m some.module [args]   -> runpy.run_module(..., "__main__")
+  agentacct /path/to/script.py …    -> runpy.run_path(..., "__main__")
+  agentacct <command> …             -> the agentacct.cli Typer app
+
+This keeps ONE binary working as both the CLI (MCP server, daemon, onboard) and
+the hook runner, with no change to onboard's command generation or to existing
+pip/pipx installs (which point the same hook commands at a real python).
+"""
+from __future__ import annotations
+
+import multiprocessing
+import os
+import runpy
+import sys
+
+
+def _run_as_interpreter() -> bool:
+    """Handle the ``python``-interpreter forms the hooks use. Returns True if it
+    dispatched (the process should exit), False to fall through to the CLI."""
+
+    argv = sys.argv
+    if len(argv) >= 3 and argv[1] == "-m":
+        # `<cli> -m module [args]` -> run that module as __main__.
+        module = argv[2]
+        sys.argv = [module, *argv[3:]]
+        runpy.run_module(module, run_name="__main__", alter_sys=True)
+        return True
+    if len(argv) >= 2:
+        first = argv[1]
+        # `<cli> script.py [args]` -> run that file as __main__. Guard on a real
+        # .py file so a Typer subcommand that merely ends in ".py" is impossible
+        # to confuse (Typer command names never do).
+        if first.endswith(".py") and os.path.isfile(first):
+            sys.argv = [first, *argv[2:]]
+            runpy.run_path(first, run_name="__main__")
+            return True
+    return False
+
+
+def main() -> None:
+    # uvicorn/textual may spawn; freeze_support keeps a frozen re-exec sane.
+    multiprocessing.freeze_support()
+    if _run_as_interpreter():
+        return
+    from agentacct.cli import app
+
+    app()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Ships a self-contained installer app so a non-developer can install agentacct without Python, pipx, or a terminal. The app embeds a **frozen standalone CLI** and drives the normal `agentacct onboard` from a one-click screen. No core data/counting paths change.

## Why

The app is a GUI over the daemon; it cannot replace the CLI. The MCP servers the coding agents connect to (`agentacct mcp serve`), the daemon (`agentacct serve`), and the recording hooks are all the Python CLI. So a machine with no Python needs the CLI as a standalone binary. This freezes it and ships it in the app.

## Packaging (`packaging/`)

- **`freeze-cli.sh`** — PyInstaller *onedir* freeze (~0.5s warm start; onefile re-extracts 24MB per launch, unusable for a CLI launched by every hook/MCP connection). The frozen binary is a drop-in for a pip/pipx `agentacct`.
- **`pyinstaller_entry.py`** — the frozen entry. Besides the CLI it emulates the two Python-interpreter forms the Claude Code hooks invoke it with (`<cli> -m agentacct.statusline_hook`, `<cli> <hook>.py`), so one binary is CLI + hook runner with **zero change to onboard or to existing pip/pipx installs**.
- **`build-dmg.sh`** — freeze → build app (embeds CLI) → sign → DMG → notarize. Signing/notarization are **env-gated** (`DEVELOPER_ID` / `NOTARY_PROFILE`): the same script makes an unsigned DMG today and a signed+notarized one once a Developer ID exists — no code change.
- **`entitlements.plist`** — hardened-runtime entitlements a frozen Python binary needs to run notarized.

`apps/agentacct/Scripts/build-app.sh` embeds the frozen CLI into `Contents/Resources/cli/` when present; dev builds skip it and stay fast.

## App setup flow

`SetupModel` / `SetupSheet`:
1. Copy the embedded CLI → `~/.local/share/agentacct/cli/` (stable; an app upgrade replaces it in place so every registration stays valid).
2. Write a `~/.local/bin/agentacct` wrapper on PATH.
3. Run `agentacct onboard --agent auto --yes` from the installed binary, which registers MCP servers, hooks, and standing instructions and stamps the stable installed path into every config.

A packaged build whose recorder isn't installed offers setup once on first launch; a dev build (no embedded CLI) never prompts.

## Verified end-to-end

- Frozen binary runs `mcp serve` (MCP initialize + tools capability), the daemon (HTTP 200), `onboard` (writes CLAUDE.md / settings.json / .claude.json / hooks), and **both hook forms** (statusline `-m`, SessionStart `script.py`).
- The install simulation writes stable installed paths into every hook, and those hook commands run via the installed binary.
- `build-dmg.sh` produces a 29MB DMG; mounting it and running the app's embedded CLI works (`--version`, `mcp serve`).

## Not in scope (blocked on Apple Developer account)

Code signing + notarization — wired and env-gated, runs once `DEVELOPER_ID` + `NOTARY_PROFILE` are set. Until then the DMG is unsigned (first launch needs right-click → Open).
