### PR TITLE
M1: the Work Receipt as a first-class object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **The Work Receipt — one canonical answer to "what did this task do, and can I
+  trust it".** A new `agentacct.receipt.v1` projects one converged Task (a root
+  session with its continuations and subagents) into the eight questions a
+  reviewer needs — task, actors, actions, cost, evidence, outcome, gaps, and
+  per-field provenance — each dimension carrying where its data came from
+  (client log / MCP / hook / CI / git / human) and what could **not** be proven.
+  It keeps two axes deliberately separate: *decision status* (what a human or
+  agent SAYS happened) and *evidence strength* (how well that is actually
+  PROVEN). An agent reporting "done" never raises evidence strength, and a human
+  review never counts as machine verification. Read one with
+  `agentacct receipt <task>` (or `agentacct receipts` to list them), over the API
+  at `GET /v1/receipt?task=` and `GET /v1/tasks`, in the macOS app's new Receipts
+  pane, and in the TUI (press `t`). Cost now also carries its *basis* — a local
+  client-session figure vs a pricing-table estimate — not just its confidence.
+- **Privacy-safe tool-category capture for the Actions dimension.** The installed
+  Claude Code PreToolUse hook now records a coarse tool CATEGORY per step
+  (read / edit / execute / search / network / agent / plan / mcp / other),
+  derived from the tool NAME alone — never its arguments, results, or paths —
+  spooled locally and folded into each Task by `agentacct usage import-local`.
+  A session with no captured activity shows an honest gap, never a fabricated
+  zero.
 - **A `/v1` native-shell lane on the local API.** `GET /v1/glance` returns usage
   windows, provider limits, plan-calibration status, and recent sessions in one
   versioned, additive-only payload — computed by the exact same functions

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -18,6 +18,9 @@ final class DashboardStore: ObservableObject {
     @Published private(set) var usage: UsageSummary?
     @Published private(set) var detail: V1SessionDetail?
     @Published private(set) var detailError: String?
+    @Published private(set) var receiptTasks: [ReceiptSummary] = []
+    @Published private(set) var receipt: Receipt?
+    @Published private(set) var receiptError: String?
     @Published private(set) var errorText: String?
     @Published private(set) var isRefreshing = false
     @Published private(set) var isLoadingMore = false
@@ -122,6 +125,44 @@ final class DashboardStore: ObservableObject {
         }
     }
 
