### PR TITLE
feat(receipt): evidence coverage — per-step grade + honest per-tier ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,22 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   re-claimed automatically if the slot frees up.
 
 ### Changed
+- **The Receipt's evidence axis is now honest COVERAGE, not a single grade word.**
+  Each step carries an evidence grade — none / claimed / self-checked /
+  independently-checked / externally-verified — set by WHO attested it (the
+  agent's own report, then a check the harness observed, then a CI/provider
+  check), with a one-line reason for why. A Task no longer collapses to one
+  categorical grade; it shows the per-tier ratio over its checkable steps
+  (e.g. `3/10 self-checked · 7 unchecked`) — the counts are the headline, never a
+  percentage that implies more than a count. A Task with no machine-verifiable
+  step reads `Not gradeable`, never a fabricated 0. Beneath the ratio an honest
+  ledger discloses what it does not cover: steps that ran in subagents, checks
+  that attach to no step, non-verifiable steps, and still-open steps. The tier is
+  keyed only on a check's trusted source, so an agent naming its own check
+  `github_actions` cannot forge external verification. Rendered across the CLI
+  (`agentacct receipt` / `receipts`), the TUI, the macOS app, and the
+  `/v1/session` per-step wire (each step now carries its grade and each check its
+  source).
 - **The shared usage view builder moved out of the web module** into
   `usage_view.py`, so the data layer (TUI, `now`, plan calibration) no longer
   imports the web server for pure data logic.
@@ -45,6 +61,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fingerprint behind the TUI's caches and the glance cache folds in the
   source-namespace binding fields, so an in-place TOFU bind refreshes live
   totals immediately instead of waiting for an unrelated event.
+
+### Fixed
+- **Subagent sessions in the Work drill-down show a name, not a raw id.** A
+  subagent carries no session title, so its row used to read as a bare session
+  id until expanded; it now falls back to the subagent's first recorded step
+  title.
+- **The Work drill-down no longer lists a Task's subagents twice.** Expanding the
+  root session re-listed the same subagents that already appear as sibling rows
+  in the session tree; the session tree is now the single list.
 
 ### Removed
 - **The HTML browser dashboard.** The web display layer (`/`, `/tokens`, `/raw`,

--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -20,14 +20,39 @@ func receiptDecisionTint(_ key: String?) -> Color {
     }
 }
 
-/// Evidence-strength color (how well PROVEN). A failing check is never "strong"
-/// proof — it lands on the decision axis as a finding, not here.
+/// Evidence-coverage color, keyed on the strongest tier present (most
+/// independent is warmest). A failing check is never positive proof — it lands
+/// on the decision axis as a finding, not here.
 func receiptEvidenceTint(_ key: String?) -> Color {
     switch key {
-    case "verified": return Theme.green
-    case "checked": return Theme.blue
-    case "reported": return Theme.orange
-    default: return Theme.textMuted
+    case "externally_verified": return Theme.green
+    case "independently_checked": return Theme.cyan
+    case "self_checked": return Theme.blue
+    case "unchecked": return Theme.orange
+    default: return Theme.textMuted  // undefined / not gradeable
+    }
+}
+
+/// Per-step evidence-grade color (adds ``claimed`` / ``none`` to the tier ramp).
+func stepGradeTint(_ grade: String?) -> Color {
+    switch grade {
+    case "externally_verified": return Theme.green
+    case "independently_checked": return Theme.cyan
+    case "self_checked": return Theme.blue
+    case "claimed": return Theme.orange
+    default: return Theme.textMuted  // none
+    }
+}
+
+/// Short chip label for a per-step grade.
+func stepGradeLabel(_ grade: String?) -> String {
+    switch grade {
+    case "externally_verified": return "external"
+    case "independently_checked": return "independent"
+    case "self_checked": return "self-checked"
+    case "claimed": return "unchecked"
+    case "none": return "none"
+    default: return grade ?? "none"
     }
 }
 
@@ -59,7 +84,7 @@ struct ReceiptRow: View {
                 .lineLimit(2)
             HStack(spacing: 6) {
                 AxisChip(text: task.decisionStatus.key, tint: receiptDecisionTint(task.decisionStatus.key))
-                AxisChip(text: task.evidenceStrength.key, tint: receiptEvidenceTint(task.evidenceStrength.key))
+                AxisChip(text: task.evidenceStrength.compactHeadline, tint: receiptEvidenceTint(task.evidenceStrength.key))
                 Spacer()
                 Text(task.cost.text).font(.caption).foregroundStyle(Theme.textMuted)
             }
@@ -125,13 +150,7 @@ struct ReceiptCards: View {
                     detail: assertedText(receipt.axes.decisionStatus.assertedBy),
                     note: receipt.axes.decisionStatus.statement
                 )
-                axisRow(
-                    label: "Evidence strength",
-                    key: receipt.axes.evidenceStrength.key,
-                    tint: receiptEvidenceTint(receipt.axes.evidenceStrength.key),
-                    detail: evidenceDetail(receipt.axes.evidenceStrength),
-                    note: receipt.axes.evidenceStrength.strongestProof.map { "strongest proof: \($0)" }
-                )
+                evidenceCoverageRow(receipt.axes.evidenceStrength)
                 if let orthogonality = receipt.axes.orthogonalityNote {
                     Text(orthogonality).font(.caption).foregroundStyle(Theme.textFaint)
                 }
@@ -149,6 +168,26 @@ struct ReceiptCards: View {
             if let note {
                 Text(note).font(.caption).foregroundStyle(Theme.textFaint)
                     .padding(.leading, 138)
+            }
+        }
+    }
+
+    /// Evidence coverage: the ratio headline (NOT uppercased — it is counts) with
+    /// the honest ledger and the one-line definition beneath it.
+    private func evidenceCoverageRow(_ evidence: ReceiptEvidence) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Evidence coverage").font(.caption).foregroundStyle(Theme.textMuted)
+                    .frame(width: 130, alignment: .leading)
+                Text(evidence.headline).font(.callout).fontWeight(.bold)
+                    .foregroundStyle(receiptEvidenceTint(evidence.key))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let ledger = evidence.ledger {
+                Text(ledger).font(.caption).foregroundStyle(Theme.textMuted).padding(.leading, 138)
+            }
+            if let definition = evidence.definition {
+                Text(definition).font(.caption).foregroundStyle(Theme.textFaint).padding(.leading, 138)
             }
         }
     }
@@ -271,10 +310,5 @@ struct ReceiptCards: View {
     private func assertedText(_ assertedBy: String?) -> String? {
         guard let assertedBy else { return nil }
         return "asserted by \(assertedBy)"
-    }
-
-    private func evidenceDetail(_ evidence: ReceiptEvidence) -> String {
-        "\(evidence.verifiedStepCount ?? 0)/\(evidence.totalStepCount ?? 0) steps verified · "
-            + "\(evidence.checksTotal ?? 0) checks, \(evidence.checksPassed ?? 0) passed"
     }
 }

--- a/apps/agentacct/Sources/agentacct/StepComponents.swift
+++ b/apps/agentacct/Sources/agentacct/StepComponents.swift
@@ -3,38 +3,13 @@ import SwiftUI
 // Shared step / check / subagent-row components for the Work surface session
 // drill-down (WorkPane.swift). Previously part of the Sessions pane.
 
