### PR TITLE
feat(receipt): render the captured touched-file paths in the Actions dimension

### DIFF
--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -197,7 +197,7 @@ struct ReceiptCards: View {
             VStack(alignment: .leading, spacing: 8) {
                 dimensionRow("Task", taskSummary, receipt.dimensions.task.provenance)
                 dimensionRow("Actors", actorsSummary, receipt.dimensions.actors.provenance)
-                dimensionRow("Actions", actionsSummary, receipt.dimensions.actions.provenance)
+                actionsRow
                 dimensionRow("Cost", costSummary, receipt.dimensions.cost.provenance)
                 dimensionRow("Evidence", evidenceSummary, receipt.dimensions.evidence.provenance)
                 dimensionRow("Outcome", outcomeSummary, receipt.dimensions.outcome.provenance)
@@ -220,6 +220,39 @@ struct ReceiptCards: View {
                 }
             }
         }
+    }
+
+    // Actions gets its own row so the touched artifact PATHS render beneath the
+    // category summary. The paths were always captured; only the count was shown.
+    private var actionsRow: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            dimensionRow("Actions", actionsSummary, receipt.dimensions.actions.provenance)
+            let preview = actionsTouchedPreview
+            if !preview.shown.isEmpty {
+                VStack(alignment: .leading, spacing: 1) {
+                    ForEach(preview.shown, id: \.self) { path in
+                        Text(path).font(.caption).foregroundStyle(Theme.textFaint)
+                            .lineLimit(1).truncationMode(.middle)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    if preview.elided > 0 {
+                        Text("… +\(preview.elided) more").font(.caption).foregroundStyle(Theme.textFaint)
+                    }
+                }
+                .padding(.leading, 82)  // align under the summary column (74 label + 8 spacing)
+            }
+        }
+    }
+
+    // The daemon computes the preview slice + overflow (the single source of truth
+    // for the cap); the app renders those directly so it can never drift from the
+    // CLI/TUI. Fallback (older payload without the fields): show the full list.
+    private var actionsTouchedPreview: (shown: [String], elided: Int) {
+        let dim = receipt.dimensions.actions
+        if let preview = dim.touchedFilesPreview {
+            return (preview, dim.touchedFilesElided ?? 0)
+        }
+        return (dim.touchedFiles ?? [], 0)
     }
 
     @ViewBuilder

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -681,6 +681,12 @@ struct ReceiptActionsDim: Decodable {
     let toolCategoryTotal: Int?
     let touchedFiles: [String]?
     let touchedFileCount: Int?
+    // The daemon-capped preview slice + disclosed overflow — the app renders these
+    // directly so the cap has a single source of truth (the daemon) and can never
+    // drift from the CLI/TUI. Optional so an older payload without them still
+    // decodes (the app then falls back to slicing touchedFiles).
+    let touchedFilesPreview: [String]?
+    let touchedFilesElided: Int?
     let provenance: [String]?
     let gaps: [String]?
 
@@ -689,6 +695,8 @@ struct ReceiptActionsDim: Decodable {
         case toolCategoryTotal = "tool_category_total"
         case touchedFiles = "touched_files"
         case touchedFileCount = "touched_file_count"
+        case touchedFilesPreview = "touched_files_preview"
+        case touchedFilesElided = "touched_files_elided"
         case provenance, gaps
     }
 }

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -9070,7 +9070,17 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
     actions = dims.get("actions", {})
     actions_summary = _receipt_category_text(actions.get("tool_category_counts") or {})
     actions_summary += f"  · touched {int(actions.get('touched_file_count') or 0)} file(s)"
-    table.add_row("Actions", _rich_escape(actions_summary), ", ".join(actions.get("provenance") or []))
+    shown_files = actions.get("touched_files_preview") or []
+    elided_files = int(actions.get("touched_files_elided") or 0)
+    if shown_files:
+        # Show the actual artifact paths, not just the count. The daemon already
+        # capped the slice and disclosed the overflow; only the count was ever
+        # surfaced before.
+        lines = "\n".join(str(path) for path in shown_files)
+        if elided_files:
+            lines += f"\n… +{elided_files} more"
+        actions_summary += f"\n[dim]{_rich_escape(lines)}[/dim]"
+    table.add_row("Actions", actions_summary, ", ".join(actions.get("provenance") or []))
 
     cost = dims.get("cost", {})
     table.add_row("Cost", _receipt_cost_text(cost), ", ".join(cost.get("provenance") or []))

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -148,6 +148,26 @@ def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
 
