### PR TITLE
fix(receipt): make gaps mean genuinely-missing, not structural noise

### DIFF
--- a/apps/agentacct/Sources/agentacct/WorkPane.swift
+++ b/apps/agentacct/Sources/agentacct/WorkPane.swift
@@ -145,7 +145,10 @@ private struct WorkDetail: View {
                         }
                     }
                     ForEach(group.members) { member in
-                        SessionDrillRow(member: member)
+                        SessionDrillRow(
+                            member: member,
+                            initiallyExpanded: group.role == "primary" && member.role == "root"
+                        )
                     }
                 }
             }
@@ -159,11 +162,18 @@ private struct WorkDetail: View {
 /// slot would clobber across several expanded sessions).
 private struct SessionDrillRow: View {
     let member: ReceiptSessionMember
+    let initiallyExpanded: Bool
     @EnvironmentObject var dashboard: DashboardStore
-    @State private var expanded = false
+    @State private var expanded: Bool
     @State private var detail: V1SessionDetail?
     @State private var loading = false
     @State private var failed = false
+
+    init(member: ReceiptSessionMember, initiallyExpanded: Bool = false) {
+        self.member = member
+        self.initiallyExpanded = initiallyExpanded
+        _expanded = State(initialValue: initiallyExpanded)
+    }
 
     private var label: String {
         if let title = member.title, !title.isEmpty { return title }
@@ -201,6 +211,11 @@ private struct SessionDrillRow: View {
         }
         .background(Theme.card, in: RoundedRectangle(cornerRadius: 9, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous).strokeBorder(Theme.border, lineWidth: 1))
+        .task {
+            // The root session opens expanded — its step-by-step is the point;
+            // load its steps up front.
+            if expanded, detail == nil, !loading { await load() }
+        }
     }
 
     @ViewBuilder

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -286,7 +286,15 @@ def _boundary(task: Mapping[str, Any]) -> dict[str, Any]:
         (_text(session.get("project")) for session in sessions if isinstance(session, Mapping) and _text(session.get("project"))),
         None,
     )
-    scope = next(
+    project_identity_state = next(
+        (
+            _text(session.get("project_identity_state"))
+            for session in sessions
+            if isinstance(session, Mapping) and _text(session.get("project_identity_state"))
+        ),
+        None,
+    )
+    namespace_scope = next(
         (
             _text(session.get("identity_scope_state"))
             for session in sessions
@@ -294,6 +302,16 @@ def _boundary(task: Mapping[str, Any]) -> dict[str, Any]:
         ),
         None,
     )
+    # An explicitly identified project binds the Task even when it carries no
+    # cryptographic org-namespace fingerprint (only codex / org-scoped sessions
+    # have one). Report the strongest binding, so a claude-code Task in a known
+    # project reads as "project"-scoped rather than "unscoped".
+    if project_identity_state == "explicit":
+        identity_scope = "project"
+    elif namespace_scope:
+        identity_scope = namespace_scope
+    else:
+        identity_scope = "unscoped"
     root_keys = task.get("root_keys") if isinstance(task.get("root_keys"), list) else []
     return {
         "primary_root": _mapping(task.get("primary_root")) or None,
@@ -301,7 +319,8 @@ def _boundary(task: Mapping[str, Any]) -> dict[str, Any]:
         "session_count": int(task.get("session_count") or 0),
         "is_continuation": bool(task.get("continuation_id")),
         "project": project,
-        "identity_scope": scope or "unscoped",
+        "project_identity_state": project_identity_state or None,
+        "identity_scope": identity_scope,
     }
 
 
@@ -318,7 +337,7 @@ def _task_dimension(task: Mapping[str, Any], title: str) -> dict[str, Any]:
     if not objectives:
         gaps.append("No explicit objective was recorded for this Task.")
     if boundary["identity_scope"] == "unscoped":
-        gaps.append("Task identity is unscoped (no org/project namespace to bind it).")
+        gaps.append("This Task could not be bound to a project or namespace.")
     provenance = [SOURCE_MCP] if objectives else []
     if boundary["session_count"]:
         provenance.append(SOURCE_CLIENT_LOG)
@@ -352,10 +371,41 @@ def _actors_dimension(task: Mapping[str, Any], intelligence: Mapping[str, Any]) 
     }
 
 
+def _evidence_touched_files(task: Mapping[str, Any]) -> list[str]:
+    """File paths the Task's machine checks recorded — a section often lists no
+    files of its own while the checks it ran named the exact paths, so those
+    paths would otherwise be dropped from the Actions dimension."""
+
+    paths: list[str] = []
+    seen: set[str] = set()
+    items = task.get("work_items") if isinstance(task.get("work_items"), list) else []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        for event in item.get("evidence_events") or []:
+            if not isinstance(event, Mapping):
+                continue
+            for candidate in event.get("files") or []:
+                path = _text(candidate)
+                if path and path not in seen:
+                    seen.add(path)
+                    paths.append(path)
+    return paths
+
+
 def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
     actions = _mapping(task.get("actions"))
     counts = _mapping(actions.get("tool_category_counts"))
-    touched = actions.get("touched_files") if isinstance(actions.get("touched_files"), list) else []
+    section_files = actions.get("touched_files") if isinstance(actions.get("touched_files"), list) else []
+    # Union the section-recorded files with the paths the Task's machine checks
+    # named: either source alone routinely misses files the other has.
+    touched: list[str] = []
+    seen: set[str] = set()
+    for candidate in (*section_files, *_evidence_touched_files(task)):
+        path = _text(candidate)
+        if path and path not in seen:
+            seen.add(path)
+            touched.append(path)
     provenance: list[str] = []
     gaps: list[str] = []
     if touched:
@@ -371,8 +421,8 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "tool_category_counts": dict(counts),
         "tool_category_total": int(actions.get("tool_category_total") or 0),
-        "touched_files": list(touched),
-        "touched_file_count": int(actions.get("touched_file_count") or len(touched)),
+        "touched_files": touched,
+        "touched_file_count": len(touched),
         "provenance": sorted(set(provenance)) or [SOURCE_NONE],
         "gaps": gaps,
     }
