### PR TITLE
fix(app): make the whole Receipt row a tap target

### DIFF
--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -140,6 +140,11 @@ private struct ReceiptRow: View {
             selected ? AnyShapeStyle(Theme.cardAlt) : AnyShapeStyle(.clear),
             in: RoundedRectangle(cornerRadius: 7, style: .continuous)
         )
+        // The whole card is the tap target, not just the text — an unselected
+        // row's background is `.clear`, which SwiftUI does not hit-test, so
+        // without this the blank areas of the card swallow the tap (SessionRow
+        // already does this).
+        .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
An unselected Receipt row's background is `.clear`, which SwiftUI does not hit-test, so clicks only registered on the row's text/chips — the blank card area swallowed them (the list felt laggy / unclickable). Add `.contentShape(Rectangle())` so the entire row is the tap target, matching SessionRow which already does this. One line; `swift build` clean.