### PR TITLE
feat(hook): independent checks from a PostToolUse exit-code hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Independent checks from a PostToolUse hook — the only local evidence that is
+  not the agent's own word.** When the agent runs a recognized test / build /
+  lint / typecheck command, the installed Claude Code PostToolUse hook records
+  the exit code the HARNESS observed and projects it as a `client_hook` machine
+  check — which lifts that step from `self-checked` (the agent said so) to
+  `independently-checked`. Privacy holds the WorkEvent line exactly like the
+  tool-category capture: only a coarse check kind, the runner name, and a sha256
+  DIGEST of the command are ever recorded — never the command string, its
+  arguments, its environment, or its output; an unrecognized or ambiguous
+  command is not captured at all. Because the hook sees the command but not which
+  recorded step it was for, each check is attached to the step that was active in
+  its session when it ran; any that cannot be placed is disclosed as an
+  unattributed check in the Receipt's evidence ledger, never guessed onto a step.
+  Read-only: the hook never blocks or edits a tool result. Re-run
+  `agentacct hooks claude-code install --force` (or `agentacct onboard`) to add
+  the PostToolUse entry.
 - **The Work Receipt — one canonical answer to "what did this task do, and can I
   trust it".** A new `agentacct.receipt.v1` projects one converged Task (a root
   session with its continuations and subagents) into the eight questions a

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -107,7 +107,12 @@ from .store_resolution import is_recognized_global_store
 from .supervisor import OwnedSupervisor, SupervisorError
 from .task_continuations import ContinuationTaskStore
 from .task_identity import TaskIdentityCodec