+# The Actions dimension already CAPTURES every touched artifact path; surfaces
+# previewed only the COUNT. This previews a capped slice of the actual paths and
+# DISCLOSES the remainder rather than silently truncating (the receipt's honesty
+# rule: a bound on coverage is stated, never hidden).
+RECEIPT_TOUCHED_FILES_PREVIEW = 12
+
+
+def touched_files_preview(
+    actions: Mapping[str, Any], *, limit: int = RECEIPT_TOUCHED_FILES_PREVIEW
+) -> tuple[list[str], int]:
+    """Return (paths to show, count elided). Called ONCE, in ``_actions_dimension``,
+    which bakes the result into the receipt as ``touched_files_preview`` /
+    ``touched_files_elided`` — so every surface (CLI, TUI, macOS app) renders the
+    same daemon-provided slice and the cap has a single source of truth."""
+
+    files = [str(path) for path in (actions.get("touched_files") or []) if str(path).strip()]
+    shown = files if limit is None or limit < 0 else files[:limit]
+    return shown, max(0, len(files) - len(shown))
+
+
 # --- Evidence axis ------------------------------------------------------------
 
 def _check_source(check: Mapping[str, Any]) -> str:
@@ -578,11 +598,17 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
         gaps.append(
             "Tool categories were not instrumented for this session; Actions shows touched files only."
         )
+    # Compute the capped preview + disclosed overflow ONCE, here, so every surface
+    # (CLI, TUI, and the macOS app) renders the daemon-provided slice and never
+    # re-derives the cap client-side — the single source of truth for the cap.
+    preview, elided = touched_files_preview({"touched_files": touched})
     return {
         "tool_category_counts": dict(counts),
         "tool_category_total": int(actions.get("tool_category_total") or 0),
         "touched_files": touched,
         "touched_file_count": len(touched),
+        "touched_files_preview": preview,
+        "touched_files_elided": elided,
         "provenance": sorted(set(provenance)) or [SOURCE_NONE],
         "gaps": gaps,
     }

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1261,6 +1261,13 @@ def _render_receipt_markup(receipt: dict) -> str:
         f"[b]Actions[/]   {_escape(category_text)} · touched {actions.get('touched_file_count', 0)} file(s)"
         f"   [dim]\\[{_prov('actions')}][/]"
     )
+    for _path in actions.get("touched_files_preview") or []:
+        # The actual artifact paths, already captured — previously only the count
+        # was shown. The daemon capped the slice and disclosed the overflow.
+        lines.append(f"           [dim]{_escape(str(_path))}[/]")
+    _elided_files = int(actions.get("touched_files_elided") or 0)
+    if _elided_files:
+        lines.append(f"           [dim]… +{_elided_files} more[/]")
 
     cost = dims.get("cost") or {}
     lines.append(f"[b]Cost[/]      {_escape(_receipt_summary_cost(cost))}   [dim]\\[{_prov('cost')}][/]")

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -221,6 +221,39 @@ def test_actions_shows_touched_files_and_gaps_missing_categories() -> None:
     assert "mcp" in actions["provenance"]
 
 
+def test_touched_files_preview_caps_and_discloses_overflow() -> None:
+    from agentacct.receipt import RECEIPT_TOUCHED_FILES_PREVIEW, touched_files_preview
+
+    files = [f"src/f{i}.py" for i in range(RECEIPT_TOUCHED_FILES_PREVIEW + 5)]
+    shown, elided = touched_files_preview({"touched_files": files})
+    assert shown == files[:RECEIPT_TOUCHED_FILES_PREVIEW]
+    assert elided == 5  # the overflow is disclosed, never silently dropped
+
+    # Under the cap: everything shown, nothing elided; blanks are ignored.
+    shown, elided = touched_files_preview({"touched_files": ["src/a.py", "", "  "]})
+    assert shown == ["src/a.py"]
+    assert elided == 0
+
+    # No files → empty preview, no overflow.
+    assert touched_files_preview({}) == ([], 0)
+
+
+def test_actions_dimension_bakes_the_capped_preview_and_overflow() -> None:
+    # The daemon computes the preview slice + overflow ONCE, so every surface
+    # renders the same values and the cap has a single source of truth.
+    from agentacct.receipt import RECEIPT_TOUCHED_FILES_PREVIEW
+
+    files = [f"src/f{i}.py" for i in range(RECEIPT_TOUCHED_FILES_PREVIEW + 3)]
+    task = _task(
+        [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0, "files": files}],
+        actions={"tool_category_counts": {}, "tool_category_total": 0, "touched_files": files, "touched_file_count": len(files)},
+    )
+    actions = _receipt(task)["dimensions"]["actions"]
+    assert actions["touched_files"] == files  # full list still present
+    assert actions["touched_files_preview"] == files[:RECEIPT_TOUCHED_FILES_PREVIEW]
+    assert actions["touched_files_elided"] == 3
+
+
 def test_actions_with_categories_declares_hook_provenance() -> None:
     task = _task(
         [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}],