-/// One subagent row: role-aware label (Task first line > title > agent type),
-/// an agent-type chip, plan share and fresh tokens.
-struct DescendantRow: View {
-    let child: V1Descendant
-
-    var body: some View {
-        HStack(spacing: 9) {
-            StatusDot(color: Theme.statusColor(child.status), size: 6)
-            Text(child.displayTitle)
-                .font(Type.body)
-                .foregroundStyle(Theme.text)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            if let agentType = child.agentType {
-                Chip(text: agentType, tint: Theme.purple)
-            }
-            Spacer(minLength: 8)
-            if let pct = Fmt.planPct(child.planPct) {
-                Text(pct)
-                    .font(Type.numeric)
-                    .foregroundStyle(Theme.accent)
-            }
-            if let tokens = child.usage?.freshTokens {
-                Text(UsageTotals.compact(Int(tokens)))
-                    .font(Type.tiny.monospacedDigit())
-                    .foregroundStyle(Theme.textFaint)
-                    .frame(width: 48, alignment: .trailing)
-            }
-        }
-        .padding(.horizontal, 9)
-        .padding(.vertical, 6)
-        .help(child.task ?? child.displayTitle)
+/// Tint for a check's independence: agent-reported is muted (the agent's own
+/// word), hook-observed is cyan, CI/provider is green.
+func checkIndependenceTint(_ sourceType: String?) -> Color {
+    switch sourceType {
+    case "ci", "external", "provider": return Theme.green
+    case "client_hook": return Theme.cyan
+    default: return Theme.textMuted
     }
 }
 
@@ -97,7 +72,12 @@ struct StepCard: View {
                             .font(Type.tiny)
                             .foregroundStyle(Theme.textFaint)
                     }
-                    if let evidence = step.evidenceStatus {
+                    // The M2 per-step grade (self-checked / independent / …) is the
+                    // primary signal; fall back to the older evidence_status only
+                    // if an older daemon did not send a grade.
+                    if let grade = step.evidenceGrade {
+                        Chip(text: stepGradeLabel(grade), tint: stepGradeTint(grade))
+                    } else if let evidence = step.evidenceStatus {
                         Chip(text: evidence, tint: evidenceTint(evidence))
                     }
                 }
@@ -132,7 +112,14 @@ struct StepCard: View {
                                 .foregroundStyle(Theme.purple)
                         }
                     }
-                    if let why = evidenceExplanation {
+                    // "Why this grade" — the daemon-supplied reason for the M2
+                    // grade, else the older evidence_status explanation.
+                    if let why = step.evidenceGradeReason {
+                        Text(why)
+                            .font(Type.tiny)
+                            .foregroundStyle(stepGradeTint(step.evidenceGrade))
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else if let why = evidenceExplanation {
                         Text(why)
                             .font(Type.tiny)
                             .foregroundStyle(evidenceTint(step.evidenceStatus))
@@ -225,6 +212,9 @@ struct CheckRow: View {
                     .font(Type.tiny.monospacedDigit())
                     .foregroundStyle(Theme.textFaint)
             }
+            // Who attested this check — an agent-reported check is the agent's
+            // own word no matter what its summary text claims.
+            Chip(text: check.independence, tint: checkIndependenceTint(check.sourceType))
             if check.supersessionState == "superseded" {
                 Chip(text: "superseded", tint: Theme.textFaint)
             }

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -133,6 +133,8 @@ struct V1Step: Decodable, Identifiable {
     let usage: V1StepUsage?
     let joinConfidence: String?
     let evidenceStatus: String?
+    let evidenceGrade: String?
+    let evidenceGradeReason: String?
     let models: [V1ModelLane]?
     let checks: [V1Check]?
 
@@ -148,6 +150,8 @@ struct V1Step: Decodable, Identifiable {
         case nextStep = "next_step"
         case joinConfidence = "join_confidence"
         case evidenceStatus = "evidence_status"
+        case evidenceGrade = "evidence_grade"
+        case evidenceGradeReason = "evidence_grade_reason"
     }
 }
 
@@ -201,6 +205,7 @@ struct V1Check: Decodable, Identifiable {
     let result: String?
     let summary: String?
     let exitCode: Int?
+    let sourceType: String?
     let checkIdentity: String?
     let supersessionState: String?
     let resolutionScope: String?
@@ -213,6 +218,17 @@ struct V1Check: Decodable, Identifiable {
 
     var id: String { eventId ?? UUID().uuidString }
 
+    /// How independent of the agent this check is — the honest counter to a
+    /// check whose free-text summary claims "CI green" while its source is only
+    /// the agent's own report.
+    var independence: String {
+        switch sourceType {
+        case "ci", "external", "provider": return "CI"
+        case "client_hook": return "hook"
+        default: return "agent-reported"
+        }
+    }
+
     enum CodingKeys: String, CodingKey {
         case summary, files
         case eventId = "event_id"
@@ -220,6 +236,7 @@ struct V1Check: Decodable, Identifiable {
         case evidenceType = "evidence_type"
         case result
         case exitCode = "exit_code"
+        case sourceType = "source_type"
         case checkIdentity = "check_identity"
         case supersessionState = "supersession_state"
         case resolutionScope = "resolution_scope"
@@ -482,24 +499,85 @@ struct ReceiptDecision: Decodable {
     }
 }
 
+struct ReceiptByTier: Decodable {
+    let externallyVerified: Int?
+    let independentlyChecked: Int?
+    let selfChecked: Int?
+    let unchecked: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case externallyVerified = "externally_verified"
+        case independentlyChecked = "independently_checked"
+        case selfChecked = "self_checked"
+        case unchecked
+    }
+}
+
+/// Evidence COVERAGE (M2): per-tier ratios over the checkable steps — the counts
+/// ARE the headline, never a single collapsed grade word. ``key`` is a coarse
+/// tier ordinal used only for colour. Mirrors the daemon's
+/// ``evidence_coverage_headline`` / ``evidence_coverage_ledger`` so no surface
+/// words the same evidence differently.
 struct ReceiptEvidence: Decodable {
     let key: String
-    let label: String?
-    let verifiedStepCount: Int?
-    let totalStepCount: Int?
+    let gradeable: Bool?
+    let strongestTier: String?
+    let checkableTotal: Int?
+    let checkedTotal: Int?
+    let byTier: ReceiptByTier?
+    let notCheckable: Int?
+    let openOrIncomplete: Int?
+    let hiddenInSubagents: Int?
+    let unattributedChecks: Int?
+    let totalSteps: Int?
     let checksTotal: Int?
     let checksPassed: Int?
     let checksFailed: Int?
-    let strongestProof: String?
+    let definition: String?
 
     enum CodingKeys: String, CodingKey {
-        case key, label
-        case verifiedStepCount = "verified_step_count"
-        case totalStepCount = "total_step_count"
+        case key, gradeable, definition
+        case strongestTier = "strongest_tier"
+        case checkableTotal = "checkable_total"
+        case checkedTotal = "checked_total"
+        case byTier = "by_tier"
+        case notCheckable = "not_checkable"
+        case openOrIncomplete = "open_or_incomplete"
+        case hiddenInSubagents = "hidden_in_subagents"
+        case unattributedChecks = "unattributed_checks"
+        case totalSteps = "total_steps"
         case checksTotal = "checks_total"
         case checksPassed = "checks_passed"
         case checksFailed = "checks_failed"
-        case strongestProof = "strongest_proof"
+    }
+
+    /// The coverage ratio, tier by tier. The one non-ratio case is
+    /// ``Not gradeable`` (no checkable step — a 0/0 ratio is meaningless).
+    var headline: String {
+        if gradeable != true { return "Not gradeable (no verifiable steps recorded)" }
+        let total = checkableTotal ?? 0
+        var parts: [String] = []
+        if let value = byTier?.externallyVerified, value > 0 { parts.append("\(value)/\(total) externally-verified") }
+        if let value = byTier?.independentlyChecked, value > 0 { parts.append("\(value)/\(total) independently-checked") }
+        if let value = byTier?.selfChecked, value > 0 { parts.append("\(value)/\(total) self-checked") }
+        if let value = byTier?.unchecked, value > 0 { parts.append("\(value) unchecked") }
+        return parts.isEmpty ? "0/\(total) checked" : parts.joined(separator: " · ")
+    }
+
+    /// A compact list-row form: "checked/checkable" tinted by the strongest tier.
+    var compactHeadline: String {
+        if gradeable != true { return "not gradeable" }
+        return "\(checkedTotal ?? 0)/\(checkableTotal ?? 0) checked"
+    }
+
+    /// The honest ledger: where the evidence is, and what the ratio does not cover.
+    var ledger: String? {
+        var bits: [String] = []
+        if let value = hiddenInSubagents, value > 0 { bits.append("\(value) step(s) ran in subagents") }
+        if let value = notCheckable, value > 0 { bits.append("\(value) non-verifiable (research/docs)") }
+        if let value = unattributedChecks, value > 0 { bits.append("\(value) check(s) attach to no step") }
+        if let value = openOrIncomplete, value > 0 { bits.append("\(value) step(s) still open") }
+        return bits.isEmpty ? nil : bits.joined(separator: " · ")
     }
 }
 

--- a/apps/agentacct/Sources/agentacct/WorkPane.swift
+++ b/apps/agentacct/Sources/agentacct/WorkPane.swift
@@ -234,10 +234,11 @@ private struct SessionDrillRow: View {
                 } else {
                     ForEach(detail.steps) { StepCard(step: $0) }
                 }
-                if !detail.descendants.isEmpty {
-                    SectionCaption(tone: Theme.textFaint, text: "Subagent sessions · \(detail.descendants.count)")
-                    ForEach(detail.descendants) { DescendantRow(child: $0) }
-                }
+                // The Task's subagents are already listed once, flat and
+                // expandable, as sibling SessionDrillRows in this group's member
+                // list. Re-listing this session's descendants here showed the
+                // same subagents a second time (a confusing "41 and 41"), so the
+                // member list is the single source of truth for the tree.
             }
         }
     }

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8976,6 +8976,8 @@ def _find_receipt_task(projection: dict[str, Any], task_id: str) -> dict[str, An
 
 
 def _render_receipt_text(receipt: dict[str, Any]) -> None:
+    from .receipt import evidence_coverage_headline, evidence_coverage_ledger
+
     axes = receipt.get("axes", {})
     dims = receipt.get("dimensions", {})
     decision = axes.get("decision_status", {})
@@ -8990,16 +8992,12 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
     )
     if decision.get("statement"):
         console.print(f"                     [dim]{_rich_escape(str(decision['statement']))}[/dim]")
-    console.print(
-        f"  Evidence strength  [bold]{str(evidence.get('key') or 'none').upper()}[/bold]"
-        f"  ({int(evidence.get('verified_step_count') or 0)}/{int(evidence.get('total_step_count') or 0)}"
-        f" steps verified · {int(evidence.get('checks_total') or 0)} checks,"
-        f" {int(evidence.get('checks_passed') or 0)} passed)"
-    )
-    if evidence.get("strongest_proof"):
-        console.print(
-            f"                     [dim]strongest proof: {_rich_escape(str(evidence['strongest_proof']))}[/dim]"
-        )
+    console.print(f"  Evidence coverage  [bold]{_rich_escape(evidence_coverage_headline(evidence))}[/bold]")
+    ledger = evidence_coverage_ledger(evidence)
+    if ledger:
+        console.print(f"                     [dim]{_rich_escape(ledger)}[/dim]")
+    if evidence.get("definition"):
+        console.print(f"                     [dim]{_rich_escape(str(evidence['definition']))}[/dim]")
     if axes.get("orthogonality_note"):
         console.print(f"  [dim]{axes['orthogonality_note']}[/dim]")
 
@@ -9075,7 +9073,12 @@ def receipts(
     """List recent Tasks with their Receipt summary (decision × evidence, cost)."""
 
     from .api import build_store_task_projection, _task_title
-    from .receipt import RECEIPT_SCHEMA_VERSION, build_receipt_summary, latest_store_activity
+    from .receipt import (
+        RECEIPT_SCHEMA_VERSION,
+        build_receipt_summary,
+        evidence_coverage_headline,
+        latest_store_activity,
+    )
 
     resolved = _resolve_cli_store_dir(store_dir).path
     projection = build_store_task_projection(resolved)
@@ -9105,14 +9108,14 @@ def receipts(
     table.add_column("Task")
     table.add_column("Title")
     table.add_column("Decision")
-    table.add_column("Evidence")
+    table.add_column("Evidence coverage")
     table.add_column("Cost")
     for row in rows:
         table.add_row(
             str(row["task_id"])[:16],
             _rich_escape(str(row.get("title") or "")[:48]),
             str(row["decision_status"]["key"]),
-            str(row["evidence_strength"]["key"]),
+            _rich_escape(evidence_coverage_headline(row.get("evidence_strength") or {})),
             _receipt_cost_text(row.get("cost") or {}),
         )
     console.print(table)

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -42,8 +42,15 @@ from typing import Any
 
 from .task_intelligence import build_task_intelligence
 from .task_outcome import (
+    EVIDENCE_GRADE_RANK,
+    GRADE_CLAIMED,
+    GRADE_EXTERNALLY_VERIFIED,
+    GRADE_INDEPENDENTLY_CHECKED,
+    GRADE_SELF_CHECKED,
+    NON_CHECK_RELEVANT_KINDS,
     latest_task_checks,
     reduce_task_outcome,
+    step_evidence_grade,
     step_verification_counts,
     task_newest_event_at,
 )
@@ -144,11 +151,13 @@ def _mapping(value: Any) -> Mapping[str, Any]:
 # --- Evidence axis ------------------------------------------------------------
 
 def _check_source(check: Mapping[str, Any]) -> str:
+    # Trust ``source_type`` only. The raw ``source`` is agent-authored and would
+    # let an MCP check forge the CI label; see task_outcome._check_independence,
+    # which is the load-bearing version of this same rule for the evidence tier.
     source_type = _text(check.get("source_type")).lower()
-    source = _text(check.get("source")).lower()
     if source_type == "client_hook":
         return SOURCE_HOOK
-    if source_type in {"ci", "external", "provider"} or source in {"ci", "github_actions"}:
+    if source_type in {"ci", "external", "provider"}:
         return SOURCE_CI
     return SOURCE_MCP
 
@@ -180,45 +189,196 @@ def _project_checks(task: Mapping[str, Any]) -> list[dict[str, Any]]:
     return shaped
 
 
-def _evidence_strength(verification: Mapping[str, Any], checks: list[Mapping[str, Any]]) -> dict[str, Any]:
-    """Grade positive proof ONLY. Never raised by agent claims or human review.
+_TIER_BY_GRADE = {
+    GRADE_EXTERNALLY_VERIFIED: "externally_verified",
+    GRADE_INDEPENDENTLY_CHECKED: "independently_checked",
+    GRADE_SELF_CHECKED: "self_checked",
+}
+# strongest first — the coarse tier used for colour and list sort/filter only.
+_TIER_ORDER = ("externally_verified", "independently_checked", "self_checked")
 
-    A failing check is not positive proof, so it never lifts the grade — it
-    lands on the decision axis as a finding instead.
+
+def _step_passed_check_ids(item: Mapping[str, Any]) -> set[str]:
+    """Event-ids of the passing checks linked to ONE step (its projected latest
+    checks, else its raw evidence events)."""
+
+    raw = (
+        item.get("current_check_events")
+        if isinstance(item.get("current_check_events"), list)
+        else item.get("evidence_events")
+    )
+    ids: set[str] = set()
+    if isinstance(raw, list):
+        for event in raw:
+            if not isinstance(event, Mapping):
+                continue
+            if _text(event.get("result")).lower() != "passed":
+                continue
+            event_id = _text(event.get("event_id"))
+            if event_id:
+                ids.add(event_id)
+    return ids
+
+
+def _evidence_strength(
+    task: Mapping[str, Any],
+    checks: list[Mapping[str, Any]],
+    verification: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Coverage-first evidence: per-tier RATIOS over the checkable steps, plus an
+    honesty LEDGER. There is deliberately NO single collapsed grade word — the
+    counts ARE the headline; a categorical label would re-hide exactly the
+    variation the ladder exists to show. One coarse ``strongest_tier`` is kept
+    for colour + list sort/filter only, never as a headline word.
+
+    Graded from positive proof ONLY (a failing check lands on the decision axis
+    as a finding, never here) and from the same disjoint inputs as before, so it
+    stays orthogonal to ``decision_status``: an agent's "done" or a human review
+    never lifts a tier.
     """
 
-    verified = int(verification.get("verified_step_count") or 0)
-    total = int(verification.get("total_step_count") or 0)
-    reported = int(verification.get("agent_reported_step_count") or 0)
+    items = _items(task)
+    tiers = {
+        "externally_verified": 0,
+        "independently_checked": 0,
+        "self_checked": 0,
+        "unchecked": 0,  # a checkable terminal step with only an agent claim (grade 'claimed')
+    }
+    not_checkable = 0
+    open_or_incomplete = 0
+    checkable = 0
+    # "Hidden in a subagent" means the step ran in a session that is NOT a root —
+    # a genuine subagent. A continuation ROOT (the same agent resuming in a new
+    # session) is a root, not a subagent, so its steps must not be counted here,
+    # or the ledger would falsely say a continued Task's own work "ran in
+    # subagents". root_keys lists every root (primary + continuations).
+    root_session_ids = {
+        _text(ref.get("client_session_id"))
+        for ref in (task.get("root_keys") if isinstance(task.get("root_keys"), list) else [])
+        if isinstance(ref, Mapping) and _text(ref.get("client_session_id"))
+    }
+    primary_session = _text(_mapping(task.get("primary_root")).get("client_session_id"))
+    if primary_session:
+        root_session_ids.add(primary_session)
+    hidden_in_subagents = 0
+    for item in items:
+        status = _text(item.get("latest_status")).lower()
+        if status not in _SUCCESS_STATUSES:
+            open_or_incomplete += 1
+            continue
+        session = _text(item.get("client_session_id"))
+        if session and root_session_ids and session not in root_session_ids:
+            hidden_in_subagents += 1
+        kind = _text(item.get("kind")).lower() or "unknown"
+        if kind in NON_CHECK_RELEVANT_KINDS:
+            not_checkable += 1
+            continue
+        checkable += 1
+        grade = step_evidence_grade(item)["grade"]
+        tiers[_TIER_BY_GRADE.get(grade, "unchecked")] += 1
+
+    strongest_tier = next((tier for tier in _TIER_ORDER if tiers[tier]), None)
+    checked_total = sum(tiers[tier] for tier in _TIER_ORDER)
+
+    # Unattributed checks: task-pool passing checks linked to no visible step —
+    # they still count toward "N passed" but attach to nothing you can see.
+    linked: set[str] = set()
+    for item in items:
+        linked |= _step_passed_check_ids(item)
+    task_passing_ids = {
+        _text(event.get("event_id"))
+        for event in latest_task_checks(task)
+        if isinstance(event, Mapping)
+        and _text(event.get("result")).lower() == "passed"
+        and _text(event.get("event_id"))
+    }
+    unattributed_checks = len(task_passing_ids - linked)
+
     passed = sum(1 for check in checks if _text(check.get("result")).lower() == "passed")
     failed = sum(1 for check in checks if _text(check.get("result")).lower() in {"failed", "error"})
 
-    if total > 0 and verified == total:
-        key = "verified"
-    elif verified > 0 or passed > 0:
-        key = "checked"
-    elif reported > 0:
-        key = "reported"
+    # Coarse key kept ONLY for colour + list sort/filter. It is an ordinal, not a
+    # headline: undefined < unchecked < self_checked < independently < externally.
+    if checkable == 0:
+        key = "undefined"
     else:
-        key = "none"
+        key = strongest_tier or "unchecked"
 
-    strongest = next(
-        (check for check in checks if _text(check.get("result")).lower() == "passed"),
-        None,
-    )
     return {
         "key": key,
-        "label": key.title(),
-        "verified_step_count": verified,
-        "total_step_count": total,
-        "agent_reported_step_count": reported,
+        "gradeable": checkable > 0,
+        "strongest_tier": strongest_tier,
+        # the headline — per-tier ratios over checkable steps
+        "checkable_total": checkable,
+        "checked_total": checked_total,
+        "by_tier": dict(tiers),
+        # the ledger — what makes the ratio trustworthy
+        "not_checkable": not_checkable,
+        "open_or_incomplete": open_or_incomplete,
+        "hidden_in_subagents": hidden_in_subagents,
+        "unattributed_checks": unattributed_checks,
+        "total_steps": len(items),
+        # check-event tallies + continuity fields for existing readers
         "checks_total": len(checks),
         "checks_passed": passed,
         "checks_failed": failed,
-        "strongest_proof": (_text(strongest.get("name") or strongest.get("summary")) or None)
-        if strongest is not None
-        else None,
+        "verified_step_count": int(verification.get("verified_step_count") or 0),
+        "total_step_count": int(verification.get("total_step_count") or 0),
+        "agent_reported_step_count": int(verification.get("agent_reported_step_count") or 0),
+        "definition": (
+            "X of Y checkable steps carry a passing check; the tiers show how independent "
+            "that check is. These are counts, not a probability of correctness."
+        ),
     }
+
+
+# The coverage headline + ledger — ONE formatting shared by CLI / TUI / app, so
+# no two surfaces can word the same evidence differently (the M1 vocabulary rule).
+EVIDENCE_TIER_LABEL = {
+    "externally_verified": "externally-verified",
+    "independently_checked": "independently-checked",
+    "self_checked": "self-checked",
+}
+
+
+def evidence_coverage_headline(evidence: Mapping[str, Any]) -> str:
+    """The coverage ratio, tier by tier — the headline IS the counts, never a
+    single collapsed grade word. The one non-ratio case is ``Not gradeable`` (no
+    checkable step, where a 0/0 ratio would be meaningless)."""
+
+    if not evidence.get("gradeable"):
+        return "Not gradeable (no verifiable steps recorded)"
+    by_tier = evidence.get("by_tier") or {}
+    total = int(evidence.get("checkable_total") or 0)
+    parts = [
+        f"{int(by_tier[tier])}/{total} {label}"
+        for tier, label in EVIDENCE_TIER_LABEL.items()
+        if by_tier.get(tier)
+    ]
+    if by_tier.get("unchecked"):
+        parts.append(f"{int(by_tier['unchecked'])} unchecked")
+    return " · ".join(parts) if parts else f"0/{total} checked"
+
+
+def evidence_coverage_ledger(evidence: Mapping[str, Any]) -> str:
+    """The honest ledger beneath the ratio: where the evidence is, and what the
+    ratio does NOT cover — steps hidden in subagents, checks that attach to no
+    step, non-verifiable steps, and still-open steps."""
+
+    bits: list[str] = []
+    hidden = int(evidence.get("hidden_in_subagents") or 0)
+    if hidden:
+        bits.append(f"{hidden} step(s) ran in subagents")
+    not_checkable = int(evidence.get("not_checkable") or 0)
+    if not_checkable:
+        bits.append(f"{not_checkable} non-verifiable (research/docs)")
+    unattributed = int(evidence.get("unattributed_checks") or 0)
+    if unattributed:
+        bits.append(f"{unattributed} check(s) attach to no step")
+    still_open = int(evidence.get("open_or_incomplete") or 0)
+    if still_open:
+        bits.append(f"{still_open} step(s) still open")
+    return " · ".join(bits)
 
 
 # --- Decision axis ------------------------------------------------------------
@@ -560,6 +720,15 @@ def _sessions_block(task: Mapping[str, Any]) -> list[dict[str, Any]]:
 
     primary = _mapping(task.get("primary_root"))
     primary_key = (_text(primary.get("client")), _text(primary.get("client_session_id")))
+    # Only roots carry a ``client_session_title``; a subagent's is null, so the
+    # drill-down showed a raw session id until you expanded it. Recover a name
+    # from the subagent's FIRST recorded step so the row is legible up front.
+    step_title_by_session: dict[str, str] = {}
+    for item in _items(task):
+        session_id = _text(item.get("client_session_id"))
+        title = _text(item.get("title") or item.get("objective") or item.get("summary"))
+        if session_id and title and session_id not in step_title_by_session:
+            step_title_by_session[session_id] = title
     sessions_by_key: dict[tuple[str, str], Mapping[str, Any]] = {}
     raw_sessions = task.get("sessions") if isinstance(task.get("sessions"), list) else []
     for session in raw_sessions:
@@ -591,7 +760,11 @@ def _sessions_block(task: Mapping[str, Any]) -> list[dict[str, Any]]:
                     "client_session_id": key[1],
                     "session_kind": _text(session.get("session_kind")) or None,
                     "role": "root" if key == root_key else "subagent",
-                    "title": _text(session.get("client_session_title")) or None,
+                    "title": (
+                        _text(session.get("client_session_title"))
+                        or step_title_by_session.get(key[1])
+                        or None
+                    ),
                     "project": _text(session.get("project")) or None,
                     "last_activity_at": _number(session.get("last_activity_at")) or None,
                 }
@@ -637,7 +810,7 @@ def build_receipt(
     )
     verification = step_verification_counts(task)
     checks = _project_checks(task)
-    evidence_strength = _evidence_strength(verification, checks)
+    evidence_strength = _evidence_strength(task, checks, verification)
     decision = _decision_status(task, latest_store_activity_at=latest_store_activity_at)
     decision_brief = _mapping(intelligence.get("decision_brief"))
 
@@ -666,8 +839,8 @@ def build_receipt(
             "decision_status": decision,
             "evidence_strength": evidence_strength,
             "orthogonality_note": (
-                "Evidence strength and decision status are separate axes: an agent reporting "
-                "'done' never raises evidence strength, and a human review or approval never "
+                "Evidence coverage and decision status are separate axes: an agent reporting "
+                "'done' never adds a passing check, and a human review or approval never "
                 "counts as machine verification."
             ),
         },
@@ -704,7 +877,7 @@ def build_receipt_summary(
 
     verification = step_verification_counts(task)
     checks = _project_checks(task)
-    evidence_strength = _evidence_strength(verification, checks)
+    evidence_strength = _evidence_strength(task, checks, verification)
     decision = _decision_status(task, latest_store_activity_at=latest_store_activity_at)
     usage = _mapping(task.get("usage"))
     return {
@@ -717,9 +890,13 @@ def build_receipt_summary(
         },
         "evidence_strength": {
             "key": evidence_strength["key"],
-            "label": evidence_strength["label"],
-            "verified_step_count": evidence_strength["verified_step_count"],
-            "total_step_count": evidence_strength["total_step_count"],
+            "gradeable": evidence_strength["gradeable"],
+            "strongest_tier": evidence_strength["strongest_tier"],
+            "checkable_total": evidence_strength["checkable_total"],
+            "checked_total": evidence_strength["checked_total"],
+            "by_tier": evidence_strength["by_tier"],
+            "hidden_in_subagents": evidence_strength["hidden_in_subagents"],
+            "unattributed_checks": evidence_strength["unattributed_checks"],
         },
         "cost": {
             "estimated_cost_usd": usage.get("estimated_cost_usd"),
@@ -749,7 +926,10 @@ def latest_store_activity(tasks: list[Mapping[str, Any]]) -> float | None:
 __all__ = [
     "RECEIPT_SCHEMA_VERSION",
     "PROVENANCE_LEGEND",
+    "EVIDENCE_TIER_LABEL",
     "build_receipt",
     "build_receipt_summary",
+    "evidence_coverage_headline",
+    "evidence_coverage_ledger",
     "latest_store_activity",
 ]

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -33,6 +33,42 @@ _HANDED_OFF_STATUS = "handed_off"
 # progress" to an equally honest partial state; it never infers completion.
 _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS = 24 * 60 * 60
 
+# --- Per-step evidence grade (M2) --------------------------------------------
+# ONE vocabulary, shared by the per-step grade and the task-level headline,
+# ordered by WHO attested — most independent of the agent-under-test wins. It is
+# derived ONLY from recorded checks + step status, the same disjoint inputs as
+# the task evidence axis, so it never rises on an agent's "done" or a human
+# review. On this machine, and today, every real check is agent-reported, so the
+# top two rungs stay empty until a hook / CI source populates them — that is the
+# honest picture, not a bug.
+GRADE_NONE = "none"
+GRADE_CLAIMED = "claimed"
+GRADE_SELF_CHECKED = "self_checked"
+GRADE_INDEPENDENTLY_CHECKED = "independently_checked"
+GRADE_EXTERNALLY_VERIFIED = "externally_verified"
+
+EVIDENCE_GRADE_RANK: dict[str, int] = {
+    GRADE_NONE: 0,
+    GRADE_CLAIMED: 1,
+    GRADE_SELF_CHECKED: 2,
+    GRADE_INDEPENDENTLY_CHECKED: 3,
+    GRADE_EXTERNALLY_VERIFIED: 4,
+}
+
+# A step is graded as a terminal success on these statuses. ``resolved`` (an
+# evidence-backed blocker resolution) is graded like a completion here, even
+# though ``_step_is_verified`` — kept deliberately untouched for the decision
+# axis — counts only completed/passed. The grade shows evidence per step; the
+# verified-count is the conservative all-or-nothing measure feeding the outcome
+# reducer. They agree on completed/passed steps (asserted by a test).
+_GRADE_SUCCESS_STATUSES = {"completed", "passed", "resolved"}
+
+# A step whose ``kind`` is one of these produces no machine-verifiable artifact,
+# so it is EXCUSED from the task headline (it still carries a per-step grade).
+# Every other kind — including ``unknown``/``other`` — is check-relevant: an
+# unlabeled step does not get a free pass. See the M2 spec (owner decision Q2).
+NON_CHECK_RELEVANT_KINDS = {"research", "review", "planning", "docs"}
+
 
 def _text(value: Any) -> str:
     return str(value or "").strip()
@@ -82,6 +118,95 @@ def _step_is_verified(item: Mapping[str, Any]) -> bool:
     projected_checks = isinstance(item.get("current_check_events"), list)
     evidence_strong = _text(item.get("evidence_status")).lower() == "strong"
     return latest_all_pass or (evidence_strong and not checks and not projected_checks)
+
+
+def _check_independence(event: Mapping[str, Any]) -> str:
+    """How independent of the agent-under-test is this check? ``external`` >
+    ``independent`` > ``self``.
+
+    Keyed ONLY on the trusted ``source_type``. The raw ``source`` is
+    agent-authored — ``agentacct_record_machine_check`` takes it verbatim, and
+    the ledger hard-codes ``source_type='mcp_agent_reported'`` for every MCP
+    check regardless — so trusting ``source`` here would let an agent forge the
+    external tier simply by naming its source ``github_actions``. A real
+    CI/provider check carries a trusted ``source_type`` in {ci, external,
+    provider}; the hook path sets ``client_hook``. Everything else is the
+    agent's own word, no matter what its ``source`` or summary claims.
+    """
+
+    source_type = _text(event.get("source_type")).lower()
+    if source_type in {"ci", "external", "provider"}:
+        return "external"
+    if source_type == "client_hook":
+        return "independent"
+    return "self"
+
+
+_INDEPENDENCE_GRADE = {
+    "external": GRADE_EXTERNALLY_VERIFIED,
+    "independent": GRADE_INDEPENDENTLY_CHECKED,
+    "self": GRADE_SELF_CHECKED,
+}
+_INDEPENDENCE_RANK = {"self": 0, "independent": 1, "external": 2}
+
+
+def step_evidence_grade(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Grade ONE step by the strongest POSITIVE proof for it.
+
+    Positive proof only: a failing check never lifts the grade — it lands on the
+    decision axis as a finding. The grade reads the SAME check series
+    ``_step_is_verified`` reads, so a step graded ``self_checked`` or better is
+    exactly a verified step (on completed/passed statuses), and the grade and the
+    verified-count can never disagree. Returns ``{grade, reason, checks}``.
+    """
+
+    status = _text(item.get("latest_status")).lower()
+    if status not in _GRADE_SUCCESS_STATUSES:
+        detail = status or "no status"
+        return {"grade": GRADE_NONE, "reason": f"{detail}: not a terminal success — nothing proven", "checks": 0}
+    raw = (
+        item.get("current_check_events")
+        if isinstance(item.get("current_check_events"), list)
+        else item.get("evidence_events")
+    )
+    events = [event for event in raw if isinstance(event, Mapping)] if isinstance(raw, list) else []
+    checks = latest_check_events(events, task_scoped=True)
+    latest_all_pass = bool(checks) and all(
+        _text(event.get("result")).lower() == "passed" for event in checks
+    )
+    if latest_all_pass:
+        tier = max(
+            (_check_independence(event) for event in checks),
+            key=lambda name: _INDEPENDENCE_RANK[name],
+        )
+        grade = _INDEPENDENCE_GRADE[tier]
+        proof = _text(
+            next(
+                (
+                    event.get("name") or event.get("summary")
+                    for event in checks
+                    if _check_independence(event) == tier
+                ),
+                "",
+            )
+        ) or "a recorded check"
+        reason = {
+            GRADE_EXTERNALLY_VERIFIED: f"CI/provider check passed ({proof[:60]})",
+            GRADE_INDEPENDENTLY_CHECKED: f"the harness observed a check pass ({proof[:60]}) — independent of the agent",
+            GRADE_SELF_CHECKED: f"the agent reported a check passed ({proof[:60]}) — the agent's own, not independent",
+        }[grade]
+        return {"grade": grade, "reason": reason, "checks": len(checks)}
+    projected_checks = isinstance(item.get("current_check_events"), list)
+    evidence_strong = _text(item.get("evidence_status")).lower() == "strong"
+    if evidence_strong and not checks and not projected_checks:
+        return {"grade": GRADE_SELF_CHECKED, "reason": "agent-reported evidence, no linked check series", "checks": 0}
+    if any(_text(event.get("result")).lower() in {"failed", "error"} for event in checks):
+        return {
+            "grade": GRADE_CLAIMED,
+            "reason": "marked done, but a recorded check is currently failing (see the decision axis)",
+            "checks": len(checks),
+        }
+    return {"grade": GRADE_CLAIMED, "reason": "marked done; no passing machine check for this step", "checks": 0}
 
 
 def step_verification_counts(task: Mapping[str, Any]) -> dict[str, int]:
@@ -502,8 +627,16 @@ __all__ = [
     "evidence_event_key",
     "finding_check_key",
     "step_verification_counts",
+    "step_evidence_grade",
     "latest_check_events",
     "latest_task_checks",
     "task_newest_event_at",
     "reduce_task_outcome",
+    "EVIDENCE_GRADE_RANK",
+    "GRADE_NONE",
+    "GRADE_CLAIMED",
+    "GRADE_SELF_CHECKED",
+    "GRADE_INDEPENDENTLY_CHECKED",
+    "GRADE_EXTERNALLY_VERIFIED",
+    "NON_CHECK_RELEVANT_KINDS",
 ]

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1181,7 +1181,13 @@ def _receipt_decision_color(key: str) -> str:
 
 
 def _receipt_evidence_color(key: str) -> str:
-    return {"verified": "green", "checked": "blue", "reported": "yellow"}.get(key, "dim")
+    # The coarse tier ordinal drives colour only; the numbers carry the truth.
+    return {
+        "externally_verified": "green",
+        "independently_checked": "cyan",
+        "self_checked": "blue",
+        "unchecked": "yellow",
+    }.get(key, "dim")
 
 
 def _receipt_summary_cost(cost: dict) -> str:
@@ -1215,14 +1221,14 @@ def _render_receipt_markup(receipt: dict) -> str:
     )
     if decision.get("statement"):
         lines.append(f"                   [dim]{_escape(str(decision['statement']))}[/]")
-    lines.append(
-        f"Evidence strength  [b {ecolor}]{str(evidence.get('key') or '').upper()}[/]"
-        f"  [dim]({evidence.get('verified_step_count', 0)}/{evidence.get('total_step_count', 0)}"
-        f" steps verified · {evidence.get('checks_total', 0)} checks,"
-        f" {evidence.get('checks_passed', 0)} passed)[/]"
-    )
-    if evidence.get("strongest_proof"):
-        lines.append(f"                   [dim]strongest proof: {_escape(str(evidence['strongest_proof']))}[/]")
+    from .receipt import evidence_coverage_headline, evidence_coverage_ledger
+
+    lines.append(f"Evidence coverage  [b {ecolor}]{_escape(evidence_coverage_headline(evidence))}[/]")
+    _ledger = evidence_coverage_ledger(evidence)
+    if _ledger:
+        lines.append(f"                   [dim]{_escape(_ledger)}[/]")
+    if evidence.get("definition"):
+        lines.append(f"                   [dim]{_escape(str(evidence['definition']))}[/]")
     if axes.get("orthogonality_note"):
         lines.append(f"[dim]{_escape(str(axes['orthogonality_note']))}[/]")
     lines.append("")
@@ -1374,6 +1380,8 @@ class ReceiptsScreen(Screen):
     def _populate(self, rows: list) -> None:
         if not self.is_mounted:
             return
+        from .receipt import evidence_coverage_headline
+
         table = self.query_one("#receipts", DataTable)
         table.clear()
         self._by_id.clear()
@@ -1386,7 +1394,7 @@ class ReceiptsScreen(Screen):
             table.add_row(
                 _escape(str(summary.get("title") or task_id))[:46],
                 f"[{_receipt_decision_color(decision['key'])}]{decision['key']}[/]",
-                f"[{_receipt_evidence_color(evidence['key'])}]{evidence['key']}[/]",
+                f"[{_receipt_evidence_color(evidence['key'])}]{_escape(evidence_coverage_headline(evidence))}[/]",
                 _escape(_receipt_summary_cost(summary.get("cost") or {})),
                 _humanize_ago(summary.get("last_activity_at"), now),
                 key=task_id,

--- a/src/agentacct/v1_sessions.py
+++ b/src/agentacct/v1_sessions.py
@@ -33,6 +33,8 @@ import time
 from threading import Lock
 from typing import Any, Callable
 
+from .task_outcome import step_evidence_grade
+
 V1_SESSIONS_SCHEMA_VERSION = "agentacct.v1-sessions.v1"
 V1_SESSION_DETAIL_SCHEMA_VERSION = "agentacct.v1-session-detail.v1"
 
@@ -460,6 +462,10 @@ _STEP_CHECK_FIELDS = (
     "result",
     "summary",
     "exit_code",
+    # Independence category (mcp_agent_reported / client_hook / ci) — not
+    # sensitive, and it is what lets a surface show that a check saying "CI
+    # green" in its summary is really only agent-reported.
+    "source_type",
     "check_identity",
     "supersession_state",
     "superseded_by_event_id",
@@ -487,8 +493,14 @@ def _project_step(item: dict[str, Any], models: list[dict[str, Any]]) -> dict[st
         for event in (evidence_events if isinstance(evidence_events, list) else [])
         if isinstance(event, dict)
     ]
+    grade = step_evidence_grade(item)
     return {
         "work_id": item.get("work_id"),
+        # Per-step evidence grade (M2) + a one-line reason ("why strong/weak/
+        # none"). Graded by WHO attested; today every check is agent-reported,
+        # so a step tops out at self_checked until a hook / CI source lands.
+        "evidence_grade": grade.get("grade"),
+        "evidence_grade_reason": grade.get("reason"),
         "section_id": item.get("section_id"),
         "title": item.get("title"),
         "latest_status": item.get("latest_status"),

--- a/tests/test_evidence_grade.py
+++ b/tests/test_evidence_grade.py
@@ -1,0 +1,165 @@
+"""M2 evidence grade engine: the per-step ladder + the task-level coverage ratio.
+
+These lock the honesty spine: an agent-reported check is 'self_checked' (never
+independent), the grade agrees with the untouched verified-count on
+completed/passed steps, and the task level is per-tier ratios + a ledger, with a
+'Not gradeable' floor rather than a fabricated number.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentacct.receipt import _evidence_strength
+from agentacct.task_outcome import (
+    EVIDENCE_GRADE_RANK,
+    GRADE_SELF_CHECKED,
+    _step_is_verified,
+    step_evidence_grade,
+)
+
+
+def _check(eid: str, source_type: str, *, result: str = "passed", ident: str | None = None) -> dict[str, Any]:
+    return {
+        "event_id": eid,
+        "result": result,
+        "source_type": source_type,
+        "name": ident or eid,
+        "check_identity": ident or eid,
+        "check_identity_stable": True,
+    }
+
+
+_MCP = _check("eA", "mcp_agent_reported", ident="cA")
+_HOOK = _check("eB", "client_hook", ident="cB")
+# A real external check is trusted via source_type, never the agent-set source.
+_CI = _check("eC", "ci", ident="cC")
+_FAIL = _check("eA", "mcp_agent_reported", result="failed", ident="cA")
+
+
+def _grade(status: str, checks: list[dict[str, Any]], **extra: Any) -> str:
+    return step_evidence_grade({"latest_status": status, "current_check_events": checks, **extra})["grade"]
+
+
+def test_step_grade_ladder_by_source() -> None:
+    assert _grade("completed", [_MCP]) == "self_checked"
+    assert _grade("completed", [_HOOK]) == "independently_checked"
+    assert _grade("completed", [_CI]) == "externally_verified"
+    # strongest independence wins when several pass
+    assert _grade("completed", [_MCP, _HOOK]) == "independently_checked"
+
+
+def test_agent_cannot_forge_external_tier_via_source() -> None:
+    # The honesty keystone: an MCP-recorded check whose agent-set `source` names
+    # a CI system, but whose trusted source_type is the ledger's
+    # mcp_agent_reported, must grade self_checked — never externally/independently
+    # verified. The evidence tier must be un-forgeable by the agent-under-test.
+    forged = {
+        "result": "passed",
+        "source_type": "mcp_agent_reported",
+        "source": "github_actions",
+        "name": "CI green on 3.11/3.12/3.13",
+        "check_identity": "cForge",
+        "check_identity_stable": True,
+    }
+    assert _grade("completed", [forged]) == "self_checked"
+
+
+def test_step_grade_claimed_and_none() -> None:
+    assert _grade("completed", []) == "claimed"
+    assert _grade("completed", [_FAIL]) == "claimed"  # failing check → decision axis, not evidence
+    assert _grade("in_progress", [_MCP]) == "none"
+    assert _grade("failed", [_MCP]) == "none"
+    # resolved (evidence-backed blocker clearance) is graded like a completion
+    assert _grade("resolved", [_MCP]) == "self_checked"
+    # strong log evidence with no linked check series → self_checked
+    assert step_evidence_grade({"latest_status": "completed", "evidence_status": "strong"})["grade"] == "self_checked"
+
+
+def test_step_grade_carries_a_reason() -> None:
+    assert "not independent" in _reason("completed", [_MCP])
+    assert "independent of the agent" in _reason("completed", [_HOOK])
+    assert "no passing machine check" in _reason("completed", [])
+
+
+def _reason(status: str, checks: list[dict[str, Any]]) -> str:
+    return step_evidence_grade({"latest_status": status, "current_check_events": checks})["reason"]
+
+
+def test_grade_and_verified_count_never_disagree() -> None:
+    # _step_is_verified is untouched; a step is verified exactly when its grade
+    # reaches self_checked (on completed/passed statuses).
+    for status in ("completed", "passed"):
+        for checks in ([_MCP], [_HOOK], [], [_FAIL]):
+            item = {"latest_status": status, "current_check_events": checks}
+            verified = EVIDENCE_GRADE_RANK[step_evidence_grade(item)["grade"]] >= EVIDENCE_GRADE_RANK[GRADE_SELF_CHECKED]
+            assert verified == _step_is_verified(item), (status, checks)
+
+
+def _item(status: str, kind: str, checks: list[dict[str, Any]], sess: str = "S0") -> dict[str, Any]:
+    return {"latest_status": status, "kind": kind, "client_session_id": sess,
+            "current_check_events": checks, "evidence_events": checks}
+
+
+def test_task_coverage_ratios_ledger_and_hidden_accounting() -> None:
+    task = {
+        "primary_root": {"client_session_id": "S0"},
+        "work_items": [
+            _item("completed", "implementation", [_MCP]),            # self_checked, checkable
+            _item("completed", "testing", [_HOOK]),                  # independently_checked, checkable
+            _item("completed", "implementation", []),                # unchecked, checkable
+            _item("completed", "research", [_check("eD", "mcp_agent_reported", ident="cD")]),  # excused
+            _item("in_progress", "implementation", [_MCP]),          # open
+            _item("completed", "implementation", [_check("eF", "mcp_agent_reported", ident="cF")], sess="S1"),  # hidden
+        ],
+        "task_evidence_events": [_check("eZ", "mcp_agent_reported", ident="cZ")],  # orphan, on no step
+        "current_check_events": None,
+    }
+    s = _evidence_strength(task, [], {"verified_step_count": 0, "total_step_count": 6, "agent_reported_step_count": 0})
+    assert s["checkable_total"] == 4
+    assert s["by_tier"] == {"externally_verified": 0, "independently_checked": 1, "self_checked": 2, "unchecked": 1}
+    assert s["strongest_tier"] == "independently_checked"
+    assert s["key"] == "independently_checked"
+    assert s["not_checkable"] == 1
+    assert s["open_or_incomplete"] == 1
+    assert s["hidden_in_subagents"] == 1
+    assert s["unattributed_checks"] == 1
+    assert s["gradeable"] is True
+
+
+def test_continuation_root_step_is_not_hidden_in_subagents() -> None:
+    # A step recorded in a CONTINUATION root (same agent resuming in a new
+    # session) is a root, not a subagent — it must not inflate hidden_in_subagents
+    # (that would falsely say a continued Task's own work "ran in subagents").
+    task = {
+        "primary_root": {"client_session_id": "S0"},
+        "root_keys": [{"client_session_id": "S0"}, {"client_session_id": "S1"}],
+        "work_items": [
+            _item("completed", "implementation", [_MCP]),               # S0 primary root
+            _item("completed", "implementation", [_MCP], sess="S1"),    # S1 continuation root
+        ],
+    }
+    assert _evidence_strength(task, [], {})["hidden_in_subagents"] == 0
+    # A genuine subagent step (a session that is NOT a root) still counts.
+    task["work_items"].append(_item("completed", "implementation", [_MCP], sess="SUB"))
+    assert _evidence_strength(task, [], {})["hidden_in_subagents"] == 1
+
+
+def test_task_all_unchecked_has_no_strongest_tier_but_is_gradeable() -> None:
+    task = {"primary_root": {"client_session_id": "S0"},
+            "work_items": [_item("completed", "implementation", []), _item("completed", "testing", [])]}
+    s = _evidence_strength(task, [], {})
+    assert s["gradeable"] is True
+    assert s["strongest_tier"] is None
+    assert s["key"] == "unchecked"
+    assert s["by_tier"]["unchecked"] == 2
+
+
+def test_task_not_gradeable_when_no_checkable_step() -> None:
+    task = {"primary_root": {"client_session_id": "S0"},
+            "work_items": [_item("completed", "research", []), _item("completed", "docs", [])]}
+    s = _evidence_strength(task, [], {})
+    assert s["gradeable"] is False
+    assert s["key"] == "undefined"
+    assert s["checkable_total"] == 0
+    assert s["not_checkable"] == 2

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -114,17 +114,24 @@ def test_receipt_has_all_eight_dimensions_and_two_named_axes() -> None:
         assert "gaps" in receipt["dimensions"][name]
 
 
-def test_agent_reported_done_is_never_evidence_verified() -> None:
-    # A completed step with no linked check: the agent SAID done, nothing PROVES it.
+def test_agent_reported_done_is_never_evidence_checked() -> None:
+    # A completed step with no linked check: the agent SAID done, nothing PROVES
+    # it — so it sits in the 'unchecked' tier, never any CHECKED tier.
     receipt = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))
     assert receipt["axes"]["decision_status"]["key"] == "reported"
     assert receipt["axes"]["decision_status"]["asserted_by"] == "agent_report"
-    assert receipt["axes"]["evidence_strength"]["key"] != "verified"
-    assert receipt["axes"]["evidence_strength"]["key"] == "reported"
+    evidence = receipt["axes"]["evidence_strength"]
+    assert evidence["strongest_tier"] is None
+    assert evidence["key"] == "unchecked"
+    assert evidence["by_tier"]["unchecked"] == 1
+    assert evidence["by_tier"]["self_checked"] == 0
+    assert evidence["checkable_total"] == 1
 
 
-def test_passing_current_check_verifies_on_both_axes() -> None:
-    check = _check("passed", at=200.0)
+def test_passing_hook_check_is_independently_checked() -> None:
+    # A hook-observed passing check is independent of the agent-under-test — the
+    # only local way to reach 'independently_checked'.
+    check = _check("passed", at=200.0)  # _check defaults source_type=client_hook
     task = _task(
         [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0, "current_check_events": [check]}],
         task_checks=[check],
@@ -132,9 +139,38 @@ def test_passing_current_check_verifies_on_both_axes() -> None:
     receipt = _receipt(task)
     assert receipt["axes"]["decision_status"]["key"] == "verified"
     assert receipt["axes"]["decision_status"]["asserted_by"] == "machine"
-    assert receipt["axes"]["evidence_strength"]["key"] == "verified"
-    assert receipt["axes"]["evidence_strength"]["checks_passed"] == 1
+    evidence = receipt["axes"]["evidence_strength"]
+    assert evidence["strongest_tier"] == "independently_checked"
+    assert evidence["by_tier"]["independently_checked"] == 1
+    assert evidence["checks_passed"] == 1
     assert receipt["dimensions"]["evidence"]["checks"][0]["source"] == "hook"
+
+
+def test_agent_reported_check_is_self_checked_not_independent() -> None:
+    # An mcp_agent_reported passing check is the agent's own word — it is
+    # 'self_checked', never promoted to independent verification, no matter what
+    # the check's free-text summary claims.
+    check = _check("passed", at=200.0, source_type="mcp_agent_reported")
+    task = _task(
+        [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0, "current_check_events": [check]}],
+        task_checks=[check],
+    )
+    evidence = _receipt(task)["axes"]["evidence_strength"]
+    assert evidence["strongest_tier"] == "self_checked"
+    assert evidence["by_tier"]["self_checked"] == 1
+    assert evidence["by_tier"]["independently_checked"] == 0
+
+
+def test_pure_research_task_is_not_gradeable() -> None:
+    # A step that produces no machine-verifiable output is excused from the
+    # ratio; with no checkable step at all, the task is honestly Not gradeable —
+    # never a fabricated 0.
+    task = _task([{"work_id": "w", "latest_status": "completed", "kind": "research", "updated_at": 100.0}])
+    evidence = _receipt(task)["axes"]["evidence_strength"]
+    assert evidence["gradeable"] is False
+    assert evidence["key"] == "undefined"
+    assert evidence["checkable_total"] == 0
+    assert evidence["not_checkable"] == 1
 
 
 def test_human_resolved_finding_is_human_asserted_but_not_evidence_verified() -> None:
@@ -151,7 +187,9 @@ def test_human_resolved_finding_is_human_asserted_but_not_evidence_verified() ->
     assert receipt["axes"]["decision_status"]["key"] == "finding"
     assert receipt["axes"]["decision_status"]["asserted_by"] == "human"
     assert "not machine verification" in receipt["axes"]["decision_status"]["statement"]
-    assert receipt["axes"]["evidence_strength"]["key"] != "verified"
+    # A failing check is not positive proof — evidence reaches no CHECKED tier,
+    # and a human dispositioning it never lifts the evidence axis.
+    assert receipt["axes"]["evidence_strength"]["strongest_tier"] is None
     # Provenance of the outcome field is the human, not a check.
     assert receipt["dimensions"]["outcome"]["provenance"] == ["human"]
 

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -257,7 +257,7 @@ def test_unknown_task_is_a_404_not_an_empty_fabrication(tmp_path: Path) -> None:
     assert client.get("/v1/receipt?task=task_deadbeef", headers=_auth()).status_code == 404
 
 
-def test_receipt_reports_verified_when_a_current_check_passes(tmp_path: Path) -> None:
+def test_receipt_self_checked_when_an_agent_reported_check_passes(tmp_path: Path) -> None:
     service = SentinelService(tmp_path)
     _record_usage(service, session_id="s1", at=100.0)
     _record_section(service, session_id="s1", section_id="sec-1", status="completed", at=100.0)
@@ -267,8 +267,12 @@ def test_receipt_reports_verified_when_a_current_check_passes(tmp_path: Path) ->
     task_id = client.get("/v1/tasks", headers=_auth()).json()["tasks"][0]["task_id"]
     receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
     assert receipt["axes"]["decision_status"]["key"] == "verified"
-    assert receipt["axes"]["evidence_strength"]["key"] == "verified"
-    assert receipt["dimensions"]["evidence"]["checks_passed"] == 1
+    # An agent-reported (mcp) check is the agent's OWN word — self_checked, never
+    # promoted to independent/external verification.
+    evidence = receipt["axes"]["evidence_strength"]
+    assert evidence["strongest_tier"] == "self_checked"
+    assert evidence["by_tier"]["self_checked"] == 1
+    assert evidence["checks_passed"] == 1
     # The touched file recorded on the section rides the Actions dimension.
     assert "src/login.py" in receipt["dimensions"]["actions"]["touched_files"]
 

--- a/tests/test_receipt_cli.py
+++ b/tests/test_receipt_cli.py
@@ -116,8 +116,10 @@ def test_receipt_text_render_is_scannable(tmp_path: Path) -> None:
     )["tasks"][0]["task_id"]
     result = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
     assert result.exit_code == 0, result.output
-    for marker in ("Work Receipt", "Decision status", "Evidence strength", "Provenance"):
+    for marker in ("Work Receipt", "Decision status", "Evidence coverage", "Provenance"):
         assert marker in result.output
+    # The evidence line is a coverage RATIO, not a categorical grade word.
+    assert "unchecked" in result.output or "checked" in result.output
 
 
 def test_receipt_text_survives_rich_markup_in_recorded_titles(tmp_path: Path) -> None:

--- a/tests/test_receipt_tui.py
+++ b/tests/test_receipt_tui.py
@@ -103,8 +103,13 @@ def test_render_receipt_markup_contains_axes_and_dimensions() -> None:
         "actions": {"tool_category_counts": {}, "tool_category_total": 0, "touched_files": [], "touched_file_count": 0},
     }
     markup = _render_receipt_markup(build_receipt(task, public_task_id="task_x", title="Add rate limit"))
-    for marker in ("Decision status", "Evidence strength", "[b]Task[/]", "[b]Cost[/]", "Provenance"):
+    for marker in ("Decision status", "Evidence coverage", "[b]Task[/]", "[b]Cost[/]", "Provenance"):
         assert marker in markup
+    # The evidence line is a coverage RATIO, not a bare axis phrase. Assert the
+    # actual content (one completed no-check step reads "1 unchecked") so a
+    # regression that empties the headline cannot hide behind the orthogonality
+    # note, which also contains the phrase "Evidence coverage".
+    assert "unchecked" in markup
 
 
 def test_receipts_screen_lists_a_task_and_opens_its_detail(tmp_path: Path) -> None:
@@ -132,6 +137,9 @@ def test_receipts_screen_lists_a_task_and_opens_its_detail(tmp_path: Path) -> No
             assert isinstance(app.screen, ReceiptDetailScreen)
             assert app.screen.query_one("#receipt-body", Static) is not None
             assert "Decision status" in app.screen._body_text
-            assert "Evidence strength" in app.screen._body_text
+            assert "Evidence coverage" in app.screen._body_text
+            # Assert the ratio content, not just the axis phrase (which the
+            # orthogonality note also contains).
+            assert "unchecked" in app.screen._body_text
 
     _run(scenario())

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -873,6 +873,12 @@ def test_detail_steps_carry_tui_grade_depth(tmp_path):
     assert "command" not in checks[0]
     assert checks[0]["command_redacted"] is True
     assert "pytest -q --token secret" not in str(checks[0])
+    # M2 per-step grade on the wire — the PRIMARY signal the app's StepCard reads.
+    # An agent-reported passing check grades self_checked (never independent), and
+    # the check carries its trusted source_type so a surface can show independence.
+    assert step["evidence_grade"] == "self_checked"
+    assert step["evidence_grade_reason"]
+    assert checks[0]["source_type"] == "mcp_agent_reported"
 
 
 def test_detail_descendants_and_plan_block(tmp_path):


### PR DESCRIPTION
## What

Replaces the Receipt's single evidence-strength grade word with an honest coverage model.

- **Per-step grade** (`none < claimed < self_checked < independently_checked < externally_verified`), set by WHO attested it — the agent's own report, then a check the harness observed, then a CI/provider check — each with a one-line reason.
- **Task headline = per-tier ratio** over the checkable steps (e.g. `3/10 self-checked · 7 unchecked`), not one categorical word. The counts are the headline; there is no percentage that implies more than a count. No machine-verifiable step → `Not gradeable`, never a fabricated 0.
- **Honest ledger** beneath the ratio discloses what it does not cover: steps that ran in subagents, checks that attach to no step, non-verifiable steps, still-open steps.
- The tier is keyed only on a check's **trusted `source_type`** — an agent cannot forge external verification via a self-set `source`.
- Rendered across the CLI (`receipt` / `receipts`), the TUI, the macOS app, and the `/v1/session` per-step wire (each step carries its grade, each check its source).
- Fixes the Work drill-down: subagent rows show a title (fallback to the subagent's first step) instead of a raw id, and the subagent tree is no longer listed twice.

## Why

The old axis collapsed most real tasks into a single "checked" bucket and let an agent-reported check read as "verified". The coverage model makes the honest picture legible — how much of a task is proven, by how independent a check, and what is not gradeable — without ever showing a value it cannot support. `_step_is_verified` and the decision axis are unchanged.

## Testing

- Full suite: **2973 passed, 1 skipped**.
- `swift build`: clean.
- One adversarial review round (find → verify → synthesize): 5 findings, all fixed and regression-tested — including a HIGH: an agent could forge `externally_verified` by setting `source="github_actions"` on its own recorded check (now keyed on the trusted `source_type` only, which the ledger hard-codes for agent checks).

## Follow-up (separate PR)

The PostToolUse exit-code hook that lights up `independently_checked` — a full new capture pipeline plus session+time linkage — lands as its own reviewed PR.