+    /// The Task list for the Receipts pane (one compact Receipt summary each).
+    func fetchReceipts() async {
+        do {
+            let payload: ReceiptTasksPayload = try await client.getAuthed("/v1/tasks?limit=200")
+            receiptTasks = payload.tasks
+            receiptError = nil
+        } catch GlanceClientError.noDiscovery(_) {
+            receiptError = "daemon not running (no discovery file) — start it with `agentacct start`"
+        } catch {
+            receiptError = "receipts fetch failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// One Task's full Receipt. 404 (task unknown / recorded elsewhere) is a
+    /// first-class message; a CANCELLED fetch (the user picked another Task)
+    /// writes nothing so a late error can't mask the fresh receipt.
+    func fetchReceipt(taskId: String) async {
+        receipt = nil
+        receiptError = nil
+        do {
+            let encoded = taskId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? taskId
+            let payload: Receipt = try await client.getAuthed("/v1/receipt?task=\(encoded)")
+            guard !Task.isCancelled else { return }
+            receipt = payload
+            receiptError = nil
+        } catch is CancellationError {
+            return
+        } catch let error as URLError where error.code == .cancelled {
+            return
+        } catch GlanceClientError.http(404) {
+            guard !Task.isCancelled else { return }
+            receiptError = "this Task is not in the store (it may have been recorded elsewhere)"
+        } catch {
+            guard !Task.isCancelled else { return }
+            receiptError = "receipt fetch failed: \(error.localizedDescription)"
+        }
+    }
+
     /// The plan status for one client (three-state honesty), if known.
     func planStatus(for clientName: String) -> V1PlanStatus? {
         planStatuses.first { $0.client == clientName }
@@ -153,11 +194,13 @@ final class DashboardStore: ObservableObject {
 @MainActor
 final class AppSelection: ObservableObject {
     @Published var sessionId: String?
+    @Published var taskId: String?
     @Published var pane: MainPane = .dashboard
 }
 
 enum MainPane: String, CaseIterable, Identifiable {
     case dashboard = "Dashboard"
+    case receipts = "Receipts"
     case sessions = "Sessions"
     case usage = "Usage"
     case limits = "Limits"

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -23,6 +23,7 @@ struct MainWindow: View {
             Group {
                 switch selection.pane {
                 case .dashboard: DashboardPane()
+                case .receipts: ReceiptsPane()
                 case .sessions: SessionsPane()
                 case .usage: UsagePane()
                 case .limits: LimitsPane()
@@ -163,6 +164,7 @@ extension MainPane {
     var icon: String {
         switch self {
         case .dashboard: return "gauge.with.dots.needle.50percent"
+        case .receipts: return "checklist"
         case .sessions: return "rectangle.stack.fill"
         case .usage: return "chart.bar.fill"
         case .limits: return "gauge.with.needle.fill"

--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -1,0 +1,346 @@
+import SwiftUI
+
+// The Receipts pane: Task list (left) -> one Task's Work Receipt (right).
+//
+// A Receipt answers the 8 questions for one converged Task and keeps the two
+// honesty axes visibly SEPARATE: decision status (what a human/agent SAYS) and
+// evidence strength (how well that is PROVEN). Both colors and both labels are
+// distinct so an agent's "done" never reads as machine verification. Honesty
+// rides the payload — nothing here re-derives an axis or invents a number.
+
+/// Decision-status color (what is CLAIMED). Deliberately a different function
+/// from ``evidenceStrengthTint`` so the two axes can never share a color.
+func receiptDecisionTint(_ key: String?) -> Color {
+    switch key {
+    case "verified": return Theme.green
+    case "finding", "failed", "blocked": return Theme.red
+    case "reported", "mostly_done", "in_progress": return Theme.orange
+    case "handed_off", "resolved", "finding_superseded": return Theme.blue
+    default: return Theme.textMuted
+    }
+}
+
+/// Evidence-strength color (how well PROVEN). A failing check is never "strong"
+/// proof — it lands on the decision axis as a finding, not here.
+func receiptEvidenceTint(_ key: String?) -> Color {
+    switch key {
+    case "verified": return Theme.green
+    case "checked": return Theme.blue
+    case "reported": return Theme.orange
+    default: return Theme.textMuted
+    }
+}
+
+/// Provenance-source chip color: the strongest source is warmest.
+func receiptSourceTint(_ source: String) -> Color {
+    switch source {
+    case "ci": return Theme.green
+    case "hook": return Theme.blue
+    case "mcp": return Theme.accent
+    case "git": return Theme.orange
+    case "human": return Theme.orange
+    case "client_log": return Theme.textMuted
+    default: return Theme.textFaint
+    }
+}
+
+struct ReceiptsPane: View {
+    @EnvironmentObject var dashboard: DashboardStore
+    @EnvironmentObject var selection: AppSelection
+    @State private var query = ""
+
+    private var visibleTasks: [ReceiptSummary] {
+        guard !query.isEmpty else { return dashboard.receiptTasks }
+        let needle = query.lowercased()
+        return dashboard.receiptTasks.filter {
+            ($0.title ?? "").lowercased().contains(needle) || $0.taskId.lowercased().contains(needle)
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            taskList
+                .frame(width: 320)
+            Rectangle().fill(Theme.border).frame(width: 1)
+            detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .task { await dashboard.fetchReceipts() }
+    }
+
+    private var taskList: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Image(systemName: "magnifyingglass").foregroundStyle(Theme.textFaint)
+                TextField("Filter tasks", text: $query)
+                    .textFieldStyle(.plain)
+            }
+            .padding(8)
+            Rectangle().fill(Theme.border.opacity(0.6)).frame(height: 1)
+            if let error = dashboard.receiptError, dashboard.receiptTasks.isEmpty {
+                Text(error).font(.callout).foregroundStyle(Theme.textMuted)
+                    .padding().frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollBox {
+                    VStack(spacing: 2) {
+                        ForEach(visibleTasks) { task in
+                            ReceiptRow(task: task, selected: task.taskId == selection.taskId)
+                                .onTapGesture { select(task.taskId) }
+                        }
+                    }
+                    .padding(6)
+                }
+            }
+        }
+        .background(Theme.surface.opacity(0.4))
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if let receipt = dashboard.receipt {
+            ReceiptDetail(receipt: receipt)
+        } else if let error = dashboard.receiptError, selection.taskId != nil {
+            Text(error).font(.callout).foregroundStyle(Theme.textMuted).padding()
+        } else {
+            VStack(spacing: 8) {
+                Image(systemName: "checklist").font(.largeTitle).foregroundStyle(Theme.textFaint)
+                Text("Select a Task to read its Work Receipt")
+                    .foregroundStyle(Theme.textMuted)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func select(_ taskId: String) {
+        selection.taskId = taskId
+        Task { await dashboard.fetchReceipt(taskId: taskId) }
+    }
+}
+
+private struct ReceiptRow: View {
+    let task: ReceiptSummary
+    let selected: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(task.title ?? task.taskId)
+                .font(.callout).fontWeight(.medium)
+                .foregroundStyle(Theme.text)
+                .lineLimit(2)
+            HStack(spacing: 6) {
+                AxisChip(text: task.decisionStatus.key, tint: receiptDecisionTint(task.decisionStatus.key))
+                AxisChip(text: task.evidenceStrength.key, tint: receiptEvidenceTint(task.evidenceStrength.key))
+                Spacer()
+                Text(task.cost.text).font(.caption).foregroundStyle(Theme.textMuted)
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            selected ? AnyShapeStyle(Theme.cardAlt) : AnyShapeStyle(.clear),
+            in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+        )
+    }
+}
+
+private struct AxisChip: View {
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption2).fontWeight(.semibold)
+            .padding(.horizontal, 6).padding(.vertical, 2)
+            .background(tint.opacity(0.18), in: Capsule())
+            .foregroundStyle(tint)
+    }
+}
+
+private struct ReceiptDetail: View {
+    let receipt: Receipt
+
+    var body: some View {
+        ScrollBox {
+            VStack(alignment: .leading, spacing: 14) {
+                header
+                axesCard
+                dimensionsCard
+                gapsCard
+                provenanceCard
+            }
+            .padding(16)
+            .frame(maxWidth: 720, alignment: .leading)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(receipt.title ?? "Task").font(.title3).fontWeight(.semibold)
+                .foregroundStyle(Theme.text)
+            Text(receipt.taskId).font(.caption).foregroundStyle(Theme.textFaint)
+        }
+    }
+
+    private var axesCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 10) {
+                axisRow(
+                    label: "Decision status",
+                    key: receipt.axes.decisionStatus.key,
+                    tint: receiptDecisionTint(receipt.axes.decisionStatus.key),
+                    detail: assertedText(receipt.axes.decisionStatus.assertedBy),
+                    note: receipt.axes.decisionStatus.statement
+                )
+                axisRow(
+                    label: "Evidence strength",
+                    key: receipt.axes.evidenceStrength.key,
+                    tint: receiptEvidenceTint(receipt.axes.evidenceStrength.key),
+                    detail: evidenceDetail(receipt.axes.evidenceStrength),
+                    note: receipt.axes.evidenceStrength.strongestProof.map { "strongest proof: \($0)" }
+                )
+                if let orthogonality = receipt.axes.orthogonalityNote {
+                    Text(orthogonality).font(.caption).foregroundStyle(Theme.textFaint)
+                }
+            }
+        }
+    }
+
+    private func axisRow(label: String, key: String, tint: Color, detail: String?, note: String?) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 8) {
+                Text(label).font(.caption).foregroundStyle(Theme.textMuted).frame(width: 130, alignment: .leading)
+                Text(key.uppercased()).font(.callout).fontWeight(.bold).foregroundStyle(tint)
+                if let detail { Text(detail).font(.caption).foregroundStyle(Theme.textMuted) }
+            }
+            if let note {
+                Text(note).font(.caption).foregroundStyle(Theme.textFaint)
+                    .padding(.leading, 138)
+            }
+        }
+    }
+
+    private var dimensionsCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 8) {
+                dimensionRow("Task", taskSummary, receipt.dimensions.task.provenance)
+                dimensionRow("Actors", actorsSummary, receipt.dimensions.actors.provenance)
+                dimensionRow("Actions", actionsSummary, receipt.dimensions.actions.provenance)
+                dimensionRow("Cost", costSummary, receipt.dimensions.cost.provenance)
+                dimensionRow("Evidence", evidenceSummary, receipt.dimensions.evidence.provenance)
+                dimensionRow("Outcome", outcomeSummary, receipt.dimensions.outcome.provenance)
+            }
+        }
+    }
+
+    private func dimensionRow(_ name: String, _ summary: String, _ provenance: [String]?) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(name).font(.caption).fontWeight(.semibold).foregroundStyle(Theme.textMuted)
+                .frame(width: 74, alignment: .leading)
+            Text(summary).font(.callout).foregroundStyle(Theme.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(spacing: 4) {
+                ForEach(provenance ?? [], id: \.self) { source in
+                    Text(source).font(.caption2)
+                        .padding(.horizontal, 5).padding(.vertical, 1)
+                        .background(receiptSourceTint(source).opacity(0.16), in: Capsule())
+                        .foregroundStyle(receiptSourceTint(source))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var gapsCard: some View {
+        let items = receipt.dimensions.gaps.items ?? []
+        if !items.isEmpty {
+            Card {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Gaps (\(items.count)) — what could not be proven")
+                        .font(.callout).fontWeight(.semibold).foregroundStyle(Theme.text)
+                    ForEach(items) { item in
+                        HStack(alignment: .top, spacing: 6) {
+                            Text(item.dimension).font(.caption2).foregroundStyle(Theme.textFaint)
+                                .frame(width: 70, alignment: .leading)
+                            Text(item.reason).font(.caption).foregroundStyle(Theme.textMuted)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var provenanceCard: some View {
+        let legend = receipt.dimensions.provenance.legend ?? [:]
+        if !legend.isEmpty {
+            Card {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Provenance").font(.callout).fontWeight(.semibold).foregroundStyle(Theme.text)
+                    ForEach(legend.keys.sorted(), id: \.self) { source in
+                        HStack(alignment: .top, spacing: 6) {
+                            Text(source).font(.caption2).fontWeight(.semibold)
+                                .foregroundStyle(receiptSourceTint(source))
+                                .frame(width: 78, alignment: .leading)
+                            Text(legend[source] ?? "").font(.caption).foregroundStyle(Theme.textMuted)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - dimension summaries
+
+    private var taskSummary: String {
+        let dim = receipt.dimensions.task
+        var parts = (dim.objectives ?? []).prefix(2).joined(separator: "; ")
+        if parts.isEmpty { parts = "no objective recorded" }
+        if let project = dim.boundary?.project { parts += " · project \(project)" }
+        return parts
+    }
+
+    private var actorsSummary: String {
+        let dim = receipt.dimensions.actors
+        var parts: [String] = []
+        if let agent = dim.primaryAgent { parts.append(agent) }
+        if let models = dim.models, !models.isEmpty { parts.append(models.joined(separator: ", ")) }
+        if let subagents = dim.subagentSessionCount, subagents > 0 { parts.append("\(subagents) subagents") }
+        return parts.isEmpty ? "—" : parts.joined(separator: " · ")
+    }
+
+    private var actionsSummary: String {
+        let dim = receipt.dimensions.actions
+        let counts = dim.toolCategoryCounts ?? [:]
+        let categories = counts.isEmpty
+            ? "not instrumented"
+            : counts.sorted { $0.key < $1.key }.map { "\($0.key)×\($0.value)" }.joined(separator: " ")
+        return "\(categories) · touched \(dim.touchedFileCount ?? 0) file(s)"
+    }
+
+    private var costSummary: String {
+        let dim = receipt.dimensions.cost
+        guard let cost = dim.estimatedCostUsd else { return "—" }
+        let basis = dim.costBasis ?? "unknown basis"
+        return String(format: "$%.2f · %@%@", cost, basis, (dim.costComplete ?? true) ? "" : " (partial)")
+    }
+
+    private var evidenceSummary: String {
+        let dim = receipt.dimensions.evidence
+        return "\(dim.checksTotal ?? 0) checks · \(dim.checksPassed ?? 0) passed · \(dim.checksFailed ?? 0) failed"
+    }
+
+    private var outcomeSummary: String {
+        let dim = receipt.dimensions.outcome
+        return "\(dim.decisionStatus ?? "—") · asserted by \(dim.assertedBy ?? "none")"
+    }
+
+    private func assertedText(_ assertedBy: String?) -> String? {
+        guard let assertedBy else { return nil }
+        return "asserted by \(assertedBy)"
+    }
+
+    private func evidenceDetail(_ evidence: ReceiptEvidence) -> String {
+        "\(evidence.verifiedStepCount ?? 0)/\(evidence.totalStepCount ?? 0) steps verified · "
+            + "\(evidence.checksTotal ?? 0) checks, \(evidence.checksPassed ?? 0) passed"
+    }
+}

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -378,3 +378,271 @@ extension Fmt {
         return pct >= 0.1 ? String(format: "≈%.1f%%", pct) : "≈<0.1%"
     }
 }
+
+// MARK: - Receipt (agentacct.receipt.v1)
+//
+// One converged Task's Work Receipt: the 8 questions, the two orthogonal axes
+// (decision status × evidence strength), per-field provenance, and gaps. As
+// with every /v1 decodable: additive-only, unknown keys tolerated, honesty
+// rides the payload (the app never re-derives an axis or invents a number).
+
+struct ReceiptTasksPayload: Decodable {
+    let schema: String
+    let tasks: [ReceiptSummary]
+    let total: Int?
+    let truncated: Bool?
+}
+
+struct ReceiptSummary: Decodable, Identifiable {
+    let taskId: String
+    let title: String?
+    let decisionStatus: ReceiptDecision
+    let evidenceStrength: ReceiptEvidence
+    let cost: ReceiptCost
+    let sessionCount: Int?
+    let lastActivityAt: Double?
+
+    var id: String { taskId }
+
+    enum CodingKeys: String, CodingKey {
+        case taskId = "task_id"
+        case title
+        case decisionStatus = "decision_status"
+        case evidenceStrength = "evidence_strength"
+        case cost
+        case sessionCount = "session_count"
+        case lastActivityAt = "last_activity_at"
+    }
+}
+
+struct ReceiptDecision: Decodable {
+    let key: String
+    let label: String?
+    let statement: String?
+    let assertedBy: String?
+
+    enum CodingKeys: String, CodingKey {
+        case key, label, statement
+        case assertedBy = "asserted_by"
+    }
+}
+
+struct ReceiptEvidence: Decodable {
+    let key: String
+    let label: String?
+    let verifiedStepCount: Int?
+    let totalStepCount: Int?
+    let checksTotal: Int?
+    let checksPassed: Int?
+    let checksFailed: Int?
+    let strongestProof: String?
+
+    enum CodingKeys: String, CodingKey {
+        case key, label
+        case verifiedStepCount = "verified_step_count"
+        case totalStepCount = "total_step_count"
+        case checksTotal = "checks_total"
+        case checksPassed = "checks_passed"
+        case checksFailed = "checks_failed"
+        case strongestProof = "strongest_proof"
+    }
+}
+
+struct ReceiptCost: Decodable {
+    let estimatedCostUsd: Double?
+    let costBasis: String?
+    let costConfidence: String?
+    let costComplete: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case estimatedCostUsd = "estimated_cost_usd"
+        case costBasis = "cost_basis"
+        case costConfidence = "cost_confidence"
+        case costComplete = "cost_complete"
+    }
+
+    /// None-never-$0: an absent estimate is "—", never a fabricated zero.
+    var text: String {
+        guard let estimatedCostUsd else { return "—" }
+        let basis = costBasis ?? "unknown basis"
+        return String(format: "$%.2f · %@", estimatedCostUsd, basis)
+    }
+}
+
+struct Receipt: Decodable {
+    let schemaVersion: String
+    let taskId: String
+    let title: String?
+    let axes: ReceiptAxes
+    let dimensions: ReceiptDimensions
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case taskId = "task_id"
+        case title, axes, dimensions
+    }
+}
+
+struct ReceiptAxes: Decodable {
+    let decisionStatus: ReceiptDecision
+    let evidenceStrength: ReceiptEvidence
+    let orthogonalityNote: String?
+
+    enum CodingKeys: String, CodingKey {
+        case decisionStatus = "decision_status"
+        case evidenceStrength = "evidence_strength"
+        case orthogonalityNote = "orthogonality_note"
+    }
+}
+
+struct ReceiptDimensions: Decodable {
+    let task: ReceiptTaskDim
+    let actors: ReceiptActorsDim
+    let actions: ReceiptActionsDim
+    let cost: ReceiptCostDim
+    let evidence: ReceiptEvidenceDim
+    let outcome: ReceiptOutcomeDim
+    let gaps: ReceiptGapsDim
+    let provenance: ReceiptProvenanceDim
+}
+
+struct ReceiptBoundary: Decodable {
+    let project: String?
+    let identityScope: String?
+    let sessionCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case project
+        case identityScope = "identity_scope"
+        case sessionCount = "session_count"
+    }
+}
+
+struct ReceiptTaskDim: Decodable {
+    let objectives: [String]?
+    let boundary: ReceiptBoundary?
+    let provenance: [String]?
+    let gaps: [String]?
+}
+
+struct ReceiptActorsDim: Decodable {
+    let primaryAgent: String?
+    let models: [String]?
+    let subagentSessionCount: Int?
+    let childSessionCount: Int?
+    let provenance: [String]?
+    let gaps: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case primaryAgent = "primary_agent"
+        case models
+        case subagentSessionCount = "subagent_session_count"
+        case childSessionCount = "child_session_count"
+        case provenance, gaps
+    }
+}
+
+struct ReceiptActionsDim: Decodable {
+    let toolCategoryCounts: [String: Int]?
+    let toolCategoryTotal: Int?
+    let touchedFiles: [String]?
+    let touchedFileCount: Int?
+    let provenance: [String]?
+    let gaps: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case toolCategoryCounts = "tool_category_counts"
+        case toolCategoryTotal = "tool_category_total"
+        case touchedFiles = "touched_files"
+        case touchedFileCount = "touched_file_count"
+        case provenance, gaps
+    }
+}
+
+struct ReceiptCostDim: Decodable {
+    let estimatedCostUsd: Double?
+    let costBasis: String?
+    let costConfidence: String?
+    let costComplete: Bool?
+    let provenance: [String]?
+    let gaps: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case estimatedCostUsd = "estimated_cost_usd"
+        case costBasis = "cost_basis"
+        case costConfidence = "cost_confidence"
+        case costComplete = "cost_complete"
+        case provenance, gaps
+    }
+}
+
+struct ReceiptCheck: Decodable, Identifiable {
+    let kind: String?
+    let name: String?
+    let result: String?
+    let exitCode: Int?
+    let scope: String?
+    let source: String?
+
+    var id: String { "\(name ?? "check")-\(result ?? "")-\(exitCode ?? 0)" }
+
+    enum CodingKeys: String, CodingKey {
+        case kind, name, result, scope, source
+        case exitCode = "exit_code"
+    }
+}
+
+struct ReceiptEvidenceDim: Decodable {
+    let checks: [ReceiptCheck]?
+    let checksTotal: Int?
+    let checksPassed: Int?
+    let checksFailed: Int?
+    let provenance: [String]?
+    let gaps: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case checks
+        case checksTotal = "checks_total"
+        case checksPassed = "checks_passed"
+        case checksFailed = "checks_failed"
+        case provenance, gaps
+    }
+}
+
+struct ReceiptOutcomeDim: Decodable {
+    let decisionStatus: String?
+    let statement: String?
+    let assertedBy: String?
+    let provenance: [String]?
+    let gaps: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case decisionStatus = "decision_status"
+        case statement
+        case assertedBy = "asserted_by"
+        case provenance, gaps
+    }
+}
+
+struct ReceiptGapItem: Decodable, Identifiable {
+    let dimension: String
+    let reason: String
+    var id: String { "\(dimension)-\(reason)" }
+}
+
+struct ReceiptGapsDim: Decodable {
+    let items: [ReceiptGapItem]?
+    let count: Int?
+}
+
+struct ReceiptProvenanceDim: Decodable {
+    let byDimension: [String: [String]]?
+    let sourcesPresent: [String]?
+    let legend: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case byDimension = "by_dimension"
+        case sourcesPresent = "sources_present"
+        case legend
+    }
+}

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -2913,15 +2913,31 @@ def create_local_api_app(
     # cached so the receipt list/detail routes stay cheap under app polling.
     v1_receipt_projection_cache: dict[str, tuple[int, float, dict[str, Any]]] = {}
 
+    def _receipt_projection_cache_key(events: list[dict[str, Any]]) -> int:
+        # The projection also consumes the Evidence v2 client_hook store (hook
+        # mechanical checks + privacy-safe tool-category captures), which changes
+        # WITHOUT a v1 ledger event — so hashing only the event log would serve a
+        # pre-capture projection for the whole TTL and let the Receipt under-claim
+        # proven evidence. Fold a cheap monotonic marker from the evidence store
+        # into the key so any capture/import invalidates the cache immediately.
+        evidence_marker: tuple[int, ...] = (0,)
+        try:
+            if service.evidence.enabled:
+                stats = service.evidence.status()
+                evidence_marker = (stats.logical_events, stats.receipts, stats.duplicate_receipts)
+        except Exception:  # noqa: BLE001 - a stats read must never fail the route.
+            evidence_marker = (0,)
+        return hash((events_fingerprint(events), evidence_marker))
+
     def _v1_task_projection() -> dict[str, Any]:
         events = service.list_all_events()
-        fingerprint = events_fingerprint(events)
+        cache_key = _receipt_projection_cache_key(events)
         moment = time.time()
         cached = v1_receipt_projection_cache.get("projection")
-        if cached is not None and cached[0] == fingerprint and (moment - cached[1]) < 30.0:
+        if cached is not None and cached[0] == cache_key and (moment - cached[1]) < 30.0:
             return cached[2]
         projection = _dashboard_task_projection(_page_data())
-        v1_receipt_projection_cache["projection"] = (fingerprint, moment, projection)
+        v1_receipt_projection_cache["projection"] = (cache_key, moment, projection)
         return projection
 
     def _visible_tasks(projection: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -108,6 +108,12 @@ from .task_continuations import ContinuationTaskStore
 from .task_identity import TaskIdentityCodec
 from .task_outcome import evidence_event_key, finding_check_key, latest_check_events
 from .task_projection import build_task_projection
+from .receipt import (
+    RECEIPT_SCHEMA_VERSION,
+    build_receipt,
+    build_receipt_summary,
+    latest_store_activity,
+)
 from .usage_cube import (
     KNOWN_USAGE_CLIENTS,
     USAGE_CUBE_DAYS_CHOICES,
@@ -2801,6 +2807,7 @@ def create_local_api_app(
             "sessions_schema": V1_SESSIONS_SCHEMA_VERSION,
             "session_detail_schema": V1_SESSION_DETAIL_SCHEMA_VERSION,
             "plan_schema": V1_PLAN_SCHEMA_VERSION,
+            "receipt_schema": RECEIPT_SCHEMA_VERSION,
             "pid": os.getpid(),
             "store_dir": str(store_dir),
             "store_scope": store_scope,
@@ -2902,6 +2909,87 @@ def create_local_api_app(
         v1_plan_cache[days] = (fingerprint, moment, payload)
         return payload
 
+    # The decorated, evidence-attached Task projection, fingerprint + TTL
+    # cached so the receipt list/detail routes stay cheap under app polling.
+    v1_receipt_projection_cache: dict[str, tuple[int, float, dict[str, Any]]] = {}
+
+    def _v1_task_projection() -> dict[str, Any]:
+        events = service.list_all_events()
+        fingerprint = events_fingerprint(events)
+        moment = time.time()
+        cached = v1_receipt_projection_cache.get("projection")
+        if cached is not None and cached[0] == fingerprint and (moment - cached[1]) < 30.0:
+            return cached[2]
+        projection = _dashboard_task_projection(_page_data())
+        v1_receipt_projection_cache["projection"] = (fingerprint, moment, projection)
+        return projection
+
+    def _visible_tasks(projection: Mapping[str, Any]) -> list[dict[str, Any]]:
+        return [
+            task
+            for task in projection.get("tasks", [])
+            if isinstance(task, Mapping) and str(task.get("public_task_id") or "")
+        ]
+
+    @app.get("/v1/tasks")
+    def v1_tasks(
+        request: Request,
+        limit: int = Query(50, ge=1, le=500),
+        offset: int = Query(0, ge=0),
+    ) -> dict[str, Any]:
+        """The versioned Task list: one compact Receipt summary per Task
+        (the two axes + cost + activity), newest first. A Task is the
+        convergence of a root session with its continuations and subagents —
+        the unit a Receipt is written for. Cheap under polling (cached
+        projection); the per-request work is a summary map + slice."""
+
+        _require_v1_token(request)
+        projection = _v1_task_projection()
+        tasks = _visible_tasks(projection)
+        latest = latest_store_activity(tasks)
+        tasks.sort(key=lambda task: float(task.get("last_activity_at") or 0.0), reverse=True)
+        total = len(tasks)
+        window = tasks[offset : offset + limit]
+        rows = [
+            build_receipt_summary(
+                task,
+                public_task_id=str(task.get("public_task_id")),
+                title=_task_title(task),
+                latest_store_activity_at=latest,
+            )
+            for task in window
+        ]
+        return {
+            "schema": RECEIPT_SCHEMA_VERSION,
+            "tasks": rows,
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "truncated": offset + limit < total,
+        }
+
+    @app.get("/v1/receipt")
+    def v1_receipt(
+        request: Request,
+        task: str = Query(..., min_length=1, alias="task"),
+    ) -> dict[str, Any]:
+        """One Task's full Receipt: the 8 questions, the two orthogonal axes,
+        per-field provenance, and the gaps block. 404 when the store has no
+        such Task — never an empty fabrication."""
+
+        _require_v1_token(request)
+        projection = _v1_task_projection()
+        tasks = _visible_tasks(projection)
+        selected = next((row for row in tasks if str(row.get("public_task_id")) == task), None)
+        if selected is None:
+            raise HTTPException(status_code=404, detail="unknown task for this store")
+        return build_receipt(
+            selected,
+            public_task_id=str(selected.get("public_task_id")),
+            title=_task_title(selected),
+            latest_store_activity_at=latest_store_activity(tasks),
+        )
+
     @app.get("/")
     def index() -> dict[str, Any]:
         """A machine-readable front door (the HTML dashboard is retired).
@@ -2929,6 +3017,8 @@ def create_local_api_app(
                 "/v1/sessions (bearer token from the store's local-api.json)",
                 "/v1/session?client=&session_id= (bearer token from the store's local-api.json)",
                 "/v1/plan (bearer token from the store's local-api.json)",
+                "/v1/tasks (bearer token from the store's local-api.json)",
+                "/v1/receipt?task= (bearer token from the store's local-api.json)",
             ],
         }
 

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -118,6 +118,7 @@ from .context_bridge import build_client_context_join_health
 from .hooks import (
     CLAUDE_HOOK_RELATIVE_PATH,
     capture_claude_code_client_context,
+    capture_tool_activity,
     claude_code_hook_context_status,
     claude_code_hook_doctor_checks,
     claude_code_hook_paths,
@@ -3302,6 +3303,13 @@ def claude_code_pre_tool_use(
         try:
             capture_claude_code_client_context(raw, store_dir=store_dir)
         except Exception:  # noqa: BLE001 - context capture must never affect the hook decision.
+            pass
+        try:
+            # Observe only the tool CATEGORY (never the name/args) for the
+            # Receipt's Actions dimension. Separate try/except so it can never
+            # affect the decision or the context capture above.
+            capture_tool_activity(raw, store_dir=store_dir)
+        except Exception:  # noqa: BLE001 - activity capture must never affect the hook decision.
             pass
         print(json.dumps(decision, ensure_ascii=False))
     except Exception as exc:  # noqa: BLE001 - FAIL OPEN: a PreToolUse hook must NEVER block a tool call, even on an internal agentacct error. An observe-only recorder that can brick every tool call is worse than one that records nothing.
@@ -6698,6 +6706,22 @@ def _local_usage_import_payload(
                     )
                 except Exception:  # noqa: BLE001 - best-effort; recording must not fail import.
                     rate_limit_snapshots_recorded = 0
+        if not dry_run:
+            # Drain the Claude Code hook's tool-category spool into additive
+            # tool_activity_observed events (Receipt Actions dimension). Same
+            # record=service.record_event contract as the rate-limit spool; the
+            # batches are additive and content-idded, so re-import never double
+            # counts. Best-effort: a spool error can never fail the usage import.
+            from .tool_activity import ingest_tool_activity_spool
+
+            try:
+                ingest_tool_activity_spool(
+                    effective_store_dir,
+                    record=service.record_event,
+                    now=time.time(),
+                )
+            except Exception:  # noqa: BLE001 - draining the spool must never fail the import.
+                pass
         if dry_run:
             projectable_observation_identities: set[tuple[str, str, str]] = set()
             observation_conflict_identities = 0

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8945,5 +8945,206 @@ def cost_proxy(
     )
 
 
+def _receipt_cost_text(cost: dict[str, Any]) -> str:
+    amount = cost.get("estimated_cost_usd")
+    if amount is None:
+        return "—"
+    basis = cost.get("cost_basis") or "unknown basis"
+    suffix = "" if cost.get("cost_complete") else " (partial)"
+    return f"${float(amount):.2f} · {basis}{suffix}"
+
+
+def _receipt_category_text(counts: dict[str, Any]) -> str:
+    if not counts:
+        return "not instrumented"
+    return " ".join(f"{name}×{value}" for name, value in sorted(counts.items()))
+
+
+def _find_receipt_task(projection: dict[str, Any], task_id: str) -> dict[str, Any] | None:
+    tasks = [
+        task
+        for task in projection.get("tasks", [])
+        if isinstance(task, dict) and str(task.get("public_task_id") or "")
+    ]
+    exact = next((task for task in tasks if str(task.get("public_task_id")) == task_id), None)
+    if exact is not None:
+        return exact
+    # Convenience: an unambiguous id prefix (e.g. the first 12 chars) resolves.
+    matches = [task for task in tasks if str(task.get("public_task_id")).startswith(task_id)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _render_receipt_text(receipt: dict[str, Any]) -> None:
+    axes = receipt.get("axes", {})
+    dims = receipt.get("dimensions", {})
+    decision = axes.get("decision_status", {})
+    evidence = axes.get("evidence_strength", {})
+
+    console.print(f"[bold]Work Receipt[/bold] · {receipt.get('title') or 'Task'}")
+    console.print(f"[dim]{receipt.get('task_id')}[/dim]\n")
+
+    console.print(
+        f"  Decision status    [bold]{str(decision.get('key') or 'unknown').upper()}[/bold]"
+        f"  (asserted by {decision.get('asserted_by') or 'none'})"
+    )
+    if decision.get("statement"):
+        console.print(f"                     [dim]{decision['statement']}[/dim]")
+    console.print(
+        f"  Evidence strength  [bold]{str(evidence.get('key') or 'none').upper()}[/bold]"
+        f"  ({int(evidence.get('verified_step_count') or 0)}/{int(evidence.get('total_step_count') or 0)}"
+        f" steps verified · {int(evidence.get('checks_total') or 0)} checks,"
+        f" {int(evidence.get('checks_passed') or 0)} passed)"
+    )
+    if evidence.get("strongest_proof"):
+        console.print(f"                     [dim]strongest proof: {evidence['strongest_proof']}[/dim]")
+    if axes.get("orthogonality_note"):
+        console.print(f"  [dim]{axes['orthogonality_note']}[/dim]")
+
+    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+    table.add_column("Dimension")
+    table.add_column("Summary")
+    table.add_column("Source", style="dim")
+
+    task = dims.get("task", {})
+    objectives = task.get("objectives") or []
+    boundary = task.get("boundary", {})
+    task_summary = "; ".join(objectives[:2]) or "no objective recorded"
+    if boundary.get("project"):
+        task_summary += f"  · project {boundary['project']}"
+    table.add_row("Task", task_summary, ", ".join(task.get("provenance") or []))
+
+    actors = dims.get("actors", {})
+    actor_summary = " · ".join(
+        part
+        for part in (
+            actors.get("primary_agent"),
+            ", ".join(actors.get("models") or []) or None,
+            (f"{actors.get('subagent_session_count')} subagents" if actors.get("subagent_session_count") else None),
+        )
+        if part
+    )
+    table.add_row("Actors", actor_summary or "—", ", ".join(actors.get("provenance") or []))
+
+    actions = dims.get("actions", {})
+    actions_summary = _receipt_category_text(actions.get("tool_category_counts") or {})
+    actions_summary += f"  · touched {int(actions.get('touched_file_count') or 0)} file(s)"
+    table.add_row("Actions", actions_summary, ", ".join(actions.get("provenance") or []))
+
+    cost = dims.get("cost", {})
+    table.add_row("Cost", _receipt_cost_text(cost), ", ".join(cost.get("provenance") or []))
+
+    evidence_dim = dims.get("evidence", {})
+    table.add_row(
+        "Evidence",
+        f"{int(evidence_dim.get('checks_total') or 0)} checks · "
+        f"{int(evidence_dim.get('checks_passed') or 0)} passed · "
+        f"{int(evidence_dim.get('checks_failed') or 0)} failed",
+        ", ".join(evidence_dim.get("provenance") or []),
+    )
+
+    outcome = dims.get("outcome", {})
+    table.add_row(
+        "Outcome",
+        f"{outcome.get('decision_status')} · asserted by {outcome.get('asserted_by')}",
+        ", ".join(outcome.get("provenance") or []),
+    )
+    console.print(table)
+
+    gaps = dims.get("gaps", {})
+    if gaps.get("items"):
+        console.print(f"\n[bold]Gaps[/bold] ({gaps.get('count')}) — what could not be proven")
+        for item in gaps["items"]:
+            console.print(f"  · \\[{item.get('dimension')}] {item.get('reason')}")
+
+    legend = dims.get("provenance", {}).get("legend") or {}
+    if legend:
+        console.print("\n[bold]Provenance[/bold]")
+        for source, description in legend.items():
+            console.print(f"  {source} — [dim]{description}[/dim]")
+
+
+@app.command("receipts")
+def receipts(
+    store_dir: Annotated[Optional[Path], typer.Option(help=_STORE_DIR_HELP)] = None,
+    limit: Annotated[int, typer.Option(help="Maximum number of Tasks to list.")] = 20,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit the raw summary JSON.")] = False,
+) -> None:
+    """List recent Tasks with their Receipt summary (decision × evidence, cost)."""
+
+    from .api import build_store_task_projection, _task_title
+    from .receipt import RECEIPT_SCHEMA_VERSION, build_receipt_summary, latest_store_activity
+
+    resolved = _resolve_cli_store_dir(store_dir).path
+    projection = build_store_task_projection(resolved)
+    tasks = [
+        task
+        for task in projection.get("tasks", [])
+        if isinstance(task, dict) and str(task.get("public_task_id") or "")
+    ]
+    latest = latest_store_activity(tasks)
+    tasks.sort(key=lambda task: float(task.get("last_activity_at") or 0.0), reverse=True)
+    rows = [
+        build_receipt_summary(
+            task,
+            public_task_id=str(task.get("public_task_id")),
+            title=_task_title(task),
+            latest_store_activity_at=latest,
+        )
+        for task in tasks[:limit]
+    ]
+    if json_output:
+        console.print_json(data={"schema": RECEIPT_SCHEMA_VERSION, "tasks": rows})
+        return
+    if not rows:
+        console.print("No Tasks recorded in this store yet.")
+        return
+    table = Table(title="Work Receipts", header_style="bold")
+    table.add_column("Task")
+    table.add_column("Title")
+    table.add_column("Decision")
+    table.add_column("Evidence")
+    table.add_column("Cost")
+    for row in rows:
+        table.add_row(
+            str(row["task_id"])[:16],
+            str(row.get("title") or "")[:48],
+            str(row["decision_status"]["key"]),
+            str(row["evidence_strength"]["key"]),
+            _receipt_cost_text(row.get("cost") or {}),
+        )
+    console.print(table)
+
+
+@app.command("receipt")
+def receipt(
+    task_id: Annotated[str, typer.Argument(help="Public Task id (task_…); an unambiguous prefix works.")],
+    store_dir: Annotated[Optional[Path], typer.Option(help=_STORE_DIR_HELP)] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit the full agentacct.receipt.v1 JSON.")] = False,
+) -> None:
+    """Print one Task's full Work Receipt: the 8 questions, the two orthogonal
+    axes (decision status × evidence strength), per-field provenance, and gaps."""
+
+    from .api import build_store_task_projection, _task_title
+    from .receipt import build_receipt, latest_store_activity
+
+    resolved = _resolve_cli_store_dir(store_dir).path
+    projection = build_store_task_projection(resolved)
+    task = _find_receipt_task(projection, task_id)
+    if task is None:
+        console.print(f"No Task matches {task_id} in this store.")
+        raise typer.Exit(1)
+    all_tasks = [t for t in projection.get("tasks", []) if isinstance(t, dict)]
+    receipt_payload = build_receipt(
+        task,
+        public_task_id=str(task.get("public_task_id")),
+        title=_task_title(task),
+        latest_store_activity_at=latest_store_activity(all_tasks),
+    )
+    if json_output:
+        console.print_json(data=receipt_payload)
+        return
+    _render_receipt_text(receipt_payload)
+
+
 if __name__ == "__main__":
     app()

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -32,6 +32,7 @@ _exit_if_unsupported_platform(sys.platform)
 
 import typer
 from rich.console import Console
+from rich.markup import escape as _rich_escape
 from rich.table import Table
 
 from .agent_loop import AgentLoopOptions, run_agent_like_loop
@@ -8980,15 +8981,15 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
     decision = axes.get("decision_status", {})
     evidence = axes.get("evidence_strength", {})
 
-    console.print(f"[bold]Work Receipt[/bold] · {receipt.get('title') or 'Task'}")
-    console.print(f"[dim]{receipt.get('task_id')}[/dim]\n")
+    console.print(f"[bold]Work Receipt[/bold] · {_rich_escape(str(receipt.get('title') or 'Task'))}")
+    console.print(f"[dim]{_rich_escape(str(receipt.get('task_id') or ''))}[/dim]\n")
 
     console.print(
         f"  Decision status    [bold]{str(decision.get('key') or 'unknown').upper()}[/bold]"
         f"  (asserted by {decision.get('asserted_by') or 'none'})"
     )
     if decision.get("statement"):
-        console.print(f"                     [dim]{decision['statement']}[/dim]")
+        console.print(f"                     [dim]{_rich_escape(str(decision['statement']))}[/dim]")
     console.print(
         f"  Evidence strength  [bold]{str(evidence.get('key') or 'none').upper()}[/bold]"
         f"  ({int(evidence.get('verified_step_count') or 0)}/{int(evidence.get('total_step_count') or 0)}"
@@ -8996,7 +8997,9 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
         f" {int(evidence.get('checks_passed') or 0)} passed)"
     )
     if evidence.get("strongest_proof"):
-        console.print(f"                     [dim]strongest proof: {evidence['strongest_proof']}[/dim]")
+        console.print(
+            f"                     [dim]strongest proof: {_rich_escape(str(evidence['strongest_proof']))}[/dim]"
+        )
     if axes.get("orthogonality_note"):
         console.print(f"  [dim]{axes['orthogonality_note']}[/dim]")
 
@@ -9011,7 +9014,7 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
     task_summary = "; ".join(objectives[:2]) or "no objective recorded"
     if boundary.get("project"):
         task_summary += f"  · project {boundary['project']}"
-    table.add_row("Task", task_summary, ", ".join(task.get("provenance") or []))
+    table.add_row("Task", _rich_escape(task_summary), ", ".join(task.get("provenance") or []))
 
     actors = dims.get("actors", {})
     actor_summary = " · ".join(
@@ -9023,12 +9026,12 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
         )
         if part
     )
-    table.add_row("Actors", actor_summary or "—", ", ".join(actors.get("provenance") or []))
+    table.add_row("Actors", _rich_escape(actor_summary or "—"), ", ".join(actors.get("provenance") or []))
 
     actions = dims.get("actions", {})
     actions_summary = _receipt_category_text(actions.get("tool_category_counts") or {})
     actions_summary += f"  · touched {int(actions.get('touched_file_count') or 0)} file(s)"
-    table.add_row("Actions", actions_summary, ", ".join(actions.get("provenance") or []))
+    table.add_row("Actions", _rich_escape(actions_summary), ", ".join(actions.get("provenance") or []))
 
     cost = dims.get("cost", {})
     table.add_row("Cost", _receipt_cost_text(cost), ", ".join(cost.get("provenance") or []))
@@ -9054,7 +9057,7 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
     if gaps.get("items"):
         console.print(f"\n[bold]Gaps[/bold] ({gaps.get('count')}) — what could not be proven")
         for item in gaps["items"]:
-            console.print(f"  · \\[{item.get('dimension')}] {item.get('reason')}")
+            console.print(f"  · \\[{item.get('dimension')}] {_rich_escape(str(item.get('reason')))}")
 
     legend = dims.get("provenance", {}).get("legend") or {}
     if legend:
@@ -9107,7 +9110,7 @@ def receipts(
     for row in rows:
         table.add_row(
             str(row["task_id"])[:16],
-            str(row.get("title") or "")[:48],
+            _rich_escape(str(row.get("title") or "")[:48]),
             str(row["decision_status"]["key"]),
             str(row["evidence_strength"]["key"]),
             _receipt_cost_text(row.get("cost") or {}),

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -474,6 +474,42 @@ def capture_claude_code_client_context(raw: str, *, store_dir: Path | str | None
         return None
 
 
+def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> None:
+    """Record ONE coarse tool-category tick for this PreToolUse. Never raises.
+
+    The PreToolUse hook already receives the tool name (and fails open), so this
+    is the cheapest honest place to observe what KIND of tool ran. Only a
+    category derived from the tool NAME is spooled — never the name, arguments,
+    or any payload — so this stays strictly inside the WorkEvent privacy line
+    while giving the Receipt's Actions dimension a real source. The spool lands
+    in the SAME store as the client-context bridge so the usage importer drains
+    both from one place.
+    """
+
+    try:
+        from .tool_activity import record_tool_activity_tick, tool_category
+
+        event = json.loads(raw or "{}")
+        if not isinstance(event, dict):
+            return
+        session_id = event.get("session_id")
+        if not isinstance(session_id, str) or not session_id or len(session_id) > _MAX_CONTEXT_ID_LENGTH:
+            return
+        target = Path(store_dir) if store_dir is not None else _hook_store_dir_from_event(event)
+        if target is None:
+            return
+        category = tool_category(event.get("tool_name") or event.get("tool"))
+        record_tool_activity_tick(
+            target,
+            client="claude-code",
+            session_id=session_id,
+            category=category,
+            at=time.time(),
+        )
+    except Exception:  # noqa: BLE001 - activity capture must never affect the hook decision.
+        return
+
+
 def is_subagent_session_start(event: Any) -> bool:
     """True when a SessionStart event fired inside a subagent session.
 

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -41,7 +41,12 @@ from collections.abc import Mapping
 from typing import Any
 
 from .task_intelligence import build_task_intelligence
-from .task_outcome import latest_task_checks, reduce_task_outcome, step_verification_counts
+from .task_outcome import (
+    latest_task_checks,
+    reduce_task_outcome,
+    step_verification_counts,
+    task_newest_event_at,
+)
 
 
 # frozen: stored/emitted receipts carry this schema string; surfaces pin it.
@@ -566,4 +571,65 @@ def build_receipt(
     }
 
 
-__all__ = ["RECEIPT_SCHEMA_VERSION", "PROVENANCE_LEGEND", "build_receipt"]
+def build_receipt_summary(
+    task: Mapping[str, Any],
+    *,
+    public_task_id: str,
+    title: str,
+    latest_store_activity_at: float | None = None,
+) -> dict[str, Any]:
+    """A compact Receipt row for a task LIST — the two axes plus cost/activity.
+
+    Shares the exact decision/evidence reducers with ``build_receipt`` so the
+    list and the detail can never disagree, without paying for the full 8
+    dimensions per row.
+    """
+
+    verification = step_verification_counts(task)
+    checks = _project_checks(task)
+    evidence_strength = _evidence_strength(verification, checks)
+    decision = _decision_status(task, latest_store_activity_at=latest_store_activity_at)
+    usage = _mapping(task.get("usage"))
+    return {
+        "task_id": public_task_id,
+        "title": title,
+        "decision_status": {
+            "key": decision["key"],
+            "label": decision["label"],
+            "asserted_by": decision["asserted_by"],
+        },
+        "evidence_strength": {
+            "key": evidence_strength["key"],
+            "label": evidence_strength["label"],
+            "verified_step_count": evidence_strength["verified_step_count"],
+            "total_step_count": evidence_strength["total_step_count"],
+        },
+        "cost": {
+            "estimated_cost_usd": usage.get("estimated_cost_usd"),
+            "cost_basis": _text(usage.get("cost_basis")) or None,
+            "cost_complete": bool(usage.get("cost_complete")),
+        },
+        "session_count": int(task.get("session_count") or 0),
+        "last_activity_at": _number(task.get("last_activity_at")) or None,
+    }
+
+
+def latest_store_activity(tasks: list[Mapping[str, Any]]) -> float | None:
+    """The newest event time across every Task — the deterministic 'now' the
+    outcome reducer compares against (never the wall clock). See
+    ``reduce_task_outcome``'s ``latest_store_activity_at``."""
+
+    newest = max(
+        (task_newest_event_at(task) for task in tasks if isinstance(task, Mapping)),
+        default=0.0,
+    )
+    return newest or None
+
+
+__all__ = [
+    "RECEIPT_SCHEMA_VERSION",
+    "PROVENANCE_LEGEND",
+    "build_receipt",
+    "build_receipt_summary",
+    "latest_store_activity",
+]

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -1,0 +1,569 @@
+"""The Receipt: one canonical answer to the 8 questions about one Task.
+
+A Receipt is the product's core object — "a local receipt for every coding-agent
+task: what ran, what passed, what it cost, and what remains unproven." It is a
+projection over ONE converged Task (see ``task_projection``/``task_identity``)
+that a person can read in under a minute and know whether to trust, without
+reopening the transcript.
+
+It answers eight questions, each carrying its own provenance and gaps:
+
+ 1. task       — what was asked, and the boundary of this Task
+ 2. actors     — which agents / models / subagent sessions did the work
+ 3. actions    — which KINDS of tools ran, and which artifacts were touched
+ 4. cost       — tokens and dollars, and on what BASIS that number rests
+ 5. evidence   — which checks actually ran, with exit codes and scope
+ 6. outcome    — the decision status (reported / verified / blocked / …)
+ 7. gaps       — what could NOT be proven (unlinked work, missing checks, …)
+ 8. provenance — where each field came from (client log / MCP / hook / CI / …)
+
+Two axes are kept deliberately SEPARATE and named explicitly:
+
+  * ``decision_status``  — what a human or agent SAYS happened.
+  * ``evidence_strength``— how well that is actually PROVEN.
+
+An agent reporting "done" never raises evidence strength, and a human review or
+approval never counts as machine verification (a finding disposition carries
+``authoritative_for_check_result=False``). The two are computed from disjoint
+inputs so the separation cannot silently erode: evidence strength is derived
+ONLY from recorded checks and per-step verification; decision status is derived
+from work statuses, blockers, and human dispositions.
+
+This module reuses ``build_task_intelligence`` (states / decision brief /
+verification / findings / coverage / lanes / timeline) rather than reinventing
+it, and adds the two missing layers M1 requires: a unified per-field provenance
+map and a unified gaps block.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .task_intelligence import build_task_intelligence
+from .task_outcome import latest_task_checks, reduce_task_outcome, step_verification_counts
+
+
+# frozen: stored/emitted receipts carry this schema string; surfaces pin it.
+RECEIPT_SCHEMA_VERSION = "agentacct.receipt.v1"
+
+# The user-facing provenance vocabulary — ONE list every surface shares. These
+# answer "where did this fact come from", not "how strong is it" (that is the
+# evidence axis). ``human`` is first-class here (it is not, in the lower-level
+# envelope-authority model, where it is folded into "none").
+SOURCE_CLIENT_LOG = "client_log"
+SOURCE_MCP = "mcp"
+SOURCE_HOOK = "hook"
+SOURCE_CI = "ci"
+SOURCE_GIT = "git"
+SOURCE_HUMAN = "human"
+SOURCE_NONE = "none"
+
+PROVENANCE_LEGEND: dict[str, str] = {
+    SOURCE_CLIENT_LOG: "Observed in the agent's own local session / usage log.",
+    SOURCE_MCP: "Recorded by the agent through agentacct's MCP tools (sections, files, checks).",
+    SOURCE_HOOK: "Captured by an agentacct client hook (tool categories, mechanical checks).",
+    SOURCE_CI: "Reported by external CI or the model provider.",
+    SOURCE_GIT: "Derived from the git repository.",
+    SOURCE_HUMAN: "Asserted by a person (review, approval, or finding disposition).",
+    SOURCE_NONE: "Not captured by any source — recorded here as a gap, never guessed.",
+}
+
+# decision_status.key -> who ASSERTS that status. Kept separate from evidence:
+# a machine-verified outcome is asserted by the machine; a blocker or a plain
+# "done" is an agent report; a reviewed/resolved finding is a human assertion.
+_DECISION_ASSERTED_BY: dict[str, str] = {
+    "verified": "machine",
+    "finding": "machine",
+    "finding_superseded": "machine",
+    "failed": "machine",
+    "blocked": "agent_report",
+    "reported": "agent_report",
+    "resolved": "agent_report",
+    "mostly_done": "agent_report",
+    "handed_off": "agent_report",
+    "in_progress": "agent_report",
+    "observed": "none",
+    "unknown": "none",
+}
+
+_DECISION_STATEMENTS: dict[str, str] = {
+    "verified": "Recorded machine evidence verifies the latest outcome.",
+    "finding": "A recorded check found an issue in the work being reviewed.",
+    "finding_superseded": (
+        "A recorded check failed, but a later same-scope check passed; the finding is kept "
+        "in history and is not a verified outcome."
+    ),
+    "failed": "A step was recorded as failed.",
+    "blocked": "The agent recorded a blocker for this Task.",
+    "resolved": "A later passed check reports the exact blocker resolved; this is not a verified completion.",
+    "reported": "The agent reported completing work; no linked passing check verifies it yet.",
+    "handed_off": "The work was cleanly handed off (continued elsewhere); a deliberate stop, not a completion.",
+    "mostly_done": "Recorded steps completed while one or more were left open; not a claim the Task is finished.",
+    "in_progress": "This Task is still in progress.",
+    "observed": "agentacct observed this Task but no outcome was recorded.",
+    "unknown": "agentacct observed this Task but no outcome was recorded.",
+}
+
+_SUCCESS_STATUSES = {"completed", "passed", "resolved"}
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _number(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def _items(task: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    rows = task.get("work_items") if isinstance(task.get("work_items"), list) else []
+    return [row for row in rows if isinstance(row, Mapping)]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+# --- Evidence axis ------------------------------------------------------------
+
+def _check_source(check: Mapping[str, Any]) -> str:
+    source_type = _text(check.get("source_type")).lower()
+    source = _text(check.get("source")).lower()
+    if source_type == "client_hook":
+        return SOURCE_HOOK
+    if source_type in {"ci", "external", "provider"} or source in {"ci", "github_actions"}:
+        return SOURCE_CI
+    return SOURCE_MCP
+
+
+def _project_checks(task: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Shape the Task's latest-per-identity checks for the Evidence dimension."""
+
+    shaped: list[dict[str, Any]] = []
+    for check in latest_task_checks(task):
+        if not isinstance(check, Mapping):
+            continue
+        shaped.append(
+            {
+                "kind": _text(check.get("evidence_type")) or "check",
+                "name": _text(check.get("name") or check.get("summary")) or "recorded check",
+                "result": _text(check.get("result")).lower() or "unknown",
+                "exit_code": _int_or_none(check.get("exit_code")),
+                "scope": _text(
+                    check.get("resolution_scope")
+                    or check.get("project_identity")
+                    or check.get("project_dir")
+                )
+                or None,
+                "source": _check_source(check),
+                "superseded": _text(check.get("supersession_state")).lower() == "superseded",
+                "at": _number(check.get("created_at") or check.get("occurred_at")) or None,
+            }
+        )
+    return shaped
+
+
+def _evidence_strength(verification: Mapping[str, Any], checks: list[Mapping[str, Any]]) -> dict[str, Any]:
+    """Grade positive proof ONLY. Never raised by agent claims or human review.
+
+    A failing check is not positive proof, so it never lifts the grade — it
+    lands on the decision axis as a finding instead.
+    """
+
+    verified = int(verification.get("verified_step_count") or 0)
+    total = int(verification.get("total_step_count") or 0)
+    reported = int(verification.get("agent_reported_step_count") or 0)
+    passed = sum(1 for check in checks if _text(check.get("result")).lower() == "passed")
+    failed = sum(1 for check in checks if _text(check.get("result")).lower() in {"failed", "error"})
+
+    if total > 0 and verified == total:
+        key = "verified"
+    elif verified > 0 or passed > 0:
+        key = "checked"
+    elif reported > 0:
+        key = "reported"
+    else:
+        key = "none"
+
+    strongest = next(
+        (check for check in checks if _text(check.get("result")).lower() == "passed"),
+        None,
+    )
+    return {
+        "key": key,
+        "label": key.title(),
+        "verified_step_count": verified,
+        "total_step_count": total,
+        "agent_reported_step_count": reported,
+        "checks_total": len(checks),
+        "checks_passed": passed,
+        "checks_failed": failed,
+        "strongest_proof": (_text(strongest.get("name") or strongest.get("summary")) or None)
+        if strongest is not None
+        else None,
+    }
+
+
+# --- Decision axis ------------------------------------------------------------
+
+def _decision_status(
+    task: Mapping[str, Any],
+    *,
+    latest_store_activity_at: float | None,
+) -> dict[str, Any]:
+    canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
+    key = _text(canonical.get("key")) or "observed"
+
+    # Refine ``failed`` out of ``blocked`` at the Receipt layer without changing
+    # the task_outcome contract: a step recorded literally ``failed`` with no
+    # blocker text is a failure, not an agent-declared blocker.
+    if key == "blocked":
+        statuses = [_text(item.get("latest_status")).lower() for item in _items(task)]
+        has_failed = any(status == "failed" for status in statuses)
+        has_blocker = any(_text(item.get("blocker")) for item in _items(task))
+        if has_failed and not has_blocker:
+            key = "failed"
+
+    attention = _text(canonical.get("finding_attention_state"))
+    asserted_by = _DECISION_ASSERTED_BY.get(key, "none")
+    # A finding a human has reviewed or resolved is now a HUMAN assertion — and
+    # (crucially) this never touches evidence strength.
+    if key == "finding" and attention in {"reviewed", "resolved"}:
+        asserted_by = "human"
+
+    statement = _DECISION_STATEMENTS.get(key, _DECISION_STATEMENTS["unknown"])
+    if key == "finding" and attention == "resolved":
+        statement = "You marked the recorded finding resolved; this is not machine verification."
+    elif key == "finding" and attention == "reviewed":
+        statement = "Every current finding was reviewed; no passing check has replaced the failed evidence."
+
+    return {
+        "key": key,
+        "label": key.replace("_", " ").title(),
+        "statement": statement,
+        "asserted_by": asserted_by,
+        "finding_attention_state": attention or None,
+    }
+
+
+def _asserted_by_source(asserted_by: str, checks: list[Mapping[str, Any]]) -> str:
+    if asserted_by == "human":
+        return SOURCE_HUMAN
+    if asserted_by == "machine":
+        sources = {check.get("source") for check in checks}
+        if SOURCE_HOOK in sources:
+            return SOURCE_HOOK
+        if SOURCE_CI in sources:
+            return SOURCE_CI
+        return SOURCE_MCP
+    if asserted_by == "agent_report":
+        return SOURCE_MCP
+    return SOURCE_NONE
+
+
+# --- Dimension builders -------------------------------------------------------
+
+def _boundary(task: Mapping[str, Any]) -> dict[str, Any]:
+    sessions = task.get("sessions") if isinstance(task.get("sessions"), list) else []
+    project = next(
+        (_text(session.get("project")) for session in sessions if isinstance(session, Mapping) and _text(session.get("project"))),
+        None,
+    )
+    scope = next(
+        (
+            _text(session.get("identity_scope_state"))
+            for session in sessions
+            if isinstance(session, Mapping) and _text(session.get("identity_scope_state"))
+        ),
+        None,
+    )
+    root_keys = task.get("root_keys") if isinstance(task.get("root_keys"), list) else []
+    return {
+        "primary_root": _mapping(task.get("primary_root")) or None,
+        "root_count": len(root_keys),
+        "session_count": int(task.get("session_count") or 0),
+        "is_continuation": bool(task.get("continuation_id")),
+        "project": project,
+        "identity_scope": scope or "unscoped",
+    }
+
+
+def _task_dimension(task: Mapping[str, Any], title: str) -> dict[str, Any]:
+    objectives: list[str] = []
+    seen: set[str] = set()
+    for item in _items(task):
+        objective = _text(item.get("objective") or item.get("title") or item.get("summary"))
+        if objective and objective not in seen:
+            seen.add(objective)
+            objectives.append(objective)
+    boundary = _boundary(task)
+    gaps: list[str] = []
+    if not objectives:
+        gaps.append("No explicit objective was recorded for this Task.")
+    if boundary["identity_scope"] == "unscoped":
+        gaps.append("Task identity is unscoped (no org/project namespace to bind it).")
+    provenance = [SOURCE_MCP] if objectives else []
+    if boundary["session_count"]:
+        provenance.append(SOURCE_CLIENT_LOG)
+    return {
+        "title": title,
+        "objectives": objectives,
+        "boundary": boundary,
+        "provenance": sorted(set(provenance)) or [SOURCE_NONE],
+        "gaps": gaps,
+    }
+
+
+def _actors_dimension(task: Mapping[str, Any], intelligence: Mapping[str, Any]) -> dict[str, Any]:
+    lanes = intelligence.get("lanes") if isinstance(intelligence.get("lanes"), list) else []
+    models = list(intelligence.get("models") or ())
+    primary = next((lane for lane in lanes if isinstance(lane, Mapping) and lane.get("role") == "primary"), None)
+    supporting = [lane for lane in lanes if isinstance(lane, Mapping) and lane.get("role") == "supporting"]
+    gaps: list[str] = []
+    if not models:
+        gaps.append("No model was observed for this Task's usage.")
+    if supporting and not any(lane.get("session_kinds") for lane in supporting):
+        gaps.append("Subagent roles were not scanned, so supporting sessions show as counts only.")
+    return {
+        "primary_agent": _text(primary.get("client")) if isinstance(primary, Mapping) else None,
+        "models": models,
+        "lanes": lanes,
+        "subagent_session_count": int(task.get("supporting_count") or 0),
+        "child_session_count": int(task.get("child_count") or 0),
+        "provenance": [SOURCE_CLIENT_LOG],
+        "gaps": gaps,
+    }
+
+
+def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
+    actions = _mapping(task.get("actions"))
+    counts = _mapping(actions.get("tool_category_counts"))
+    touched = actions.get("touched_files") if isinstance(actions.get("touched_files"), list) else []
+    provenance: list[str] = []
+    gaps: list[str] = []
+    if touched:
+        provenance.append(SOURCE_MCP)
+    else:
+        gaps.append("No touched files were recorded for this Task's steps.")
+    if counts:
+        provenance.append(SOURCE_HOOK)
+    else:
+        gaps.append(
+            "Tool categories were not instrumented for this session; Actions shows touched files only."
+        )
+    return {
+        "tool_category_counts": dict(counts),
+        "tool_category_total": int(actions.get("tool_category_total") or 0),
+        "touched_files": list(touched),
+        "touched_file_count": int(actions.get("touched_file_count") or len(touched)),
+        "provenance": sorted(set(provenance)) or [SOURCE_NONE],
+        "gaps": gaps,
+    }
+
+
+def _cost_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
+    usage = _mapping(task.get("usage"))
+    cost_complete = bool(usage.get("cost_complete"))
+    estimated = usage.get("estimated_cost_usd")
+    cost_basis = _text(usage.get("cost_basis")) or None
+    cost_confidence = _text(usage.get("cost_confidence")) or None
+    gaps: list[str] = []
+    if not cost_complete:
+        gaps.append("Cost is incomplete: some usage rows are unpriced or excluded.")
+    if cost_confidence in {"estimated_from_tokens", "estimated"}:
+        gaps.append("Cost is a pricing-table estimate from token counts, not a billed amount.")
+    if estimated is None and int(usage.get("rows") or 0) == 0:
+        gaps.append("No usage was recorded for this Task.")
+    return {
+        "estimated_cost_usd": estimated,
+        "cost_basis": cost_basis,
+        "cost_confidence": cost_confidence,
+        "cost_complete": cost_complete,
+        "tokens": {
+            "fresh": int(usage.get("fresh_tokens") or 0),
+            "cache_creation": int(usage.get("cache_creation_tokens") or 0),
+            "cache_read": int(usage.get("cache_read_tokens") or 0),
+            "total": int(usage.get("total_tokens") or 0),
+        },
+        "provenance": [SOURCE_CLIENT_LOG] if int(usage.get("rows") or 0) else [SOURCE_NONE],
+        "gaps": gaps,
+    }
+
+
+def _evidence_dimension(checks: list[Mapping[str, Any]], strength: Mapping[str, Any]) -> dict[str, Any]:
+    sources = sorted({_text(check.get("source")) for check in checks if _text(check.get("source"))})
+    gaps: list[str] = []
+    if not checks:
+        gaps.append("No machine checks were recorded for this Task.")
+    reported_only = int(strength.get("agent_reported_step_count") or 0)
+    if reported_only:
+        gaps.append(f"{reported_only} completed step(s) have no linked passing check.")
+    return {
+        "checks": list(checks),
+        "checks_total": int(strength.get("checks_total") or 0),
+        "checks_passed": int(strength.get("checks_passed") or 0),
+        "checks_failed": int(strength.get("checks_failed") or 0),
+        "provenance": sources or [SOURCE_NONE],
+        "gaps": gaps,
+    }
+
+
+def _outcome_dimension(
+    decision: Mapping[str, Any],
+    verification: Mapping[str, Any],
+    decision_brief: Mapping[str, Any],
+    checks: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    asserted_by = _text(decision.get("asserted_by")) or "none"
+    gaps: list[str] = []
+    if decision.get("key") in {"in_progress", "observed", "unknown"}:
+        gaps.append("No terminal outcome has been recorded for this Task yet.")
+    return {
+        "decision_status": decision.get("key"),
+        "statement": decision.get("statement"),
+        "asserted_by": asserted_by,
+        "per_step": {
+            "verified": int(verification.get("verified_step_count") or 0),
+            "total": int(verification.get("total_step_count") or 0),
+            "agent_reported": int(verification.get("agent_reported_step_count") or 0),
+        },
+        "owner": decision_brief.get("owner"),
+        "next_action": decision_brief.get("next_action"),
+        "provenance": [_asserted_by_source(asserted_by, checks)],
+        "gaps": gaps,
+    }
+
+
+# --- Roll-ups (dimensions 7 & 8) ---------------------------------------------
+
+def _roll_up_gaps(
+    dimensions: Mapping[str, Mapping[str, Any]],
+    coverage: list[Mapping[str, Any]],
+    task: Mapping[str, Any],
+) -> dict[str, Any]:
+    items: list[dict[str, str]] = []
+    for name, dimension in dimensions.items():
+        for reason in dimension.get("gaps", []) or []:
+            items.append({"dimension": name, "reason": reason})
+    # Coverage rows the intelligence layer already computed that aren't fully
+    # recorded are honest gaps too (kept distinct from the per-dimension ones).
+    for row in coverage:
+        if not isinstance(row, Mapping):
+            continue
+        state = _text(row.get("state"))
+        if state and state not in {"recorded"}:
+            items.append(
+                {
+                    "dimension": "coverage",
+                    "reason": f"{_text(row.get('dimension')) or 'dimension'} is {state}.",
+                }
+            )
+    unlinked = int(task.get("session_unlinked_work_count") or 0)
+    if unlinked:
+        items.append(
+            {
+                "dimension": "actors",
+                "reason": f"{unlinked} work item(s) could not be tied to an exact session.",
+            }
+        )
+    return {"items": items, "count": len(items)}
+
+
+def _roll_up_provenance(dimensions: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    by_field: dict[str, list[str]] = {}
+    present: set[str] = set()
+    for name, dimension in dimensions.items():
+        sources = [source for source in (dimension.get("provenance") or []) if source]
+        by_field[name] = sources or [SOURCE_NONE]
+        present.update(by_field[name])
+    return {
+        "by_dimension": by_field,
+        "sources_present": sorted(present),
+        "legend": {source: PROVENANCE_LEGEND[source] for source in sorted(present) if source in PROVENANCE_LEGEND},
+    }
+
+
+# --- Public entry point -------------------------------------------------------
+
+def build_receipt(
+    task: Mapping[str, Any],
+    *,
+    public_task_id: str,
+    title: str,
+    control: Mapping[str, Any] | None = None,
+    timeline_limit: int = 50,
+    latest_store_activity_at: float | None = None,
+) -> dict[str, Any]:
+    """Project one enriched Task into a canonical ``agentacct.receipt.v1``.
+
+    ``task`` is a single element of a decorated, evidence-attached Task
+    projection (``build_store_task_projection(...)["tasks"][i]`` after
+    ``_attach_evidence_to_task_projection``). ``build_task_intelligence`` is
+    reused for the states / decision brief / verification / findings / coverage
+    / lanes / timeline; this function adds the two orthogonal axes and the
+    unified provenance and gaps roll-ups.
+    """
+
+    intelligence = build_task_intelligence(
+        task,
+        public_task_id=public_task_id,
+        title=title,
+        control=control,
+        timeline_limit=timeline_limit,
+        latest_store_activity_at=latest_store_activity_at,
+    )
+    verification = step_verification_counts(task)
+    checks = _project_checks(task)
+    evidence_strength = _evidence_strength(verification, checks)
+    decision = _decision_status(task, latest_store_activity_at=latest_store_activity_at)
+    decision_brief = _mapping(intelligence.get("decision_brief"))
+
+    dimensions: dict[str, dict[str, Any]] = {
+        "task": _task_dimension(task, title),
+        "actors": _actors_dimension(task, intelligence),
+        "actions": _actions_dimension(task),
+        "cost": _cost_dimension(task),
+        "evidence": _evidence_dimension(checks, evidence_strength),
+        "outcome": _outcome_dimension(decision, verification, decision_brief, checks),
+    }
+    coverage = intelligence.get("coverage") if isinstance(intelligence.get("coverage"), list) else []
+    dimensions["gaps"] = _roll_up_gaps(dimensions, coverage, task)
+    dimensions["provenance"] = _roll_up_provenance(dimensions)
+
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "task_id": public_task_id,
+        "title": title,
+        "axes": {
+            "decision_status": decision,
+            "evidence_strength": evidence_strength,
+            "orthogonality_note": (
+                "Evidence strength and decision status are separate axes: an agent reporting "
+                "'done' never raises evidence strength, and a human review or approval never "
+                "counts as machine verification."
+            ),
+        },
+        "dimensions": dimensions,
+        # Rich sub-objects reused verbatim by the CLI / app / TUI surfaces.
+        "lanes": intelligence.get("lanes"),
+        "timeline": intelligence.get("timeline"),
+        "findings": intelligence.get("findings"),
+        "coverage": intelligence.get("coverage"),
+        "duration_seconds": intelligence.get("duration_seconds"),
+        "models": intelligence.get("models"),
+        "usage": intelligence.get("usage"),
+        "raw_evidence": intelligence.get("raw_evidence"),
+    }
+
+
+__all__ = ["RECEIPT_SCHEMA_VERSION", "PROVENANCE_LEGEND", "build_receipt"]

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -81,7 +81,9 @@ _DECISION_ASSERTED_BY: dict[str, str] = {
     "verified": "machine",
     "finding": "machine",
     "finding_superseded": "machine",
-    "failed": "machine",
+    # ``failed`` is refined out of ``blocked`` from an agent-recorded work status,
+    # not a machine check — so it is an agent report, exactly like ``blocked``.
+    "failed": "agent_report",
     "blocked": "agent_report",
     "reported": "agent_report",
     "resolved": "agent_report",
@@ -542,8 +544,13 @@ def build_receipt(
         "outcome": _outcome_dimension(decision, verification, decision_brief, checks),
     }
     coverage = intelligence.get("coverage") if isinstance(intelligence.get("coverage"), list) else []
-    dimensions["gaps"] = _roll_up_gaps(dimensions, coverage, task)
-    dimensions["provenance"] = _roll_up_provenance(dimensions)
+    # Roll both meta-dimensions up over ONLY the six content dimensions, before
+    # inserting them — ``gaps`` and ``provenance`` carry no provenance of their
+    # own, so including them would manufacture a spurious ``none`` source.
+    gaps = _roll_up_gaps(dimensions, coverage, task)
+    provenance = _roll_up_provenance(dimensions)
+    dimensions["gaps"] = gaps
+    dimensions["provenance"] = provenance
 
     return {
         "schema_version": RECEIPT_SCHEMA_VERSION,

--- a/src/agentacct/task_projection.py
+++ b/src/agentacct/task_projection.py
@@ -972,6 +972,36 @@ def build_task_projection(
                 run_work_ids[run_id].append(work_id)
         task_associations = associations.get(task_key, [])
         supporting_keys = member_keys - root_keys
+        # Actions dimension: which KINDS of tools ran (hook-captured category
+        # counts, summed over the Task's sessions) and which repo-relative
+        # artifacts were touched (union of every step's files). Both are pure
+        # aggregates of already-recorded, privacy-reviewed data — no tool names
+        # or arguments ever reach here.
+        tool_category_counts: dict[str, int] = {}
+        for key in ordered_members:
+            counts = sessions[key].get("tool_category_counts")
+            if not isinstance(counts, Mapping):
+                continue
+            for category, value in counts.items():
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    name = _text(category)
+                    if name:
+                        tool_category_counts[name] = tool_category_counts.get(name, 0) + value
+        touched_files: list[str] = []
+        seen_touched_files: set[str] = set()
+        for item in task_work:
+            files = item.get("files") if isinstance(item.get("files"), list) else []
+            for candidate in files:
+                path = _text(candidate)
+                if path and path not in seen_touched_files:
+                    seen_touched_files.add(path)
+                    touched_files.append(path)
+        actions = {
+            "tool_category_counts": dict(sorted(tool_category_counts.items())),
+            "tool_category_total": sum(tool_category_counts.values()),
+            "touched_files": touched_files,
+            "touched_file_count": len(touched_files),
+        }
         tasks.append(
             {
                 "task_id": task_id,
@@ -1009,6 +1039,7 @@ def build_task_projection(
                 ],
                 "usage": usage,
                 "models": models,
+                "actions": actions,
             }
         )
 

--- a/src/agentacct/task_projection.py
+++ b/src/agentacct/task_projection.py
@@ -539,6 +539,7 @@ def _aggregate_usage(
     cost_complete = True
     usage_confidences: set[str] = set()
     cost_confidences: set[str] = set()
+    cost_bases: set[str] = set()
     partial_without_counts = {"cache_creation": False, "cache_read": False}
     # ``set`` is the final guard against callers repeating member keys.
     for key in sorted(set(session_keys)):
@@ -602,10 +603,13 @@ def _aggregate_usage(
             usage_present = True
             usage_confidence = _text(usage.get("usage_confidence"))
             cost_confidence = _text(usage.get("cost_confidence"))
+            cost_basis = _text(usage.get("cost_basis"))
             if usage_confidence:
                 usage_confidences.add(usage_confidence)
             if cost_confidence:
                 cost_confidences.add(cost_confidence)
+            if cost_basis:
+                cost_bases.add(cost_basis)
             if unpriced_rows or usage.get("estimated_cost_usd") is None:
                 cost_complete = False
             else:
@@ -645,6 +649,17 @@ def _aggregate_usage(
         if len(cost_confidences) == 1
         else "mixed"
         if cost_confidences
+        else None
+    )
+    # ``cost_basis`` rides alongside ``cost_confidence`` so a Task's Cost reads
+    # both "how sure" and "what kind of number": one basis if every priced row
+    # agrees, ``mixed`` when they disagree (e.g. some client-reported, some
+    # pricing-table estimate), ``None`` when no additive row carried a basis.
+    totals["cost_basis"] = (
+        next(iter(cost_bases))
+        if len(cost_bases) == 1
+        else "mixed"
+        if cost_bases
         else None
     )
     for prefix in ("cache_creation", "cache_read"):

--- a/src/agentacct/tool_activity.py
+++ b/src/agentacct/tool_activity.py
@@ -1,0 +1,293 @@
+"""Privacy-safe tool-CATEGORY capture for the Receipt's Actions dimension.
+
+The Actions question a Receipt must answer is "what kinds of things did the
+agent do". WorkEvent (``work_events.py``) deliberately excludes tool names,
+arguments, and results, and this module holds that same line: it records only a
+COARSE CATEGORY derived from a tool's NAME (never the name itself, never its
+arguments, never a path). The taxonomy is intentionally derivable from the tool
+name ALONE — we do not try to tell ``git commit`` from ``ls`` inside ``execute``,
+because that would require reading arguments.
+
+The capture path mirrors the terminal-CLI statusLine spool
+(``rate_limits.write_claude_statusline_spool``): the installed Claude Code
+PreToolUse hook already sees every tool name and fails open, so it appends one
+tiny category tick to a per-store spool (no daemon required, O(1), best-effort).
+``agentacct usage import-local`` later drains the spool into additive
+``tool_activity_observed`` events, which the work ledger reduces into a
+per-session ``tool_category_counts`` and the Task projection sums into
+``task["actions"]``. A session with no captured ticks honestly carries no
+counts (the Receipt shows a Gap), never a fabricated zero.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any, Callable
+
+
+# frozen: stored ``tool_activity_observed`` events carry this event_type forever.
+TOOL_ACTIVITY_EVENT_TYPE = "tool_activity_observed"
+TOOL_ACTIVITY_CAPTURE_BASIS = "client_hook_tool_category"
+_SPOOL_RELATIVE_PATH = Path("spool") / "claude-tool-activity.jsonl"
+
+# The complete, closed category set. Every tool name maps to exactly one of
+# these; anything unrecognised is ``other`` (honest, never dropped silently).
+TOOL_CATEGORIES: frozenset[str] = frozenset(
+    {"read", "edit", "execute", "search", "network", "agent", "plan", "mcp", "other"}
+)
+
+# Name-only taxonomy. Keys are lower-cased tool names. Only the tool NAME is
+# consulted — never its arguments — so this map can never leak a command, path,
+# or payload. ``mcp__*`` tools are collapsed to ``mcp`` by prefix below so no
+# specific MCP tool name is ever recorded.
+_CATEGORY_BY_TOOL_NAME: dict[str, str] = {
+    "read": "read",
+    "notebookread": "read",
+    "edit": "edit",
+    "write": "edit",
+    "multiedit": "edit",
+    "notebookedit": "edit",
+    "bash": "execute",
+    "bashoutput": "execute",
+    "killshell": "execute",
+    "killbash": "execute",
+    "grep": "search",
+    "glob": "search",
+    "ls": "search",
+    "webfetch": "network",
+    "websearch": "network",
+    "task": "agent",
+    "agent": "agent",
+    "todowrite": "plan",
+    "exitplanmode": "plan",
+    "enterplanmode": "plan",
+}
+
+
+def tool_category(tool_name: Any) -> str:
+    """Map a tool NAME to a coarse category. Never inspects arguments.
+
+    Unknown names return ``other`` rather than being dropped, so the count of
+    what the agent did stays honest. ``mcp__<server>__<tool>`` collapses to
+    ``mcp`` by prefix, so a specific MCP tool name is never recorded.
+    """
+
+    name = str(tool_name or "").strip().lower()
+    if not name:
+        return "other"
+    if name.startswith("mcp__"):
+        return "mcp"
+    return _CATEGORY_BY_TOOL_NAME.get(name, "other")
+
+
+def tool_activity_spool_path(store_dir: Path | str) -> Path:
+    return Path(store_dir) / _SPOOL_RELATIVE_PATH
+
+
+def record_tool_activity_tick(
+    store_dir: Path | str,
+    *,
+    client: str,
+    session_id: str,
+    category: str,
+    at: float,
+) -> None:
+    """Append ONE category tick to the store spool. Best-effort; never raises.
+
+    Only the four small scalars ``{c, s, k, t}`` are written — client, session
+    id, category, and a timestamp. No tool name, no arguments, no path. The line
+    is a single tiny JSON object written with ``O_APPEND`` so concurrent hook
+    processes (many tool calls in flight) never corrupt or interleave lines.
+    """
+
+    try:
+        if category not in TOOL_CATEGORIES:
+            category = "other"
+        client = str(client or "").strip()
+        session_id = str(session_id or "").strip()
+        if not client or not session_id:
+            return
+        target = tool_activity_spool_path(store_dir)
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        line = json.dumps(
+            {"c": client, "s": session_id, "k": category, "t": float(at)},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, (line + "\n").encode("utf-8"))
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001 - capture must never affect the hook.
+        return
+
+
+def drain_tool_activity_spool(
+    store_dir: Path | str,
+    *,
+    now: float | None = None,
+    token: str | None = None,
+) -> list[dict[str, Any]]:
+    """Consume the spool and return additive ``tool_activity_observed`` events.
+
+    The spool is atomically renamed aside before being read, so hook ticks that
+    land during the drain go to a freshly recreated spool and are picked up by
+    the NEXT drain. Each returned event is one batch of per-session category
+    counts; because batches are additive and carry a unique id, re-reducing the
+    event log is idempotent and re-importing never double counts. A few ticks
+    appended between the read and the rename can be lost — an acceptable, honest
+    undercount (Actions means "at least this much"), never an overcount.
+    """
+
+    spool = tool_activity_spool_path(store_dir)
+    if not spool.exists():
+        return []
+    batch_token = token or uuid.uuid4().hex
+    consuming = spool.with_name(f".{spool.name}.consuming-{os.getpid()}-{batch_token}")
+    try:
+        os.replace(spool, consuming)
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return []
+    try:
+        raw = consuming.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    finally:
+        try:
+            consuming.unlink()
+        except OSError:
+            pass
+
+    counts: dict[tuple[str, str], dict[str, int]] = {}
+    latest: dict[tuple[str, str], float] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, Mapping):
+            continue
+        client = str(row.get("c") or "").strip()
+        session = str(row.get("s") or "").strip()
+        category = str(row.get("k") or "").strip()
+        if not client or not session:
+            continue
+        if category not in TOOL_CATEGORIES:
+            category = "other"
+        key = (client, session)
+        bucket = counts.setdefault(key, {})
+        bucket[category] = bucket.get(category, 0) + 1
+        stamp = row.get("t")
+        if isinstance(stamp, (int, float)) and not isinstance(stamp, bool):
+            latest[key] = max(latest.get(key, 0.0), float(stamp))
+
+    events: list[dict[str, Any]] = []
+    for (client, session), bucket in sorted(counts.items()):
+        created_at = latest.get((client, session)) or (float(now) if now is not None else 0.0)
+        digest = uuid.uuid5(
+            uuid.NAMESPACE_URL, f"{batch_token}\0{client}\0{session}"
+        ).hex
+        events.append(
+            {
+                "event_id": f"toolact:{digest}",
+                "created_at": created_at,
+                "source": client,
+                "event_type": TOOL_ACTIVITY_EVENT_TYPE,
+                "run_id": None,
+                "metadata": {
+                    "client": client,
+                    "client_session_id": session,
+                    "tool_category_counts": dict(sorted(bucket.items())),
+                    "capture_basis": TOOL_ACTIVITY_CAPTURE_BASIS,
+                    "captured_at": created_at,
+                    "sentinel_semantic_kind": "tool_activity",
+                },
+            }
+        )
+    return events
+
+
+def ingest_tool_activity_spool(
+    store_dir: Path | str,
+    *,
+    record: Callable[[dict[str, Any]], Any],
+    now: float | None = None,
+    token: str | None = None,
+) -> int:
+    """Drain the spool and hand each batch event to ``record``. Never raises.
+
+    Mirrors ``rate_limits.record_snapshots_transitionally``'s
+    ``record=service.record_event`` contract so the usage importer can call it
+    the same way it records rate-limit snapshots.
+    """
+
+    try:
+        events = drain_tool_activity_spool(store_dir, now=now, token=token)
+    except Exception:  # noqa: BLE001 - a spool drain must never fail the import.
+        return 0
+    written = 0
+    for event in events:
+        try:
+            record(event)
+            written += 1
+        except Exception:  # noqa: BLE001 - one bad record must not abort the rest.
+            continue
+    return written
+
+
+def build_tool_activity_by_session(
+    events: Iterable[Mapping[str, Any]],
+) -> dict[tuple[str, str], dict[str, int]]:
+    """Sum ``tool_activity_observed`` batch counts per (client, session).
+
+    Batches are additive: reducing the whole event log sums every recorded
+    batch, so the per-session total is stable no matter how many import runs
+    produced it. Only known categories and positive integer counts are kept.
+    """
+
+    result: dict[tuple[str, str], dict[str, int]] = {}
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        if event.get("event_type") != TOOL_ACTIVITY_EVENT_TYPE:
+            continue
+        metadata = event.get("metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        client = str(metadata.get("client") or "").strip()
+        session = str(metadata.get("client_session_id") or "").strip()
+        if not client or not session:
+            continue
+        counts = metadata.get("tool_category_counts")
+        if not isinstance(counts, Mapping):
+            continue
+        bucket = result.setdefault((client, session), {})
+        for category, value in counts.items():
+            if category not in TOOL_CATEGORIES:
+                continue
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                continue
+            bucket[category] = bucket.get(category, 0) + value
+    return {key: value for key, value in result.items() if value}
+
+
+__all__ = [
+    "TOOL_ACTIVITY_CAPTURE_BASIS",
+    "TOOL_ACTIVITY_EVENT_TYPE",
+    "TOOL_CATEGORIES",
+    "build_tool_activity_by_session",
+    "drain_tool_activity_spool",
+    "ingest_tool_activity_spool",
+    "record_tool_activity_tick",
+    "tool_activity_spool_path",
+    "tool_category",
+]

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -398,6 +398,7 @@ class AgentAcctTUI(App):
         Binding("r", "refresh", "Refresh"),
         Binding("w", "cycle_window", "Cycle window"),
         Binding("s", "open_sessions", "Sessions"),
+        Binding("t", "open_receipts", "Receipts"),
         Binding("u", "open_usage", "Usage"),
         Binding("p", "screenshot", "Snapshot"),
     ]
@@ -924,6 +925,9 @@ class AgentAcctTUI(App):
     def action_open_sessions(self) -> None:
         self._show_top_level(SessionsScreen)
 
+    def action_open_receipts(self) -> None:
+        self._show_top_level(ReceiptsScreen)
+
     def action_open_usage(self) -> None:
         self._show_top_level(UsageScreen)
 
@@ -1153,6 +1157,301 @@ class SessionsScreen(Screen):
     def action_refresh(self) -> None:
         self._set_loading(True, "Rebuilding the work ledger…")
         self._load(force=True)
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+
+_RECEIPTS_LIMIT = 300
+
+
+def _receipt_decision_color(key: str) -> str:
+    return {
+        "verified": "green",
+        "finding": "red",
+        "failed": "red",
+        "blocked": "red",
+        "reported": "yellow",
+        "mostly_done": "yellow",
+        "in_progress": "yellow",
+        "handed_off": "blue",
+        "resolved": "blue",
+        "finding_superseded": "blue",
+    }.get(key, "dim")
+
+
+def _receipt_evidence_color(key: str) -> str:
+    return {"verified": "green", "checked": "blue", "reported": "yellow"}.get(key, "dim")
+
+
+def _receipt_summary_cost(cost: dict) -> str:
+    amount = cost.get("estimated_cost_usd")
+    if amount is None:
+        return "—"
+    return f"${float(amount):.2f} · {cost.get('cost_basis') or 'unknown basis'}"
+
+
+def _render_receipt_markup(receipt: dict) -> str:
+    """One Task's Work Receipt as Rich markup for the detail Static.
+
+    Shares the exact build_receipt vocabulary the CLI, app, and API render —
+    the two orthogonal axes up top, a per-dimension line with its provenance,
+    then the gaps roll-up and the provenance legend.
+    """
+
+    axes = receipt.get("axes") or {}
+    dims = receipt.get("dimensions") or {}
+    decision = axes.get("decision_status") or {}
+    evidence = axes.get("evidence_strength") or {}
+    lines: list[str] = []
+    lines.append(f"[b]{_escape(str(receipt.get('title') or 'Task'))}[/b]")
+    lines.append(f"[dim]{_escape(str(receipt.get('task_id') or ''))}[/dim]\n")
+
+    dcolor = _receipt_decision_color(str(decision.get("key")))
+    ecolor = _receipt_evidence_color(str(evidence.get("key")))
+    lines.append(
+        f"Decision status    [b {dcolor}]{str(decision.get('key') or '').upper()}[/]"
+        f"  [dim](asserted by {decision.get('asserted_by')})[/]"
+    )
+    if decision.get("statement"):
+        lines.append(f"                   [dim]{_escape(str(decision['statement']))}[/]")
+    lines.append(
+        f"Evidence strength  [b {ecolor}]{str(evidence.get('key') or '').upper()}[/]"
+        f"  [dim]({evidence.get('verified_step_count', 0)}/{evidence.get('total_step_count', 0)}"
+        f" steps verified · {evidence.get('checks_total', 0)} checks,"
+        f" {evidence.get('checks_passed', 0)} passed)[/]"
+    )
+    if evidence.get("strongest_proof"):
+        lines.append(f"                   [dim]strongest proof: {_escape(str(evidence['strongest_proof']))}[/]")
+    if axes.get("orthogonality_note"):
+        lines.append(f"[dim]{_escape(str(axes['orthogonality_note']))}[/]")
+    lines.append("")
+
+    def _prov(name: str) -> str:
+        return ", ".join((dims.get(name) or {}).get("provenance") or [])
+
+    task = dims.get("task") or {}
+    objectives = "; ".join((task.get("objectives") or [])[:2]) or "no objective recorded"
+    if (task.get("boundary") or {}).get("project"):
+        objectives += f" · project {task['boundary']['project']}"
+    lines.append(f"[b]Task[/]      {_escape(objectives)}   [dim]\\[{_prov('task')}][/]")
+
+    actors = dims.get("actors") or {}
+    actor_parts = [
+        part
+        for part in (
+            actors.get("primary_agent"),
+            ", ".join(actors.get("models") or []) or None,
+            (f"{actors.get('subagent_session_count')} subagents" if actors.get("subagent_session_count") else None),
+        )
+        if part
+    ]
+    lines.append(f"[b]Actors[/]    {_escape(' · '.join(actor_parts) or '—')}   [dim]\\[{_prov('actors')}][/]")
+
+    actions = dims.get("actions") or {}
+    counts = actions.get("tool_category_counts") or {}
+    category_text = " ".join(f"{k}×{v}" for k, v in sorted(counts.items())) if counts else "not instrumented"
+    lines.append(
+        f"[b]Actions[/]   {_escape(category_text)} · touched {actions.get('touched_file_count', 0)} file(s)"
+        f"   [dim]\\[{_prov('actions')}][/]"
+    )
+
+    cost = dims.get("cost") or {}
+    lines.append(f"[b]Cost[/]      {_escape(_receipt_summary_cost(cost))}   [dim]\\[{_prov('cost')}][/]")
+
+    ev = dims.get("evidence") or {}
+    lines.append(
+        f"[b]Evidence[/]  {ev.get('checks_total', 0)} checks · {ev.get('checks_passed', 0)} passed · "
+        f"{ev.get('checks_failed', 0)} failed   [dim]\\[{_prov('evidence')}][/]"
+    )
+
+    outcome = dims.get("outcome") or {}
+    lines.append(
+        f"[b]Outcome[/]   {outcome.get('decision_status')} · asserted by {outcome.get('asserted_by')}"
+        f"   [dim]\\[{_prov('outcome')}][/]"
+    )
+
+    gaps = (dims.get("gaps") or {}).get("items") or []
+    if gaps:
+        lines.append(f"\n[b]Gaps[/] ({len(gaps)}) — what could not be proven")
+        for gap in gaps:
+            lines.append(f"  · [dim]\\[{gap.get('dimension')}][/] {_escape(str(gap.get('reason')))}")
+
+    legend = (dims.get("provenance") or {}).get("legend") or {}
+    if legend:
+        lines.append("\n[b]Provenance[/]")
+        for source in sorted(legend):
+            lines.append(f"  [b]{source}[/] — [dim]{_escape(str(legend[source]))}[/]")
+
+    return "\n".join(lines)
+
+
+class ReceiptsScreen(Screen):
+    """The Task list: one converged Task per row with its Receipt summary
+    (decision × evidence, cost). Select one to read its full Work Receipt."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+        Binding("r", "refresh", "Rebuild"),
+        Binding("q", "quit", "Quit"),
+        Binding("p", "screenshot", "Snapshot"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._by_id: dict[str, dict] = {}
+
+    def compose(self) -> ComposeResult:
+        yield _navbar("receipts")
+        yield Static("", id="sessions-status")
+        yield LoadingIndicator(id="sessions-loading")
+        yield DataTable(id="receipts", cursor_type="row", zebra_stripes=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = "agentacct"
+        self.sub_title = "receipts"
+        self.query_one("#receipts", DataTable).add_columns(
+            "task", "decision", "evidence", "cost", "activity"
+        )
+        self.query_one("#sessions-status", Static).update(
+            "Building receipts (one-time, a few seconds)…"
+        )
+        self._load()
+
+    def _set_loading(self, loading: bool) -> None:
+        try:
+            self.query_one("#sessions-loading", LoadingIndicator).display = loading
+        except Exception:  # noqa: BLE001 - cosmetic only
+            pass
+
+    @work(thread=True, exclusive=True)
+    def _load(self) -> None:
+        from textual.worker import get_current_worker
+
+        worker = get_current_worker()
+        app = self.app
+        try:
+            from .api import build_store_task_projection, _task_title
+            from .receipt import build_receipt_summary, latest_store_activity
+
+            projection = build_store_task_projection(app.store_dir)
+            tasks = [
+                task
+                for task in projection.get("tasks", [])
+                if isinstance(task, dict) and str(task.get("public_task_id") or "")
+            ]
+            latest = latest_store_activity(tasks)
+            tasks.sort(key=lambda task: float(task.get("last_activity_at") or 0.0), reverse=True)
+            rows = [
+                (
+                    task,
+                    build_receipt_summary(
+                        task,
+                        public_task_id=str(task.get("public_task_id")),
+                        title=_task_title(task),
+                        latest_store_activity_at=latest,
+                    ),
+                )
+                for task in tasks[:_RECEIPTS_LIMIT]
+            ]
+        except Exception as exc:  # noqa: BLE001 - surface, never crash the screen.
+            if not worker.is_cancelled:
+                app.call_from_thread(self._show_error, str(exc))
+            return
+        if worker.is_cancelled:
+            return
+        app.call_from_thread(self._populate, rows)
+
+    def _show_error(self, message: str) -> None:
+        if not self.is_mounted:
+            return
+        self._set_loading(False)
+        self.query_one("#sessions-status", Static).update(
+            f"[red]could not build receipts:[/] {_escape(message)}"
+        )
+
+    def _populate(self, rows: list) -> None:
+        if not self.is_mounted:
+            return
+        table = self.query_one("#receipts", DataTable)
+        table.clear()
+        self._by_id.clear()
+        now = time.time()
+        for task, summary in rows:
+            task_id = str(summary["task_id"])
+            self._by_id[task_id] = task
+            decision = summary["decision_status"]
+            evidence = summary["evidence_strength"]
+            table.add_row(
+                _escape(str(summary.get("title") or task_id))[:46],
+                f"[{_receipt_decision_color(decision['key'])}]{decision['key']}[/]",
+                f"[{_receipt_evidence_color(evidence['key'])}]{evidence['key']}[/]",
+                _escape(_receipt_summary_cost(summary.get("cost") or {})),
+                _humanize_ago(summary.get("last_activity_at"), now),
+                key=task_id,
+            )
+        self._set_loading(False)
+        self.query_one("#sessions-status", Static).update(
+            f"[b]{len(rows)} tasks[/]      [dim]Enter open · r rebuild · Esc back[/]"
+        )
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        key = event.row_key.value if event.row_key is not None else None
+        task = self._by_id.get(str(key)) if key is not None else None
+        if task is not None:
+            self.app.push_screen(ReceiptDetailScreen(task))
+
+    def action_refresh(self) -> None:
+        self._set_loading(True)
+        self.query_one("#sessions-status", Static).update("Rebuilding receipts…")
+        self._load()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+
+class ReceiptDetailScreen(Screen):
+    """One Task's full Work Receipt: the 8 questions, the two orthogonal axes,
+    per-field provenance, and the gaps block."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+        Binding("backspace", "back", "Back"),
+        Binding("q", "quit", "Quit"),
+        Binding("p", "screenshot", "Snapshot"),
+    ]
+
+    def __init__(self, task: dict) -> None:
+        super().__init__()
+        # NB: Textual's Widget base uses ``self._task`` for its message-pump
+        # asyncio.Task — never shadow it. Store the Task RECORD under our own name.
+        self._task_record = task
+        self._body_text = ""
+
+    def compose(self) -> ComposeResult:
+        yield _navbar("receipt")
+        with VerticalScroll(id="detail-scroll"):
+            try:
+                from .api import _task_title
+                from .receipt import build_receipt, latest_store_activity
+
+                receipt = build_receipt(
+                    self._task_record,
+                    public_task_id=str(self._task_record.get("public_task_id")),
+                    title=_task_title(self._task_record),
+                    latest_store_activity_at=latest_store_activity([self._task_record]),
+                )
+                markup = _render_receipt_markup(receipt)
+            except Exception as exc:  # noqa: BLE001 - surface, never crash the screen.
+                markup = f"[red]could not render receipt:[/] {_escape(str(exc))}"
+            self._body_text = markup
+            yield Static(markup, id="receipt-body")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = "agentacct"
+        self.sub_title = "receipt"
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -13,6 +13,7 @@ from .confidence import (
     normalize_cost_confidence,
     normalize_usage_confidence,
 )
+from .tool_activity import build_tool_activity_by_session
 from .join_rules import (
     annotate_usage_source_namespace_ambiguity,
     decide_attribution,
@@ -198,6 +199,18 @@ def build_work_ledger(
         session_observations=session_observations,
         local_session_observations=local_session_observations,
     )
+    # Tool-category counts (Receipt Actions dimension) ride onto each session
+    # rollup entry when the Claude Code hook captured them. Batches are additive
+    # so this sum is stable across imports; a session with no captured activity
+    # gets NO key, so the Receipt shows an honest Gap, never a fabricated zero.
+    tool_activity_by_session = build_tool_activity_by_session(events)
+    if tool_activity_by_session:
+        for entry in session_rollup.get("sessions", []):
+            counts = tool_activity_by_session.get(
+                (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
+            )
+            if counts:
+                entry["tool_category_counts"] = dict(counts)
     rollup_summary = session_rollup.get("summary")
     if isinstance(rollup_summary, dict):
         rollup_summary["mechanical_projection"] = dict(session_observation_diagnostics or {})

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -8,7 +8,11 @@ from hashlib import sha256
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from .confidence import normalize_cost_confidence, normalize_usage_confidence
+from .confidence import (
+    normalize_cost_basis,
+    normalize_cost_confidence,
+    normalize_usage_confidence,
+)
 from .join_rules import (
     annotate_usage_source_namespace_ambiguity,
     decide_attribution,
@@ -2901,6 +2905,7 @@ def _session_usage_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "turns_total": sum(turn_counts) if turn_counts else None,
         "estimated_cost_usd": sum(priced) if priced else None,
         "cost_confidence": _single_or_mixed(row.get("cost_confidence") for row in rows),
+        "cost_basis": _single_or_mixed(row.get("cost_basis") for row in rows),
         "usage_confidence": _single_or_mixed(row.get("usage_confidence") for row in rows),
         "model_lanes": sorted(
             lanes.values(),
@@ -3727,6 +3732,12 @@ def _usage_event(event: dict[str, Any]) -> dict[str, Any] | None:
         "estimated_cost_usd": _safe_optional_float(event.get("estimated_cost_usd")) if usage_additive else None,
         "usage_confidence": normalize_usage_confidence(event.get("usage_confidence")),
         "cost_confidence": normalize_cost_confidence(event.get("cost_confidence")) if usage_additive else "unknown",
+        # ``cost_basis`` answers "what kind of number is this" (provider invoice /
+        # local client session / pricing-table estimate / subscription). It is
+        # stamped upstream but was historically dropped at this read hop, so the
+        # Cost dimension could show confidence but never basis. Non-additive rows
+        # carry no cost, so they carry no basis.
+        "cost_basis": normalize_cost_basis(event.get("cost_basis") if usage_additive else None),
     }
 
 
@@ -3859,6 +3870,7 @@ def _proxy_usage_event(event: dict[str, Any]) -> dict[str, Any]:
         "estimated_cost_usd": _safe_optional_float(event.get("estimated_cost_usd")),
         "usage_confidence": normalize_usage_confidence(event.get("usage_confidence")),
         "cost_confidence": normalize_cost_confidence(event.get("cost_confidence")),
+        "cost_basis": normalize_cost_basis(event.get("cost_basis")),
     }
 
 

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,0 +1,214 @@
+"""The Receipt projector: 8 dimensions, two orthogonal axes, provenance, gaps.
+
+The load-bearing tests here are the ORTHOGONALITY invariants from M1's
+acceptance bar: an agent's "done" never becomes evidence-verified, and a human
+review/resolution never becomes machine verification.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentacct.finding_disposition import finding_target_digest
+from agentacct.receipt import RECEIPT_SCHEMA_VERSION, build_receipt
+
+
+def _check(
+    result: str,
+    *,
+    name: str = "pytest",
+    kind: str = "test",
+    at: float = 200.0,
+    exit_code: int = 0,
+    source_type: str = "client_hook",
+) -> dict[str, Any]:
+    return {
+        "event_id": f"evt_{name}_{result}",
+        "result": result,
+        "name": name,
+        "evidence_type": kind,
+        "created_at": at,
+        "exit_code": exit_code,
+        "source_type": source_type,
+        "source": "claude-code",
+        "check_identity": f"check:{name}",
+        "check_identity_stable": True,
+    }
+
+
+def _task(
+    items: list[dict[str, Any]],
+    *,
+    task_checks: list[dict[str, Any]] | None = None,
+    finding_episodes: list[dict[str, Any]] | None = None,
+    usage: dict[str, Any] | None = None,
+    actions: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    task: dict[str, Any] = {
+        "task_id": "task_x",
+        "primary_root": {"client": "claude-code", "client_session_id": "s1"},
+        "root_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "session_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "sessions": [
+            {
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "project": "acme",
+                "identity_scope_state": "explicit",
+                "last_activity_at": 100.0,
+                "usage": {},
+            }
+        ],
+        "session_count": 1,
+        "supporting_count": 0,
+        "child_count": 0,
+        "internal_count": 0,
+        "last_activity_at": 100.0,
+        "work_items": items,
+        "work_associations": [],
+        "usage": usage
+        if usage is not None
+        else {
+            "rows": 1,
+            "estimated_cost_usd": 0.5,
+            "cost_complete": True,
+            "cost_basis": "pricing_table",
+            "cost_confidence": "estimated_from_tokens",
+            "total_tokens": 1000,
+            "fresh_tokens": 800,
+        },
+        "models": ["claude-opus"],
+        "actions": actions
+        if actions is not None
+        else {"tool_category_counts": {}, "tool_category_total": 0, "touched_files": [], "touched_file_count": 0},
+    }
+    if task_checks is not None:
+        task["current_check_events"] = task_checks
+    if finding_episodes is not None:
+        task["finding_episodes"] = finding_episodes
+    return task
+
+
+def _receipt(task: dict[str, Any]):
+    return build_receipt(task, public_task_id="task_x", title="Add rate limit")
+
+
+def test_receipt_has_all_eight_dimensions_and_two_named_axes() -> None:
+    receipt = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))
+    assert receipt["schema_version"] == RECEIPT_SCHEMA_VERSION
+    assert set(receipt["dimensions"]) == {
+        "task",
+        "actors",
+        "actions",
+        "cost",
+        "evidence",
+        "outcome",
+        "gaps",
+        "provenance",
+    }
+    assert "decision_status" in receipt["axes"]
+    assert "evidence_strength" in receipt["axes"]
+    # Every content dimension carries its own provenance and gaps.
+    for name in ("task", "actors", "actions", "cost", "evidence", "outcome"):
+        assert "provenance" in receipt["dimensions"][name]
+        assert "gaps" in receipt["dimensions"][name]
+
+
+def test_agent_reported_done_is_never_evidence_verified() -> None:
+    # A completed step with no linked check: the agent SAID done, nothing PROVES it.
+    receipt = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))
+    assert receipt["axes"]["decision_status"]["key"] == "reported"
+    assert receipt["axes"]["decision_status"]["asserted_by"] == "agent_report"
+    assert receipt["axes"]["evidence_strength"]["key"] != "verified"
+    assert receipt["axes"]["evidence_strength"]["key"] == "reported"
+
+
+def test_passing_current_check_verifies_on_both_axes() -> None:
+    check = _check("passed", at=200.0)
+    task = _task(
+        [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0, "current_check_events": [check]}],
+        task_checks=[check],
+    )
+    receipt = _receipt(task)
+    assert receipt["axes"]["decision_status"]["key"] == "verified"
+    assert receipt["axes"]["decision_status"]["asserted_by"] == "machine"
+    assert receipt["axes"]["evidence_strength"]["key"] == "verified"
+    assert receipt["axes"]["evidence_strength"]["checks_passed"] == 1
+    assert receipt["dimensions"]["evidence"]["checks"][0]["source"] == "hook"
+
+
+def test_human_resolved_finding_is_human_asserted_but_not_evidence_verified() -> None:
+    # The orthogonality keystone: a human dispositioning a finding changes the
+    # DECISION axis to a human assertion but must never touch EVIDENCE strength.
+    failing = _check("failed", exit_code=1, at=200.0)
+    episodes = [{"target_digest": finding_target_digest(failing), "disposition_state": "resolved"}]
+    task = _task(
+        [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0, "current_check_events": [failing]}],
+        task_checks=[failing],
+        finding_episodes=episodes,
+    )
+    receipt = _receipt(task)
+    assert receipt["axes"]["decision_status"]["key"] == "finding"
+    assert receipt["axes"]["decision_status"]["asserted_by"] == "human"
+    assert "not machine verification" in receipt["axes"]["decision_status"]["statement"]
+    assert receipt["axes"]["evidence_strength"]["key"] != "verified"
+    # Provenance of the outcome field is the human, not a check.
+    assert receipt["dimensions"]["outcome"]["provenance"] == ["human"]
+
+
+def test_failed_is_distinct_from_blocked() -> None:
+    failed = _receipt(_task([{"work_id": "w", "latest_status": "failed", "updated_at": 100.0}]))
+    assert failed["axes"]["decision_status"]["key"] == "failed"
+    blocked = _receipt(
+        _task([{"work_id": "w", "latest_status": "blocked", "updated_at": 100.0, "blocker": "needs a key"}])
+    )
+    assert blocked["axes"]["decision_status"]["key"] == "blocked"
+
+
+def test_actions_shows_touched_files_and_gaps_missing_categories() -> None:
+    task = _task(
+        [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0, "files": ["src/a.py"]}],
+        actions={"tool_category_counts": {}, "tool_category_total": 0, "touched_files": ["src/a.py"], "touched_file_count": 1},
+    )
+    actions = _receipt(task)["dimensions"]["actions"]
+    assert actions["touched_files"] == ["src/a.py"]
+    assert actions["tool_category_counts"] == {}
+    assert any("not instrumented" in reason for reason in actions["gaps"])
+    # Touched files are MCP-sourced; the missing categories are an honest gap.
+    assert "mcp" in actions["provenance"]
+
+
+def test_actions_with_categories_declares_hook_provenance() -> None:
+    task = _task(
+        [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}],
+        actions={"tool_category_counts": {"read": 3}, "tool_category_total": 3, "touched_files": [], "touched_file_count": 0},
+    )
+    actions = _receipt(task)["dimensions"]["actions"]
+    assert actions["tool_category_counts"] == {"read": 3}
+    assert "hook" in actions["provenance"]
+
+
+def test_cost_dimension_carries_basis_and_flags_estimate_gap() -> None:
+    cost = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))["dimensions"]["cost"]
+    assert cost["cost_basis"] == "pricing_table"
+    assert any("estimate" in reason for reason in cost["gaps"])
+
+
+def test_provenance_rollup_covers_every_dimension_with_a_legend() -> None:
+    receipt = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))
+    provenance = receipt["dimensions"]["provenance"]
+    for name in ("task", "actors", "actions", "cost", "evidence", "outcome"):
+        assert name in provenance["by_dimension"]
+        assert provenance["by_dimension"][name]  # never empty
+    for source in provenance["sources_present"]:
+        assert source in provenance["legend"]
+
+
+def test_gaps_rollup_flattens_dimension_gaps_with_labels() -> None:
+    receipt = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))
+    gaps = receipt["dimensions"]["gaps"]
+    assert gaps["count"] == len(gaps["items"])
+    dimensions_with_gaps = {item["dimension"] for item in gaps["items"]}
+    # A no-check completed step surfaces gaps under both cost (estimate) and
+    # evidence (no machine checks / unverified step).
+    assert "evidence" in dimensions_with_gaps

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -159,10 +159,15 @@ def test_human_resolved_finding_is_human_asserted_but_not_evidence_verified() ->
 def test_failed_is_distinct_from_blocked() -> None:
     failed = _receipt(_task([{"work_id": "w", "latest_status": "failed", "updated_at": 100.0}]))
     assert failed["axes"]["decision_status"]["key"] == "failed"
+    # A recorded-failed status is an AGENT report, not a machine assertion — its
+    # outcome provenance must never borrow an unrelated passing check's source.
+    assert failed["axes"]["decision_status"]["asserted_by"] == "agent_report"
+    assert failed["dimensions"]["outcome"]["provenance"] == ["mcp"]
     blocked = _receipt(
         _task([{"work_id": "w", "latest_status": "blocked", "updated_at": 100.0, "blocker": "needs a key"}])
     )
     assert blocked["axes"]["decision_status"]["key"] == "blocked"
+    assert blocked["axes"]["decision_status"]["asserted_by"] == "agent_report"
 
 
 def test_actions_shows_touched_files_and_gaps_missing_categories() -> None:
@@ -200,8 +205,36 @@ def test_provenance_rollup_covers_every_dimension_with_a_legend() -> None:
     for name in ("task", "actors", "actions", "cost", "evidence", "outcome"):
         assert name in provenance["by_dimension"]
         assert provenance["by_dimension"][name]  # never empty
+    # The provenance map covers ONLY the six content dimensions; the gaps and
+    # provenance meta-dimensions have no source of their own and must never be
+    # rolled up as a spurious "none".
+    assert "gaps" not in provenance["by_dimension"]
+    assert "provenance" not in provenance["by_dimension"]
     for source in provenance["sources_present"]:
         assert source in provenance["legend"]
+
+
+def test_provenance_never_manufactures_a_none_source_when_all_grounded() -> None:
+    # A verified task with a passing check grounds every content dimension —
+    # the provenance map must not advertise a phantom "none".
+    check = _check("passed", at=200.0)
+    task = _task(
+        [
+            {
+                "work_id": "w",
+                "latest_status": "completed",
+                "updated_at": 100.0,
+                "current_check_events": [check],
+                "files": ["src/a.py"],
+                "objective": "add rate limit",
+            }
+        ],
+        task_checks=[check],
+        actions={"tool_category_counts": {"read": 2}, "tool_category_total": 2, "touched_files": ["src/a.py"], "touched_file_count": 1},
+    )
+    provenance = _receipt(task)["dimensions"]["provenance"]
+    assert "none" not in provenance["sources_present"]
+    assert "none" not in provenance["legend"]
 
 
 def test_gaps_rollup_flattens_dimension_gaps_with_labels() -> None:

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -1,0 +1,173 @@
+"""The /v1/receipt and /v1/tasks native-shell lane."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from agentacct.api import create_local_api_app
+from agentacct.receipt import RECEIPT_SCHEMA_VERSION
+from agentacct.service import SentinelService
+
+TOKEN = "test-v1-token"
+NS = "sha256:receipt-api-ns"
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": f"Bearer {TOKEN}"}
+
+
+def _app(tmp_path: Path) -> TestClient:
+    return TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+
+
+def _record_usage(service: SentinelService, *, session_id: str, at: float) -> None:
+    service.record_event(
+        {
+            "event_id": f"evt_usage_{session_id}",
+            "created_at": at,
+            "source": "claude-code-local-session-import",
+            "event_type": "model_usage",
+            "run_id": None,
+            "provider": "claude-code",
+            "model": "claude-opus-4-8",
+            "estimated_input_tokens": 100,
+            "estimated_output_tokens": 25,
+            "estimated_cost_usd": 0.5,
+            "usage_confidence": "client_reported",
+            "cost_confidence": "estimated_from_tokens",
+            "cost_basis": "pricing_table",
+            "metadata": {
+                "usage_source": "local_client_session_store",
+                "usage_provenance": "agent_sentinel_local_usage_import",
+                "client": "claude-code",
+                "client_session_id": session_id,
+                "cached_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "project_dir": "/tmp/project",
+                "started_at": at,
+                "updated_at": at,
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "source_namespace_fingerprint": NS,
+            },
+        },
+        trusted_usage_import=True,
+    )
+
+
+def _record_section(service: SentinelService, *, session_id: str, section_id: str, status: str, at: float) -> None:
+    service.record_event(
+        {
+            "event_id": f"evt_section_{session_id}_{section_id}_{status}",
+            "created_at": at,
+            "source": "claude-code",
+            "event_type": f"section_{status}",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "claude-code",
+                "client_session_id": session_id,
+                "client_context_keys_authored": ["client_session_id"],
+                "project_dir": "/tmp/project",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": section_id,
+                "section_status": status,
+                "section_title": "Add rate limit to login",
+                "kind": "implementation",
+                "files": ["src/login.py"],
+            },
+        }
+    )
+
+
+def _record_passing_check(service: SentinelService, *, session_id: str, section_id: str, at: float) -> None:
+    service.record_event(
+        {
+            "event_id": f"evt_check_{session_id}_{section_id}",
+            "created_at": at,
+            "source": "claude-code",
+            "event_type": "machine_check",
+            "run_id": None,
+            "metadata": {
+                "result": "passed",
+                "evidence_type": "test",
+                "summary": "pytest passed",
+                "name": "pytest",
+                "exit_code": 0,
+                "section_id": section_id,
+                "client": "claude-code",
+                "client_session_id": session_id,
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "project_dir": "/tmp/project",
+            },
+        }
+    )
+
+
+def test_receipt_routes_require_a_bearer_token(tmp_path: Path) -> None:
+    client = _app(tmp_path)
+    assert client.get("/v1/tasks").status_code == 401
+    assert client.get("/v1/receipt?task=task_x").status_code == 401
+
+
+def test_version_advertises_the_receipt_schema(tmp_path: Path) -> None:
+    version = _app(tmp_path).get("/v1/version", headers=_auth()).json()
+    assert version["receipt_schema"] == RECEIPT_SCHEMA_VERSION
+
+
+def test_tasks_list_and_receipt_detail_for_an_observed_task(tmp_path: Path) -> None:
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    client = _app(tmp_path)
+
+    listing = client.get("/v1/tasks", headers=_auth()).json()
+    assert listing["schema"] == RECEIPT_SCHEMA_VERSION
+    assert listing["total"] == 1
+    row = listing["tasks"][0]
+    task_id = row["task_id"]
+    assert task_id.startswith("task_")
+    assert "decision_status" in row and "evidence_strength" in row
+
+    receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
+    assert receipt["schema_version"] == RECEIPT_SCHEMA_VERSION
+    assert set(receipt["dimensions"]) == {
+        "task",
+        "actors",
+        "actions",
+        "cost",
+        "evidence",
+        "outcome",
+        "gaps",
+        "provenance",
+    }
+    assert receipt["axes"]["decision_status"]["asserted_by"] in {"agent_report", "human", "machine", "none"}
+    # cost_basis threads all the way to the wire.
+    assert receipt["dimensions"]["cost"]["cost_basis"] == "pricing_table"
+
+
+def test_unknown_task_is_a_404_not_an_empty_fabrication(tmp_path: Path) -> None:
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    client = _app(tmp_path)
+    assert client.get("/v1/receipt?task=task_deadbeef", headers=_auth()).status_code == 404
+
+
+def test_receipt_reports_verified_when_a_current_check_passes(tmp_path: Path) -> None:
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    _record_section(service, session_id="s1", section_id="sec-1", status="completed", at=100.0)
+    _record_passing_check(service, session_id="s1", section_id="sec-1", at=200.0)
+    client = _app(tmp_path)
+
+    task_id = client.get("/v1/tasks", headers=_auth()).json()["tasks"][0]["task_id"]
+    receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
+    assert receipt["axes"]["decision_status"]["key"] == "verified"
+    assert receipt["axes"]["evidence_strength"]["key"] == "verified"
+    assert receipt["dimensions"]["evidence"]["checks_passed"] == 1
+    # The touched file recorded on the section rides the Actions dimension.
+    assert "src/login.py" in receipt["dimensions"]["actions"]["touched_files"]

--- a/tests/test_receipt_cli.py
+++ b/tests/test_receipt_cli.py
@@ -15,7 +15,7 @@ runner = CliRunner()
 NS = "sha256:receipt-cli-ns"
 
 
-def _seed(store: Path) -> None:
+def _seed(store: Path, *, title: str = "Add rate limit to login") -> None:
     service = SentinelService(store)
     service.record_event(
         {
@@ -67,7 +67,8 @@ def _seed(store: Path) -> None:
                 "identity_scope_state": "explicit",
                 "section_id": "sec-1",
                 "section_status": "completed",
-                "section_title": "Add rate limit to login",
+                "section_title": title,
+                "objective": title,
                 "kind": "implementation",
                 "files": ["src/login.py"],
             },
@@ -117,6 +118,21 @@ def test_receipt_text_render_is_scannable(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     for marker in ("Work Receipt", "Decision status", "Evidence strength", "Provenance"):
         assert marker in result.output
+
+
+def test_receipt_text_survives_rich_markup_in_recorded_titles(tmp_path: Path) -> None:
+    # Agent-recorded titles/objectives are arbitrary text; a bracket-tag title
+    # must never crash the render (MarkupError) or be silently reinterpreted.
+    _seed(tmp_path, title="cleanup [/] wip [red]danger[/red]")
+    listing = runner.invoke(app, ["receipts", "--store-dir", str(tmp_path)])
+    assert listing.exit_code == 0, listing.output
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    # The literal bracket text is preserved (escaped), not interpreted away.
+    assert "[/]" in detail.output
 
 
 def test_receipt_unknown_task_exits_nonzero(tmp_path: Path) -> None:

--- a/tests/test_receipt_cli.py
+++ b/tests/test_receipt_cli.py
@@ -1,0 +1,126 @@
+"""The `agentacct receipt` / `agentacct receipts` CLI — the acceptance vehicle."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agentacct.cli import app
+from agentacct.receipt import RECEIPT_SCHEMA_VERSION
+from agentacct.service import SentinelService
+
+runner = CliRunner()
+NS = "sha256:receipt-cli-ns"
+
+
+def _seed(store: Path) -> None:
+    service = SentinelService(store)
+    service.record_event(
+        {
+            "event_id": "evt_usage_s1",
+            "created_at": 100.0,
+            "source": "claude-code-local-session-import",
+            "event_type": "model_usage",
+            "run_id": None,
+            "provider": "claude-code",
+            "model": "claude-opus-4-8",
+            "estimated_input_tokens": 100,
+            "estimated_output_tokens": 25,
+            "estimated_cost_usd": 0.5,
+            "usage_confidence": "client_reported",
+            "cost_confidence": "estimated_from_tokens",
+            "cost_basis": "pricing_table",
+            "metadata": {
+                "usage_source": "local_client_session_store",
+                "usage_provenance": "agent_sentinel_local_usage_import",
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "cached_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "project_dir": "/tmp/project",
+                "started_at": 100.0,
+                "updated_at": 100.0,
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "source_namespace_fingerprint": NS,
+            },
+        },
+        trusted_usage_import=True,
+    )
+    service.record_event(
+        {
+            "event_id": "evt_section_s1",
+            "created_at": 100.0,
+            "source": "claude-code",
+            "event_type": "section_completed",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "client_context_keys_authored": ["client_session_id"],
+                "project_dir": "/tmp/project",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": "sec-1",
+                "section_status": "completed",
+                "section_title": "Add rate limit to login",
+                "kind": "implementation",
+                "files": ["src/login.py"],
+            },
+        }
+    )
+
+
+def test_receipts_list_json(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    result = runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema"] == RECEIPT_SCHEMA_VERSION
+    assert len(payload["tasks"]) == 1
+    assert payload["tasks"][0]["task_id"].startswith("task_")
+
+
+def test_receipt_detail_json_has_all_eight_dimensions(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    listing = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )
+    task_id = listing["tasks"][0]["task_id"]
+    result = runner.invoke(app, ["receipt", task_id, "--json", "--store-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    receipt = json.loads(result.output)
+    assert receipt["schema_version"] == RECEIPT_SCHEMA_VERSION
+    assert set(receipt["dimensions"]) == {
+        "task",
+        "actors",
+        "actions",
+        "cost",
+        "evidence",
+        "outcome",
+        "gaps",
+        "provenance",
+    }
+    assert receipt["dimensions"]["cost"]["cost_basis"] == "pricing_table"
+
+
+def test_receipt_text_render_is_scannable(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    result = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    for marker in ("Work Receipt", "Decision status", "Evidence strength", "Provenance"):
+        assert marker in result.output
+
+
+def test_receipt_unknown_task_exits_nonzero(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    result = runner.invoke(app, ["receipt", "task_deadbeef", "--store-dir", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "No Task matches" in result.output

--- a/tests/test_receipt_tui.py
+++ b/tests/test_receipt_tui.py
@@ -1,0 +1,137 @@
+"""The TUI Receipts screen + Receipt detail (Textual, headless via run_test)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from textual.widgets import DataTable, Static
+
+from agentacct.receipt import build_receipt
+from agentacct.service import SentinelService
+from agentacct.tui import (
+    AgentAcctTUI,
+    ReceiptDetailScreen,
+    ReceiptsScreen,
+    _render_receipt_markup,
+)
+
+NS = "sha256:receipt-tui-ns"
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def _seed(store: Path) -> None:
+    service = SentinelService(store)
+    service.record_event(
+        {
+            "event_id": "evt_usage_s1",
+            "created_at": 100.0,
+            "source": "claude-code-local-session-import",
+            "event_type": "model_usage",
+            "run_id": None,
+            "provider": "claude-code",
+            "model": "claude-opus-4-8",
+            "estimated_input_tokens": 100,
+            "estimated_output_tokens": 25,
+            "estimated_cost_usd": 0.5,
+            "usage_confidence": "client_reported",
+            "cost_confidence": "estimated_from_tokens",
+            "cost_basis": "pricing_table",
+            "metadata": {
+                "usage_source": "local_client_session_store",
+                "usage_provenance": "agent_sentinel_local_usage_import",
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "cached_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "project_dir": "/tmp/project",
+                "started_at": 100.0,
+                "updated_at": 100.0,
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "source_namespace_fingerprint": NS,
+            },
+        },
+        trusted_usage_import=True,
+    )
+    service.record_event(
+        {
+            "event_id": "evt_section_s1",
+            "created_at": 100.0,
+            "source": "claude-code",
+            "event_type": "section_completed",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "client_context_keys_authored": ["client_session_id"],
+                "project_dir": "/tmp/project",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": "sec-1",
+                "section_status": "completed",
+                "section_title": "Add rate limit to login",
+                "kind": "implementation",
+            },
+        }
+    )
+
+
+def test_render_receipt_markup_contains_axes_and_dimensions() -> None:
+    task = {
+        "task_id": "task_x",
+        "primary_root": {"client": "claude-code", "client_session_id": "s1"},
+        "root_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "session_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "sessions": [
+            {"client": "claude-code", "client_session_id": "s1", "project": "acme", "identity_scope_state": "explicit", "last_activity_at": 100.0, "usage": {}}
+        ],
+        "session_count": 1,
+        "supporting_count": 0,
+        "child_count": 0,
+        "internal_count": 0,
+        "last_activity_at": 100.0,
+        "work_items": [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0, "objective": "add rate limit"}],
+        "work_associations": [],
+        "usage": {"rows": 1, "estimated_cost_usd": 0.5, "cost_complete": True, "cost_basis": "pricing_table", "total_tokens": 1000},
+        "models": ["claude-opus-4-8"],
+        "actions": {"tool_category_counts": {}, "tool_category_total": 0, "touched_files": [], "touched_file_count": 0},
+    }
+    markup = _render_receipt_markup(build_receipt(task, public_task_id="task_x", title="Add rate limit"))
+    for marker in ("Decision status", "Evidence strength", "[b]Task[/]", "[b]Cost[/]", "Provenance"):
+        assert marker in markup
+
+
+def test_receipts_screen_lists_a_task_and_opens_its_detail(tmp_path: Path) -> None:
+    _seed(tmp_path)
+
+    async def scenario() -> None:
+        app = AgentAcctTUI(store_dir=tmp_path, refresh_seconds=3600)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("t")  # open the Receipts screen
+            await pilot.pause()
+            assert isinstance(app.screen, ReceiptsScreen)
+            table = app.screen.query_one("#receipts", DataTable)
+            # The list is built on a thread worker; give it real time to land.
+            for _ in range(60):
+                if table.row_count >= 1:
+                    break
+                await asyncio.sleep(0.05)
+                await pilot.pause()
+            assert table.row_count >= 1
+            # Open the first row's full Receipt.
+            table.move_cursor(row=0)
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(app.screen, ReceiptDetailScreen)
+            assert app.screen.query_one("#receipt-body", Static) is not None
+            assert "Decision status" in app.screen._body_text
+            assert "Evidence strength" in app.screen._body_text
+
+    _run(scenario())

--- a/tests/test_task_projection.py
+++ b/tests/test_task_projection.py
@@ -17,6 +17,7 @@ def _session(
     fresh_tokens: int = 10,
     total_tokens: int | None = None,
     cost: float | None = 0.10,
+    cost_basis: str | None = None,
     model: str | None = None,
     last_activity_at: float = 1.0,
 ) -> dict[str, Any]:
@@ -37,6 +38,8 @@ def _session(
         "estimated_cost_usd": cost,
         "model_lanes": [{"model": model or f"model-{session_id}"}],
     }
+    if cost_basis is not None:
+        usage["cost_basis"] = cost_basis
     return {
         "client": client,
         "client_session_id": session_id,
@@ -498,6 +501,32 @@ def test_transitive_session_root_is_task_boundary_and_usage_is_deduped() -> None
     )
     assert root_association["session_attribution"] == "upstream"
     assert root_association["exact_session_id"] is None
+
+
+def test_cost_basis_aggregates_single_mixed_and_absent_across_task_sessions() -> None:
+    # Cost basis rides alongside cost so a Task can say what KIND of number its
+    # cost is. One basis across the Task's sessions => that basis; disagreement
+    # => "mixed"; no session carried a basis => None (never a fabricated value).
+    same_a = build_task_projection(
+        [
+            _session("root", cost_basis="local_client_session"),
+            _session("child", parent="root", kind="child", cost_basis="local_client_session"),
+        ],
+        [],
+    )
+    assert same_a["tasks"][0]["usage"]["cost_basis"] == "local_client_session"
+
+    mixed = build_task_projection(
+        [
+            _session("root", cost_basis="local_client_session"),
+            _session("child", parent="root", kind="child", cost_basis="pricing_table"),
+        ],
+        [],
+    )
+    assert mixed["tasks"][0]["usage"]["cost_basis"] == "mixed"
+
+    absent = build_task_projection([_session("root")], [])
+    assert absent["tasks"][0]["usage"]["cost_basis"] is None
 
 
 def test_task_keeps_held_codex_child_as_supporting_identity_without_adding_usage() -> None:

--- a/tests/test_task_projection.py
+++ b/tests/test_task_projection.py
@@ -529,6 +529,23 @@ def test_cost_basis_aggregates_single_mixed_and_absent_across_task_sessions() ->
     assert absent["tasks"][0]["usage"]["cost_basis"] is None
 
 
+def test_actions_touched_files_union_dedupes_across_steps() -> None:
+    projection = build_task_projection(
+        [_session("root")],
+        [
+            {"work_id": "w1", "client": "codex", "client_session_id": "root", "files": ["src/a.py", "src/b.py"]},
+            {"work_id": "w2", "client": "codex", "client_session_id": "root", "files": ["src/b.py", "src/c.py"]},
+        ],
+    )
+    actions = projection["tasks"][0]["actions"]
+    assert actions["touched_files"] == ["src/a.py", "src/b.py", "src/c.py"]
+    assert actions["touched_file_count"] == 3
+    # No tool categories were captured for these sessions: honest empty counts
+    # (the Receipt renders this as a Gap), never a fabricated zero-of-everything.
+    assert actions["tool_category_counts"] == {}
+    assert actions["tool_category_total"] == 0
+
+
 def test_task_keeps_held_codex_child_as_supporting_identity_without_adding_usage() -> None:
     root = _session(
         "root",

--- a/tests/test_tool_activity.py
+++ b/tests/test_tool_activity.py
@@ -1,0 +1,121 @@
+"""Privacy-safe tool-category capture for the Receipt's Actions dimension."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agentacct.hooks import capture_tool_activity
+from agentacct.tool_activity import (
+    TOOL_ACTIVITY_EVENT_TYPE,
+    TOOL_CATEGORIES,
+    build_tool_activity_by_session,
+    drain_tool_activity_spool,
+    record_tool_activity_tick,
+    tool_activity_spool_path,
+    tool_category,
+)
+
+
+def test_tool_category_maps_names_only_and_collapses_mcp() -> None:
+    assert tool_category("Read") == "read"
+    assert tool_category("MultiEdit") == "edit"
+    assert tool_category("Bash") == "execute"
+    assert tool_category("Grep") == "search"
+    assert tool_category("WebFetch") == "network"
+    assert tool_category("Task") == "agent"
+    assert tool_category("TodoWrite") == "plan"
+    # Any MCP tool collapses to a single bucket by PREFIX, so a specific MCP
+    # tool name (which could reveal a connector) is never recorded.
+    assert tool_category("mcp__github__create_issue") == "mcp"
+    assert tool_category("mcp__anything__at__all") == "mcp"
+    # Unknown names are bucketed honestly, never dropped.
+    assert tool_category("SomeFutureTool") == "other"
+    assert tool_category("") == "other"
+    assert tool_category(None) == "other"
+    # Every produced category is in the closed set.
+    for name in ("Read", "Bash", "mcp__x__y", "Unknown", ""):
+        assert tool_category(name) in TOOL_CATEGORIES
+
+
+def test_spool_tick_and_drain_roundtrip(tmp_path: Path) -> None:
+    for category in ("read", "read", "edit", "execute"):
+        record_tool_activity_tick(
+            tmp_path, client="claude-code", session_id="sess-1", category=category, at=100.0
+        )
+    events = drain_tool_activity_spool(tmp_path, now=200.0, token="t1")
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_type"] == TOOL_ACTIVITY_EVENT_TYPE
+    assert event["metadata"]["client"] == "claude-code"
+    assert event["metadata"]["client_session_id"] == "sess-1"
+    assert event["metadata"]["tool_category_counts"] == {"read": 2, "edit": 1, "execute": 1}
+    # The spool is consumed: a second drain sees nothing.
+    assert drain_tool_activity_spool(tmp_path, now=300.0, token="t2") == []
+
+
+def test_drained_event_never_carries_tool_names_or_arguments(tmp_path: Path) -> None:
+    record_tool_activity_tick(
+        tmp_path, client="claude-code", session_id="s", category="execute", at=1.0
+    )
+    # The spool bytes themselves must not contain a tool name or command.
+    spool_text = tool_activity_spool_path(tmp_path).read_text(encoding="utf-8")
+    assert "Bash" not in spool_text and "tool_name" not in spool_text
+    assert "execute" in spool_text
+    [event] = drain_tool_activity_spool(tmp_path, now=2.0, token="t")
+    allowed = {
+        "client",
+        "client_session_id",
+        "tool_category_counts",
+        "capture_basis",
+        "captured_at",
+        "sentinel_semantic_kind",
+    }
+    assert set(event["metadata"]) <= allowed
+    blob = json.dumps(event)
+    for forbidden in ("tool_name", "tool_input", "command", "arguments", "args"):
+        assert forbidden not in blob
+
+
+def test_build_tool_activity_by_session_sums_batches_and_rejects_junk() -> None:
+    def batch(session: str, counts: dict) -> dict:
+        return {
+            "event_type": TOOL_ACTIVITY_EVENT_TYPE,
+            "metadata": {
+                "client": "claude-code",
+                "client_session_id": session,
+                "tool_category_counts": counts,
+            },
+        }
+
+    result = build_tool_activity_by_session(
+        [
+            batch("s1", {"read": 2, "edit": 1}),
+            batch("s1", {"read": 3, "search": 5}),
+            batch("s2", {"execute": 4}),
+            # Unknown categories and non-positive/boolean counts are ignored.
+            batch("s1", {"not_a_category": 9, "edit": -1, "read": True}),
+            # Non-activity events are ignored.
+            {"event_type": "model_usage", "metadata": {"client": "x", "client_session_id": "s1"}},
+        ]
+    )
+    assert result[("claude-code", "s1")] == {"read": 5, "edit": 1, "search": 5}
+    assert result[("claude-code", "s2")] == {"execute": 4}
+
+
+def test_capture_tool_activity_records_category_from_raw_event(tmp_path: Path) -> None:
+    raw = json.dumps(
+        {"session_id": "hooksess", "tool_name": "Edit", "tool_input": {"file_path": "/secret/path.py"}}
+    )
+    capture_tool_activity(raw, store_dir=tmp_path)
+    # The captured tick is a category only; the file path/tool_input never lands.
+    spool_text = tool_activity_spool_path(tmp_path).read_text(encoding="utf-8")
+    assert "secret" not in spool_text and "Edit" not in spool_text
+    [event] = drain_tool_activity_spool(tmp_path, now=1.0, token="t")
+    assert event["metadata"]["tool_category_counts"] == {"edit": 1}
+    assert event["metadata"]["client"] == "claude-code"
+
+
+def test_capture_tool_activity_without_session_is_a_noop(tmp_path: Path) -> None:
+    capture_tool_activity(json.dumps({"tool_name": "Read"}), store_dir=tmp_path)
+    assert not tool_activity_spool_path(tmp_path).exists()

--- a/tests/test_work_ledger_session_rollup.py
+++ b/tests/test_work_ledger_session_rollup.py
@@ -39,6 +39,7 @@ def _usage(
     namespace_fingerprint: str | None = None,
     source_namespace_fingerprint: str | None = None,
     parent_source_namespace_fingerprint: str | None = None,
+    cost_basis: str | None = None,
 ) -> dict:
     metadata = {
         "usage_source": "local_client_session_store",
@@ -76,6 +77,7 @@ def _usage(
         "estimated_cost_usd": cost,
         "usage_confidence": "client_reported",
         "cost_confidence": "estimated_from_tokens",
+        "cost_basis": cost_basis,
         "metadata": metadata,
     }
 
@@ -1301,3 +1303,15 @@ def test_rollup_never_contradicts_attributions_property() -> None:
                     if (row["client"], row["client_session_id"]) in child_keys
                 )
                 assert children_usage["total_tokens"] == expected_child_total
+
+
+def test_cost_basis_flows_from_usage_event_into_session_rollup() -> None:
+    # The basis was stamped upstream but historically dropped at the ledger read
+    # hop, so a session could show cost confidence but never its basis.
+    rollup = _rollup([_usage(session="s1", cost_basis="local_client_session")])
+    assert _entry(rollup, "codex", "s1")["usage"]["cost_basis"] == "local_client_session"
+
+
+def test_cost_basis_without_upstream_stamp_reduces_to_none_not_a_guess() -> None:
+    rollup = _rollup([_usage(session="s2")])
+    assert _entry(rollup, "codex", "s2")["usage"]["cost_basis"] == "none"

--- a/tests/test_work_ledger_session_rollup.py
+++ b/tests/test_work_ledger_session_rollup.py
@@ -1315,3 +1315,42 @@ def test_cost_basis_flows_from_usage_event_into_session_rollup() -> None:
 def test_cost_basis_without_upstream_stamp_reduces_to_none_not_a_guess() -> None:
     rollup = _rollup([_usage(session="s2")])
     assert _entry(rollup, "codex", "s2")["usage"]["cost_basis"] == "none"
+
+
+def _tool_activity_event(session: str, counts: dict, *, client: str = "codex") -> dict:
+    from agentacct.tool_activity import TOOL_ACTIVITY_EVENT_TYPE
+
+    return {
+        "event_id": f"toolact:{client}:{session}",
+        "created_at": 150.0,
+        "source": client,
+        "event_type": TOOL_ACTIVITY_EVENT_TYPE,
+        "run_id": None,
+        "metadata": {
+            "client": client,
+            "client_session_id": session,
+            "tool_category_counts": counts,
+            "capture_basis": "client_hook_tool_category",
+        },
+    }
+
+
+def test_tool_category_counts_ride_onto_session_rollup_and_task() -> None:
+    ledger = build_work_ledger(
+        [_usage(session="s1"), _tool_activity_event("s1", {"read": 3, "edit": 2})]
+    )
+    entry = _entry(ledger["session_rollup"], "codex", "s1")
+    assert entry["tool_category_counts"] == {"read": 3, "edit": 2}
+    projection = build_task_projection(
+        ledger["session_rollup"]["sessions"], ledger["work_items"]
+    )
+    actions = projection["tasks"][0]["actions"]
+    assert actions["tool_category_counts"] == {"edit": 2, "read": 3}
+    assert actions["tool_category_total"] == 5
+
+
+def test_session_without_captured_activity_gets_no_counts_key() -> None:
+    # Honest Gap, not a fabricated zero: a session the hook never observed
+    # carries no tool_category_counts key at all.
+    ledger = build_work_ledger([_usage(session="quiet")])
+    assert "tool_category_counts" not in _entry(ledger["session_rollup"], "codex", "quiet")


### PR DESCRIPTION
## M1 — the Work Receipt as a first-class object

*A local receipt for every coding-agent task: see what ran, what passed, what it cost, and what remains unproven.*

This adds a canonical **Work Receipt** over one converged Task — a root session with its continuations and subagents folded into a single Task identity. A new `agentacct.receipt.v1` projects that Task into the eight questions a reviewer needs, and renders it identically across the CLI, the API, the macOS app, and the TUI.

### The eight questions
`task` · `actors` · `actions` · `cost` · `evidence` · `outcome` · `gaps` · `provenance`. Each content dimension carries **where its data came from** (client log / MCP / hook / CI / git / human) and **what could not be proven**.

### Two axes, kept deliberately separate
- **decision status** — what a human or agent *says* happened (`reported` / `verified` / `blocked` / `failed` / `finding` / `handed_off` / …), tagged with who asserts it.
- **evidence strength** — how well that is actually *proven* (`none` / `reported` / `checked` / `verified`), computed **only** from recorded checks and per-step verification.

They are computed from disjoint inputs, so an agent reporting "done" never raises evidence strength, and a human review or finding-disposition never counts as machine verification.

### What's included
- **Receipt projector** (`receipt.py`) built on top of the existing `build_task_intelligence`, plus a unified per-field provenance map and a unified gaps roll-up.
- **Privacy-safe tool-category capture** for the Actions dimension: the already-installed Claude Code PreToolUse hook records a coarse category (read / edit / execute / search / network / agent / plan / mcp / other) derived from the tool **name alone** — never its arguments, results, or paths — spooled locally and folded into each Task by `agentacct usage import-local`. A session with no captured activity shows an honest gap, never a fabricated zero. (Codex parity is a follow-up.)
- **`GET /v1/receipt?task=` and `GET /v1/tasks`** on the local API, bearer-gated and cached (the cache key folds in an Evidence-store marker so a hook capture invalidates it immediately).
- **`agentacct receipt <task>` / `agentacct receipts`** — a scannable terminal receipt (`--json` emits the raw `receipt.v1`).
- **A Receipts pane in the macOS app** and a **Receipts screen in the TUI** (press `t`), both on the same shared vocabulary.
- **`cost_basis` now reaches the read side**, so Cost reports its *basis* (local client session vs pricing-table estimate), not just its confidence.

### Verification
- Full suite green (**2950 passed, 1 skipped**); +21 new tests covering the projector, the two-axis orthogonality invariants, the capture privacy boundary, the endpoints, the CLI, and the TUI screen.
- `swift build` clean; the Swift decodables' keys verified against the live `/v1/receipt` payload.
- Dogfooded end-to-end: the receipt for a real in-progress task renders all eight dimensions with the two axes diverging honestly (decision *in-progress* vs evidence *checked*).
- An adversarial review pass over the diff surfaced five findings (markup escaping, a provenance meta-dimension roll-up, a `failed`-vs-`machine` mislabel, and the cache-invalidation gap); all are fixed here with regression tests.

### Follow-ups (out of scope)
- Codex tool-category capture (needs a category reduction on the opt-in codex hook or a general rollout-log classifier).
- The Evidence-store staleness the receipt cache now handles is still present in the sibling `/v1/session` / ledger caches (pre-existing) — worth a shared fix later.