--- a/tests/test_receipt_cli.py
+++ b/tests/test_receipt_cli.py
@@ -122,6 +122,92 @@ def test_receipt_text_render_is_scannable(tmp_path: Path) -> None:
     assert "unchecked" in result.output or "checked" in result.output
 
 
+def test_receipt_detail_discloses_touched_files_overflow(tmp_path: Path) -> None:
+    # >12 touched files: the CLI shows the 12-path preview and DISCLOSES the
+    # remainder ("… +N more"), never silently truncating — exercised at the
+    # acceptance layer, not just the shared unit helper.
+    files = [f"src/f{i:02d}.py" for i in range(15)]
+    SentinelService(tmp_path).record_event(
+        {
+            "event_id": "evt_sec_many",
+            "created_at": 100.0,
+            "source": "claude-code",
+            "event_type": "section_completed",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "client_context_keys_authored": ["client_session_id"],
+                "project_dir": "/tmp/project",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": "sec-many",
+                "section_status": "completed",
+                "section_title": "t",
+                "objective": "t",
+                "kind": "implementation",
+                "files": files,
+            },
+        }
+    )
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "src/f11.py" in detail.output  # 12th path (index 11) is shown
+    assert "src/f12.py" not in detail.output  # 13th is beyond the cap
+    assert "… +3 more" in detail.output  # overflow disclosed
+
+
+def test_receipt_detail_lists_touched_file_paths(tmp_path: Path) -> None:
+    # The seeded section records files=["src/login.py"]; the detail must now show
+    # the actual path, not merely "touched 1 file(s)".
+    _seed(tmp_path)
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "src/login.py" in detail.output
+
+
+def test_receipt_detail_escapes_markup_in_touched_paths(tmp_path: Path) -> None:
+    # File paths are user-controlled; a bracket-tag path must render literally,
+    # never interpreted (no MarkupError, no silent tag drop / injection).
+    SentinelService(tmp_path).record_event(
+        {
+            "event_id": "evt_sec_markup",
+            "created_at": 100.0,
+            "source": "claude-code",
+            "event_type": "section_completed",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "client_context_keys_authored": ["client_session_id"],
+                "project_dir": "/tmp/project",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": "sec-markup",
+                "section_status": "completed",
+                "section_title": "t",
+                "objective": "t",
+                "kind": "implementation",
+                "files": ["src/[red]evil[/red].py"],
+            },
+        }
+    )
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "[red]evil[/red].py" in detail.output  # literal, not interpreted away
+
+
 def test_receipt_text_survives_rich_markup_in_recorded_titles(tmp_path: Path) -> None:
     # Agent-recorded titles/objectives are arbitrary text; a bracket-tag title
     # must never crash the render (MarkupError) or be silently reinterpreted.

--- a/tests/test_receipt_tui.py
+++ b/tests/test_receipt_tui.py
@@ -112,6 +112,58 @@ def test_render_receipt_markup_contains_axes_and_dimensions() -> None:
     assert "unchecked" in markup
 
 
