### PR TITLE
perf(receipt): cut the /v1 decorate layer ~800ms → ~180ms

### DIFF
--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -1292,9 +1292,20 @@ def _attach_evidence_to_task_projection(
     task_work_items_by_series: dict[tuple[str, str], list[dict[str, Any]]] = {}
     unresolved_items_by_strict_series: dict[str, list[dict[str, Any]]] = {}
 
+    # O(n) dedup instead of O(n^2): each target list gets a companion key set.
+    # The lists live for the whole call and are only ever appended to here, so
+    # id(rows) is a stable handle and the set stays in sync — same membership
+    # test and same append order as the prior all(...) scan.
+    _append_unique_seen: dict[int, set[tuple[str, ...]]] = {}
+
     def append_unique(rows: list[dict[str, Any]], event: Mapping[str, Any]) -> None:
+        seen = _append_unique_seen.get(id(rows))
+        if seen is None:
+            seen = {_evidence_event_key(row) for row in rows}
+            _append_unique_seen[id(rows)] = seen
         key = _evidence_event_key(event)
-        if all(_evidence_event_key(row) != key for row in rows):
+        if key not in seen:
+            seen.add(key)
             rows.append(dict(event))
 
     for task_id, task in task_by_id.items():
@@ -1369,6 +1380,28 @@ def _attach_evidence_to_task_projection(
     allow_legacy_unscoped = not require_namespace_for_client_hook
     event_candidates: dict[tuple[str, ...], set[str]] = {}
     assignment_diagnostics: dict[tuple[str, ...], dict[str, Any]] = {}
+
+    # namespace_join_compatible(event, fact) reads `fact` ONLY through its
+    # namespace fingerprint and identity_scope_state=='explicit' (see
+    # join_rules), so all(...) over a task's facts equals all(...) over its
+    # facts collapsed to distinct (fingerprint, scope-explicit) signatures. A
+    # single task often carries hundreds of same-signature facts; deduping here
+    # turns the per-event all() from O(facts) into O(distinct signatures) with
+    # an identical result. Built once — namespace_facts_by_task is complete.
+    namespace_fact_reps: dict[str, list[Mapping[str, Any]]] = {}
+    for _task_id, _facts in namespace_facts_by_task.items():
+        _seen_signatures: set[tuple[str, bool]] = set()
+        _reps: list[Mapping[str, Any]] = []
+        for _fact in _facts:
+            _signature = (
+                str(_fact.get("namespace_fingerprint") or _fact.get("session_namespace_fingerprint") or "").strip(),
+                str(_fact.get("identity_scope_state") or "").strip() == "explicit",
+            )
+            if _signature in _seen_signatures:
+                continue
+            _seen_signatures.add(_signature)
+            _reps.append(_fact)
+        namespace_fact_reps[_task_id] = _reps
 
     for event in evidence_events:
         if not isinstance(event, dict):
@@ -1464,7 +1497,7 @@ def _attach_evidence_to_task_projection(
             if namespace_facts_by_task.get(task_id)
             and all(
                 namespace_join_compatible(event, fact, allow_legacy_unscoped=allow_legacy_unscoped)
-                for fact in namespace_facts_by_task[task_id]
+                for fact in namespace_fact_reps[task_id]
             )
         }
         event_key = _evidence_event_key(event)
@@ -2333,6 +2366,12 @@ def _canonical_session_rollup_payload(read: CanonicalSessionListRead) -> dict[st
 # inert; it matters only for stores fed by the `agentacct run` flow.)
 _LEDGER_RUN_REPORT_LIMIT = 100
 
+# Ledger dict key under which the derived-ledger builder stashes the mechanical
+# check events it derived from the Evidence store, so the warm /v1 page assembly
+# can attach them without re-reading the Evidence store. Present only on ledgers
+# built by the app's _derived_work_ledger; absent from a bare build_work_ledger.
+_LEDGER_MECHANICAL_CHECK_EVENTS_KEY = "__page_mechanical_check_events__"
+
 
 def _collect_service_run_reports(service: SentinelService, *, limit: int = _LEDGER_RUN_REPORT_LIMIT) -> list[dict[str, Any]]:
     reports = []
@@ -2438,24 +2477,39 @@ def build_page_data(
     # page's usage view and mechanical checks reflect the SAME snapshot the
     # injected ledger was reduced from — not a second, possibly newer read.
     events = events if events is not None else service.list_all_events()
-    mechanical_envelopes, observation_diagnostics = _mechanical_projection_envelopes_for(service, store_dir)
-    session_observations = (
-        build_session_observations(
-            mechanical_envelopes,
-            default_project_label=store_project_label if store_scope == "project" else None,
-            diagnostics=observation_diagnostics,
+    # When a pre-built ledger is injected AND it carries the mechanical check
+    # events its own build derived from the Evidence store (the /v1 task lane),
+    # reuse them instead of reading the Evidence store again (~350ms). The
+    # session observations and run reports only feed build_work_ledger, which is
+    # skipped on an injected ledger, so they are dead work here too. On the
+    # self-build path (ledger is None) everything is computed as before.
+    stashed_checks = ledger.get(_LEDGER_MECHANICAL_CHECK_EVENTS_KEY) if ledger is not None else None
+    if stashed_checks is not None:
+        mechanical_check_events = stashed_checks
+        session_observations = []
+        observation_diagnostics = {}
+        run_reports = []
+    else:
+        mechanical_envelopes, observation_diagnostics = _mechanical_projection_envelopes_for(service, store_dir)
+        session_observations = (
+            build_session_observations(
+                mechanical_envelopes,
+                default_project_label=store_project_label if store_scope == "project" else None,
+                diagnostics=observation_diagnostics,
+            )
+            if mechanical_envelopes
+            else []
         )
-        if mechanical_envelopes
-        else []
-    )
+        run_reports = _collect_service_run_reports(service, limit=_LEDGER_RUN_REPORT_LIMIT)
+        mechanical_check_events = build_mechanical_check_events(mechanical_envelopes)
     cost_events = sorted(cost_ledger.read_events(), key=lambda item: float(item.get("created_at") or 0.0), reverse=True)
     return _dashboard_page_data(
         events=events,
         cost_events=cost_events,
-        run_reports=_collect_service_run_reports(service, limit=_LEDGER_RUN_REPORT_LIMIT),
+        run_reports=run_reports,
         session_observations=session_observations,
         session_observation_diagnostics=observation_diagnostics,
-        mechanical_check_events=build_mechanical_check_events(mechanical_envelopes),
+        mechanical_check_events=mechanical_check_events,
         store_project_label=store_project_label,
         store_project_identity=store_project_identity,
         store_scope=store_scope,
@@ -2694,7 +2748,7 @@ def create_local_api_app(
                 if mechanical_envelopes
                 else []
             )
-            return build_work_ledger(
+            ledger = build_work_ledger(
                 loaded_events,
                 run_reports=_collect_run_reports(limit=_LEDGER_RUN_REPORT_LIMIT),
                 cost_events=cost_ledger.read_events(),
@@ -2703,6 +2757,13 @@ def create_local_api_app(
                 store_project_label=store_project_label,
                 store_scope=store_scope,
             )
+            # Stash the mechanical check events derived from the envelopes this
+            # build already loaded, so build_page_data's warm /v1 path can attach
+            # them without paying the ~350ms Evidence-store read a second time.
+            # Same fingerprint + TTL staleness bound WorkLedgerCache already
+            # applies to its other Evidence-derived secondary inputs.
+            ledger[_LEDGER_MECHANICAL_CHECK_EVENTS_KEY] = build_mechanical_check_events(mechanical_envelopes)
+            return ledger
 
         return ledger_cache.ledger(fingerprint, _build)
 

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -7,11 +7,13 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from agentacct.api import (
+    _LEDGER_MECHANICAL_CHECK_EVENTS_KEY,
     _LEDGER_RUN_REPORT_LIMIT,
     _collect_service_run_reports,
     _dashboard_task_projection,
     _mechanical_projection_envelopes_for,
     _store_scope_and_label,
+    build_mechanical_check_events,
     build_page_data,
     create_local_api_app,
 )
@@ -239,6 +241,34 @@ def test_injecting_the_shared_derived_ledger_matches_the_self_built_projection(
     derived_ledger = _derived_style_ledger(service, tmp_path)
     injected = _dashboard_task_projection(
         build_page_data(tmp_path, events=events, ledger=derived_ledger)
+    )
+
+    assert injected == reference
+
+
+def test_injecting_a_ledger_with_stashed_mechanical_checks_matches_self_build(
+    tmp_path: Path,
+) -> None:
+    """The warm /v1 lane reuses the mechanical check events the ledger build
+    stashed instead of re-reading the Evidence store. A ledger carrying that
+    stash must produce the same task projection build_page_data self-builds by
+    reading the Evidence store fresh — this locks that the stashed-events branch
+    of build_page_data attaches the identical evidence."""
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    _record_section(service, session_id="s1", section_id="sec-1", status="completed", at=101.0)
+    _record_passing_check(service, session_id="s1", section_id="sec-1", at=102.0)
+
+    reference = _dashboard_task_projection(build_page_data(tmp_path))
+
+    events = service.list_all_events()
+    ledger = _derived_style_ledger(service, tmp_path)
+    envelopes, _diagnostics = _mechanical_projection_envelopes_for(service, tmp_path)
+    ledger[_LEDGER_MECHANICAL_CHECK_EVENTS_KEY] = build_mechanical_check_events(envelopes)
+
+    injected = _dashboard_task_projection(
+        build_page_data(tmp_path, events=events, ledger=ledger)
     )
 
     assert injected == reference


### PR DESCRIPTION
After #78/#79 cut the work-ledger build from ~7.5s to ~1.0s, the remaining ~1.2s of a cold `/v1/tasks` / `/v1/receipt` was the "decorate" layer — building the task projection and attaching evidence over the (now warm) ledger. Profiling the live store put ~800ms of that in two roughly equal halves; both are addressed here, byte-identically.

**`_attach_evidence_to_task_projection`: ~245ms → ~48ms**
- Per evidence event it ran `all(namespace_join_compatible(event, fact) for fact in a task's facts)`. `namespace_join_compatible(event, fact)` reads the `fact` **only** through `_namespace_fingerprint(fact)` and `fact.identity_scope_state == "explicit"`, so a task's hundreds of facts collapse to their distinct `(fingerprint, scope-explicit)` signatures with no change to `all(...)`. Deduped once up front (on the live store this turned 258,225 `namespace_join_compatible` calls into hundreds).
- `append_unique` recomputed the event key for every existing row on every append (O(n²)); it now carries a per-list key set (O(n)), same membership test and append order.

**Reuse the mechanical check events instead of re-reading the Evidence store: ~350ms → ~0 on the warm path**
- The derived-ledger build already reads the Evidence store to compute its envelopes; it now stashes the resulting `mechanical_check_events` on the ledger. On the warm `/v1` path `build_page_data` attaches those instead of reading the Evidence store a second time, and skips the `session_observations` / `run_reports` work that only feeds `build_work_ledger` (dead when a ledger is injected). Same fingerprint + TTL staleness the shared ledger cache already accepts; the self-build path (`ledger is None`, e.g. `/tasks` and the CLI) is unchanged.

Result: decorate ~800ms → ~180ms, so the cold `/v1` path is ~1.2s (ledger ~1.0s + decorate ~0.2s). Warm requests were already instant.

Verification:
- Live-store read-only diff (182 tasks, 563 envelopes): the full `/v1` task projection is **byte-identical** between main and this change.
- Full `pytest`: 2958 passed, 0 failed (adds a golden test asserting a stashed-ledger projection equals the self-build).
