### PR TITLE
fix(usage): stop one symlink under ~/.claude/projects from zeroing the Claude import (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,18 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`/work-events`, `/capture/*`, connectors, `/v1/traces`) are untouched. Also
   retires the migration-era `canonical verify-read-canary` command.
 
+### Fixed
+- **`usage import-local --client claude-code` no longer imports zero sessions
+  when a single symlink exists under `~/.claude/projects/`.** A descendant
+  directory symlink (e.g. a shared memory directory linked into a project dir, a
+  common cross-machine sync pattern) previously aborted the entire Claude
+  transcript walk on the first symlinked component, discarding every legitimate
+  transcript in the home — while `usage discover-sources` still reported them,
+  making the failure baffling. The no-follow policy is unchanged (a directory
+  symlink is never traversed, so no foreign subtree is imported); the offending
+  link is now skipped, counted as `skipped_unsafe_paths`, and surfaced in the
+  import summary instead of silently zeroing the import (reported in #84).
+
 ## [0.8.1] - 2026-08-05
 
 ### Fixed

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -7182,11 +7182,42 @@ def _print_usage_import_payload(payload: dict[str, object], *, store_dir: Path, 
             f"{reprice_action} {payload.get('repriced_events', 0)} previously unknown-cost row(s) "
             "whose model now resolves in the pricing catalog (unknown→priced only)."
         )
+    source_diagnostics = payload.get("source_diagnostics")
+
+    def _skipped_unsafe_count(row: Mapping[str, object]) -> int:
+        try:
+            value = int(row.get("skipped_unsafe_paths") or 0)
+        except (TypeError, ValueError):
+            return 0
+        return max(0, value)
+
+    skipped_unsafe_total = (
+        sum(
+            _skipped_unsafe_count(row)
+            for row in source_diagnostics.values()
+            if isinstance(row, Mapping)
+        )
+        if isinstance(source_diagnostics, Mapping)
+        else 0
+    )
+    if skipped_unsafe_total:
+        print(
+            f"Skipped {skipped_unsafe_total} symlinked path(s) under a scanned home "
+            "(directory symlinks are never followed for safety; the rest of the "
+            "tree was imported normally). Run `agentacct usage discover-sources` "
+            "to see the full tree."
+        )
     if not payload.get("scanned_sessions"):
         scanned_homes = payload.get("scanned_homes") if isinstance(payload.get("scanned_homes"), list) else []
         checked = "; ".join(str(home) for home in scanned_homes) if scanned_homes else "no client homes"
+        unsafe_hint = (
+            " Some paths under a scanned home were skipped as unsafe symlinks "
+            "(see the line above)."
+            if skipped_unsafe_total
+            else ""
+        )
         print(
-            f"No local client session files found (checked {checked}). "
+            f"No local client session files found (checked {checked}).{unsafe_hint} "
             "Run `agentacct usage discover-sources` to see what was scanned, "
             "or point at a custom location with --claude-home/--codex-home/--cursor-home "
             "or the matching client --*-home option."

--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -1455,6 +1455,7 @@ def _initial_claude_discovery_stats() -> dict[str, Any]:
         "sessions_without_usage": 0,
         "error_count": 0,
         "error_codes": [],
+        "skipped_unsafe_paths": 0,
         "source_present": False,
     }
 
@@ -1639,6 +1640,7 @@ def _discover_source_tree_files_no_follow(
     unsafe_code: str,
     traversal_code: str,
     changed_code: str,
+    skipped_dir_symlinks: list[Path] | None = None,
 ) -> list[_NoFollowTreeFile]:
     """Exhaustively enumerate a source tree without following or hiding errors.
 
@@ -1695,14 +1697,25 @@ def _discover_source_tree_files_no_follow(
                 # A non-carrier symlink must not condemn the whole walk: the
                 # previous fwalk-based scanner silently ignored file/broken
                 # symlinks, and a stray "latest"-style link would otherwise
-                # zero out the entire home's discovery forever. Directory
-                # symlinks stay fatal — following one could smuggle an
-                # unbounded foreign subtree into a "complete" scan.
+                # zero out the entire home's discovery forever.
                 try:
                     target = os.stat(name, dir_fd=directory_fd, follow_symlinks=True)
                 except OSError:
                     continue
                 if stat.S_ISDIR(target.st_mode):
+                    # A directory symlink is never FOLLOWED — descending it
+                    # could smuggle an unbounded foreign subtree into a
+                    # "complete" scan. But a single such link must not condemn
+                    # the whole tree either. Callers that pass
+                    # ``skipped_dir_symlinks`` record the skip and keep
+                    # enumerating every legitimate sibling; without it the link
+                    # stays fatal (unchanged for callers that require closure).
+                    # One stray `memory -> <shared dir>` link under
+                    # ~/.claude/projects previously zeroed a home's 6000+
+                    # transcripts on import (issue #84).
+                    if skipped_dir_symlinks is not None:
+                        skipped_dir_symlinks.append(root_path / relative / name)
+                        continue
                     raise _ClientUsageDiscoveryReadError(unsafe_code)
                 continue
             child_relative = relative / name
@@ -1789,6 +1802,7 @@ def _discover_claude_transcript_paths(
     projects_root: Path,
     *,
     projects_root_fd: int,
+    skipped_dir_symlinks: list[Path] | None = None,
 ) -> list[_NoFollowTreeFile]:
     """Enumerate JSONL candidates from the held source-root descriptor."""
 
@@ -1799,6 +1813,7 @@ def _discover_claude_transcript_paths(
         unsafe_code="claude_transcript_unsafe_path",
         traversal_code="claude_transcript_discovery_failed",
         changed_code="claude_transcript_changed_during_scan",
+        skipped_dir_symlinks=skipped_dir_symlinks,
     )
 
 
@@ -1976,10 +1991,12 @@ def _discover_claude_code_usage_from_home(
         raise _ClaudeTranscriptUnsafePathError(
             "claude projects root was not opened from its source boundary"
         )
+    skipped_dir_symlinks: list[Path] = []
     try:
         candidate_files = _discover_claude_transcript_paths(
             projects_root,
             projects_root_fd=projects_root_fd,
+            skipped_dir_symlinks=skipped_dir_symlinks,
         )
     except _ClaudeTranscriptUnsafePathError:
         raise
@@ -2018,6 +2035,14 @@ def _discover_claude_code_usage_from_home(
         error_count += 1
         if code not in error_codes:
             error_codes.append(code)
+
+    # A descendant directory symlink is never followed (no-follow policy), but
+    # it no longer aborts the whole home. Surface each skipped link as an unsafe
+    # path — exactly as a symlinked transcript FILE is — so the skip stays
+    # visible in diagnostics while every legitimate sibling still imports
+    # (issue #84).
+    for _skipped_symlink in skipped_dir_symlinks:
+        record_error("claude_transcript_unsafe_path")
 
     path_entries: list[tuple[Path, float]] = []
     fingerprints: dict[Path, _ClaudeFileFingerprint] = {}
@@ -2341,6 +2366,7 @@ def _discover_claude_code_usage_from_home(
                 ),
                 "error_count": error_count,
                 "error_codes": error_codes,
+                "skipped_unsafe_paths": len(skipped_dir_symlinks),
             }
         )
     return events
@@ -2866,6 +2892,15 @@ def _merge_multi_home_discovery_stats(
             ),
         }
     )
+    # Skipped-symlink accounting is specific to the Claude transcript walk (the
+    # only source that opts into skip-and-continue over abort, issue #84). Add
+    # it only when a per-home stat actually carries it so sources that keep the
+    # stricter fail-closed policy do not gain a spurious always-zero field.
+    if any("skipped_unsafe_paths" in stats for stats in per_home):
+        target["skipped_unsafe_paths"] = sum(
+            _safe_nonnegative_int(stats.get("skipped_unsafe_paths"))
+            for stats in per_home
+        )
 
 
 def _client_session_id_for_file(session_id: str, path: Path) -> str:
@@ -4252,6 +4287,15 @@ def discover_client_usage_with_diagnostics(
                 else None
             ),
         }
+        # Skipped-symlink accounting is specific to the Claude transcript walk
+        # (issue #84): the only source that skips-and-continues over an
+        # unfollowable directory symlink instead of failing the home closed.
+        # Expose it only where it is actually tracked so other sources keep a
+        # stable diagnostic shape.
+        if "skipped_unsafe_paths" in stats:
+            diagnostics[client_name]["skipped_unsafe_paths"] = _safe_nonnegative_int(
+                stats.get("skipped_unsafe_paths")
+            )
     return ClientUsageDiscoveryResult(
         events=candidates,
         diagnostics=diagnostics,

--- a/tests/test_client_usage.py
+++ b/tests/test_client_usage.py
@@ -2156,6 +2156,7 @@ def test_discover_claude_usage_limit_selects_complete_recent_root_group(
         "usage_sessions": 3,
         "sessions_without_usage": 0,
         "source_present": True,
+        "skipped_unsafe_paths": 0,
     }
 
 
@@ -2959,10 +2960,30 @@ def test_claude_projects_root_symlink_is_rejected_as_unsafe(tmp_path):
     ]
 
 
-def test_claude_descendant_directory_symlink_fails_closed(tmp_path):
+def test_claude_descendant_directory_symlink_is_skipped_not_fatal(tmp_path):
+    # issue #84: a descendant directory symlink is never FOLLOWED (that could
+    # smuggle a foreign subtree into a "complete" scan), but it must not abort
+    # the whole home. The link is skipped and surfaced; every legitimate
+    # sibling transcript still imports instead of the home returning zero.
     claude_home = _make_claude_home(tmp_path)
     projects_root = claude_home / "projects"
     foreign_home = _make_claude_home(tmp_path / "foreign")
+    # Plant a distinctly-named transcript behind the symlink so the test proves
+    # no-follow: if the link were traversed, this id would appear in the import.
+    (foreign_home / "projects" / "-tmp-project" / "foreign-only.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "sessionId": "foreign-secret",
+                "message": {
+                    "model": "claude-opus-4-8",
+                    "usage": {"input_tokens": 99, "output_tokens": 9},
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     (projects_root / "linked-project").symlink_to(
         foreign_home / "projects" / "-tmp-project"
     )
@@ -2973,10 +2994,15 @@ def test_claude_descendant_directory_symlink_fails_closed(tmp_path):
         limit_sessions=10,
     )
 
-    assert result.events == []
-    assert result.diagnostics["claude-code"]["error_codes"] == [
-        "claude_transcript_unsafe_path"
-    ]
+    imported_ids = [event.client_session_id for event in result.events]
+    assert imported_ids == ["claude-session"]
+    # The foreign session behind the symlink is NOT imported (no-follow holds).
+    assert "foreign-secret" not in imported_ids
+    assert result.events[0].source_parse_complete is True
+    diagnostic = result.diagnostics["claude-code"]
+    assert diagnostic["error_codes"] == ["claude_transcript_unsafe_path"]
+    assert diagnostic["error_count"] == 1
+    assert diagnostic["skipped_unsafe_paths"] == 1
 
 
 def test_claude_non_carrier_file_symlinks_do_not_block_discovery(tmp_path):
@@ -3003,7 +3029,10 @@ def test_claude_non_carrier_file_symlinks_do_not_block_discovery(tmp_path):
     assert diagnostic["error_codes"] == []
 
 
-def test_claude_non_carrier_symlink_to_directory_still_fails_closed(tmp_path):
+def test_claude_non_carrier_symlink_to_directory_is_skipped_not_fatal(tmp_path):
+    # issue #84: a directory symlink nested beside real transcripts (e.g. a
+    # "current"-style convenience pointer) is skipped and surfaced, but the
+    # sibling transcript in the same project still imports.
     claude_home = _make_claude_home(tmp_path)
     project = claude_home / "projects" / "-tmp-project"
     outside_dir = tmp_path / "outside-dir"
@@ -3016,10 +3045,76 @@ def test_claude_non_carrier_symlink_to_directory_still_fails_closed(tmp_path):
         limit_sessions=10,
     )
 
-    assert result.events == []
-    assert result.diagnostics["claude-code"]["error_codes"] == [
-        "claude_transcript_unsafe_path"
+    assert [event.client_session_id for event in result.events] == [
+        "claude-session"
     ]
+    assert result.events[0].source_parse_complete is True
+    diagnostic = result.diagnostics["claude-code"]
+    assert diagnostic["error_codes"] == ["claude_transcript_unsafe_path"]
+    assert diagnostic["error_count"] == 1
+    assert diagnostic["skipped_unsafe_paths"] == 1
+
+
+def test_claude_shared_memory_symlink_does_not_zero_the_home(tmp_path):
+    # issue #84 reproduction: a shared memory directory symlinked into a project
+    # dir (a common cross-machine sync pattern) used to raise on the first
+    # symlinked component of the O_NOFOLLOW walk, and the caller discarded every
+    # transcript in the home. Now the link is skipped and the real sessions
+    # import. Two projects, each with its own session, plus one shared-memory
+    # symlink apiece.
+    claude_home = tmp_path / "claude-home"
+    projects_root = claude_home / "projects"
+    shared_memory = tmp_path / "shared-memory"
+    shared_memory.mkdir(parents=True)
+    (shared_memory / "MEMORY.md").write_text("shared notes\n", encoding="utf-8")
+
+    for index, project_name in enumerate(("-Users-me", "-Users-me-Downloads")):
+        project = projects_root / project_name
+        project.mkdir(parents=True)
+        session = project / f"session-{index}.jsonl"
+        session.write_text(
+            "\n".join(
+                json.dumps(row)
+                for row in (
+                    {
+                        "type": "ai-title",
+                        "sessionId": f"session-{index}",
+                        "aiTitle": "Real work",
+                    },
+                    {
+                        "type": "assistant",
+                        "sessionId": f"session-{index}",
+                        "message": {
+                            "model": "claude-opus-4-8",
+                            "usage": {
+                                "input_tokens": 11,
+                                "output_tokens": 3,
+                            },
+                        },
+                    },
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (project / "memory").symlink_to(shared_memory, target_is_directory=True)
+
+    result = discover_client_usage_with_diagnostics(
+        client="claude-code",
+        claude_home=claude_home,
+        limit_sessions=10,
+    )
+
+    assert {event.client_session_id for event in result.events} == {
+        "session-0",
+        "session-1",
+    }
+    assert all(event.source_parse_complete is True for event in result.events)
+    diagnostic = result.diagnostics["claude-code"]
+    assert diagnostic["error_codes"] == ["claude_transcript_unsafe_path"]
+    # One skipped memory symlink per project.
+    assert diagnostic["skipped_unsafe_paths"] == 2
+    assert diagnostic["error_count"] == 2
 
 
 def test_claude_non_regular_jsonl_is_rejected_without_blocking(tmp_path):

--- a/tests/test_first_run_friendly_errors.py
+++ b/tests/test_first_run_friendly_errors.py
@@ -182,6 +182,97 @@ def test_usage_import_local_zero_scan_hint_reflects_actual_scanned_homes(tmp_pat
         assert unscanned not in result.output, (unscanned, result.output)
 
 
+def test_usage_import_local_symlink_does_not_zero_the_import(tmp_path):
+    # issue #84: a directory symlink under ~/.claude/projects (a common shared-
+    # memory sync pattern) used to abort the whole Claude import with a
+    # misleading "No local client session files found", even though real
+    # transcripts sat right beside it. The real session must import, and the
+    # skipped symlink must be surfaced rather than silently swallowing the home.
+    store = tmp_path / "state"
+    claude_home = tmp_path / "claude-home"
+    project = claude_home / "projects" / "-Users-me"
+    project.mkdir(parents=True)
+    session = project / "real-session.jsonl"
+    session.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in (
+                {"type": "ai-title", "sessionId": "real-session", "aiTitle": "Real work"},
+                {
+                    "type": "assistant",
+                    "sessionId": "real-session",
+                    "message": {
+                        "model": "claude-opus-4-8",
+                        "usage": {"input_tokens": 12, "output_tokens": 4},
+                    },
+                },
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    shared_memory = tmp_path / "shared-memory"
+    shared_memory.mkdir()
+    (project / "memory").symlink_to(shared_memory, target_is_directory=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "usage",
+            "import-local",
+            "--store-dir",
+            str(store),
+            "--client",
+            "claude-code",
+            "--claude-home",
+            str(claude_home),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    # The real transcript imports rather than the whole home returning zero.
+    assert "Imported 1 local client usage session(s)" in result.output
+    assert "No local client session files found" not in result.output
+    # The skipped symlink is surfaced, not silently swallowed.
+    assert "Skipped 1 symlinked path(s)" in result.output
+
+
+def test_usage_import_local_all_symlink_home_explains_the_skip_not_just_zero(tmp_path):
+    # issue #84, the pure shape: a home whose ONLY project entry is a directory
+    # symlink and no real transcript. The scan legitimately finds zero sessions,
+    # but the zero-result message must now explain WHY (skipped unsafe symlink)
+    # instead of the bare, misleading "No local client session files found" that
+    # originally sent the reporter down the wrong path.
+    store = tmp_path / "state"
+    claude_home = tmp_path / "claude-home"
+    project = claude_home / "projects" / "-Users-me"
+    project.mkdir(parents=True)
+    shared_memory = tmp_path / "shared-memory"
+    shared_memory.mkdir()
+    (project / "memory").symlink_to(shared_memory, target_is_directory=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "usage",
+            "import-local",
+            "--store-dir",
+            str(store),
+            "--client",
+            "claude-code",
+            "--claude-home",
+            str(claude_home),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    # Zero real sessions in this home — the misleading bare message still appears,
+    # but now carries the reason so it is no longer baffling.
+    assert "No local client session files found" in result.output
+    assert "Skipped 1 symlinked path(s)" in result.output
+    assert "skipped as unsafe symlinks" in result.output
+
+
 def test_runs_command_omits_empty_started_field_for_runner_runs(tmp_path):
     # Runner metadata has no wall-clock started_at, so the human listing must
     # not print a dead empty `started=` column.


### PR DESCRIPTION
Fixes #84.

## Problem

`agentacct usage import-local --client claude-code` imported **0 sessions** and printed `No local client session files found` whenever **any** symlink existed under `~/.claude/projects/` — even though `usage discover-sources` correctly listed thousands of sessions in the same tree. As @guboking reported, a shared memory directory symlinked into a project dir (a common cross-machine sync pattern) was enough to trigger it:

```
~/.claude/projects/-Users-me/memory           -> <shared dir>
~/.claude/projects/-Users-me-Downloads/memory -> <shared dir>
```

## Root cause

The no-follow transcript walker (`_discover_source_tree_files_no_follow` in `src/agentacct/client_usage.py`) raised a **fatal** `claude_transcript_unsafe_path` on the first **directory** symlink it hit. The Claude caller re-raised, and `discover_claude_code_usage` caught it and set `discovered = []` for the **entire** home — so one stray link discarded every legitimate transcript. `discover-sources` uses a different, lighter scan, which is why it still found everything and the two disagreed.

## Fix

Skip an unfollowable directory symlink and **continue** instead of aborting the home. The no-follow policy is unchanged — the link is **never traversed**, so no foreign subtree is imported — but the rest of the tree is enumerated normally. This mirrors how non-carrier file symlinks and other unsafe paths were already handled (issue #53): reject-and-surface, don't block clean siblings.

- Directory symlinks are skipped (opt-in, via a `skipped_dir_symlinks` accumulator) only on the Claude import path. **Codex keeps its stricter fail-closed walk.**
- Each skip is counted in a new `skipped_unsafe_paths` diagnostic and surfaced as `claude_transcript_unsafe_path`.
- The CLI import summary now prints a `Skipped N symlinked path(s)…` line, and the zero-result message explains the skip instead of the bare, misleading "No local client session files found".

### Before → after (exact repro from the issue)

```
# before: Imported 0 local client usage session(s).
#         No local client session files found (checked …).

# after:
Imported 1 local client usage session(s).
Skipped 1 symlinked path(s) under a scanned home (directory symlinks are never
followed for safety; the rest of the tree was imported normally). …
```

## Testing

- Full suite: **2965 passed, 1 skipped**.
- Updated the two tests that encoded the old fatal-on-directory-symlink behavior.
- Added regression tests: a discovery-level test that plants a distinctly-named transcript **behind** the symlink and asserts it is **not** imported (proving no-follow still holds), a two-project shared-memory reproduction, and CLI-level tests for both the "real session beside a symlink" and "home is only a symlink" shapes.
- Adversarial review across security / correctness / scope / test-coverage lenses: no security or correctness regressions found; the one confirmed test-coverage gap was closed.

---

@guboking — thanks for the detailed report and the offer to test. If you can, please try this branch against your setup (the one with 6229 sessions) and confirm the import now picks them up and reports the skipped `memory` links. Appreciate it!
