### PR TITLE
perf(ledger): index the usage↔work attribution join

### DIFF
--- a/src/agentacct/join_rules.py
+++ b/src/agentacct/join_rules.py
@@ -397,6 +397,74 @@ def pair_match(
     return {"join_keys": join_keys, "id_tiers": id_tiers, "vetoes": sorted(set(vetoes))}
 
 
+# The id keys pair_match() joins on. A usage row U and a work candidate W can
+# only produce a non-None pair_match — a join key OR a veto — when at least one
+# of these equalities holds:
+#     U.client_session_id        == W.client_session_id
+#     U.client_transcript_id     == W.client_transcript_id
+#     U.run_id                   == W.run_id
+#     U.parent_client_session_id == W.client_session_id
+#     U.client_session_id        == W.parent_client_session_id
+# Every veto pair_match can emit is gated behind one of these equalities (the
+# session/transcript equality branches, or namespace/source vetoes that only
+# fire once join_keys is non-empty), so a pair sharing NONE of them contributes
+# nothing to attribution — pair_match returns None. Indexing candidates by these
+# fields lets the attribution loops pair_match only the ~1% of candidates that
+# could possibly match, with byte-identical results.
+#
+# Each entry is (key_read_on_the_query_row, field_the_index_is_keyed_on). The
+# relation is structurally symmetric, so the SAME table drives both directions
+# (usage->work candidates and work->usage candidates). Keep it in lockstep with
+# pair_match().
+_JOIN_INDEX_LOOKUPS: tuple[tuple[str, str], ...] = (
+    ("client_session_id", "client_session_id"),
+    ("parent_client_session_id", "client_session_id"),
+    ("client_transcript_id", "client_transcript_id"),
+    ("run_id", "run_id"),
+    ("client_session_id", "parent_client_session_id"),
+)
+_JOIN_INDEX_FIELDS: tuple[str, ...] = (
+    "client_session_id",
+    "client_transcript_id",
+    "run_id",
+    "parent_client_session_id",
+)
+
+
+class JoinCandidateIndex:
+    """Index a candidate list by the id keys pair_match() joins on.
+
+    Lets the two O(usage x work) attribution loops pair_match only the
+    candidates that could possibly match a given row, instead of scanning the
+    whole list (the dominant cost of build_work_ledger). Provably lossless: a
+    candidate sharing none of _JOIN_INDEX_LOOKUPS' keys returns None from
+    pair_match (no join key, no veto), so skipping it cannot change any
+    decision. ``matches`` returns the subset in the candidates' ORIGINAL order,
+    so the caller sees the identical match/veto/candidate sequence a full scan
+    would produce.
+    """
+
+    def __init__(self, candidates: list[dict[str, Any]]) -> None:
+        self._by: dict[str, dict[Any, list[tuple[int, dict[str, Any]]]]] = {
+            field: {} for field in _JOIN_INDEX_FIELDS
+        }
+        for position, candidate in enumerate(candidates):
+            for field in _JOIN_INDEX_FIELDS:
+                value = candidate.get(field)
+                if value:
+                    self._by[field].setdefault(value, []).append((position, candidate))
+
+    def matches(self, row: dict[str, Any]) -> list[dict[str, Any]]:
+        gathered: dict[int, dict[str, Any]] = {}
+        for row_key, index_field in _JOIN_INDEX_LOOKUPS:
+            value = row.get(row_key)
+            if not value:
+                continue
+            for position, candidate in self._by[index_field].get(value, ()):
+                gathered[position] = candidate
+        return [candidate for _position, candidate in sorted(gathered.items())]
+
+
 def pair_confidence(match: dict[str, Any]) -> str:
     """Display confidence for a single pair match (used by the join inspector)."""
 

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -15,6 +15,7 @@ from .confidence import (
 )
 from .tool_activity import build_tool_activity_by_session
 from .join_rules import (
+    JoinCandidateIndex,
     annotate_usage_source_namespace_ambiguity,
     decide_attribution,
     namespace_join_compatible,
@@ -89,6 +90,7 @@ def build_work_ledger(
     session_observation_diagnostics: dict[str, int] | None = None,
     store_project_label: str | None = None,
     store_scope: str | None = None,
+    use_index: bool = True,
 ) -> dict[str, Any]:
     """Build the derived local work ledger from imported facts and MCP meaning.
 
@@ -149,6 +151,7 @@ def build_work_ledger(
         usage_events,
         projectable_work_events,
         allow_legacy_unscoped_namespace=allow_legacy_unscoped_namespace,
+        use_index=use_index,
     )
     work_items = build_work_items(
         projectable_work_events,
@@ -168,6 +171,7 @@ def build_work_ledger(
         work_items,
         attributions,
         allow_legacy_unscoped_namespace=allow_legacy_unscoped_namespace,
+        use_index=use_index,
     )
     _attach_join_explanations(work_items, join_inspector["work_item_join_explanations"])
     usage_reconciliation = build_usage_reconciliation(usage_events, work_items, attributions)
@@ -852,6 +856,7 @@ def build_attributions(
     work_events: list[dict[str, Any]],
     *,
     allow_legacy_unscoped_namespace: bool = False,
+    use_index: bool = True,
 ) -> list[dict[str, Any]]:
     projectable_work_events, _diagnostics = _projectable_work_event_cohorts(
         work_events,
@@ -860,11 +865,18 @@ def build_attributions(
     latest_work_by_id = _latest_work_by_id(projectable_work_events)
     work_candidates = list(latest_work_by_id.values())
     usage_events = annotate_usage_source_namespace_ambiguity(usage_events)
+    # Give each usage row only the candidates that share an id key with it —
+    # the rest return None from pair_match (see JoinCandidateIndex). The subset
+    # preserves work_candidates' order, so decide_attribution sees the identical
+    # match/veto sequence a full scan would. ``use_index=False`` restores the
+    # full scan for the byte-equal golden test.
+    candidate_index = JoinCandidateIndex(work_candidates) if use_index else None
     attributions: list[dict[str, Any]] = []
     for usage in usage_events:
+        candidates = candidate_index.matches(usage) if candidate_index is not None else work_candidates
         decision = decide_attribution(
             usage,
-            work_candidates,
+            candidates,
             allow_legacy_unscoped_namespace=allow_legacy_unscoped_namespace,
         )
         work = decision.get("work")
@@ -1366,6 +1378,7 @@ def build_join_inspector(
     attributions: list[dict[str, Any]],
     *,
     allow_legacy_unscoped_namespace: bool = False,
+    use_index: bool = True,
 ) -> dict[str, Any]:
     """Explain why each work item did or did not receive usage attribution."""
 
@@ -1386,12 +1399,19 @@ def build_join_inspector(
             if candidate_id:
                 ambiguous_work_ids.add(str(candidate_id))
 
+    # Each item only pair_matches the usage rows that share an id key with it
+    # (the rest return None from pair_match); the subset keeps usage_events'
+    # order so the candidate sequence is identical to a full scan. The full
+    # usage_events list is still passed to the explanation/nearest-usage helpers
+    # below unchanged. ``use_index=False`` restores the full scan for the test.
+    usage_index = JoinCandidateIndex(usage_events) if use_index else None
     explanations: dict[str, dict[str, Any]] = {}
     for item in work_items:
         work_id = str(item.get("work_id") or item.get("section_id") or "")
         attributed = attributions_by_work.get(work_id, [])
         candidates = []
-        for usage in usage_events:
+        candidate_usage_rows = usage_index.matches(item) if usage_index is not None else usage_events
+        for usage in candidate_usage_rows:
             match = pair_match(
                 usage,
                 item,

--- a/tests/test_work_ledger.py
+++ b/tests/test_work_ledger.py
@@ -1687,3 +1687,51 @@ def test_work_ledger_schema_version_bumped_to_v2() -> None:
     # v2: session_rollup + attention_groups, cache triples, attributed-first
     # reconciliation, diagnostic filtering (release-note item).
     assert build_work_ledger([])["schema_version"] == "agent-sentinel.work-ledger.v2"
+
+
+def _join_index_parity_events() -> list[dict]:
+    """Events that drive every attribution / join-inspector path the join index
+    must preserve: two sibling sections in one session (ambiguity guard), an
+    exact single-section allocation with a superseded check, a transcript-only
+    match, a run_id grouping hint across sessions, and unmatched usage."""
+
+    return [
+        # sess-A: two sibling sections -> usage stays unallocated (ambiguous).
+        _usage_event(session="sess-A", event_id="a", created_at=10),
+        _section_event(session="sess-A", section_id="A1", status="completed", created_at=11),
+        _section_event(session="sess-A", section_id="A2", status="checkpoint", created_at=12),
+        # sess-B: single section -> exact session allocation; failed check then
+        # a later passing check in the same scope (supersession).
+        _usage_event(session="sess-B", event_id="b", created_at=20),
+        _section_event(session="sess-B", section_id="B1", status="completed", created_at=21),
+        _evidence_event(section_id="B1", result="failed"),
+        _evidence_event(section_id="B1", result="passed"),
+        # transcript-only match (section carries no session id).
+        _usage_event(session="sess-C", transcript="tx-C", event_id="c", created_at=30),
+        _section_event(session="", transcript="tx-C", section_id="C1", status="completed", created_at=31),
+        # run_id grouping hint: usage.run_id == section.run_id, different sessions.
+        _usage_event(session="sess-D", event_id="d", created_at=40),
+        _section_event(session="sess-E", section_id="E1", run_id="client_codex_sess-D", status="checkpoint", created_at=41),
+        # usage with no matching section at all.
+        _usage_event(session="sess-Z", event_id="z", created_at=50),
+    ]
+
+
+def test_join_index_matches_a_full_scan_byte_for_byte() -> None:
+    """The id-key index that lets the attribution loops skip non-matching pairs
+    must produce a ledger identical to the full O(usage x work) scan. Build both
+    ways and assert deep equality, on an event set that exercises the ambiguity
+    guard, exact/transcript allocation, run_id grouping, and unmatched usage."""
+
+    events = _join_index_parity_events()
+    indexed = build_work_ledger(events, use_index=True)
+    full = build_work_ledger(events, use_index=False)
+
+    assert indexed == full
+
+    # Non-vacuous: the set must actually drive an ambiguous refusal AND real
+    # allocations, so the parity assertion is proven on the paths that matter.
+    strategies = [attribution["join_strategy"] for attribution in indexed["attributions"]]
+    assert any("ambiguous" in strategy for strategy in strategies)
+    assert "exact_client_session_id" in strategies
+    assert "exact_client_transcript_id" in strategies


### PR DESCRIPTION
治本-A (PR #77) made *warm* receipts fast by reusing the cached derived ledger, but the **first** `build_work_ledger` after a daemon restart or any event change still paid ~7.5–9s. Profiling the live store (9035 events) showed that cost is **~90% `pair_match`**, called **~6.3M times** across two O(usage × work) nested scans:

- `build_attributions` → `decide_attribution`: per usage row, scans **all** work candidates.
- `build_join_inspector`: per work item, scans **all** usage rows.

`pair_match` returns `None` — contributing **nothing** (no join key, no veto) — unless the pair shares an id key: `client_session_id`, `client_transcript_id`, `run_id`, or a parent/child session link. So ~99% of those comparisons could never match.

This adds `JoinCandidateIndex` (in `join_rules.py`, right next to `pair_match`), keyed on exactly the id fields `pair_match` joins on, and has both loops `pair_match` only the id-key-sharing subset — in original candidate order, so the match/veto/candidate sequence is unchanged. `decide_attribution` and `pair_match` are untouched. A `use_index: bool = True` seam threads `build_work_ledger` → `build_attributions`/`build_join_inspector` so a golden test builds both ways and asserts the ledger is byte-identical.

**Why it's byte-identical:** every path in `pair_match` to a non-`None` result (a join key *or* any veto) is gated behind one of those five id-key equalities — the session/transcript equality branches, and the namespace/source vetoes only fire once `join_keys` is non-empty. A candidate sharing none of those keys contributes nothing, so skipping it cannot change any decision. The index encodes exactly those five equalities (one symmetric table drives both loop directions), and returns the subset in original order.

**Alternatives considered and rejected:** serving receipts from the canonical materialized layer (`rm_task_current` carries ~1 of the Receipt's 8 dimensions; not receipt-grade), and materializing terminal work steps (unsound — attribution is a global, section-scoped join where a new active sibling section retroactively changes a terminal item's usage/cost).

Result: `build_work_ledger` cold ~7.1s → ~1.2s (`pair_match` calls 6.3M → 35K), byte-identical output. Combined with 治本-A's shared cache, the app's `/v1` tasks/receipts are fast on the first request too — the ~8–9s cold path is gone.

Verification:
- Full `pytest`: 2956 passed, 0 failed (adds the byte-equal golden test).
- Live-store read-only diff (9048 events): `use_index=True` vs `False` ledger deep-equal.
- Golden test `test_join_index_matches_a_full_scan_byte_for_byte`: asserts both build paths deep-equal on an event set exercising sibling-section ambiguity, exact/transcript allocation, run_id grouping, superseded checks, and unmatched usage.