@@ -387,8 +437,9 @@ def _cost_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
     gaps: list[str] = []
     if not cost_complete:
         gaps.append("Cost is incomplete: some usage rows are unpriced or excluded.")
-    if cost_confidence in {"estimated_from_tokens", "estimated"}:
-        gaps.append("Cost is a pricing-table estimate from token counts, not a billed amount.")
+    # A complete pricing-table estimate is not a gap — the estimate is present
+    # and its basis rides cost_basis / cost_confidence. Only genuinely missing
+    # or partial cost is a gap.
     if estimated is None and int(usage.get("rows") or 0) == 0:
         gaps.append("No usage was recorded for this Task.")
     return {
@@ -462,19 +513,14 @@ def _roll_up_gaps(
     for name, dimension in dimensions.items():
         for reason in dimension.get("gaps", []) or []:
             items.append({"dimension": name, "reason": reason})
-    # Coverage rows the intelligence layer already computed that aren't fully
-    # recorded are honest gaps too (kept distinct from the per-dimension ones).
-    for row in coverage:
-        if not isinstance(row, Mapping):
-            continue
-        state = _text(row.get("state"))
-        if state and state not in {"recorded"}:
-            items.append(
-                {
-                    "dimension": "coverage",
-                    "reason": f"{_text(row.get('dimension')) or 'dimension'} is {state}.",
-                }
-            )
+    # The coverage table (recorded / unavailable / not_recorded per dimension)
+    # already ships as its own ``coverage`` block. Folding every non-recorded
+    # row into gaps duplicated the per-dimension gaps and drowned the real,
+    # per-task ones in structural facts (no org control plane, no artifact
+    # store) that are true for every single-machine task — so gaps stay
+    # per-dimension only. ``coverage`` is unused here now but kept in the
+    # signature so callers do not change.
+    _ = coverage
     unlinked = int(task.get("session_unlinked_work_count") or 0)
     if unlinked:
         items.append(

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -193,10 +193,14 @@ def test_actions_with_categories_declares_hook_provenance() -> None:
     assert "hook" in actions["provenance"]
 
 
-def test_cost_dimension_carries_basis_and_flags_estimate_gap() -> None:
+def test_cost_dimension_carries_basis_without_gapping_a_complete_estimate() -> None:
     cost = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))["dimensions"]["cost"]
     assert cost["cost_basis"] == "pricing_table"
-    assert any("estimate" in reason for reason in cost["gaps"])
+    # The estimate-ness rides cost_basis / cost_confidence; a complete estimate
+    # is provenance, not a gap (only incomplete/missing cost is gapped).
+    assert cost["cost_confidence"] in {"estimated_from_tokens", "estimated"}
+    if cost["cost_complete"]:
+        assert not any("estimate" in reason for reason in cost["gaps"])
 
 
 def test_provenance_rollup_covers_every_dimension_with_a_legend() -> None:

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -203,6 +203,30 @@ def test_cost_dimension_carries_basis_without_gapping_a_complete_estimate() -> N
         assert not any("estimate" in reason for reason in cost["gaps"])
 
 
+def test_identity_scope_is_project_when_project_is_explicit_without_namespace() -> None:
+    # A claude-code Task in a known project: an explicit project identity but no
+    # cryptographic namespace fingerprint. It is scoped to the project, so
+    # identity is NOT a gap (this branch is Fix 1; the namespace branch is not).
+    task = _task([{"work_id": "w", "title": "do the thing", "latest_status": "completed", "updated_at": 100.0}])
+    task["sessions"][0].pop("identity_scope_state", None)
+    task["sessions"][0]["project_identity_state"] = "explicit"
+    boundary = _receipt(task)["dimensions"]["task"]["boundary"]
+    assert boundary["identity_scope"] == "project"
+    assert boundary["project_identity_state"] == "explicit"
+    assert not any("could not be bound" in gap for gap in _receipt(task)["dimensions"]["task"]["gaps"])
+
+
+def test_identity_is_gapped_only_when_truly_unbound() -> None:
+    # No namespace fingerprint AND no explicit project identity → genuinely
+    # unbound, so the identity gap fires.
+    task = _task([{"work_id": "w", "title": "do the thing", "latest_status": "completed", "updated_at": 100.0}])
+    task["sessions"][0].pop("identity_scope_state", None)
+    task["sessions"][0].pop("project_identity_state", None)
+    boundary = _receipt(task)["dimensions"]["task"]["boundary"]
+    assert boundary["identity_scope"] == "unscoped"
+    assert any("could not be bound" in gap for gap in _receipt(task)["dimensions"]["task"]["gaps"])
+
+
 def test_provenance_rollup_covers_every_dimension_with_a_legend() -> None:
     receipt = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))
     provenance = receipt["dimensions"]["provenance"]

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -198,8 +198,12 @@ def test_receipt_gaps_are_genuinely_missing_not_structural_noise(tmp_path: Path)
     dims = receipt["dimensions"]
     reasons = [item["reason"] for item in dims["gaps"]["items"]]
 