-from .task_outcome import evidence_event_key, finding_check_key, latest_check_events
+from .task_outcome import (
+    NON_CHECK_RELEVANT_KINDS,
+    evidence_event_key,
+    finding_check_key,
+    latest_check_events,
+)
 from .task_projection import build_task_projection
 from .receipt import (
     RECEIPT_SCHEMA_VERSION,
@@ -1269,6 +1274,87 @@ def _evidence_work_fact_compatible(
     return True
 
 
+def _link_mechanical_checks_by_session_time(projection: dict[str, Any]) -> dict[str, Any]:
+    """Option A: credit a PASSING ``client_hook`` check (a hook-observed exit
+    code) to the most recent CHECK-RELEVANT step begun in its session at or
+    before the check's time — the work a test/build/lint actually exercises —
+    which lifts that step from ``self_checked`` to ``independently_checked``.
+
+    A hook check carries a ``client_session_id`` and a timestamp but NO section
+    id (the harness sees the command, not which recorded step it was for), so
+    ``_attach_evidence_to_task_projection`` leaves it at the task level. Two
+    honesty guards keep this from misattributing:
+      * only a PASSING hook check is placed — a failing one is never guessed onto
+        a step (that would falsely demote an unrelated verified step); it stays
+        task-level, visible on the decision axis.
+      * only a check-relevant step (kind not research/review/planning/docs) is a
+        candidate — a test never credits a docs step.
+    A check that fits no eligible step (none had begun in that session yet) stays
+    task-level and is disclosed as an unattributed check in the receipt ledger —
+    never guessed onto an arbitrary step.
+    """
+
+    tasks = projection.get("tasks") if isinstance(projection.get("tasks"), list) else []
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        items = [item for item in (task.get("work_items") or []) if isinstance(item, dict)]
+        if not items:
+            continue
+        by_session: dict[str, list[dict[str, Any]]] = {}
+        for item in items:
+            # A test/build/lint only exercises check-relevant work — a docs or
+            # planning step is never a candidate (crediting it would also make the
+            # check vanish from the ledger, since a non-checkable step is excluded
+            # from the tiers).
+            if str(item.get("kind") or "unknown").lower() in NON_CHECK_RELEVANT_KINDS:
+                continue
+            session_id = str(item.get("client_session_id") or "")
+            if session_id:
+                by_session.setdefault(session_id, []).append(item)
+        for group in by_session.values():
+            group.sort(key=lambda item: float(item.get("started_at") or item.get("updated_at") or 0.0))
+        # Gather the task-level hook checks from BOTH pools _attach populates
+        # (a check may land in current_check_events and/or task_evidence_events);
+        # the per-item append dedups, so seeing one twice is harmless.
+        pool: list[Any] = []
+        for pool_key in ("current_check_events", "task_evidence_events"):
+            value = task.get(pool_key)
+            if isinstance(value, list):
+                pool.extend(value)
+        for check in pool:
+            if not isinstance(check, Mapping):
+                continue
+            if str(check.get("source_type") or "") != "client_hook":
+                continue
+            # Only positive proof is placed on a step; a failing hook check is
+            # never guessed onto a step (that would falsely demote an unrelated
+            # verified step) — it stays task-level, visible on the decision axis.
+            if str(check.get("result") or "").lower() != "passed":
+                continue
+            session_id = str(check.get("client_session_id") or "")
+            group = by_session.get(session_id)
+            if not group:
+                continue
+            at = float(check.get("created_at") or check.get("occurred_at") or check.get("time") or 0.0)
+            if at <= 0:
+                continue
+            active: dict[str, Any] | None = None
+            for item in group:  # ascending by started_at
+                if float(item.get("started_at") or item.get("updated_at") or 0.0) <= at:
+                    active = item
+                else:
+                    break
+            if active is None:
+                continue
+            current = active.get("current_check_events") if isinstance(active.get("current_check_events"), list) else []
+            key = _evidence_event_key(check)
+            if all(_evidence_event_key(existing) != key for existing in current):
+                current.append(dict(check))
+                active["current_check_events"] = current
+    return projection
+
+
 def _attach_evidence_to_task_projection(
     projection: dict[str, Any],
     evidence_events: list[dict[str, Any]],
@@ -2053,6 +2139,11 @@ def _dashboard_task_projection(data: _DashboardPageData) -> dict[str, Any]:
         all_evidence_events,
         require_namespace_for_client_hook=data.store_scope != "project",
     )
+    # Option A: place hook-observed checks (no section id) on the step active in
+    # their session at the time they ran, so a real test/build/lint lifts that
+    # step to independently_checked; unplaceable ones stay disclosed as
+    # unattributed in the ledger.
+    projection = _link_mechanical_checks_by_session_time(projection)
     if data.store_scope == "project":
         unassigned = projection.get("unassigned_findings")
         if isinstance(unassigned, list):

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -120,6 +120,7 @@ from .hooks import (
     CLAUDE_HOOK_RELATIVE_PATH,
     capture_claude_code_client_context,
     capture_tool_activity,
+    capture_mechanical_check,
     claude_code_hook_context_status,
     claude_code_hook_doctor_checks,
     claude_code_hook_paths,
@@ -3315,6 +3316,32 @@ def claude_code_pre_tool_use(
         print(json.dumps(decision, ensure_ascii=False))
     except Exception as exc:  # noqa: BLE001 - FAIL OPEN: a PreToolUse hook must NEVER block a tool call, even on an internal agentacct error. An observe-only recorder that can brick every tool call is worse than one that records nothing.
         print(json.dumps({"agent_sentinel": {"decision": "allow", "risk": "low", "reason": f"agentacct hook error ({type(exc).__name__}); failing open"}}, ensure_ascii=False))
+
+
+@claude_code_hooks_app.command("post-tool-use")
+def claude_code_post_tool_use(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory for the hook context bridge. Defaults to the nearest existing .agent-sentinel/state above the hook event cwd."),
+    ] = None,
+) -> None:
+    """Observe a Claude Code PostToolUse JSON event from stdin.
+
+    Read-only: when the tool was a recognized test / build / lint / typecheck
+    command, spool the exit code the harness observed as an INDEPENDENT machine
+    check (source client_hook) — the only local source that is not the agent's
+    own word. Never blocks or modifies the tool result; always returns an empty
+    response, even on error.
+    """
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_mechanical_check(raw, store_dir=store_dir)
+        except Exception:  # noqa: BLE001 - capture must never affect the tool result.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: a PostToolUse hook must never disturb the tool result.
+        print("{}")
 
 
 @claude_code_hooks_app.command("session-start")
@@ -6719,6 +6746,20 @@ def _local_usage_import_payload(
                 ingest_tool_activity_spool(
                     effective_store_dir,
                     record=service.record_event,
+                    now=time.time(),
+                )
+            except Exception:  # noqa: BLE001 - draining the spool must never fail the import.
+                pass
+            # Drain the PostToolUse mechanical-check spool into client_hook
+            # Evidence-v2 envelopes — the independent (harness-observed) checks
+            # that lift a step to independently_checked. Best-effort, same as
+            # above: a spool/evidence error can never fail the usage import.
+            from .mechanical_capture import ingest_mechanical_check_spool
+
+            try:
+                ingest_mechanical_check_spool(
+                    effective_store_dir,
+                    evidence=service.evidence,
                     now=time.time(),
                 )
             except Exception:  # noqa: BLE001 - draining the spool must never fail the import.

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -510,6 +510,77 @@ def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> N
         return
 
 
+def _hook_exit_code(event: dict[str, Any]) -> int | None:
+    """Read the Bash exit code from a PostToolUse event, tolerant of the
+    tool_output/tool_response key and exit_code/exitCode/code spellings. 0 is a
+    valid value, so a missing code (None) is kept distinct from success (0)."""
+
+    for container_key in ("tool_output", "tool_response", "toolOutput"):
+        container = event.get(container_key)
+        if not isinstance(container, dict):
+            continue
+        for code_key in ("exit_code", "exitCode", "returnCode", "code"):
+            value = container.get(code_key)
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, int):
+                return value
+    return None
+
+
+def capture_mechanical_check(raw: str, *, store_dir: Path | str | None = None) -> None:
+    """Record ONE mechanical-check tick for this PostToolUse. Never raises.
+
+    When the agent ran a recognized test / build / lint / typecheck command, spool
+    the exit code the HARNESS observed — the only local source of a check that is
+    independent of the agent's own report, and what lifts a step to
+    ``independently_checked``. Only a coarse check kind, the runner name, and a
+    sha256 command DIGEST are spooled — never the command string, its arguments,
+    or its output. The spool lands in the SAME store as the tool-activity and
+    client-context bridges so the usage importer drains them from one place.
+    """
+
+    try:
+        from .mechanical_capture import (
+            classify_command,
+            command_digest,
+            record_mechanical_check_tick,
+        )
+
+        event = json.loads(raw or "{}")
+        if not isinstance(event, dict):
+            return
+        if str(event.get("tool_name") or event.get("tool") or "").lower() != "bash":
+            return
+        session_id = event.get("session_id")
+        if not isinstance(session_id, str) or not session_id or len(session_id) > _MAX_CONTEXT_ID_LENGTH:
+            return
+        tool_input = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else {}
+        command = tool_input.get("command")
+        classified = classify_command(command)
+        if classified is None:
+            return
+        exit_code = _hook_exit_code(event)
+        if exit_code is None:
+            return
+        target = Path(store_dir) if store_dir is not None else _hook_store_dir_from_event(event)
+        if target is None:
+            return
+        check_kind, runner = classified
+        record_mechanical_check_tick(
+            target,
+            client="claude-code",
+            session_id=session_id,
+            check_kind=check_kind,
+            runner=runner,
+            digest=command_digest(str(command or "")),
+            exit_code=exit_code,
+            at=time.time(),
+        )
+    except Exception:  # noqa: BLE001 - capture must never affect the hook.
+        return
+
+
 def is_subagent_session_start(event: Any) -> bool:
     """True when a SessionStart event fired inside a subagent session.
 
@@ -818,12 +889,15 @@ _AGENT_CHRONICLE_EXECUTABLE_NAMES = (
 _CLAUDE_HOOK_WRAPPER_TEMPLATE = '''#!/usr/bin/env python3
 """Project-local Claude Code hook wrapper for agentacct.
 
-One wrapper serves BOTH hook events (dispatch on the event's own
+One wrapper serves all three hook events (dispatch on the event's own
 `hook_event_name`, so a single settings command line covers them):
 - PreToolUse: writes a agentacct allow/checkpoint/block decision JSON and
   captures per-session client context (session/transcript ids) for joins.
 - SessionStart: captures the same client context at session start and returns
   additionalContext directing the agent to record its work as sections.
+- PostToolUse: observes the exit code of test/build/lint/typecheck commands as
+  an independent machine check. Read-only — returns an empty response, never
+  blocks or edits the tool result.
 
 This wrapper intentionally shells out to the installed `agentacct` CLI so
 projects can inspect or customize it before wiring it into their Claude Code
@@ -879,8 +953,9 @@ def resolve_agentacct():
 
 def fail_open(reason, hook_event=""):
     sys.stderr.write("agentacct hook: %s; failing open\\n" % reason)
-    if hook_event == "SessionStart":
-        # The no-op SessionStart response is an empty object (nothing to add).
+    if hook_event in ("SessionStart", "PostToolUse"):
+        # SessionStart / PostToolUse no-op: an empty object. PostToolUse in
+        # particular must never block or edit the tool result on failure.
         sys.stdout.write("{}\\n")
     else:
         # "agent_sentinel" is a frozen wire key (pre-rename): consumers parse it.
@@ -903,12 +978,15 @@ def main():
                 HOOK_EVENT = value
     except ValueError:
         pass
-    subcommand = "session-start" if HOOK_EVENT == "SessionStart" else "pre-tool-use"
+    subcommand = {
+        "SessionStart": "session-start",
+        "PostToolUse": "post-tool-use",
+    }.get(HOOK_EVENT, "pre-tool-use")
     executable = resolve_agentacct()
     if executable is None:
         return fail_open("agentacct executable not found (re-run: agentacct hooks claude-code install --force)", HOOK_EVENT)
     # Equivalent shell command:
-    # agentacct hooks claude-code <pre-tool-use|session-start> [extra args]
+    # agentacct hooks claude-code <pre-tool-use|post-tool-use|session-start> [extra args]
     try:
         proc = subprocess.run(
             [executable, "hooks", "claude-code", subcommand, *AGENT_CHRONICLE_HOOK_ARGS],
@@ -1030,6 +1108,21 @@ def claude_code_settings_example(python_executable: str | None = None, *, hook_p
             ],
             "SessionStart": [
                 {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": command,
+                        }
+                    ],
+                }
+            ],
+            # PostToolUse observes the exit code of test/build/lint/typecheck
+            # commands (source client_hook) — the only local INDEPENDENT check,
+            # what lifts a step to independently_checked. Read-only: the wrapper
+            # returns an empty response and never blocks or edits a tool result.
+            "PostToolUse": [
+                {
+                    "matcher": "*",
                     "hooks": [
                         {
                             "type": "command",

--- a/src/agentacct/mechanical_capture.py
+++ b/src/agentacct/mechanical_capture.py
@@ -1,0 +1,444 @@
+"""PostToolUse exit-code capture — the ONLY local source of *independent* checks.
+
+When the agent runs a test / build / lint / typecheck command in the terminal,
+the Claude Code PostToolUse hook records the exit code the HARNESS observed —
+not one the agent typed into a summary. That is what lifts a step from
+``self_checked`` (the agent's own word) to ``independently_checked``.
+
+Privacy: only a coarse command CATEGORY (test/build/lint/typecheck), the runner
+name (``pytest``, ``cargo``, …), and a sha256 DIGEST of the command are ever
+recorded — never the command string, its arguments, its environment, or its
+output. A command that is not a clear, recognized check runner is NOT captured:
+a missed check is honest; a mislabeled one is not.
+
+The path mirrors ``tool_activity`` exactly: the hook appends one tiny JSON line
+to a per-store spool (no daemon, O(1), fail-open); ``agentacct usage
+import-local`` later drains the spool into ``agent-chronicle.evidence.v2``
+``machine_check_observed`` envelopes (source_type ``client_hook``) that the
+existing ``mechanical_checks.build_mechanical_check_events`` ingestion projects
+into Task checks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import uuid
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+_SPOOL_RELATIVE_PATH = Path("spool") / "claude-mechanical-check.jsonl"
+
+# The four check kinds the ingestion accepts (mechanical_checks._CHECK_KINDS).
+CHECK_KINDS = {"test", "build", "lint", "typecheck"}
+
+# The same validators the ingestion (mechanical_checks) enforces — a tick that
+# would not survive projection is dropped at drain time rather than written.
+_SAFE_RUNNER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/@+-]{0,159}$")
+_SHA256 = re.compile(r"^sha256:[a-f0-9]{64}$")
+
+# Leading tokens that are environment assignments or bare command wrappers to
+# skip before the real runner (e.g. ``FOO=bar sudo pytest``, ``time pytest``).
+# Only the bare wrapper NAME is skipped, not its options/arguments — a wrapper
+# invoked with a flag or a value arg (``sudo -E pytest``, ``timeout 300 pytest``,
+# ``nice -n 10 pytest``) is deliberately NOT recognized. That is a conservative
+# miss (an honest un-captured check), never a false positive.
+_WRAPPERS = {"sudo", "env", "time", "nice", "ionice", "command", "exec", "stdbuf", "nohup"}
+# Wrappers whose FIRST argument ``run`` precedes the real runner.
+_RUN_WRAPPERS = {"poetry", "uv", "pdm", "hatch", "rye", "pipenv", "npx", "bunx"}
+_ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_SHELL_SEPARATORS = {"&&", "||", ";", "|", "|&", "&"}
+# Flags that mean the invocation runs NO verification (a help/version print or a
+# dry listing). A command carrying one is not a check — recording its exit 0 as
+# a passing check would forge the evidence tier.
+_NO_OP_FLAGS = {"-h", "--help", "--version", "-V", "--collect-only", "--co", "--init"}
+
+
+def _classify_segment(tokens: list[str]) -> tuple[str, str] | None:
+    """Classify ONE simple command (already split from any shell operators)."""
+
+    # Strip env-assignments and plain wrappers off the front.
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if _ENV_ASSIGN.match(token) or token in _WRAPPERS:
+            index += 1
+            continue
+        break
+    tokens = tokens[index:]
+    if not tokens:
+        return None
+    head = tokens[0]
+    # ``poetry run pytest`` / ``uv run pytest`` / ``npx eslint`` → drop the wrapper.
+    base = os.path.basename(head)
+    if base in _RUN_WRAPPERS:
+        rest = tokens[1:]
+        if base in {"npx", "bunx"}:
+            return _classify_segment(rest)  # the tool follows directly
+        if rest and rest[0] == "run":
+            return _classify_segment(rest[1:])
+        return _classify_segment(rest)
+    args = tokens[1:]
+    a0 = args[0] if args else ""
+    # A help / version / dry-listing invocation runs no verification — not a check.
+    if any(token in _NO_OP_FLAGS for token in args):
+        return None
+
+    if base in {"pytest", "py.test"}:
+        return ("test", "pytest")
+    if base in {"python", "python3"} and "-m" in args:
+        module = args[args.index("-m") + 1] if args.index("-m") + 1 < len(args) else ""
+        module = module.split(".")[0]
+        return {
+            "pytest": ("test", "pytest"),
+            "unittest": ("test", "unittest"),
+            "mypy": ("typecheck", "mypy"),
+            "ruff": ("lint", "ruff"),
+            "flake8": ("lint", "flake8"),
+            "pylint": ("lint", "pylint"),
+        }.get(module)
+    if base in {"mypy"}:
+        return ("typecheck", "mypy")
+    if base in {"pyright", "pyright-python"}:
+        return ("typecheck", "pyright")
+    if base in {"tsc"}:
+        return ("typecheck", "tsc")
+    if base == "ruff":
+        # ``ruff format`` REWRITES files (it verifies nothing) unless it is a
+        # ``--check`` / ``--diff`` dry run; ``ruff check`` (or bare ruff) lints.
+        if a0 == "format":
+            return ("lint", "ruff") if ("--check" in args or "--diff" in args) else None
+        return ("lint", "ruff")
+    if base == "eslint":
+        # ``eslint --fix`` auto-fixes (rewrites files) rather than only reporting.
+        return None if "--fix" in args else ("lint", "eslint")
+    if base in {"flake8", "pylint", "pyflakes"}:
+        return ("lint", base)
+    if base in {"jest", "vitest", "mocha", "ava"}:
+        return ("test", base)
+    if base in {"prettier"}:
+        return ("lint", "prettier") if "--check" in args or "-c" in args else None
+    if base in {"npm", "pnpm", "yarn", "bun"}:
+        runner = base
+        sub = a0
+        target = args[1] if len(args) > 1 else ""
+        if sub == "run":
+            sub = target
+        return {
+            "test": ("test", runner),
+            "build": ("build", runner),
+            "lint": ("lint", runner),
+            "typecheck": ("typecheck", runner),
+            "type-check": ("typecheck", runner),
+            "tsc": ("typecheck", runner),
+        }.get(sub)
+    if base == "cargo":
+        return {
+            "test": ("test", "cargo"),
+            "build": ("build", "cargo"),
+            "check": ("typecheck", "cargo"),
+            "clippy": ("lint", "cargo"),
+        }.get(a0)
+    if base == "go":
+        return {"test": ("test", "go"), "build": ("build", "go"), "vet": ("lint", "go")}.get(a0)
+    if base == "swift":
+        return {"test": ("test", "swift"), "build": ("build", "swift")}.get(a0)
+    if base in {"gradle", "gradlew"} or head in {"./gradlew"}:
+        # Gradle's ``check`` lifecycle task RUNS the test task, so it is a test
+        # run, not a lint — mapping it to lint would mislabel the kind.
+        for token in args:
+            if token in {"test", "check", "build"}:
+                return {"test": ("test", "gradle"), "check": ("test", "gradle"), "build": ("build", "gradle")}[token]
+        return None
+    if base == "mvn":
+        for token in args:
+            if token in {"test", "verify"}:
+                return ("test", "maven")
+            if token in {"package", "install"}:
+                return ("build", "maven")
+        return None
+    if base == "make":
+        return {
+            "test": ("test", "make"),
+            "build": ("build", "make"),
+            "lint": ("lint", "make"),
+            "typecheck": ("typecheck", "make"),
+            "check": ("test", "make"),
+        }.get(a0)
+    return None
+
+
+def classify_command(command: Any) -> tuple[str, str] | None:
+    """Recognize a check runner in a shell command. Returns ``(check_kind,
+    runner)`` or ``None`` when the command is not an unambiguous, single check
+    whose exit code the harness actually observes.
+
+    Conservative on THREE fronts, because the exit code the PostToolUse hook sees
+    is the whole line's, not any one command's:
+      * unparseable input, no recognized runner, or two DIFFERENT recognized
+        runners → ``None`` (ambiguous);
+      * a recognized runner whose failure would be MASKED by a later ``;``,
+        ``||``, ``|`` (e.g. ``pytest || true``, ``pytest | tail``) → ``None``:
+        the line can exit 0 while the check failed. Only a runner that is the
+        exit-code-determining command counts — the last segment, or one joined
+        to the end entirely by ``&&`` (where a failure short-circuits and
+        propagates);
+      * a non-verifying invocation (``--help``/``--version``/``--collect-only``,
+        or a file-rewriting formatter) → ``None`` (see ``_classify_segment``).
+    A missed check is honest; a mislabeled one is not.
+    """
+
+    text = command if isinstance(command, str) else ""
+    text = text.strip()
+    if not text:
+        return None
+    # A newline is a shell statement separator exactly like ``;`` — a runner on
+    # an earlier line does NOT determine the whole script's exit code. shlex folds
+    # newlines into ordinary whitespace and applies ``#`` comments per line, so
+    # split into lines first, tokenize each on its own, and insert an explicit
+    # ``;`` between lines. Without this, ``pytest\necho done`` would merge into
+    # one segment and a red suite followed by a passing last line reads as a pass.
+    tokens: list[str] = []
+    for line_index, line in enumerate(re.split(r"[\r\n]+", text)):
+        if line_index:
+            tokens.append(";")
+        try:
+            tokens.extend(shlex.split(line, comments=True))
+        except ValueError:
+            return None
+    if not tokens:
+        return None
+    # Split into (segment, operator-after) pairs, preserving the operator so we
+    # can tell whether a runner's exit status reaches the line's exit code.
+    segments: list[tuple[list[str], str | None]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in _SHELL_SEPARATORS:
+            segments.append((current, token))
+            current = []
+        else:
+            current.append(token)
+    segments.append((current, None))  # final segment carries no trailing operator
+
+    recognized: list[tuple[tuple[str, str], bool]] = []
+    count = len(segments)
+    for i, (segment, _operator) in enumerate(segments):
+        result = _classify_segment(segment)
+        if result is None:
+            continue
+        # Exit-determining iff every operator from this segment to the end is
+        # ``&&`` (a failure short-circuits and propagates). The final segment has
+        # no trailing operators, so it always qualifies.
+        exit_determining = all(segments[j][1] == "&&" for j in range(i, count - 1))
+        recognized.append((result, exit_determining))
+    if not recognized:
+        return None
+    # If any recognized runner's exit is MASKED, we cannot trust the line's exit
+    # code as that check's result — record nothing.
+    if any(not exit_determining for _result, exit_determining in recognized):
+        return None
+    distinct = {result for result, _exit_determining in recognized}
+    if len(distinct) == 1:
+        return next(iter(distinct))
+    return None  # zero or ambiguous (multiple different runners)
+
+
+def command_digest(command: str) -> str:
+    """A sha256 digest of the command — the ledger's identity for the check
+    without ever storing the command text itself."""
+
+    return "sha256:" + hashlib.sha256((command or "").encode("utf-8", "replace")).hexdigest()
+
+
+def mechanical_check_spool_path(store_dir: Path | str) -> Path:
+    return Path(store_dir) / _SPOOL_RELATIVE_PATH
+
+
+def record_mechanical_check_tick(
+    store_dir: Path | str,
+    *,
+    client: str,
+    session_id: str,
+    check_kind: str,
+    runner: str,
+    digest: str,
+    exit_code: int,
+    at: float,
+) -> None:
+    """Append ONE mechanical-check tick to the spool. Best-effort; never raises.
+
+    Only small scalars are written — the check kind, the runner name, a sha256
+    command digest, the exit code, the session, and a timestamp. Never the
+    command string, its arguments, or its output.
+    """
+
+    try:
+        if check_kind not in CHECK_KINDS:
+            return
+        client = str(client or "").strip()
+        session_id = str(session_id or "").strip()
+        if not client or not session_id:
+            return
+        if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+            return
+        target = mechanical_check_spool_path(store_dir)
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        line = json.dumps(
+            {
+                "c": client,
+                "s": session_id,
+                "k": check_kind,
+                "r": str(runner or "")[:160],
+                "d": str(digest or ""),
+                "x": int(exit_code),
+                "t": float(at),
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, (line + "\n").encode("utf-8"))
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001 - capture must never affect the hook.
+        return
+
+
+def _build_envelope(tick: Mapping[str, Any]) -> Any | None:
+    """Turn one spool tick into a validated ``machine_check_observed`` Evidence-v2
+    envelope, or ``None`` if it would not survive the ingestion's checks."""
+
+    from .evidence import EvidenceEnvelope
+
+    client = str(tick.get("c") or "").strip()
+    session = str(tick.get("s") or "").strip()
+    check_kind = str(tick.get("k") or "").strip()
+    runner = str(tick.get("r") or "").strip()
+    digest = str(tick.get("d") or "").strip()
+    exit_code = tick.get("x")
+    at = tick.get("t")
+    if not client or not session or check_kind not in CHECK_KINDS:
+        return None
+    if isinstance(exit_code, bool) or not isinstance(exit_code, int) or not -65_535 <= exit_code <= 65_535:
+        return None
+    if isinstance(at, bool) or not isinstance(at, (int, float)) or float(at) <= 0:
+        return None
+    if not _SAFE_RUNNER.fullmatch(runner) or not _SHA256.fullmatch(digest):
+        return None
+    try:
+        return EvidenceEnvelope.create(
+            assertion="observed",
+            event_type="machine_check_observed",
+            source_type="client_hook",
+            source_system=client,
+            source_instance=session,
+            source_schema="claude_code_post_tool_use.v1",
+            adapter="claude_code_post_tool_use",
+            event_timestamp=float(at),
+            dimensions=["machine_check"],
+            measurement_basis="hook_exit_code",
+            subjects={"client_session_id": session},
+            payload={
+                "capture_basis": "host_hook",
+                "attributes": {
+                    "check_kind": check_kind,
+                    "runner": runner,
+                    "command_digest": digest,
+                    "exit_code": int(exit_code),
+                    "passed": int(exit_code) == 0,
+                },
+            },
+            tags=["mechanical_capture"],
+        )
+    except Exception:  # noqa: BLE001 - a malformed tick must never break the drain.
+        return None
+
+
+def drain_mechanical_check_spool(
+    store_dir: Path | str,
+    *,
+    now: float | None = None,
+    token: str | None = None,
+) -> list[Any]:
+    """Consume the spool and return one Evidence-v2 envelope per valid tick.
+
+    The spool is atomically renamed aside before being read, so ticks that land
+    during the drain go to a freshly recreated spool and are picked up by the
+    NEXT drain (mirrors ``tool_activity.drain_tool_activity_spool``). Each
+    envelope's idempotency key is derived from its content, so re-importing an
+    identical check is deduped by the Evidence store, never double-counted.
+    """
+
+    spool = mechanical_check_spool_path(store_dir)
+    if not spool.exists():
+        return []
+    batch_token = token or uuid.uuid4().hex
+    consuming = spool.with_name(f".{spool.name}.consuming-{os.getpid()}-{batch_token}")
+    try:
+        os.replace(spool, consuming)
+    except (FileNotFoundError, OSError):
+        return []
+    try:
+        raw = consuming.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    finally:
+        try:
+            consuming.unlink()
+        except OSError:
+            pass
+    envelopes: list[Any] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            tick = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(tick, Mapping):
+            continue
+        envelope = _build_envelope(tick)
+        if envelope is not None:
+            envelopes.append(envelope)
+    return envelopes
+
+
+def ingest_mechanical_check_spool(
+    store_dir: Path | str,
+    *,
+    evidence: Any,
+    now: float | None = None,
+    token: str | None = None,
+) -> int:
+    """Drain the spool and append each check as a ``client_hook`` Evidence-v2
+    envelope via ``evidence.append``. Never raises; returns how many were written.
+    ``evidence`` is ``service.evidence`` (the fail-open EvidenceRuntime)."""
+
+    try:
+        envelopes = drain_mechanical_check_spool(store_dir, now=now, token=token)
+    except Exception:  # noqa: BLE001 - a spool drain must never fail the import.
+        return 0
+    written = 0
+    for envelope in envelopes:
+        try:
+            evidence.append(envelope)
+            written += 1
+        except Exception:  # noqa: BLE001 - one bad append must not abort the rest.
+            continue
+    return written
+
+
+__all__ = [
+    "CHECK_KINDS",
+    "classify_command",
+    "command_digest",
+    "mechanical_check_spool_path",
+    "record_mechanical_check_tick",
+    "drain_mechanical_check_spool",
+    "ingest_mechanical_check_spool",
+]

--- a/tests/test_hooks_claude_code.py
+++ b/tests/test_hooks_claude_code.py
@@ -764,11 +764,16 @@ def test_render_wrapper_embeds_absolute_path_with_bare_name_fallback():
 
     assert "'/opt/venv/bin/agent-sentinel'" in text
     assert "'agent-chronicle'" in text
-    # The wrapper dispatches on hook_event_name: SessionStart events run the
-    # session-start subcommand, everything else runs pre-tool-use. The parsed
+    # The wrapper dispatches on hook_event_name: SessionStart -> session-start,
+    # PostToolUse -> post-tool-use, everything else -> pre-tool-use. The parsed
     # event name lives in a module-global so the __main__ last-resort handler
     # fails open with the event-appropriate shape too.
-    assert '"session-start" if HOOK_EVENT == "SessionStart" else "pre-tool-use"' in text
+    assert '"SessionStart": "session-start"' in text
+    assert '"PostToolUse": "post-tool-use"' in text
+    assert '.get(HOOK_EVENT, "pre-tool-use")' in text
+    # PostToolUse (like SessionStart) fails open to an empty object, never a
+    # blocking decision.
+    assert 'hook_event in ("SessionStart", "PostToolUse")' in text
     assert '[executable, "hooks", "claude-code", subcommand, *AGENT_CHRONICLE_HOOK_ARGS]' in text
     # Bytes + replace: undecodable stdin can never raise before the event is known.
     assert 'sys.stdin.buffer.read().decode("utf-8", "replace")' in text

--- a/tests/test_mechanical_capture.py
+++ b/tests/test_mechanical_capture.py
@@ -1,0 +1,242 @@
+"""The PostToolUse mechanical-check capture pipeline (M2 P2): classify a command,
+spool it, drain into a client_hook Evidence-v2 envelope, and link it (option A)
+to the step active in its session at the check's time — which lifts that step to
+``independently_checked``. Privacy: a command's text/args/output are never
+recorded, only a category, a runner name, and a sha256 digest.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agentacct.hooks import capture_mechanical_check
+from agentacct.mechanical_capture import (
+    classify_command,
+    command_digest,
+    drain_mechanical_check_spool,
+    ingest_mechanical_check_spool,
+    mechanical_check_spool_path,
+    record_mechanical_check_tick,
+    _build_envelope,
+)
+from agentacct.mechanical_checks import build_mechanical_check_events
+from agentacct.task_outcome import step_evidence_grade
+from agentacct.api import _attach_evidence_to_task_projection, _link_mechanical_checks_by_session_time
+
+
+def test_classify_command_recognizes_common_runners() -> None:
+    assert classify_command("pytest -q") == ("test", "pytest")
+    assert classify_command("PYTHONPATH=src python -m pytest tests/") == ("test", "pytest")
+    assert classify_command("python3 -m mypy src") == ("typecheck", "mypy")
+    assert classify_command("npm run build") == ("build", "npm")
+    assert classify_command("yarn lint") == ("lint", "yarn")
+    assert classify_command("cargo test --all") == ("test", "cargo")
+    assert classify_command("cargo check") == ("typecheck", "cargo")
+    assert classify_command("ruff check .") == ("lint", "ruff")
+    assert classify_command("tsc --noEmit") == ("typecheck", "tsc")
+    assert classify_command("go test ./...") == ("test", "go")
+    assert classify_command("swift build") == ("build", "swift")
+    assert classify_command("poetry run pytest") == ("test", "pytest")
+    assert classify_command("uv run ruff check") == ("lint", "ruff")
+    assert classify_command("make test") == ("test", "make")
+    # gradle check RUNS the tests -> kind test, not lint.
+    assert classify_command("gradle check") == ("test", "gradle")
+    # ruff format is a check ONLY as a --check dry run.
+    assert classify_command("ruff format --check .") == ("lint", "ruff")
+    # A runner reached only after a non-runner &&-chain still determines the exit.
+    assert classify_command("cd repo && pytest") == ("test", "pytest")
+
+
+def test_classify_command_conservative_on_non_checks_and_ambiguity() -> None:
+    for command in ["echo hi", "ls -la", "git commit -m x", "cat f | grep x", "prettier --write ."]:
+        assert classify_command(command) is None
+    # Two DIFFERENT runners in one line is ambiguous — not captured.
+    assert classify_command("ruff check && pytest -q") is None
+    assert classify_command("") is None
+    assert classify_command(None) is None
+
+
+def test_classify_command_rejects_masked_exit_codes() -> None:
+    # The harness observes the LAST command's exit code, so a runner whose
+    # failure is masked by ;, ||, |, or a NEWLINE must not be recorded (a red
+    # suite could exit 0). && is safe (a failure short-circuits and propagates).
+    for command in [
+        "pytest || true", "pytest ; echo done", "pytest | tail -20", "npm test | cat",
+        # A newline is a statement separator: a runner that is not the LAST line
+        # does not determine the script's exit code.
+        "pytest tests/\necho done", "pytest\ngit status", "mypy src\r\necho finished",
+        "pytest  # run tests\necho ok",  # per-line comment must not hide the trailing echo
+    ]:
+        assert classify_command(command) is None, repr(command)
+    # But a runner that IS the last line still counts.
+    assert classify_command("cd repo\npytest -q") == ("test", "pytest")
+
+
+def test_classify_command_rejects_noop_probes_and_file_mutations() -> None:
+    # Nothing is verified by a help/version print, a dry listing, or a formatter
+    # that rewrites files — recording their exit 0 as a pass would forge the tier.
+    for command in ["pytest --version", "pytest --collect-only", "mypy --help", "tsc --init",
+                    "ruff --version", "ruff format .", "eslint --fix"]:
+        assert classify_command(command) is None, command
+
+
+def test_envelope_round_trips_into_a_client_hook_check() -> None:
+    tick = {"c": "claude-code", "s": "sess-1", "k": "test", "r": "pytest",
+            "d": command_digest("pytest -q"), "x": 0, "t": 1000.0}
+    envelope = _build_envelope(tick)
+    assert envelope is not None
+    rows = build_mechanical_check_events([envelope])
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["source_type"] == "client_hook"
+    assert row["result"] == "passed"
+    assert row["evidence_type"] == "test"
+    assert row["client_session_id"] == "sess-1"
+    # A hook check carries no section/work/run id — option A links it by time.
+    assert row["section_id"] is None and row["work_id"] is None and row["run_id"] is None
+    # The command text never appears anywhere on the wire.
+    assert row["command"] is None and row["command_redacted"] is True
+    assert "pytest -q" not in json.dumps(row, default=str)
+    # A failing exit code projects a failed check.
+    fail = build_mechanical_check_events([_build_envelope({**tick, "x": 1, "d": command_digest("pytest x")})])[0]
+    assert fail["result"] == "failed"
+
+
+def test_spool_record_drain_ingest(tmp_path) -> None:
+    record_mechanical_check_tick(tmp_path, client="claude-code", session_id="s", check_kind="test",
+                                 runner="pytest", digest=command_digest("pytest"), exit_code=0, at=100.0)
+    assert mechanical_check_spool_path(tmp_path).exists()
+    envelopes = drain_mechanical_check_spool(tmp_path)
+    assert len(envelopes) == 1
+    # The spool is consumed by the drain (rename-aside), so a second drain is empty.
+    assert drain_mechanical_check_spool(tmp_path) == []
+
+    class _FakeEvidence:
+        def __init__(self) -> None:
+            self.appended: list = []
+
+        def append(self, envelope) -> None:
+            self.appended.append(envelope)
+
+    record_mechanical_check_tick(tmp_path, client="claude-code", session_id="s", check_kind="lint",
+                                 runner="ruff", digest=command_digest("ruff check"), exit_code=0, at=200.0)
+    evidence = _FakeEvidence()
+    assert ingest_mechanical_check_spool(tmp_path, evidence=evidence) == 1
+    assert len(evidence.appended) == 1
+
+
+def _post_tool_use(command: str, exit_code, *, tool: str = "Bash") -> str:
+    return json.dumps({
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess-1",
+        "tool_name": tool,
+        "tool_input": {"command": command},
+        "tool_output": {"exit_code": exit_code, "stdout": "", "stderr": ""},
+    })
+
+
+def test_capture_hook_spools_a_check_only_for_recognized_commands(tmp_path) -> None:
+    capture_mechanical_check(_post_tool_use("pytest -q", 0), store_dir=tmp_path)
+    lines = mechanical_check_spool_path(tmp_path).read_text().splitlines()
+    assert len(lines) == 1
+    tick = json.loads(lines[0])
+    assert tick["k"] == "test" and tick["r"] == "pytest" and tick["x"] == 0
+    assert tick["d"].startswith("sha256:")
+    assert "pytest" == tick["r"] and "pytest -q" not in lines[0]  # command text not spooled
+
+    # Non-check command, non-Bash tool, and a missing exit code each spool nothing.
+    capture_mechanical_check(_post_tool_use("echo hi", 0), store_dir=tmp_path)
+    capture_mechanical_check(_post_tool_use("pytest", 0, tool="Read"), store_dir=tmp_path)
+    capture_mechanical_check(json.dumps({"hook_event_name": "PostToolUse", "session_id": "s",
+                                         "tool_name": "Bash", "tool_input": {"command": "pytest"},
+                                         "tool_output": {"stdout": ""}}), store_dir=tmp_path)
+    assert len(mechanical_check_spool_path(tmp_path).read_text().splitlines()) == 1  # still just the first
+
+
+def _hook_check(session: str, at: float, result: str = "passed") -> dict:
+    return {"event_id": f"evidence:{at}", "source_type": "client_hook", "result": result,
+            "client_session_id": session, "created_at": at, "evidence_type": "test",
+            "check_identity": f"client-hook:{at}", "check_identity_stable": True}
+
+
+def test_link_attaches_hook_check_to_the_step_active_at_its_time() -> None:
+    task = {
+        "task_id": "t1",
+        "work_items": [
+            {"work_id": "w1", "client_session_id": "S", "kind": "implementation", "latest_status": "completed", "started_at": 100.0, "current_check_events": []},
+            {"work_id": "w2", "client_session_id": "S", "kind": "implementation", "latest_status": "completed", "started_at": 200.0, "current_check_events": []},
+        ],
+        "current_check_events": [_hook_check("S", 250.0)],
+    }
+    _link_mechanical_checks_by_session_time({"tasks": [task]})
+    # Both steps are check-relevant; the check ran at 250, so the most recent one
+    # (w2, started 200) is credited, not w1.
+    assert len(task["work_items"][1]["current_check_events"]) == 1
+    assert task["work_items"][0]["current_check_events"] == []
+    # And w2 now grades independently_checked (a hook-observed pass, not the agent's word).
+    assert step_evidence_grade(task["work_items"][1])["grade"] == "independently_checked"
+
+
+def test_link_skips_non_check_relevant_steps() -> None:
+    # A docs step is never credited with a test pass — the check goes to the
+    # active CHECK-RELEVANT step (the implementation a test actually exercises).
+    task = {
+        "task_id": "t1",
+        "work_items": [
+            {"work_id": "w1", "client_session_id": "S", "kind": "implementation", "latest_status": "completed", "started_at": 100.0, "current_check_events": []},
+            {"work_id": "w2", "client_session_id": "S", "kind": "docs", "latest_status": "completed", "started_at": 200.0, "current_check_events": []},
+        ],
+        "current_check_events": [_hook_check("S", 250.0)],
+    }
+    _link_mechanical_checks_by_session_time({"tasks": [task]})
+    assert step_evidence_grade(task["work_items"][0])["grade"] == "independently_checked"  # w1 impl
+    assert not task["work_items"][1].get("current_check_events")  # w2 docs untouched
+
+
+def test_link_does_not_attach_a_failing_hook_check() -> None:
+    # A failing hook check is not guessed onto a step — no false demotion; it
+    # stays task-level (visible on the decision axis).
+    task = {
+        "task_id": "t1",
+        "work_items": [
+            {"work_id": "w1", "client_session_id": "S", "kind": "implementation", "latest_status": "completed", "started_at": 100.0, "current_check_events": []},
+        ],
+        "current_check_events": [_hook_check("S", 250.0, result="failed")],
+    }
+    _link_mechanical_checks_by_session_time({"tasks": [task]})
+    assert not task["work_items"][0].get("current_check_events")
+
+
+def test_real_attach_then_link_lights_up_independently_checked() -> None:
+    # The full projection flow: _attach routes a hook check to the task level
+    # (no section id), then _link places it on the step active at its time — the
+    # payoff the whole hook exists for.
+    task = {
+        "task_id": "t1",
+        "session_keys": [{"client": "claude-code", "client_session_id": "S"}],
+        "sessions": [{"client": "claude-code", "client_session_id": "S", "namespace_fingerprint": ""}],
+        "work_items": [
+            {"work_id": "w1", "client": "claude-code", "client_session_id": "S", "latest_status": "completed", "started_at": 100.0, "evidence_events": []},
+            {"work_id": "w2", "client": "claude-code", "client_session_id": "S", "latest_status": "completed", "started_at": 200.0, "evidence_events": []},
+        ],
+    }
+    proj = {"tasks": [task], "unresolved_work": []}
+    check = {"event_id": "evidence:x", "source_type": "client_hook", "source": "claude-code",
+             "client": "claude-code", "result": "passed", "client_session_id": "S", "created_at": 250.0,
+             "evidence_type": "test", "check_identity": "client-hook:abc", "check_identity_stable": True}
+    _attach_evidence_to_task_projection(proj, [check], require_namespace_for_client_hook=False)
+    _link_mechanical_checks_by_session_time(proj)
+    assert step_evidence_grade(task["work_items"][1])["grade"] == "independently_checked"
+    assert not task["work_items"][0].get("current_check_events")
+
+
+def test_link_leaves_a_pre_step_check_unattached() -> None:
+    task = {
+        "task_id": "t1",
+        "work_items": [
+            {"work_id": "w1", "client_session_id": "S", "latest_status": "completed", "started_at": 100.0, "current_check_events": []},
+        ],
+        "current_check_events": [_hook_check("S", 50.0)],  # ran before any step began
+    }
+    _link_mechanical_checks_by_session_time({"tasks": [task]})
+    assert task["work_items"][0]["current_check_events"] == []  # honest: stays unattributed


### PR DESCRIPTION
## What

Adds **independent checks from a Claude Code PostToolUse hook** — the only local evidence that is not the agent's own word. When the agent runs a recognized test / build / lint / typecheck command, the hook records the exit code the HARNESS observed and projects it as a `client_hook` machine check, which lifts that step from `self-checked` to `independently-checked`.

- **Privacy** holds the WorkEvent line: only a coarse check kind, the runner name, and a **sha256 digest** of the command are ever recorded — never the command string, its arguments, environment, or output. Verified end-to-end (spool → envelope → projected check → every surface).
- **Read-only**: the hook never blocks or edits a tool result; every capture path fails open and returns an empty response.
- **Conservative classification**: a command is captured only when a recognized runner actually determines the line's exit code AND actually runs a check. Skipped: exit codes masked by `;` / `||` / `|` / a newline (`pytest || true`, `pytest | tail`, a multi-line script whose last line is an `echo`), no-op probes (`--version`, `--collect-only`, `--help`), and file-rewriting formatters (`ruff format`, `eslint --fix`). A missed check is honest; a mislabeled one is not.
- **Linkage (session + time, option A)**: a hook check carries no section id, so a **passing** check is credited to the most recent **check-relevant** step in its session at or before the check's time; a failing check is never guessed onto a step; any check that fits no eligible step stays disclosed as an unattributed check in the Receipt ledger.

Pipeline: `mechanical_capture` (classify → spool → drain → a `machine_check_observed` Evidence-v2 envelope → `service.evidence.append`), `hooks.capture_mechanical_check`, a `post-tool-use` CLI subcommand, an `import-local` drain, and `api._link_mechanical_checks_by_session_time`. The wrapper and `settings.json` now wire a PostToolUse entry — run `agentacct hooks claude-code install --force` (or `agentacct onboard`) to add it.

## Testing

- Full suite: **2985 passed, 1 skipped**.
- **Two adversarial review rounds** (find → verify → synthesize). The first (15 agents) found 4 honesty defects — shell-masked exit codes, no-op/mutation invocations, `gradle check` mislabeled as lint, and linkage mis-attribution (a test crediting a docs step / a failing test demoting an unrelated verified step). A targeted re-verify found a 5th — newline statement separators. **All fixed and regression-tested** (`tests/test_mechanical_capture.py`). Privacy, fail-open, envelope construction, and the spool/drain plumbing reviewed **clean**.

## Base

Branches off `main` (includes #86). No Swift change — the app already renders `independently-checked` from #86.
