### PR TITLE
perf(ledger): index the evidence→work-item link scans

### DIFF
--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -158,6 +158,7 @@ def build_work_ledger(
         evidence_events,
         attributions,
         allow_legacy_unscoped_namespace=allow_legacy_unscoped_namespace,
+        use_index=use_index,
     )
     blocker_resolution_diagnostics = apply_blocker_resolutions(
         work_items,
@@ -913,6 +914,7 @@ def build_work_items(
     attributions: list[dict[str, Any]],
     *,
     allow_legacy_unscoped_namespace: bool = False,
+    use_index: bool = True,
 ) -> list[dict[str, Any]]:
     work_events, _diagnostics = _projectable_work_event_cohorts(
         work_events,
@@ -1107,6 +1109,28 @@ def build_work_items(
         if work_id:
             usage_by_work.setdefault(str(work_id), []).append(attribution)
 
+    # Both evidence link scans below are otherwise O(evidence x grouped). Index
+    # grouped ONCE by the raw keys each scan matches on — position (to keep
+    # grouped's insertion order in the results), section_id, and run_id — so
+    # each evidence event visits only the handful of items it could reference.
+    # Lossless: the indexes reproduce the exact same candidate set and order the
+    # full scans yield. ``use_index=False`` restores the scans for the test.
+    grouped_position: dict[str, int] | None = None
+    work_ids_by_section: dict[str, list[str]] | None = None
+    work_ids_by_run: dict[str, list[str]] | None = None
+    if use_index:
+        grouped_position = {}
+        work_ids_by_section = {}
+        work_ids_by_run = {}
+        for position, (work_id, item) in enumerate(grouped.items()):
+            grouped_position[work_id] = position
+            section_id = str(item.get("section_id") or "")
+            if section_id:
+                work_ids_by_section.setdefault(section_id, []).append(work_id)
+            run_id_value = item.get("run_id")
+            if run_id_value:
+                work_ids_by_run.setdefault(run_id_value, []).append(work_id)
+
     evidence_by_work: dict[str, list[dict[str, Any]]] = {}
     for evidence in evidence_events:
         linked_ids = _evidence_link_ids(evidence)
@@ -1121,6 +1145,8 @@ def build_work_items(
                 linked_ids,
                 grouped,
                 allow_legacy_unscoped_namespace=allow_legacy_unscoped_namespace,
+                work_ids_by_section=work_ids_by_section,
+                grouped_position=grouped_position,
             )
             if len(candidates) == 1:
                 evidence_by_work.setdefault(candidates[0], []).append(evidence)
@@ -1128,7 +1154,11 @@ def build_work_items(
         run_id = evidence.get("run_id")
         if not run_id:
             continue
-        for work_id, item in grouped.items():
+        run_candidate_ids = (
+            work_ids_by_run.get(run_id, ()) if work_ids_by_run is not None else grouped
+        )
+        for work_id in run_candidate_ids:
+            item = grouped[work_id]
             if item.get("run_id") == run_id and _evidence_run_context_compatible(
                 evidence,
                 item,
@@ -4330,19 +4360,34 @@ def _evidence_candidate_work_ids(
     grouped: dict[str, dict[str, Any]],
     *,
     allow_legacy_unscoped_namespace: bool,
+    work_ids_by_section: dict[str, list[str]] | None = None,
+    grouped_position: dict[str, int] | None = None,
 ) -> list[str]:
     """Resolve an evidence event's raw section/work references to work items.
 
     References match either the composite work_id or the raw section_id.
     When the evidence carries client/session context, items with conflicting
     context are dropped, and an exact session match narrows the candidates.
+
+    ``work_ids_by_section``/``grouped_position`` (built once by the caller) turn
+    the reference match from a full scan of ``grouped`` into direct lookups; the
+    result is the same candidate set in the same grouped order.
     """
 
-    candidates = [
-        work_id
-        for work_id, item in grouped.items()
-        if work_id in linked_ids or str(item.get("section_id") or "") in linked_ids
-    ]
+    if work_ids_by_section is None or grouped_position is None:
+        candidates = [
+            work_id
+            for work_id, item in grouped.items()
+            if work_id in linked_ids or str(item.get("section_id") or "") in linked_ids
+        ]
+    else:
+        matched: set[str] = set()
+        for linked in linked_ids:
+            if linked in grouped:
+                matched.add(linked)
+            for work_id in work_ids_by_section.get(linked, ()):
+                matched.add(work_id)
+        candidates = sorted(matched, key=lambda work_id: grouped_position[work_id])
     candidates = [
         work_id
         for work_id in candidates

--- a/tests/test_work_ledger.py
+++ b/tests/test_work_ledger.py
@@ -1735,3 +1735,35 @@ def test_join_index_matches_a_full_scan_byte_for_byte() -> None:
     assert any("ambiguous" in strategy for strategy in strategies)
     assert "exact_client_session_id" in strategies
     assert "exact_client_transcript_id" in strategies
+
+
+def test_evidence_link_index_matches_a_full_scan_byte_for_byte() -> None:
+    """The evidence->work_item link scans (by section_id and by run_id) are also
+    indexed under the same use_index seam. Build the ledger both ways over
+    several sections each carrying section-linked evidence and assert the whole
+    ledger is identical, so the evidence-link index preserves grouped order and
+    the exact one-candidate linking rule."""
+
+    events = [
+        _usage_event(session="sess-1", event_id="1", created_at=10),
+        _section_event(session="sess-1", section_id="sec-1", status="completed", created_at=11),
+        _evidence_event(section_id="sec-1", result="passed"),
+        _usage_event(session="sess-2", event_id="2", created_at=20),
+        _section_event(session="sess-2", section_id="sec-2", status="completed", created_at=21),
+        _evidence_event(section_id="sec-2", result="failed"),
+        _evidence_event(section_id="sec-2", result="passed"),
+        _section_event(session="sess-3", section_id="sec-3", status="checkpoint", created_at=31),
+        _evidence_event(section_id="sec-3", result="passed"),
+    ]
+
+    indexed = build_work_ledger(events, use_index=True)
+    full = build_work_ledger(events, use_index=False)
+
+    assert indexed == full
+
+    # Non-vacuous: the section-linked evidence must actually attach via the
+    # indexed candidate resolution, so parity is proven on real linkages.
+    statuses = {item["section_id"]: item.get("evidence_status") for item in indexed["work_items"]}
+    assert statuses.get("sec-1") == "strong"  # single passing check
+    assert statuses.get("sec-3") == "strong"
+    assert statuses.get("sec-2") not in (None, "none")  # evidenced (fail + pass both attached)


### PR DESCRIPTION
Follow-up to #78 (indexing the usage↔work attribution join). After that landed, the ledger's remaining cost had a second quadratic: `build_work_items` linked each evidence event to work items with **two O(evidence × grouped) scans** — one matching an evidence event's references by `section_id`/`work_id`, and a `run_id` fallback — each scanning every grouped work item per evidence event.

This indexes the grouped items **once** before the evidence loop:
- `work_ids_by_section`: `section_id → [work_ids]`
- `work_ids_by_run`: `run_id → [work_ids]`
- `grouped_position`: `work_id → insertion index` (to keep grouped order in results)

Each evidence event then visits only the items it could reference, in the same grouped insertion order. The linking logic (`_evidence_candidate_work_ids`, the one-candidate gate, `_evidence_run_context_compatible`) is unchanged. The `use_index` seam introduced in #78 gates it (`build_work_ledger → build_work_items → _evidence_candidate_work_ids`), so a golden test builds the ledger both ways and asserts it is byte-identical.

**Why it's byte-identical:** for the section scan, a grouped item is a candidate iff its `work_id ∈ linked_ids` or its `section_id ∈ linked_ids`; the index reproduces exactly that set (empty section ids can't match — `_evidence_link_ids` filters falsy values, so `linked_ids` never contains `""`), sorted by grouped position → same set, same order. For the run_id scan, `work_ids_by_run[run_id]` is exactly the grouped items with that run id, in grouped order; the retained `item.run_id == run_id` check is redundant-but-harmless.

Result (live store, 9083 events): combined with #78, `build_work_ledger` drops from ~7.2s to ~1.0s, byte-identical output. This closes the last quadratic in the cold ledger build.

Verification:
- Full `pytest`: 2957 passed, 0 failed (adds a byte-equal golden test for the evidence-link index).
- Live-store read-only diff: `use_index=True` vs `False` ledger deep-equal on 9083 events.
- Golden test `test_evidence_link_index_matches_a_full_scan_byte_for_byte`: both build paths deep-equal, and asserts the section-linked evidence actually attaches (non-vacuous).