-    # Touched files recovered from the check evidence, not gapped.
+    # Touched files recovered from the check evidence, not gapped. The section
+    # itself records only src/login.py; tests/test_login.py exists ONLY on the
+    # machine check, so asserting it proves the evidence-file union (not the
+    # section path) — this fails if the union is reverted.
     assert "src/login.py" in dims["actions"]["touched_files"]
+    assert "tests/test_login.py" in dims["actions"]["touched_files"]
     assert not any("No touched files" in r for r in reasons)
     # A known project is scoped, not "unscoped" — no identity gap.
     assert dims["task"]["boundary"]["identity_scope"] != "unscoped"

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -158,6 +158,59 @@ def test_receipt_exposes_constituent_sessions_and_summary_carries_primary_root(
     assert root_members[0]["client_session_id"] == "s1"
 
 
+def test_receipt_gaps_are_genuinely_missing_not_structural_noise(tmp_path: Path) -> None:
+    """A Receipt's gaps should mean 'genuinely missing for this Task', not
+    structural facts about the deployment or data we have but failed to roll up.
+    A Task in a known project, whose checks recorded the files they touched,
+    with a complete pricing-table cost estimate, must NOT gap identity, touched
+    files, the coverage table, or the estimate basis."""
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    _record_section(service, session_id="s1", section_id="sec-1", status="completed", at=101.0)
+    # A passing check that records the files it touched; the section lists none.
+    service.record_event(
+        {
+            "event_id": "evt_check_with_files",
+            "created_at": 102.0,
+            "source": "claude-code",
+            "event_type": "machine_check",
+            "metadata": {
+                "result": "passed",
+                "evidence_type": "test",
+                "summary": "pytest passed",
+                "name": "pytest",
+                "exit_code": 0,
+                "section_id": "sec-1",
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "project_dir": "/tmp/project",
+                "files": ["src/login.py", "tests/test_login.py"],
+            },
+        }
+    )
+    client = _app(tmp_path)
+    task_id = client.get("/v1/tasks", headers=_auth()).json()["tasks"][0]["task_id"]
+    receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
+
+    dims = receipt["dimensions"]
+    reasons = [item["reason"] for item in dims["gaps"]["items"]]
+
+    # Touched files recovered from the check evidence, not gapped.
+    assert "src/login.py" in dims["actions"]["touched_files"]
+    assert not any("No touched files" in r for r in reasons)
+    # A known project is scoped, not "unscoped" — no identity gap.
+    assert dims["task"]["boundary"]["identity_scope"] != "unscoped"
+    assert not any("could not be bound to a project" in r for r in reasons)
+    # The coverage table is no longer folded into gaps.
+    assert not any(item["dimension"] == "coverage" for item in dims["gaps"]["items"])
+    # A complete pricing-table estimate is not a gap.
+    assert dims["cost"]["cost_complete"] is True
+    assert not any("pricing-table estimate" in r for r in reasons)
+
+
 def test_version_advertises_the_receipt_schema(tmp_path: Path) -> None:
     version = _app(tmp_path).get("/v1/version", headers=_auth()).json()
     assert version["receipt_schema"] == RECEIPT_SCHEMA_VERSION


### PR DESCRIPTION
QA of the new Work pane surfaced that nearly every Receipt reads as all-gaps. Investigation (store-wide, 182 tasks) found the honesty model was flagging **structural facts about single-machine / claude-code usage** and **data we have but did not roll up** as "gaps" — so the gaps drowned out the real ones. Store-wide gap items drop **1943 -> 894**; the remainder are all per-task real.

Four fixes:
- **Identity**: an explicitly identified project (`project_identity_state == "explicit"`) binds a Task even without a cryptographic org-namespace fingerprint (a codex/org concept). `_boundary` now reports `identity_scope: "project"` and the gap fires only when the Task is truly unbound. Was firing on 182/182 tasks, ~130 of which have a known project.
- **Touched files**: `touched_files` now unions the section-recorded files with the files each machine check recorded (`work_item.evidence_events[].files`) — a section often lists no files while its checks named the exact paths. (This session example: the receipt now shows `api.py`, `test_receipt_api.py`, `join_rules.py`, … instead of "no touched files".)
- **Coverage**: stop folding the whole coverage table into gaps — it duplicated the per-dimension gaps and buried the real ones under control-unavailable / artifacts-not-recorded (true for every single-machine task). Coverage still ships as its own `coverage` block.
- **Cost**: a complete pricing-table estimate is provenance (`cost_basis` / `cost_confidence`), not a gap; incomplete and missing cost stay gapped.

Also: the Work pane opens the **root session steps by default** (the step-by-step is the point).

Verification: full pytest **2960 passed, 0 failed** (adds a gaps test; updates the one cost test that encoded the old behavior); `swift build` clean; live-store before/after gap counts as above.