### PR TITLE
feat(receipt): show handed_off as a recency-aware lifecycle marker beside the decision word

### DIFF
--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -85,6 +85,12 @@ struct ReceiptRow: View {
             HStack(spacing: 6) {
                 AxisChip(text: task.decisionStatus.key, tint: receiptDecisionTint(task.decisionStatus.key))
                 AxisChip(text: task.evidenceStrength.compactHeadline, tint: receiptEvidenceTint(task.evidenceStrength.key))
+                // Parallel deliberate-stop marker, shown only when it adds info the
+                // decision word does not already state. Purple unifies with the
+                // step-level handoff chip (Theme.statusColor("handed_off")).
+                if task.handedOff == true && task.decisionStatus.key != "handed_off" {
+                    AxisChip(text: "↗ handed off", tint: Theme.purple)
+                }
                 Spacer()
                 Text(task.cost.text).font(.caption).foregroundStyle(Theme.textMuted)
             }
@@ -150,6 +156,18 @@ struct ReceiptCards: View {
                     detail: assertedText(receipt.axes.decisionStatus.assertedBy),
                     note: receipt.axes.decisionStatus.statement
                 )
+                // Lifecycle marker, shown BESIDE the decision word (not instead of
+                // it) when it adds information the decision word does not state.
+                if let handoff = receipt.axes.handoff, handoff.handedOff == true,
+                   receipt.axes.decisionStatus.key != "handed_off" {
+                    axisRow(
+                        label: "Lifecycle",
+                        key: "↗ handed off",
+                        tint: Theme.purple,
+                        detail: assertedText(handoff.assertedBy),
+                        note: handoff.statement
+                    )
+                }
                 evidenceCoverageRow(receipt.axes.evidenceStrength)
                 if let orthogonality = receipt.axes.orthogonalityNote {
                     Text(orthogonality).font(.caption).foregroundStyle(Theme.textFaint)

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -419,6 +419,9 @@ struct ReceiptSummary: Decodable, Identifiable {
     let sessionCount: Int?
     let primaryRoot: ReceiptSessionRef?
     let lastActivityAt: Double?
+    // Recency-aware handoff lifecycle marker (parallel to the decision word).
+    // Optional so an older daemon payload without the field still decodes.
+    let handedOff: Bool?
 
     var id: String { taskId }
 
@@ -431,6 +434,7 @@ struct ReceiptSummary: Decodable, Identifiable {
         case sessionCount = "session_count"
         case primaryRoot = "primary_root"
         case lastActivityAt = "last_activity_at"
+        case handedOff = "handed_off"
     }
 }
 
@@ -620,12 +624,32 @@ struct Receipt: Decodable {
 struct ReceiptAxes: Decodable {
     let decisionStatus: ReceiptDecision
     let evidenceStrength: ReceiptEvidence
+    // A third, orthogonal signal: the deliberate-stop lifecycle marker, kept out
+    // of decisionStatus so a handoff shows BESIDE a finding/blocked headline.
+    // Optional so an older daemon payload without the field still decodes.
+    let handoff: ReceiptHandoff?
     let orthogonalityNote: String?
 
     enum CodingKeys: String, CodingKey {
         case decisionStatus = "decision_status"
         case evidenceStrength = "evidence_strength"
+        case handoff
         case orthogonalityNote = "orthogonality_note"
+    }
+}
+
+/// The handoff lifecycle marker. ``handedOff`` is the recency-aware disposition
+/// from the daemon — true only when the handoff is the Task's frontier (nothing
+/// still-open is newer), so a resumed Task does not carry it.
+struct ReceiptHandoff: Decodable {
+    let handedOff: Bool?
+    let statement: String?
+    let assertedBy: String?
+
+    enum CodingKeys: String, CodingKey {
+        case handedOff = "handed_off"
+        case statement
+        case assertedBy = "asserted_by"
     }
 }
 

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -9033,6 +9033,13 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
     )
     if decision.get("statement"):
         console.print(f"                     [dim]{_rich_escape(str(decision['statement']))}[/dim]")
+    handoff = axes.get("handoff", {})
+    if handoff.get("handed_off") and str(decision.get("key") or "") != "handed_off":
+        # The deliberate-stop lifecycle marker, shown BESIDE the decision word (not
+        # instead of it) so a finding/blocked headline never hides the handoff.
+        console.print("  Lifecycle          [magenta]↗ Handed off[/magenta]")
+        if handoff.get("statement"):
+            console.print(f"                     [dim]{_rich_escape(str(handoff['statement']))}[/dim]")
     console.print(f"  Evidence coverage  [bold]{_rich_escape(evidence_coverage_headline(evidence))}[/bold]")
     ledger = evidence_coverage_ledger(evidence)
     if ledger:
@@ -9152,10 +9159,16 @@ def receipts(
     table.add_column("Evidence coverage")
     table.add_column("Cost")
     for row in rows:
+        decision_key = str(row["decision_status"]["key"])
+        decision_cell = decision_key
+        if row.get("handed_off") and decision_key != "handed_off":
+            # Parallel lifecycle marker: shown beside a finding/blocked/… word so a
+            # clean handoff is never hidden by the louder problem.
+            decision_cell += "  [magenta]↗ handed off[/magenta]"
         table.add_row(
             str(row["task_id"])[:16],
             _rich_escape(str(row.get("title") or "")[:48]),
-            str(row["decision_status"]["key"]),
+            decision_cell,
             _rich_escape(evidence_coverage_headline(row.get("evidence_strength") or {})),
             _receipt_cost_text(row.get("cost") or {}),
         )

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -387,8 +387,10 @@ def _decision_status(
     task: Mapping[str, Any],
     *,
     latest_store_activity_at: float | None,
+    canonical: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
+    if canonical is None:
+        canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
     key = _text(canonical.get("key")) or "observed"
 
     # Refine ``failed`` out of ``blocked`` at the Receipt layer without changing
@@ -420,6 +422,27 @@ def _decision_status(
         "statement": statement,
         "asserted_by": asserted_by,
         "finding_attention_state": attention or None,
+    }
+
+
+def _handoff_marker(canonical: Mapping[str, Any]) -> dict[str, Any]:
+    """The handoff LIFECYCLE marker — a signal kept deliberately SEPARATE from the
+    decision word, alongside the two axes.
+
+    A Task can read ``finding`` (a red check you must act on) AND still have been
+    cleanly handed off: the decision word carries the louder problem, this marker
+    carries the deliberate stop, and neither hides the other. ``handed_off`` here
+    is the recency-aware disposition from ``reduce_task_outcome`` — true only when
+    the handoff is the frontier (nothing still-open is newer than it), so a Task
+    that was handed off and then RESUMED does not carry the marker. Surfaces show
+    the chip only when it adds information the decision word does not already state
+    (i.e. ``handed_off`` is true AND ``decision_status.key != "handed_off"``)."""
+
+    handed_off = bool(canonical.get("handoff_current"))
+    return {
+        "handed_off": handed_off,
+        "statement": _DECISION_STATEMENTS["handed_off"] if handed_off else None,
+        "asserted_by": "agent_report",
     }
 
 
@@ -811,7 +834,11 @@ def build_receipt(
     verification = step_verification_counts(task)
     checks = _project_checks(task)
     evidence_strength = _evidence_strength(task, checks, verification)
-    decision = _decision_status(task, latest_store_activity_at=latest_store_activity_at)
+    canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
+    decision = _decision_status(
+        task, latest_store_activity_at=latest_store_activity_at, canonical=canonical
+    )
+    handoff = _handoff_marker(canonical)
     decision_brief = _mapping(intelligence.get("decision_brief"))
 
     dimensions: dict[str, dict[str, Any]] = {
@@ -838,6 +865,10 @@ def build_receipt(
         "axes": {
             "decision_status": decision,
             "evidence_strength": evidence_strength,
+            # A third, orthogonal signal: the deliberate-stop lifecycle marker.
+            # Kept out of ``decision_status`` on purpose so a handoff can be shown
+            # BESIDE a finding/blocked headline instead of being masked by it.
+            "handoff": handoff,
             "orthogonality_note": (
                 "Evidence coverage and decision status are separate axes: an agent reporting "
                 "'done' never adds a passing check, and a human review or approval never "
@@ -878,7 +909,10 @@ def build_receipt_summary(
     verification = step_verification_counts(task)
     checks = _project_checks(task)
     evidence_strength = _evidence_strength(task, checks, verification)
-    decision = _decision_status(task, latest_store_activity_at=latest_store_activity_at)
+    canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
+    decision = _decision_status(
+        task, latest_store_activity_at=latest_store_activity_at, canonical=canonical
+    )
     usage = _mapping(task.get("usage"))
     return {
         "task_id": public_task_id,
@@ -888,6 +922,11 @@ def build_receipt_summary(
             "label": decision["label"],
             "asserted_by": decision["asserted_by"],
         },
+        # The recency-aware handoff lifecycle marker for the list row's parallel
+        # chip. A flat bool keeps the row compact; the detail Receipt carries the
+        # full ``axes.handoff`` object. Rendered as a chip only when it is not
+        # already the decision word (see ``_handoff_marker``).
+        "handed_off": bool(canonical.get("handoff_current")),
         "evidence_strength": {
             "key": evidence_strength["key"],
             "gradeable": evidence_strength["gradeable"],

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -461,6 +461,32 @@ def reduce_task_outcome(
         ),
         default=0.0,
     )
+    # Handoff DISPOSITION (recency-aware), computed up front so EVERY return path
+    # carries it — even ``blocked``/``finding``, where a red check outranks the
+    # handoff in the decision WORD but the handoff fact must still be shown beside
+    # it. A handoff is the Task's CURRENT disposition only when it is the frontier:
+    # there is a ``handed_off`` step and NO still-open step is newer than the
+    # newest handoff. If a later step reopened the work (an open step postdates the
+    # handoff), the Task genuinely resumed and is in progress — the handoff is
+    # history, not the headline. A tie (equal timestamps) resolves to the handoff:
+    # a deliberate stop is a more honest summary than an incidental open step
+    # beside it. This is what lets the task headline finally agree with the
+    # per-session badge (``v1_sessions``/``glance``), which already ranks
+    # ``handed_off`` above ``in_progress``.
+    _handoff_times = [
+        _number(item.get("updated_at") or item.get("started_at"))
+        for item, status in zip(items, statuses)
+        if status == _HANDED_OFF_STATUS
+    ]
+    _open_times = [
+        _number(item.get("updated_at") or item.get("started_at"))
+        for item, status in zip(items, statuses)
+        if status in _ACTIVE_STATUSES
+    ]
+    newest_handoff_at = max(_handoff_times, default=None)
+    handoff_current = newest_handoff_at is not None and (
+        not _open_times or newest_handoff_at >= max(_open_times)
+    )
     checks = latest_task_checks(task)
     # Explicit work state is the product's user-action contract. A current
     # failed check may explain the blocker, but it must never demote a
@@ -476,6 +502,7 @@ def reduce_task_outcome(
             "latest_checks": checks,
             "max_work_updated_at": max_work_updated_at,
             "open_step_count": open_step_count,
+            "handoff_current": handoff_current,
             **step_counts,
         }
     current_failures = [
@@ -531,6 +558,7 @@ def reduce_task_outcome(
                 "finding_attention_state": attention_state,
                 "max_work_updated_at": max_work_updated_at,
                 "open_step_count": open_step_count,
+                "handoff_current": handoff_current,
                 **step_counts,
             }
         # Every current failure was superseded by a later same-scope pass: the
@@ -545,6 +573,7 @@ def reduce_task_outcome(
             "superseded_findings": superseded_failures,
             "max_work_updated_at": max_work_updated_at,
             "open_step_count": open_step_count,
+            "handoff_current": handoff_current,
             **step_counts,
         }
     if statuses and any(status == _RESOLVED_STATUS for status in statuses) and all(
@@ -554,6 +583,16 @@ def reduce_task_outcome(
         # An explicit blocker resolution is an evidence-backed agent claim,
         # not a completion report and not authoritative verification.
         key = "resolved"
+    elif handoff_current:
+        # DECISION 1 (reordered): a clean handoff is the Task's disposition even
+        # when a step is still open, PROVIDED the handoff is the frontier (see
+        # ``handoff_current`` above — nothing still-open is newer than it). Moved
+        # ABOVE the open-step branch: one stray open step must no longer bury a
+        # deliberate stop. It stays BELOW ``blocked``/``finding`` (the early
+        # returns), so a red check recorded at handoff time is never hidden. A
+        # deliberate stop — never a completed/verified claim, never a
+        # blocker/failure.
+        key = "handed_off"
     elif open_step_count:
         # DECISION 3a: one un-closed step must not drag a mostly-finished Task to
         # plain "in progress" — but silence is NOT evidence of abandonment. The
@@ -578,11 +617,6 @@ def reduce_task_outcome(
         key = "mostly_done" if left_behind else "in_progress"
     elif not items:
         key = "observed"
-    elif any(status == _HANDED_OFF_STATUS for status in statuses):
-        # DECISION 1: every step is terminal and at least one was a clean
-        # handoff. A deliberate stop — never a completed/verified claim, never a
-        # blocker/failure.
-        key = "handed_off"
     else:
         all_successful = all(status in _SUCCESS_STATUSES for status in statuses)
         passing_checks = [event for event in checks if _text(event.get("result")).lower() == "passed"]
@@ -619,6 +653,7 @@ def reduce_task_outcome(
         "latest_checks": checks,
         "max_work_updated_at": max_work_updated_at,
         "open_step_count": open_step_count,
+        "handoff_current": handoff_current,
         **step_counts,
     }
 

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1221,6 +1221,13 @@ def _render_receipt_markup(receipt: dict) -> str:
     )
     if decision.get("statement"):
         lines.append(f"                   [dim]{_escape(str(decision['statement']))}[/]")
+    handoff = axes.get("handoff") or {}
+    if handoff.get("handed_off") and str(decision.get("key") or "") != "handed_off":
+        # Parallel deliberate-stop marker beside the decision word (never instead
+        # of it), so a finding/blocked headline does not hide a clean handoff.
+        lines.append("Lifecycle          [b magenta]↗ Handed off[/]")
+        if handoff.get("statement"):
+            lines.append(f"                   [dim]{_escape(str(handoff['statement']))}[/]")
     from .receipt import evidence_coverage_headline, evidence_coverage_ledger
 
     lines.append(f"Evidence coverage  [b {ecolor}]{_escape(evidence_coverage_headline(evidence))}[/]")
@@ -1391,9 +1398,13 @@ class ReceiptsScreen(Screen):
             self._by_id[task_id] = task
             decision = summary["decision_status"]
             evidence = summary["evidence_strength"]
+            decision_cell = f"[{_receipt_decision_color(decision['key'])}]{decision['key']}[/]"
+            if summary.get("handed_off") and str(decision["key"]) != "handed_off":
+                # Parallel deliberate-stop marker beside the decision word.
+                decision_cell += " [magenta]↗ handed off[/]"
             table.add_row(
                 _escape(str(summary.get("title") or task_id))[:46],
-                f"[{_receipt_decision_color(decision['key'])}]{decision['key']}[/]",
+                decision_cell,
                 f"[{_receipt_evidence_color(evidence['key'])}]{_escape(evidence_coverage_headline(evidence))}[/]",
                 _escape(_receipt_summary_cost(summary.get("cost") or {})),
                 _humanize_ago(summary.get("last_activity_at"), now),

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -114,6 +114,74 @@ def test_receipt_has_all_eight_dimensions_and_two_named_axes() -> None:
         assert "gaps" in receipt["dimensions"][name]
 
 
+def test_receipt_exposes_handoff_marker_axis_and_summary_flag() -> None:
+    # A handed_off frontier surfaces as BOTH the decision word and the parallel
+    # handoff axis; the compact summary carries the flat bool for the list row.
+    from agentacct.receipt import build_receipt_summary
+
+    task = _task(
+        [
+            {"work_id": "a", "latest_status": "completed", "updated_at": 100.0},
+            {"work_id": "b", "latest_status": "handed_off", "updated_at": 200.0},
+        ]
+    )
+    receipt = _receipt(task)
+    assert receipt["axes"]["handoff"]["handed_off"] is True
+    assert receipt["axes"]["handoff"]["statement"]
+    assert receipt["axes"]["handoff"]["asserted_by"] == "agent_report"
+    assert receipt["axes"]["decision_status"]["key"] == "handed_off"
+
+    summary = build_receipt_summary(task, public_task_id="task_x", title="t")
+    assert summary["handed_off"] is True
+
+
+def test_blocked_receipt_still_carries_the_handoff_marker() -> None:
+    # A hard problem (blocked/finding) outranks the handoff in the decision WORD,
+    # but the handoff fact must not vanish — it rides the parallel axis so a
+    # surface can show it beside the red headline.
+    task = _task(
+        [
+            {"work_id": "a", "latest_status": "blocked", "updated_at": 100.0},
+            {"work_id": "b", "latest_status": "handed_off", "updated_at": 200.0},
+        ]
+    )
+    receipt = _receipt(task)
+    assert receipt["axes"]["decision_status"]["key"] in {"blocked", "failed"}
+    assert receipt["axes"]["handoff"]["handed_off"] is True
+
+
+def test_resumed_task_receipt_shows_no_handoff_marker() -> None:
+    # A later open step postdates the handoff: the Task resumed, so neither the
+    # decision word nor the marker report a handoff. Assert BOTH the detail axis
+    # AND the flat summary flag (the two are independent expressions that drive
+    # the detail view vs the list row) so a non-recency regression of either is
+    # caught — the list row is the exact dogfood surface this PR fixes.
+    from agentacct.receipt import build_receipt_summary
+
+    task = _task(
+        [
+            {"work_id": "a", "latest_status": "handed_off", "updated_at": 100.0},
+            {"work_id": "b", "latest_status": "started", "updated_at": 200.0},
+        ]
+    )
+    receipt = _receipt(task)
+    assert receipt["axes"]["decision_status"]["key"] == "in_progress"
+    assert receipt["axes"]["handoff"]["handed_off"] is False
+    summary = build_receipt_summary(task, public_task_id="task_x", title="t")
+    assert summary["handed_off"] is False
+
+
+def test_summary_handed_off_flag_is_false_without_any_handoff() -> None:
+    # The flat list-row flag must be False for a task that never handed off — a
+    # plain completed task must never paint a handoff chip.
+    from agentacct.receipt import build_receipt_summary
+
+    task = _task([{"work_id": "a", "latest_status": "completed", "updated_at": 100.0}])
+    summary = build_receipt_summary(task, public_task_id="task_x", title="t")
+    assert summary["handed_off"] is False
+    assert _receipt(task)["axes"]["handoff"]["handed_off"] is False
+
+
 def test_agent_reported_done_is_never_evidence_checked() -> None:
     # A completed step with no linked check: the agent SAID done, nothing PROVES
     # it — so it sits in the 'unchecked' tier, never any CHECKED tier.

--- a/tests/test_receipt_cli.py
+++ b/tests/test_receipt_cli.py
@@ -76,6 +76,88 @@ def _seed(store: Path, *, title: str = "Add rate limit to login") -> None:
     )
 
 
+def _add_section(store: Path, *, section_id: str, status: str, at: float) -> None:
+    SentinelService(store).record_event(
+        {
+            "event_id": f"evt_{section_id}",
+            "created_at": at,
+            "source": "claude-code",
+            "event_type": f"section_{status}",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "client_context_keys_authored": ["client_session_id"],
+                "project_dir": "/tmp/project",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": section_id,
+                "section_status": status,
+                "section_title": "handoff task",
+                "objective": "handoff task",
+                "kind": "implementation",
+            },
+        }
+    )
+
+
+def test_receipts_show_handoff_marker_beside_a_hard_problem(tmp_path: Path) -> None:
+    # End-to-end: a blocked step + a later handoff → the decision word is the hard
+    # problem (BLOCKED) while the deliberate stop rides a parallel marker in both
+    # the list and the detail. This is the dogfood bug the change fixes.
+    _seed(tmp_path)  # session s1 + one completed section
+    _add_section(tmp_path, section_id="sec-blocked", status="blocked", at=150.0)
+    _add_section(tmp_path, section_id="sec-handoff", status="handed_off", at=200.0)
+
+    listing = runner.invoke(app, ["receipts", "--store-dir", str(tmp_path)])
+    assert listing.exit_code == 0, listing.output
+    assert "handed off" in listing.output.lower()
+
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "BLOCKED" in detail.output  # the hard problem is the decision word
+    assert "Handed off" in detail.output  # the parallel marker is still shown
+
+
+def test_receipts_pure_handoff_shows_no_duplicate_marker(tmp_path: Path) -> None:
+    # Invariant #4 end-to-end: a cleanly handed-off task's decision word IS
+    # handed_off, so the parallel "↗ handed off" marker must be suppressed — the
+    # handoff is never stated twice. (Only the completed + handed_off sections;
+    # no open successor, so the decision word is handed_off.)
+    _seed(tmp_path)  # session s1 + one completed section
+    _add_section(tmp_path, section_id="sec-handoff", status="handed_off", at=200.0)
+
+    listing = runner.invoke(app, ["receipts", "--store-dir", str(tmp_path)])
+    assert listing.exit_code == 0, listing.output
+    assert "handed_off" in listing.output  # the decision word itself
+    assert "↗" not in listing.output  # but NOT the parallel marker glyph
+
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "HANDED_OFF" in detail.output
+    assert "Lifecycle" not in detail.output  # no duplicate marker row
+
+
+def test_receipts_list_hides_marker_for_a_resumed_task(tmp_path: Path) -> None:
+    # Invariant #3 end-to-end on the list surface: a task handed off then resumed
+    # (a later open step) must show NO handoff marker anywhere — the exact stale-
+    # marker failure the recency guard prevents.
+    _seed(tmp_path)  # session s1 + one completed section
+    _add_section(tmp_path, section_id="sec-handoff", status="handed_off", at=150.0)
+    _add_section(tmp_path, section_id="sec-open", status="started", at=200.0)
+
+    listing = runner.invoke(app, ["receipts", "--store-dir", str(tmp_path)])
+    assert listing.exit_code == 0, listing.output
+    assert "↗" not in listing.output  # no stale handoff marker
+
+
 def test_receipts_list_json(tmp_path: Path) -> None:
     _seed(tmp_path)
     result = runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)])

--- a/tests/test_receipt_tui.py
+++ b/tests/test_receipt_tui.py
@@ -112,6 +112,72 @@ def test_render_receipt_markup_contains_axes_and_dimensions() -> None:
     assert "unchecked" in markup
 
 
+def _handoff_task(items: list[dict]) -> dict:
+    return {
+        "task_id": "task_x",
+        "primary_root": {"client": "claude-code", "client_session_id": "s1"},
+        "root_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "session_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "sessions": [
+            {"client": "claude-code", "client_session_id": "s1", "project": "acme", "identity_scope_state": "explicit", "last_activity_at": 100.0, "usage": {}}
+        ],
+        "session_count": 1,
+        "supporting_count": 0,
+        "child_count": 0,
+        "internal_count": 0,
+        "last_activity_at": 100.0,
+        "work_items": items,
+        "work_associations": [],
+        "usage": {"rows": 1, "estimated_cost_usd": 0.5, "cost_complete": True, "cost_basis": "pricing_table", "total_tokens": 1000},
+        "models": ["claude-opus-4-8"],
+        "actions": {"tool_category_counts": {}, "tool_category_total": 0, "touched_files": [], "touched_file_count": 0},
+    }
+
+
+def test_render_receipt_markup_shows_handoff_marker_beside_a_hard_problem() -> None:
+    # A blocked headline must still surface the parallel handoff marker.
+    task = _handoff_task(
+        [
+            {"work_id": "a", "latest_status": "blocked", "updated_at": 100.0, "objective": "x"},
+            {"work_id": "b", "latest_status": "handed_off", "updated_at": 200.0, "objective": "y"},
+        ]
+    )
+    markup = _render_receipt_markup(build_receipt(task, public_task_id="task_x", title="t"))
+    assert "Lifecycle" in markup
+    assert "Handed off" in markup
+
+
+def test_render_receipt_markup_no_double_marker_for_pure_handoff() -> None:
+    # Invariant #4: when the decision word IS "handed_off", the parallel marker
+    # must be suppressed — the handoff must never be stated twice. The data flag
+    # is on here (handoff_current True); only the decision-key guard suppresses
+    # the marker, so this pins that guard (a resumed-task test cannot — its flag
+    # is already off).
+    task = _handoff_task(
+        [
+            {"work_id": "a", "latest_status": "completed", "updated_at": 100.0, "objective": "x"},
+            {"work_id": "b", "latest_status": "handed_off", "updated_at": 200.0, "objective": "y"},
+        ]
+    )
+    receipt = build_receipt(task, public_task_id="task_x", title="t")
+    assert receipt["axes"]["decision_status"]["key"] == "handed_off"
+    assert receipt["axes"]["handoff"]["handed_off"] is True  # data flag on...
+    markup = _render_receipt_markup(receipt)
+    assert "Lifecycle" not in markup  # ...but the marker line is suppressed
+
+
+def test_render_receipt_markup_hides_marker_when_task_resumed() -> None:
+    # A later open step postdates the handoff: no stale marker is shown.
+    task = _handoff_task(
+        [
+            {"work_id": "a", "latest_status": "handed_off", "updated_at": 100.0, "objective": "x"},
+            {"work_id": "b", "latest_status": "started", "updated_at": 200.0, "objective": "y"},
+        ]
+    )
+    markup = _render_receipt_markup(build_receipt(task, public_task_id="task_x", title="t"))
+    assert "Lifecycle" not in markup
+
+
 def test_receipts_screen_lists_a_task_and_opens_its_detail(tmp_path: Path) -> None:
     _seed(tmp_path)
 

--- a/tests/test_task_outcome.py
+++ b/tests/test_task_outcome.py
@@ -464,6 +464,7 @@ def test_every_return_path_carries_open_step_count() -> None:
     # now carries it plus the sibling verification counts.
     count_keys = {
         "open_step_count",
+        "handoff_current",
         "verified_step_count",
         "total_step_count",
         "agent_reported_step_count",
@@ -516,3 +517,69 @@ def test_every_return_path_carries_open_step_count() -> None:
     # fall-through, and still classify as before.
     assert reduce_task_outcome(blocked)["key"] == "blocked"
     assert reduce_task_outcome(finding)["key"] == "finding"
+
+
+# --- Handoff as a recency-aware disposition (a clean stop, not "mostly done") ---
+
+
+def test_handoff_frontier_outranks_a_still_open_step() -> None:
+    # THE FIX: a clean handoff that is the Task's frontier (nothing still-open is
+    # newer) is the disposition even though one step is still open. Before, the
+    # open-step branch was checked first, so a single stray open step buried the
+    # handoff under "in progress"/"mostly done".
+    task = _multi_task(
+        [_step("started", updated_at=_NOW), _step("handed_off", updated_at=_NOW + 100)]
+    )
+    outcome = reduce_task_outcome(task)
+    assert outcome["key"] == "handed_off"
+    assert outcome["handoff_current"] is True
+
+
+def test_handoff_ties_with_open_step_resolve_to_handoff() -> None:
+    # A deliberate stop is a more honest summary than an incidental open step at
+    # the same instant, so an equal-timestamp tie resolves to the handoff.
+    task = _multi_task(
+        [_step("started", updated_at=_NOW), _step("handed_off", updated_at=_NOW)]
+    )
+    outcome = reduce_task_outcome(task)
+    assert outcome["key"] == "handed_off"
+    assert outcome["handoff_current"] is True
+
+
+def test_task_resumed_after_handoff_reads_in_progress_not_handed_off() -> None:
+    # The recency guard: when a later OPEN step postdates the newest handoff, the
+    # Task genuinely resumed — the handoff is history, not the headline, and the
+    # parallel marker is off so no surface shows a stale "handed off".
+    task = _multi_task(
+        [_step("handed_off", updated_at=_NOW), _step("started", updated_at=_NOW + 100)]
+    )
+    outcome = reduce_task_outcome(task)
+    assert outcome["key"] == "in_progress"
+    assert outcome["handoff_current"] is False
+
+
+def test_finding_outranks_handoff_but_the_marker_persists() -> None:
+    # A red check at handoff time must still be the headline (you have to see it),
+    # AND the handoff fact must not vanish — it rides the parallel marker.
+    task = _multi_task([_step("completed"), _step("handed_off", updated_at=_NOW + 100)])
+    task["task_evidence_events"] = [_check("failed", created_at=_NOW + 200, event_id="f")]
+    outcome = reduce_task_outcome(task)
+    assert outcome["key"] == "finding"
+    assert outcome["handoff_current"] is True
+
+
+def test_blocked_outranks_handoff_but_the_marker_persists() -> None:
+    task = _multi_task(
+        [_step("blocked", updated_at=_NOW), _step("handed_off", updated_at=_NOW + 100)]
+    )
+    outcome = reduce_task_outcome(task)
+    assert outcome["key"] == "blocked"
+    assert outcome["handoff_current"] is True
+
+
+def test_task_without_any_handoff_step_carries_handoff_current_false() -> None:
+    # Regression guard for the "byte-identical for non-handoff tasks" property:
+    # a Task with no handed_off step must always report the marker off.
+    for status in ("started", "completed", "checkpoint", "resolved", "blocked"):
+        outcome = reduce_task_outcome(_multi_task([_step(status)]))
+        assert outcome["handoff_current"] is False, status


### PR DESCRIPTION
## What

A cleanly handed-off Task was collapsed into the single decision word and outranked by `mostly_done`/`in_progress` and by `finding`, so a deliberate hand-off was hidden behind a softer or a louder status in both the list and the detail. Two real dogfood examples: *agentacct app 产品规划与 v3* read `finding`, *agentacct 接手与规划* read `mostly done` — both were actually handed off.

## Change

- **`reduce_task_outcome`**: a hand-off is now a recency-aware disposition. It ranks above the open-step branch when the hand-off is the frontier (no still-open step is newer than the newest hand-off) and stays below `blocked`/`finding`, matching the per-session badge precedence in `v1_sessions`/`glance`. A Task handed off and then resumed (a newer open step) stays in progress. Tasks with no hand-off step are unaffected (byte-identical).
- **Receipt**: the hand-off is exposed as a separate signal orthogonal to `decision_status` — `axes.handoff` on the detail and a flat `handed_off` flag on the summary.
- **Surfaces**: CLI, TUI, and the macOS app render a parallel "handed off" marker only when it adds information the decision word does not already state (the decision key is not itself `handed_off`).

## Verification

- Full suite: 3001 passed, 1 skipped (16 new tests). Swift build clean.
- Real-store check: *接手与规划* flips `mostly_done` → `handed_off`; *产品规划与 v3* keeps `finding` and gains the parallel marker; *项目接手* unchanged.
- Adversarial review (find → verify): reducer logic, cross-surface consistency, and integration lenses found no defects; two test-coverage gaps for the stated invariants were confirmed and closed with mutation-resistant tests.