+def test_render_receipt_markup_lists_touched_file_paths_with_overflow() -> None:
+    files = [f"src/module_{i}.py" for i in range(14)]  # > the 12 cap
+    task = {
+        "task_id": "task_x",
+        "primary_root": {"client": "claude-code", "client_session_id": "s1"},
+        "root_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "session_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "sessions": [{"client": "claude-code", "client_session_id": "s1", "project": "acme", "identity_scope_state": "explicit", "last_activity_at": 100.0, "usage": {}}],
+        "session_count": 1, "supporting_count": 0, "child_count": 0, "internal_count": 0,
+        "last_activity_at": 100.0,
+        "work_items": [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}],
+        "work_associations": [],
+        "usage": {"rows": 1, "estimated_cost_usd": 0.5, "cost_complete": True, "cost_basis": "pricing_table", "total_tokens": 1000},
+        "models": ["claude-opus-4-8"],
+        "actions": {"tool_category_counts": {"read": 3}, "tool_category_total": 3, "touched_files": files, "touched_file_count": len(files)},
+    }
+    markup = _render_receipt_markup(build_receipt(task, public_task_id="task_x", title="t"))
+    assert "src/module_0.py" in markup  # the actual paths, not just the count
+    assert "src/module_11.py" in markup  # last shown (cap 12)
+    assert "src/module_12.py" not in markup  # beyond the cap
+    assert "+2 more" in markup  # overflow disclosed, never silently dropped
+
+
+def test_render_receipt_markup_escapes_bracket_touched_paths() -> None:
+    # File paths are user-controlled; the markup must be RENDERABLE (as Textual's
+    # Static parses it) without raising, and the literal path must survive — not
+    # be interpreted away. Assert by rendering, not substring-matching the raw
+    # string (a dropped escape produces a valid string that fails only at render).
+    from rich.text import Text
+
+    styled = "src/[red]styled[/red].py"  # unescaped → tags dropped (misrepresents path)
+    unbalanced = "src/a[/]b.py"  # unescaped → MarkupError: nothing to close
+    task = {
+        "task_id": "task_x",
+        "primary_root": {"client": "claude-code", "client_session_id": "s1"},
+        "root_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "session_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "sessions": [{"client": "claude-code", "client_session_id": "s1", "project": "acme", "identity_scope_state": "explicit", "last_activity_at": 100.0, "usage": {}}],
+        "session_count": 1, "supporting_count": 0, "child_count": 0, "internal_count": 0,
+        "last_activity_at": 100.0,
+        "work_items": [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}],
+        "work_associations": [],
+        "usage": {"rows": 1, "estimated_cost_usd": 0.5, "cost_complete": True, "cost_basis": "pricing_table", "total_tokens": 1000},
+        "models": ["claude-opus-4-8"],
+        "actions": {"tool_category_counts": {}, "tool_category_total": 0, "touched_files": [styled, unbalanced], "touched_file_count": 2},
+    }
+    markup = _render_receipt_markup(build_receipt(task, public_task_id="task_x", title="t"))
+    rendered = Text.from_markup(markup)  # must not raise (covers the MarkupError mode)
+    assert styled in rendered.plain  # literal preserved (covers the dropped-tags mode)
+    assert unbalanced in rendered.plain
+
+
 def test_receipts_screen_lists_a_task_and_opens_its_detail(tmp_path: Path) -> None:
     _seed(tmp_path)
 


### PR DESCRIPTION
## What

The Actions dimension already **captured** every touched artifact path (from MCP-recorded section files + machine-check evidence), but every receipt surface showed only the **count** — the app model even decoded `touchedFiles` and then dropped it. This surfaces the actual paths.

## Change

- **`_actions_dimension`** computes a capped preview (`RECEIPT_TOUCHED_FILES_PREVIEW = 12` paths) and the disclosed overflow **once**, baking `touched_files_preview` / `touched_files_elided` into the receipt. Every surface renders the daemon-provided slice, so the cap has a single source of truth and cannot drift between CLI/TUI/app.
- **CLI, TUI, macOS app** render the paths beneath the Actions summary, with an honest `… +N more` when the list is capped. The full `touched_files` list stays in the payload for JSON/API consumers.
- User-controlled paths are escaped on every surface (a bracket-tag path renders literally, never interpreted or crashing).

## Verification

- Full suite: 2992 passed, 1 skipped (7 new tests). Swift build clean.
- Adversarial review (find → verify): the markup-injection/escaping lens found no defects; three honesty/test-coverage gaps were confirmed and closed — the single-source-of-truth refactor above, a TUI escape test that renders through Rich, and a CLI overflow-disclosure test (both mutation-verified).
