### PR TITLE
perf(receipt): serve /v1 tasks and receipts from the shared derived ledger

### DIFF
--- a/apps/agentacct/Sources/agentacct/GlanceClient.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceClient.swift
@@ -49,7 +49,11 @@ final class GlanceClient {
 
     init() {
         let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = 20
+        // The receipt/tasks routes do a full-ledger reduce on a cold cache (a
+        // few seconds on a large store); 20s let a legitimately slow first
+        // build surface as a transport error. 60s rides the cold build; the
+        // single-flight cache on the daemon keeps the warm path sub-second.
+        config.timeoutIntervalForRequest = 60
         session = URLSession(configuration: config)
     }
 

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import html
 import json
+import threading
 import math
 import os
 import secrets
@@ -2910,35 +2911,32 @@ def create_local_api_app(
         return payload
 
     # The decorated, evidence-attached Task projection, fingerprint + TTL
-    # cached so the receipt list/detail routes stay cheap under app polling.
+    # cached AND single-flighted: the build is an expensive full-ledger reduce,
+    # so concurrent app requests (the tasks list + several receipts fired at
+    # once) must share ONE build under the lock — otherwise each sync worker
+    # rebuilds in parallel and they all blow the client's request timeout.
     v1_receipt_projection_cache: dict[str, tuple[int, float, dict[str, Any]]] = {}
-
-    def _receipt_projection_cache_key(events: list[dict[str, Any]]) -> int:
-        # The projection also consumes the Evidence v2 client_hook store (hook
-        # mechanical checks + privacy-safe tool-category captures), which changes
-        # WITHOUT a v1 ledger event — so hashing only the event log would serve a
-        # pre-capture projection for the whole TTL and let the Receipt under-claim
-        # proven evidence. Fold a cheap monotonic marker from the evidence store
-        # into the key so any capture/import invalidates the cache immediately.
-        evidence_marker: tuple[int, ...] = (0,)
-        try:
-            if service.evidence.enabled:
-                stats = service.evidence.status()
-                evidence_marker = (stats.logical_events, stats.receipts, stats.duplicate_receipts)
-        except Exception:  # noqa: BLE001 - a stats read must never fail the route.
-            evidence_marker = (0,)
-        return hash((events_fingerprint(events), evidence_marker))
+    v1_receipt_projection_lock = threading.Lock()
 
     def _v1_task_projection() -> dict[str, Any]:
+        # Keyed on the v1 event log. Machine checks ARE v1 events, so they
+        # invalidate this the instant they land; the only writes it does not
+        # notice within the TTL are evidence-store-only imports (connector /
+        # capture-hook), the same bound every sibling /v1 cache already has —
+        # the real fix for that is materialization, not a hotter key.
         events = service.list_all_events()
-        cache_key = _receipt_projection_cache_key(events)
-        moment = time.time()
+        fingerprint = events_fingerprint(events)
         cached = v1_receipt_projection_cache.get("projection")
-        if cached is not None and cached[0] == cache_key and (moment - cached[1]) < 30.0:
+        if cached is not None and cached[0] == fingerprint and (time.time() - cached[1]) < 30.0:
             return cached[2]
-        projection = _dashboard_task_projection(_page_data())
-        v1_receipt_projection_cache["projection"] = (cache_key, moment, projection)
-        return projection
+        with v1_receipt_projection_lock:
+            # Double-check: a concurrent request may have just built it.
+            cached = v1_receipt_projection_cache.get("projection")
+            if cached is not None and cached[0] == fingerprint and (time.time() - cached[1]) < 30.0:
+                return cached[2]
+            projection = _dashboard_task_projection(_page_data())
+            v1_receipt_projection_cache["projection"] = (fingerprint, time.time(), projection)
+            return projection
 
     def _visible_tasks(projection: Mapping[str, Any]) -> list[dict[str, Any]]:
         return [

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -905,20 +905,28 @@ def _dashboard_page_data(
     task_csrf_token: str = "",
     ingestion_health: dict[str, Any] | None = None,
     task_identity: TaskIdentityCodec | None = None,
+    ledger: dict[str, Any] | None = None,
 ) -> _DashboardPageData:
     usage_view = _build_usage_view(list(local_usage_preview or []), events)
     # Built before any table renders: the rollup's collision-safe short
     # session labels are the ONE session-label source for every cell —
     # product pages AND raw page (full ids are href-only, locked decision).
-    ledger = build_work_ledger(
-        events,
-        run_reports=run_reports,
-        cost_events=cost_events,
-        session_observations=session_observations,
-        session_observation_diagnostics=session_observation_diagnostics,
-        store_project_label=store_project_label,
-        store_scope=store_scope,
-    )
+    # A pre-built ``ledger`` may be injected by a caller that already holds
+    # one for THIS event set (the /v1 task lane passes the shared, cached
+    # derived ledger the sessions lane keeps warm) — same builder, same
+    # inputs, so the projection is identical while the multi-second reduce is
+    # paid once and shared. run_reports/cost_events/session_observations are
+    # then unused for the ledger; they still populate the page-data fields.
+    if ledger is None:
+        ledger = build_work_ledger(
+            events,
+            run_reports=run_reports,
+            cost_events=cost_events,
+            session_observations=session_observations,
+            session_observation_diagnostics=session_observation_diagnostics,
+            store_project_label=store_project_label,
+            store_scope=store_scope,
+        )
     # Batch A contract: session_rollup and attention_groups are consumed
     # VERBATIM — grouping/labeling is never reimplemented in api.py.
     session_rollup = ledger.get("session_rollup") if isinstance(ledger.get("session_rollup"), dict) else {}
@@ -2314,7 +2322,19 @@ def _canonical_session_rollup_payload(read: CanonicalSessionListRead) -> dict[st
 # ---------------------------------------------------------------------------
 
 
-def _collect_service_run_reports(service: SentinelService, *, limit: int = 100) -> list[dict[str, Any]]:
+# ONE run-report cap for every ledger build. The self-build path
+# (build_page_data -> /tasks, the CLI, and the /v1 task lane's reference) and
+# the shared derived ledger (the /v1 sessions/tasks lane) MUST pass the same
+# value, or the two would agree only on stores with fewer reports than the
+# smaller cap — the /v1 task lane reuses the derived ledger, so a mismatch
+# would silently change what receipts show once a store accrues run reports.
+# Run reports become work-item evidence, so this is a correctness cap, not a
+# display nicety. (Under the MCP-first layout runs/ is empty and the cap is
+# inert; it matters only for stores fed by the `agentacct run` flow.)
+_LEDGER_RUN_REPORT_LIMIT = 100
+
+
+def _collect_service_run_reports(service: SentinelService, *, limit: int = _LEDGER_RUN_REPORT_LIMIT) -> list[dict[str, Any]]:
     reports = []
     for run in service.list_runs(limit=limit):
         run_id = run.get("run_id")
@@ -2389,6 +2409,8 @@ def build_page_data(
     local_usage_preview: list[ClientUsageEvent] | None = None,
     continuation_snapshot: Mapping[str, Any] | None = None,
     task_csrf_token: str = "",
+    events: list[dict[str, Any]] | None = None,
+    ledger: dict[str, Any] | None = None,
 ) -> _DashboardPageData:
     """The saved-rows page context, buildable directly from a store.
 
@@ -2411,7 +2433,11 @@ def build_page_data(
         else None
     )
     store_display_label = _store_display_label(store_dir, store_scope, store_project_label)
-    events = service.list_all_events()
+    # A caller that already loaded events for THIS build (the /v1 task lane,
+    # which also passes the matching pre-built ``ledger``) hands them in so the
+    # page's usage view and mechanical checks reflect the SAME snapshot the
+    # injected ledger was reduced from — not a second, possibly newer read.
+    events = events if events is not None else service.list_all_events()
     mechanical_envelopes, observation_diagnostics = _mechanical_projection_envelopes_for(service, store_dir)
     session_observations = (
         build_session_observations(
@@ -2426,7 +2452,7 @@ def build_page_data(
     return _dashboard_page_data(
         events=events,
         cost_events=cost_events,
-        run_reports=_collect_service_run_reports(service, limit=20),
+        run_reports=_collect_service_run_reports(service, limit=_LEDGER_RUN_REPORT_LIMIT),
         session_observations=session_observations,
         session_observation_diagnostics=observation_diagnostics,
         mechanical_check_events=build_mechanical_check_events(mechanical_envelopes),
@@ -2443,6 +2469,7 @@ def build_page_data(
         task_csrf_token=task_csrf_token,
         ingestion_health=ingestion_health_store.snapshot(),
         task_identity=task_identity,
+        ledger=ledger,
     )
 
 
@@ -2629,7 +2656,7 @@ def create_local_api_app(
     def _invalid(exc: ValueError) -> HTTPException:
         return HTTPException(status_code=422, detail=str(exc))
 
-    def _collect_run_reports(limit: int = 100) -> list[dict[str, Any]]:
+    def _collect_run_reports(limit: int = _LEDGER_RUN_REPORT_LIMIT) -> list[dict[str, Any]]:
         return _collect_service_run_reports(service, limit=limit)
 
     def _mechanical_projection_envelopes() -> tuple[list[Any], dict[str, int]]:
@@ -2669,7 +2696,7 @@ def create_local_api_app(
             )
             return build_work_ledger(
                 loaded_events,
-                run_reports=_collect_run_reports(limit=100),
+                run_reports=_collect_run_reports(limit=_LEDGER_RUN_REPORT_LIMIT),
                 cost_events=cost_ledger.read_events(),
                 session_observations=session_observations,
                 session_observation_diagnostics=observation_diagnostics,
@@ -2683,8 +2710,14 @@ def create_local_api_app(
         local_usage_preview: list[ClientUsageEvent] | None = None,
         *,
         continuation_snapshot: Mapping[str, Any] | None = None,
+        events: list[dict[str, Any]] | None = None,
+        ledger: dict[str, Any] | None = None,
     ) -> _DashboardPageData:
-        """Saved-rows page context (module-level assembly with cached stores)."""
+        """Saved-rows page context (module-level assembly with cached stores).
+
+        ``events``/``ledger`` let the /v1 task lane assemble the page over the
+        shared, cached derived ledger (kept warm by the sessions lane) instead
+        of paying build_work_ledger's multi-second reduce again."""
 
         return build_page_data(
             store_dir,
@@ -2696,6 +2729,8 @@ def create_local_api_app(
             local_usage_preview=local_usage_preview,
             continuation_snapshot=continuation_snapshot,
             task_csrf_token=task_csrf_token,
+            events=events,
+            ledger=ledger,
         )
 
     @app.get("/api/control")
@@ -2923,7 +2958,11 @@ def create_local_api_app(
         # invalidate this the instant they land; the only writes it does not
         # notice within the TTL are evidence-store-only imports (connector /
         # capture-hook), the same bound every sibling /v1 cache already has —
-        # the real fix for that is materialization, not a hotter key.
+        # the real fix for that is materialization, not a hotter key. Reusing
+        # the shared ledger stacks that ledger's own 30s TTL under this cache's,
+        # so those fingerprint-invisible inputs (cost/run-report/mechanical-obs
+        # imports) can lag up to ~60s here — the SAME staleness class and the
+        # SAME reused-ledger profile the sessions lane already accepts.
         events = service.list_all_events()
         fingerprint = events_fingerprint(events)
         cached = v1_receipt_projection_cache.get("projection")
@@ -2934,7 +2973,20 @@ def create_local_api_app(
             cached = v1_receipt_projection_cache.get("projection")
             if cached is not None and cached[0] == fingerprint and (time.time() - cached[1]) < 30.0:
                 return cached[2]
-            projection = _dashboard_task_projection(_page_data())
+            # Assemble the projection over the SHARED derived ledger instead of
+            # rebuilding the full ledger here. That ledger (WorkLedgerCache,
+            # single-flighted, fingerprint + TTL cached) is the same one the
+            # sessions lane keeps warm under polling, so the tasks/receipts the
+            # app fires alongside it pay the multi-second reduce at most once,
+            # shared — never once per request. The reduce sees the SAME inputs
+            # build_page_data would have used: the run-report cap is the shared
+            # _LEDGER_RUN_REPORT_LIMIT on both paths, and the cost-event order
+            # difference is re-sorted away inside build_proxy_usage_events. So
+            # the projection is byte-identical to the self-built one it
+            # replaces — for any store, not only the MCP-first (runs/ empty)
+            # case verified on the live store.
+            ledger = _derived_work_ledger(events, fingerprint=fingerprint)
+            projection = _dashboard_task_projection(_page_data(events=events, ledger=ledger))
             v1_receipt_projection_cache["projection"] = (fingerprint, time.time(), projection)
             return projection
 

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -6,9 +6,20 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from agentacct.api import create_local_api_app
+from agentacct.api import (
+    _LEDGER_RUN_REPORT_LIMIT,
+    _collect_service_run_reports,
+    _dashboard_task_projection,
+    _mechanical_projection_envelopes_for,
+    _store_scope_and_label,
+    build_page_data,
+    create_local_api_app,
+)
+from agentacct.cost import CostLedger
 from agentacct.receipt import RECEIPT_SCHEMA_VERSION
 from agentacct.service import SentinelService
+from agentacct.session_observations import build_session_observations
+from agentacct.work_ledger import build_proxy_usage_events, build_work_ledger
 
 TOKEN = "test-v1-token"
 NS = "sha256:receipt-api-ns"
@@ -171,3 +182,111 @@ def test_receipt_reports_verified_when_a_current_check_passes(tmp_path: Path) ->
     assert receipt["dimensions"]["evidence"]["checks_passed"] == 1
     # The touched file recorded on the section rides the Actions dimension.
     assert "src/login.py" in receipt["dimensions"]["actions"]["touched_files"]
+
+
+def _derived_style_ledger(service: SentinelService, tmp_path: Path) -> dict:
+    """Build the work ledger exactly the way the sessions lane's cached
+    ``_derived_work_ledger`` does — the shared ``_LEDGER_RUN_REPORT_LIMIT`` cap
+    and cost events in raw store order — so a golden test can prove the /v1
+    task lane's reuse of it yields the same projection build_page_data
+    self-builds (same cap; its cost events are pre-sorted but re-sorted away
+    inside the reduce)."""
+
+    events = service.list_all_events()
+    envelopes, diagnostics = _mechanical_projection_envelopes_for(service, tmp_path)
+    scope, label = _store_scope_and_label(tmp_path)
+    observations = (
+        build_session_observations(
+            envelopes,
+            default_project_label=label if scope == "project" else None,
+            diagnostics=diagnostics,
+        )
+        if envelopes
+        else []
+    )
+    return build_work_ledger(
+        events,
+        run_reports=_collect_service_run_reports(service, limit=_LEDGER_RUN_REPORT_LIMIT),
+        cost_events=CostLedger(tmp_path).read_events(),
+        session_observations=observations,
+        session_observation_diagnostics=diagnostics,
+        store_project_label=label,
+        store_scope=scope,
+    )
+
+
+def test_injecting_the_shared_derived_ledger_matches_the_self_built_projection(
+    tmp_path: Path,
+) -> None:
+    """Reusing the shared derived ledger must not change what receipts show.
+
+    The /v1 task lane assembles its projection over the sessions lane's cached
+    ledger instead of rebuilding one per request. This locks that swap: a
+    ledger built the derived lane's way, injected into build_page_data, yields
+    a task projection byte-identical to the one build_page_data self-builds.
+    """
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    _record_section(service, session_id="s1", section_id="sec-1", status="completed", at=101.0)
+    _record_passing_check(service, session_id="s1", section_id="sec-1", at=102.0)
+    _record_usage(service, session_id="s2", at=200.0)
+    _record_section(service, session_id="s2", section_id="sec-2", status="handed_off", at=201.0)
+
+    reference = _dashboard_task_projection(build_page_data(tmp_path))
+
+    events = service.list_all_events()
+    derived_ledger = _derived_style_ledger(service, tmp_path)
+    injected = _dashboard_task_projection(
+        build_page_data(tmp_path, events=events, ledger=derived_ledger)
+    )
+
+    assert injected == reference
+
+
+def test_injected_task_and_receipt_wire_output_is_unchanged(tmp_path: Path) -> None:
+    """End to end: the /v1/tasks and /v1/receipt payloads the app serves over
+    the injected shared ledger equal the ones built from the self-built
+    projection — the reuse is invisible on the wire."""
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    _record_section(service, session_id="s1", section_id="sec-1", status="completed", at=101.0)
+    _record_passing_check(service, session_id="s1", section_id="sec-1", at=102.0)
+
+    client = _app(tmp_path)
+    listing = client.get("/v1/tasks", headers=_auth()).json()
+    task_id = listing["tasks"][0]["task_id"]
+    receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
+
+    # The projection the routes consume (built over the injected shared ledger)
+    # must equal the self-built one field for field.
+    reference = _dashboard_task_projection(build_page_data(tmp_path))
+    injected = _dashboard_task_projection(
+        build_page_data(
+            tmp_path,
+            events=service.list_all_events(),
+            ledger=_derived_style_ledger(service, tmp_path),
+        )
+    )
+    assert injected == reference
+    assert listing["total"] == 1
+    assert receipt["schema_version"] == RECEIPT_SCHEMA_VERSION
+
+
+def test_proxy_usage_events_are_order_invariant() -> None:
+    """The cost-event ordering delta between the two ledger build sites is
+    provably immaterial: build_proxy_usage_events re-sorts by created_at, so
+    the raw store order the sessions lane passes and the pre-sorted order
+    build_page_data passes reduce to the identical list."""
+
+    cost_events = [
+        {"event_id": "c1", "created_at": 300.0, "estimated_cost_usd": 0.3},
+        {"event_id": "c2", "created_at": 100.0, "estimated_cost_usd": 0.1},
+        {"event_id": "c3", "created_at": 200.0, "estimated_cost_usd": 0.2},
+    ]
+    ascending = sorted(cost_events, key=lambda event: event["created_at"])
+    descending = sorted(cost_events, key=lambda event: event["created_at"], reverse=True)
+
+    assert build_proxy_usage_events(ascending) == build_proxy_usage_events(descending)
+    assert build_proxy_usage_events(cost_events) == build_proxy_usage_events(ascending)


### PR DESCRIPTION
The macOS Receipts pane was unusable: opening a few receipts returned `GlanceClientError error 2` (transport timeout) and even the sessions list failed to load. Root cause on the live store (~9k events, 182 tasks): `list_all_events` is 0.08s, but `build_work_ledger` is ~7.5s — 90% of the ~8.3s cold path — and `/v1/tasks` + `/v1/receipt` rebuilt that ledger on every request through `build_page_data`, while synchronous routes let concurrent requests each rebuild in parallel and all blow the client timeout.

Two commits, shipped together:

**Single-flight the projection cache + widen the app timeout** (mitigation)
- `_v1_task_projection` builds under one lock and caches by events fingerprint, so concurrent tasks/receipts share one build instead of a thundering herd.
- `GlanceClient` request timeout 20s → 60s.

**Serve `/v1` tasks and receipts from the shared derived ledger** (the real fix)
- `/v1/tasks` and `/v1/receipt` now reuse the fingerprint + TTL cached, single-flighted derived ledger the sessions lane already keeps warm, instead of rebuilding it. `_dashboard_page_data`/`build_page_data` take an optional injected `ledger` (short-circuiting `build_work_ledger`), and `build_page_data` takes the caller's `events` snapshot so the page assembles over the same events the ledger was reduced from. `/tasks`, `/v1/sessions`, `/v1/session`, and the CLI are unchanged.
- The two ledger build sites differed in exactly two inputs; both are now reconciled:
  - **cost-event order** — neutral: `build_proxy_usage_events` re-sorts by `created_at` with a stable sort, so the pre-sorted and raw inputs collapse to the identical sequence.
  - **run-report cap** — unified to one `_LEDGER_RUN_REPORT_LIMIT` on both the self-built and derived ledgers, so the injected projection is byte-identical to the self-built one for any store, not only stores with an empty `runs/`.

Result: on a warm ledger the `/v1` cold path drops from ~8.3s to ~0.8s, and a cold build is paid at most once, shared across every ledger route.

**Behavior note:** `build_page_data` (and its `/tasks`, CLI, and overview consumers) now considers up to 100 run reports instead of 20. This is inert under the MCP-first layout (`runs/` empty) and aligns those surfaces with the sessions lane, which already read up to 100.

Verification:
- Full `pytest`: 2955 passed, 0 failed.
- `swift build`: clean.
- Read-only diff on the live store (9009 events, 182 tasks): the injected-ledger task projection is byte-identical to the self-built one; cold path 8.3s → 0.7s.
- Golden tests added: injected-ledger projection equals the self-built projection, and `build_proxy_usage_events` is order-invariant.
