### PR TITLE
feat(receipt): capture and surface the specific tools an agent used

### DIFF
--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -287,7 +287,16 @@ struct ReceiptCards: View {
         let categories = counts.isEmpty
             ? "not instrumented"
             : counts.sorted { $0.key < $1.key }.map { "\($0.key)×\($0.value)" }.joined(separator: " ")
-        return "\(categories) · touched \(dim.touchedFileCount ?? 0) file(s)"
+        var summary = "\(categories) · touched \(dim.touchedFileCount ?? 0) file(s)"
+        // The specific tools/connectors the agent used (daemon-ranked), with the
+        // disclosed overflow — surfaced beneath the coarse category counts.
+        if let preview = dim.toolNamesPreview, !preview.isEmpty {
+            var tools = preview.map { "\($0.name)×\($0.count)" }.joined(separator: "  ")
+            let elided = dim.toolNamesElided ?? 0
+            if elided > 0 { tools += "  … +\(elided) more" }
+            summary += "\ntools: \(tools)"
+        }
+        return summary
     }
 
     private var costSummary: String {

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -681,6 +681,10 @@ struct ReceiptActionsDim: Decodable {
     let toolCategoryTotal: Int?
     let touchedFiles: [String]?
     let touchedFileCount: Int?
+    // The specific tools the agent used (daemon-ranked, most-used first) + the
+    // disclosed overflow. Optional so an older payload without them still decodes.
+    let toolNamesPreview: [ReceiptToolName]?
+    let toolNamesElided: Int?
     let provenance: [String]?
     let gaps: [String]?
 
@@ -689,8 +693,16 @@ struct ReceiptActionsDim: Decodable {
         case toolCategoryTotal = "tool_category_total"
         case touchedFiles = "touched_files"
         case touchedFileCount = "touched_file_count"
+        case toolNamesPreview = "tool_names_preview"
+        case toolNamesElided = "tool_names_elided"
         case provenance, gaps
     }
+}
+
+struct ReceiptToolName: Decodable, Identifiable {
+    let name: String
+    let count: Int
+    var id: String { name }
 }
 
 struct ReceiptCostDim: Decodable {

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -3307,7 +3307,7 @@ def claude_code_pre_tool_use(
         except Exception:  # noqa: BLE001 - context capture must never affect the hook decision.
             pass
         try:
-            # Observe only the tool CATEGORY (never the name/args) for the
+            # Observe the tool CATEGORY and NAME (never arguments/paths) for the
             # Receipt's Actions dimension. Separate try/except so it can never
             # affect the decision or the context capture above.
             capture_tool_activity(raw, store_dir=store_dir)
@@ -9070,7 +9070,16 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
     actions = dims.get("actions", {})
     actions_summary = _receipt_category_text(actions.get("tool_category_counts") or {})
     actions_summary += f"  · touched {int(actions.get('touched_file_count') or 0)} file(s)"
-    table.add_row("Actions", _rich_escape(actions_summary), ", ".join(actions.get("provenance") or []))
+    names_preview = actions.get("tool_names_preview") or []
+    if names_preview:
+        # The SPECIFIC tools/connectors the agent used (most-used first). Names are
+        # user-controlled (e.g. mcp__server__tool) so the line is rich-escaped.
+        tools = "  ".join(f"{p.get('name')}×{int(p.get('count') or 0)}" for p in names_preview)
+        elided = int(actions.get("tool_names_elided") or 0)
+        if elided:
+            tools += f"  … +{elided} more"
+        actions_summary += f"\n[dim]tools: {_rich_escape(tools)}[/dim]"
+    table.add_row("Actions", actions_summary, ", ".join(actions.get("provenance") or []))
 
     cost = dims.get("cost", {})
     table.add_row("Cost", _receipt_cost_text(cost), ", ".join(cost.get("provenance") or []))

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -475,15 +475,14 @@ def capture_claude_code_client_context(raw: str, *, store_dir: Path | str | None
 
 
 def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> None:
-    """Record ONE coarse tool-category tick for this PreToolUse. Never raises.
+    """Record ONE tool-activity tick for this PreToolUse. Never raises.
 
     The PreToolUse hook already receives the tool name (and fails open), so this
-    is the cheapest honest place to observe what KIND of tool ran. Only a
-    category derived from the tool NAME is spooled — never the name, arguments,
-    or any payload — so this stays strictly inside the WorkEvent privacy line
-    while giving the Receipt's Actions dimension a real source. The spool lands
-    in the SAME store as the client-context bridge so the usage importer drains
-    both from one place.
+    is the cheapest honest place to observe what the agent reached for. The
+    category AND the tool NAME are spooled — never arguments or any payload — so
+    the Receipt's Actions dimension can show both what KIND of tool ran and which
+    SPECIFIC tool/connector. The spool lands in the SAME store as the
+    client-context bridge so the usage importer drains both from one place.
     """
 
     try:
@@ -498,12 +497,14 @@ def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> N
         target = Path(store_dir) if store_dir is not None else _hook_store_dir_from_event(event)
         if target is None:
             return
-        category = tool_category(event.get("tool_name") or event.get("tool"))
+        tool_name = event.get("tool_name") or event.get("tool")
+        category = tool_category(tool_name)
         record_tool_activity_tick(
             target,
             client="claude-code",
             session_id=session_id,
             category=category,
+            name=tool_name,
             at=time.time(),
         )
     except Exception:  # noqa: BLE001 - activity capture must never affect the hook decision.

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -148,6 +148,34 @@ def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
 
+# Tool NAMES are an OPEN set (unlike the 9 fixed categories), so the Actions
+# dimension previews the most-used and discloses the remainder — computed ONCE
+# here so every surface renders the same ranking, the same way the touched-file
+# preview has a single source of truth.
+RECEIPT_TOOL_NAMES_PREVIEW = 10
+
+
+def tool_names_preview(
+    actions: Mapping[str, Any], *, limit: int = RECEIPT_TOOL_NAMES_PREVIEW
+) -> tuple[list[dict[str, Any]], int]:
+    """Return (top tools by count, count of distinct names elided). Sorted by
+    count descending, then name ascending for a stable tie-break."""
+
+    counts = actions.get("tool_name_counts")
+    counts = counts if isinstance(counts, Mapping) else {}
+    ordered = sorted(
+        (
+            (str(name), int(count))
+            for name, count in counts.items()
+            if isinstance(count, int) and not isinstance(count, bool) and count > 0
+        ),
+        key=lambda item: (-item[1], item[0]),
+    )
+    shown = ordered if limit is None or limit < 0 else ordered[:limit]
+    preview = [{"name": name, "count": count} for name, count in shown]
+    return preview, max(0, len(ordered) - len(shown))
+
+
 # --- Evidence axis ------------------------------------------------------------
 
 def _check_source(check: Mapping[str, Any]) -> str:
@@ -556,6 +584,8 @@ def _evidence_touched_files(task: Mapping[str, Any]) -> list[str]:
 def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
     actions = _mapping(task.get("actions"))
     counts = _mapping(actions.get("tool_category_counts"))
+    name_counts = _mapping(actions.get("tool_name_counts"))
+    names_preview, names_elided = tool_names_preview({"tool_name_counts": name_counts})
     section_files = actions.get("touched_files") if isinstance(actions.get("touched_files"), list) else []
     # Union the section-recorded files with the paths the Task's machine checks
     # named: either source alone routinely misses files the other has.
@@ -572,7 +602,7 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
         provenance.append(SOURCE_MCP)
     else:
         gaps.append("No touched files were recorded for this Task's steps.")
-    if counts:
+    if counts or name_counts:
         provenance.append(SOURCE_HOOK)
     else:
         gaps.append(
@@ -581,6 +611,10 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "tool_category_counts": dict(counts),
         "tool_category_total": int(actions.get("tool_category_total") or 0),
+        "tool_name_counts": dict(name_counts),
+        "tool_name_total": int(actions.get("tool_name_total") or 0),
+        "tool_names_preview": names_preview,
+        "tool_names_elided": names_elided,
         "touched_files": touched,
         "touched_file_count": len(touched),
         "provenance": sorted(set(provenance)) or [SOURCE_NONE],

--- a/src/agentacct/task_projection.py
+++ b/src/agentacct/task_projection.py
@@ -973,20 +973,27 @@ def build_task_projection(
         task_associations = associations.get(task_key, [])
         supporting_keys = member_keys - root_keys
         # Actions dimension: which KINDS of tools ran (hook-captured category
-        # counts, summed over the Task's sessions) and which repo-relative
-        # artifacts were touched (union of every step's files). Both are pure
-        # aggregates of already-recorded, privacy-reviewed data — no tool names
-        # or arguments ever reach here.
+        # counts), which SPECIFIC tools/connectors (hook-captured tool names), and
+        # which repo-relative artifacts were touched (union of every step's
+        # files) — each summed over the Task's sessions. All are pure aggregates
+        # of already-recorded data; tool NAMES are captured, arguments never are.
         tool_category_counts: dict[str, int] = {}
+        tool_name_counts: dict[str, int] = {}
         for key in ordered_members:
             counts = sessions[key].get("tool_category_counts")
-            if not isinstance(counts, Mapping):
-                continue
-            for category, value in counts.items():
-                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
-                    name = _text(category)
-                    if name:
-                        tool_category_counts[name] = tool_category_counts.get(name, 0) + value
+            if isinstance(counts, Mapping):
+                for category, value in counts.items():
+                    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                        name = _text(category)
+                        if name:
+                            tool_category_counts[name] = tool_category_counts.get(name, 0) + value
+            names = sessions[key].get("tool_name_counts")
+            if isinstance(names, Mapping):
+                for tool_name, value in names.items():
+                    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                        label = _text(tool_name)
+                        if label:
+                            tool_name_counts[label] = tool_name_counts.get(label, 0) + value
         touched_files: list[str] = []
         seen_touched_files: set[str] = set()
         for item in task_work:
@@ -999,6 +1006,8 @@ def build_task_projection(
         actions = {
             "tool_category_counts": dict(sorted(tool_category_counts.items())),
             "tool_category_total": sum(tool_category_counts.values()),
+            "tool_name_counts": dict(sorted(tool_name_counts.items())),
+            "tool_name_total": sum(tool_name_counts.values()),
             "touched_files": touched_files,
             "touched_file_count": len(touched_files),
         }

--- a/src/agentacct/tool_activity.py
+++ b/src/agentacct/tool_activity.py
@@ -1,12 +1,19 @@
-"""Privacy-safe tool-CATEGORY capture for the Receipt's Actions dimension.
+"""Tool-activity capture for the Receipt's Actions dimension.
 
-The Actions question a Receipt must answer is "what kinds of things did the
-agent do". WorkEvent (``work_events.py``) deliberately excludes tool names,
-arguments, and results, and this module holds that same line: it records only a
-COARSE CATEGORY derived from a tool's NAME (never the name itself, never its
-arguments, never a path). The taxonomy is intentionally derivable from the tool
-name ALONE — we do not try to tell ``git commit`` from ``ls`` inside ``execute``,
+The Actions question a Receipt must answer is "what did the agent reach for".
+This records, per tool call, a COARSE CATEGORY (read/edit/execute/…) AND the
+tool's NAME — a builtin like ``Read``/``Bash``, an ``mcp__server__tool`` name, or
+a custom command. It never records a tool's ARGUMENTS, its output, or any PATH:
+only the name and the category derived from it. The taxonomy is derivable from
+the name ALONE — we do not tell ``git commit`` from ``ls`` inside ``execute``,
 because that would require reading arguments.
+
+Capturing the NAME (a deliberate move from the earlier category-only line) is
+what lets the Receipt answer "which specific tool / connector did the agent
+use" — the raw material a manager or a diagnostic pass needs to reason "this
+tool caused that problem". The name is captured and stored LOCALLY like every
+other field; what to REDACT when a Receipt travels OUTSIDE its origin is a
+separate, later presentation concern, not a capture-time one.
 
 The capture path mirrors the terminal-CLI statusLine spool
 (``rate_limits.write_claude_statusline_spool``): the installed Claude Code
@@ -42,8 +49,9 @@ TOOL_CATEGORIES: frozenset[str] = frozenset(
 
 # Name-only taxonomy. Keys are lower-cased tool names. Only the tool NAME is
 # consulted — never its arguments — so this map can never leak a command, path,
-# or payload. ``mcp__*`` tools are collapsed to ``mcp`` by prefix below so no
-# specific MCP tool name is ever recorded.
+# or payload. ``mcp__*`` tools collapse to ``mcp`` HERE (the coarse category); the
+# specific ``mcp__server__tool`` name is preserved separately by
+# ``normalize_tool_name`` for the Actions tool-name breakdown.
 _CATEGORY_BY_TOOL_NAME: dict[str, str] = {
     "read": "read",
     "notebookread": "read",
@@ -73,7 +81,8 @@ def tool_category(tool_name: Any) -> str:
 
     Unknown names return ``other`` rather than being dropped, so the count of
     what the agent did stays honest. ``mcp__<server>__<tool>`` collapses to
-    ``mcp`` by prefix, so a specific MCP tool name is never recorded.
+    ``mcp`` by prefix for the CATEGORY only; the full name is kept separately by
+    ``normalize_tool_name``.
     """
 
     name = str(tool_name or "").strip().lower()
@@ -82,6 +91,28 @@ def tool_category(tool_name: Any) -> str:
     if name.startswith("mcp__"):
         return "mcp"
     return _CATEGORY_BY_TOOL_NAME.get(name, "other")
+
+
+# A hard bound on the captured NAME. A tool name is short (``Read``,
+# ``mcp__server__tool``); this only stops a pathological value from bloating the
+# spool. It bounds the name, never its content interpretation.
+_TOOL_NAME_MAX = 120
+
+
+def normalize_tool_name(tool_name: Any) -> str | None:
+    """The tiered tool-NAME captured alongside the category.
+
+    Returns the tool's identity verbatim — a builtin (``Read``/``Bash``), an
+    ``mcp__server__tool`` name, or a custom command — trimmed and length-bounded.
+    It reads ONLY the name: never arguments, never a path, never output. Blank in
+    -> ``None`` (nothing to record), so a missing name is an honest gap rather
+    than an empty string in the counts.
+    """
+
+    name = str(tool_name or "").strip()
+    if not name:
+        return None
+    return name[:_TOOL_NAME_MAX]
 
 
 def tool_activity_spool_path(store_dir: Path | str) -> Path:
@@ -94,14 +125,16 @@ def record_tool_activity_tick(
     client: str,
     session_id: str,
     category: str,
+    name: Any = None,
     at: float,
 ) -> None:
-    """Append ONE category tick to the store spool. Best-effort; never raises.
+    """Append ONE tick to the store spool. Best-effort; never raises.
 
-    Only the four small scalars ``{c, s, k, t}`` are written — client, session
-    id, category, and a timestamp. No tool name, no arguments, no path. The line
-    is a single tiny JSON object written with ``O_APPEND`` so concurrent hook
-    processes (many tool calls in flight) never corrupt or interleave lines.
+    Writes the small scalars ``{c, s, k, t}`` — client, session id, category, and
+    a timestamp — plus ``n``, the tool NAME, when one is given. No arguments, no
+    path, no output: only the name and its category. The line is a single tiny
+    JSON object written with ``O_APPEND`` so concurrent hook processes (many tool
+    calls in flight) never corrupt or interleave lines.
     """
 
     try:
@@ -113,8 +146,12 @@ def record_tool_activity_tick(
             return
         target = tool_activity_spool_path(store_dir)
         target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        payload = {"c": client, "s": session_id, "k": category, "t": float(at)}
+        normalized_name = normalize_tool_name(name)
+        if normalized_name:
+            payload["n"] = normalized_name
         line = json.dumps(
-            {"c": client, "s": session_id, "k": category, "t": float(at)},
+            payload,
             ensure_ascii=False,
             separators=(",", ":"),
         )
@@ -166,6 +203,7 @@ def drain_tool_activity_spool(
             pass
 
     counts: dict[tuple[str, str], dict[str, int]] = {}
+    name_counts: dict[tuple[str, str], dict[str, int]] = {}
     latest: dict[tuple[str, str], float] = {}
     for line in raw.splitlines():
         line = line.strip()
@@ -187,6 +225,13 @@ def drain_tool_activity_spool(
         key = (client, session)
         bucket = counts.setdefault(key, {})
         bucket[category] = bucket.get(category, 0) + 1
+        # Tool NAME (present only on ticks written after name capture shipped —
+        # older lines simply have no ``n``, an honest undercount of names, never
+        # a wrong one).
+        name = normalize_tool_name(row.get("n"))
+        if name:
+            name_bucket = name_counts.setdefault(key, {})
+            name_bucket[name] = name_bucket.get(name, 0) + 1
         stamp = row.get("t")
         if isinstance(stamp, (int, float)) and not isinstance(stamp, bool):
             latest[key] = max(latest.get(key, 0.0), float(stamp))
@@ -197,6 +242,24 @@ def drain_tool_activity_spool(
         digest = uuid.uuid5(
             uuid.NAMESPACE_URL, f"{batch_token}\0{client}\0{session}"
         ).hex
+        metadata: dict[str, Any] = {
+            "client": client,
+            "client_session_id": session,
+            "tool_category_counts": dict(sorted(bucket.items())),
+            "capture_basis": TOOL_ACTIVITY_CAPTURE_BASIS,
+            "captured_at": created_at,
+            "sentinel_semantic_kind": "tool_activity",
+        }
+        names = name_counts.get((client, session))
+        if names:
+            # Tool names ride as list VALUES, not dict KEYS. The store's secret
+            # redaction blanks the VALUE of any credential-shaped KEY, so a
+            # connector like ``mcp__vault__get_token`` used as a key would be
+            # silently redacted out. As ``{"name": …, "count": …}`` objects the
+            # name is a value under the innocuous key ``name`` and survives.
+            metadata["tool_names"] = [
+                {"name": name, "count": count} for name, count in sorted(names.items())
+            ]
         events.append(
             {
                 "event_id": f"toolact:{digest}",
@@ -204,14 +267,7 @@ def drain_tool_activity_spool(
                 "source": client,
                 "event_type": TOOL_ACTIVITY_EVENT_TYPE,
                 "run_id": None,
-                "metadata": {
-                    "client": client,
-                    "client_session_id": session,
-                    "tool_category_counts": dict(sorted(bucket.items())),
-                    "capture_basis": TOOL_ACTIVITY_CAPTURE_BASIS,
-                    "captured_at": created_at,
-                    "sentinel_semantic_kind": "tool_activity",
-                },
+                "metadata": metadata,
             }
         )
     return events
@@ -280,13 +336,61 @@ def build_tool_activity_by_session(
     return {key: value for key, value in result.items() if value}
 
 
+def build_tool_names_by_session(
+    events: Iterable[Mapping[str, Any]],
+) -> dict[tuple[str, str], dict[str, int]]:
+    """Sum ``tool_activity_observed`` per-NAME counts per (client, session).
+
+    Mirrors ``build_tool_activity_by_session`` for the specific tool names
+    (``Read``, ``Bash``, ``mcp__server__tool``, …). Reads the event's
+    ``tool_names`` list of ``{"name": …, "count": …}`` objects — the name is a
+    VALUE, not a dict key, so a credential-shaped connector name is never
+    redacted out by the store's secret redaction. Batches are additive, so the
+    per-session total is stable across imports. Names are an OPEN set, so unlike
+    categories they are not filtered against a fixed vocabulary — but they are
+    normalized (trimmed, length-bounded) and only positive integer counts are
+    kept. A session recorded before name capture shipped simply has no names — an
+    honest gap, never a fabricated zero.
+    """
+
+    result: dict[tuple[str, str], dict[str, int]] = {}
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        if event.get("event_type") != TOOL_ACTIVITY_EVENT_TYPE:
+            continue
+        metadata = event.get("metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        client = str(metadata.get("client") or "").strip()
+        session = str(metadata.get("client_session_id") or "").strip()
+        if not client or not session:
+            continue
+        names = metadata.get("tool_names")
+        if not isinstance(names, list):
+            continue
+        bucket = result.setdefault((client, session), {})
+        for entry in names:
+            if not isinstance(entry, Mapping):
+                continue
+            name = normalize_tool_name(entry.get("name"))
+            if not name:
+                continue
+            value = entry.get("count")
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                continue
+            bucket[name] = bucket.get(name, 0) + value
+    return {key: value for key, value in result.items() if value}
+
+
 __all__ = [
     "TOOL_ACTIVITY_CAPTURE_BASIS",
     "TOOL_ACTIVITY_EVENT_TYPE",
     "TOOL_CATEGORIES",
     "build_tool_activity_by_session",
+    "build_tool_names_by_session",
     "drain_tool_activity_spool",
     "ingest_tool_activity_spool",
+    "normalize_tool_name",
     "record_tool_activity_tick",
     "tool_activity_spool_path",
     "tool_category",

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1261,6 +1261,14 @@ def _render_receipt_markup(receipt: dict) -> str:
         f"[b]Actions[/]   {_escape(category_text)} · touched {actions.get('touched_file_count', 0)} file(s)"
         f"   [dim]\\[{_prov('actions')}][/]"
     )
+    names_preview = actions.get("tool_names_preview") or []
+    if names_preview:
+        # The specific tools/connectors, most-used first. Names are user-controlled.
+        _tools = "  ".join(f"{_escape(str(p.get('name')))}×{int(p.get('count') or 0)}" for p in names_preview)
+        _names_elided = int(actions.get("tool_names_elided") or 0)
+        if _names_elided:
+            _tools += f"  … +{_names_elided} more"
+        lines.append(f"           [dim]tools: {_tools}[/]")
 
     cost = dims.get("cost") or {}
     lines.append(f"[b]Cost[/]      {_escape(_receipt_summary_cost(cost))}   [dim]\\[{_prov('cost')}][/]")

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -13,7 +13,7 @@ from .confidence import (
     normalize_cost_confidence,
     normalize_usage_confidence,
 )
-from .tool_activity import build_tool_activity_by_session
+from .tool_activity import build_tool_activity_by_session, build_tool_names_by_session
 from .join_rules import (
     JoinCandidateIndex,
     annotate_usage_source_namespace_ambiguity,
@@ -209,13 +209,16 @@ def build_work_ledger(
     # so this sum is stable across imports; a session with no captured activity
     # gets NO key, so the Receipt shows an honest Gap, never a fabricated zero.
     tool_activity_by_session = build_tool_activity_by_session(events)
-    if tool_activity_by_session:
+    tool_names_by_session = build_tool_names_by_session(events)
+    if tool_activity_by_session or tool_names_by_session:
         for entry in session_rollup.get("sessions", []):
-            counts = tool_activity_by_session.get(
-                (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
-            )
+            entry_key = (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
+            counts = tool_activity_by_session.get(entry_key)
             if counts:
                 entry["tool_category_counts"] = dict(counts)
+            names = tool_names_by_session.get(entry_key)
+            if names:
+                entry["tool_name_counts"] = dict(names)
     rollup_summary = session_rollup.get("summary")
     if isinstance(rollup_summary, dict):
         rollup_summary["mechanical_projection"] = dict(session_observation_diagnostics or {})

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -231,6 +231,36 @@ def test_actions_with_categories_declares_hook_provenance() -> None:
     assert "hook" in actions["provenance"]
 
 
+def test_actions_dimension_exposes_tool_names_ranked_with_overflow() -> None:
+    from agentacct.receipt import RECEIPT_TOOL_NAMES_PREVIEW, tool_names_preview
+
+    # A distinct tool per rank so the top-N-by-count ordering is observable.
+    name_counts = {f"tool_{i:02d}": (100 - i) for i in range(RECEIPT_TOOL_NAMES_PREVIEW + 4)}
+    task = _task(
+        [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}],
+        actions={
+            "tool_category_counts": {"execute": 1},
+            "tool_category_total": 1,
+            "tool_name_counts": name_counts,
+            "tool_name_total": sum(name_counts.values()),
+            "touched_files": [],
+            "touched_file_count": 0,
+        },
+    )
+    actions = _receipt(task)["dimensions"]["actions"]
+    assert actions["tool_name_counts"] == name_counts  # full dict present
+    preview = actions["tool_names_preview"]
+    assert len(preview) == RECEIPT_TOOL_NAMES_PREVIEW
+    assert preview[0] == {"name": "tool_00", "count": 100}  # highest count first
+    assert actions["tool_names_elided"] == 4  # overflow disclosed, never dropped
+    assert "hook" in actions["provenance"]
+
+    # Unit: ties break by name ascending; blanks/non-positive filtered.
+    p, elided = tool_names_preview({"tool_name_counts": {"b": 2, "a": 2, "c": 0}})
+    assert [x["name"] for x in p] == ["a", "b"]
+    assert elided == 0
+
+
 def test_cost_dimension_carries_basis_without_gapping_a_complete_estimate() -> None:
     cost = _receipt(_task([{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}]))["dimensions"]["cost"]
     assert cost["cost_basis"] == "pricing_table"

--- a/tests/test_receipt_cli.py
+++ b/tests/test_receipt_cli.py
@@ -76,6 +76,131 @@ def _seed(store: Path, *, title: str = "Add rate limit to login") -> None:
     )
 
 
+def test_receipt_detail_lists_specific_tool_names(tmp_path: Path) -> None:
+    # End-to-end: a captured tool_activity event flows through the projection into
+    # the Actions dimension, and the detail shows the SPECIFIC tools (most-used
+    # first), not merely the coarse category counts.
+    _seed(tmp_path)  # session s1
+    SentinelService(tmp_path).record_event(
+        {
+            "event_id": "toolact:s1-names",
+            "created_at": 100.0,
+            "source": "claude-code",
+            "event_type": "tool_activity_observed",
+            "run_id": None,
+            "metadata": {
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "sentinel_semantic_kind": "tool_activity",
+                "tool_category_counts": {"execute": 3, "mcp": 1},
+                "tool_names": [{"name": "Bash", "count": 3}, {"name": "mcp__acme__deploy", "count": 1}],
+            },
+        }
+    )
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "tools:" in detail.output
+    assert "Bash×3" in detail.output
+    assert "mcp__acme__deploy×1" in detail.output
+
+
+def test_credential_shaped_tool_name_survives_redaction(tmp_path: Path) -> None:
+    # Connector names are user-controlled and some look credential-ish
+    # (mcp__vault__get_token). Because names ride as list VALUES (not dict keys),
+    # the store's secret redaction must NOT blank them out — the exact tools an
+    # operator most wants to see must reach the Receipt, not vanish silently.
+    _seed(tmp_path)
+    SentinelService(tmp_path).record_event(
+        {
+            "event_id": "toolact:s1-secret",
+            "created_at": 100.0,
+            "source": "claude-code",
+            "event_type": "tool_activity_observed",
+            "run_id": None,
+            "metadata": {
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "sentinel_semantic_kind": "tool_activity",
+                "tool_category_counts": {"mcp": 4},
+                "tool_names": [{"name": "mcp__vault__get_token", "count": 4}],
+            },
+        }
+    )
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "mcp__vault__get_token×4" in detail.output
+    assert "REDACTED" not in detail.output
+
+
+def test_receipt_detail_escapes_markup_in_tool_names(tmp_path: Path) -> None:
+    # Tool names are user-controlled; a bracket-tag connector name must render
+    # literally, never be interpreted as markup or crash.
+    _seed(tmp_path)
+    SentinelService(tmp_path).record_event(
+        {
+            "event_id": "toolact:s1-markup",
+            "created_at": 100.0,
+            "source": "claude-code",
+            "event_type": "tool_activity_observed",
+            "run_id": None,
+            "metadata": {
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "sentinel_semantic_kind": "tool_activity",
+                "tool_category_counts": {"mcp": 1},
+                "tool_names": [{"name": "mcp__[bold]x[/bold]__y", "count": 1}],
+            },
+        }
+    )
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "mcp__[bold]x[/bold]__y×1" in detail.output  # literal, not interpreted
+
+
+def test_receipt_detail_discloses_tool_name_overflow(tmp_path: Path) -> None:
+    # >RECEIPT_TOOL_NAMES_PREVIEW distinct tools: the detail shows the top slice
+    # and DISCLOSES the remainder at render time, never silently truncating.
+    from agentacct.receipt import RECEIPT_TOOL_NAMES_PREVIEW
+
+    n = RECEIPT_TOOL_NAMES_PREVIEW + 4
+    names = [{"name": f"tool_{i:02d}", "count": n - i} for i in range(n)]
+    _seed(tmp_path)
+    SentinelService(tmp_path).record_event(
+        {
+            "event_id": "toolact:s1-many",
+            "created_at": 100.0,
+            "source": "claude-code",
+            "event_type": "tool_activity_observed",
+            "run_id": None,
+            "metadata": {
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "sentinel_semantic_kind": "tool_activity",
+                "tool_category_counts": {"execute": 1},
+                "tool_names": names,
+            },
+        }
+    )
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    detail = runner.invoke(app, ["receipt", task_id, "--store-dir", str(tmp_path)])
+    assert detail.exit_code == 0, detail.output
+    assert "tool_00×" in detail.output  # highest count shown
+    assert "tool_09×" in detail.output  # 10th shown (cap 10)
+    assert "tool_10×" not in detail.output  # 11th beyond the cap
+    assert "… +4 more" in detail.output  # overflow disclosed
+
+
 def test_receipts_list_json(tmp_path: Path) -> None:
     _seed(tmp_path)
     result = runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)])

--- a/tests/test_receipt_tui.py
+++ b/tests/test_receipt_tui.py
@@ -112,6 +112,33 @@ def test_render_receipt_markup_contains_axes_and_dimensions() -> None:
     assert "unchecked" in markup
 
 
+def test_render_receipt_markup_lists_tool_names_and_escapes_them() -> None:
+    from rich.text import Text
+
+    task = {
+        "task_id": "task_x",
+        "primary_root": {"client": "claude-code", "client_session_id": "s1"},
+        "root_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "session_keys": [{"client": "claude-code", "client_session_id": "s1"}],
+        "sessions": [{"client": "claude-code", "client_session_id": "s1", "project": "acme", "identity_scope_state": "explicit", "last_activity_at": 100.0, "usage": {}}],
+        "session_count": 1, "supporting_count": 0, "child_count": 0, "internal_count": 0,
+        "last_activity_at": 100.0,
+        "work_items": [{"work_id": "w", "latest_status": "completed", "updated_at": 100.0}],
+        "work_associations": [],
+        "usage": {"rows": 1, "estimated_cost_usd": 0.5, "cost_complete": True, "cost_basis": "pricing_table", "total_tokens": 1000},
+        "models": ["claude-opus-4-8"],
+        # A user-controlled mcp name with bracket metacharacters must render literally.
+        "actions": {"tool_category_counts": {"execute": 3}, "tool_category_total": 3,
+                    "tool_name_counts": {"Bash": 3, "mcp__[x]__y": 1}, "tool_name_total": 4,
+                    "touched_files": [], "touched_file_count": 0},
+    }
+    markup = _render_receipt_markup(build_receipt(task, public_task_id="task_x", title="t"))
+    assert "tools:" in markup
+    assert "Bash×3" in markup
+    rendered = Text.from_markup(markup)  # must not raise (escaping)
+    assert "mcp__[x]__y×1" in rendered.plain  # metacharacters preserved literally
+
+
 def test_receipts_screen_lists_a_task_and_opens_its_detail(tmp_path: Path) -> None:
     _seed(tmp_path)
 

--- a/tests/test_tool_activity.py
+++ b/tests/test_tool_activity.py
@@ -10,11 +10,69 @@ from agentacct.tool_activity import (
     TOOL_ACTIVITY_EVENT_TYPE,
     TOOL_CATEGORIES,
     build_tool_activity_by_session,
+    build_tool_names_by_session,
     drain_tool_activity_spool,
+    normalize_tool_name,
     record_tool_activity_tick,
     tool_activity_spool_path,
     tool_category,
 )
+
+
+def test_normalize_tool_name_trims_bounds_and_rejects_blank() -> None:
+    assert normalize_tool_name("  Read  ") == "Read"
+    assert normalize_tool_name("mcp__acme__deploy") == "mcp__acme__deploy"
+    assert normalize_tool_name("") is None
+    assert normalize_tool_name(None) is None
+    assert normalize_tool_name("   ") is None
+    assert len(normalize_tool_name("x" * 500)) == 120  # bounded, never unbounded
+
+
+def test_tool_name_capture_round_trips_through_spool_and_drain(tmp_path: Path) -> None:
+    # Ticks WITH names aggregate into per-session name counts; a name-less tick
+    # (older format) still counts toward the category, an honest name undercount.
+    names = ["Bash", "Bash", "Read", "mcp__agentacct__record_section"]
+    for i, name in enumerate(names):
+        record_tool_activity_tick(
+            tmp_path, client="claude-code", session_id="s1",
+            category=tool_category(name), name=name, at=100.0 + i,
+        )
+    record_tool_activity_tick(
+        tmp_path, client="claude-code", session_id="s1", category="search", at=200.0
+    )  # no name
+
+    [event] = drain_tool_activity_spool(tmp_path, now=300.0, token="t")
+    # Names ride as list VALUES (not dict keys) so credential-shaped connector
+    # names survive the store's secret redaction.
+    got = {entry["name"]: entry["count"] for entry in event["metadata"]["tool_names"]}
+    assert got == {"Bash": 2, "Read": 1, "mcp__agentacct__record_section": 1}
+    # The name-less tick is counted as a category but contributes no name.
+    assert event["metadata"]["tool_category_counts"] == {"execute": 2, "read": 1, "mcp": 1, "search": 1}
+
+
+def test_build_tool_names_by_session_sums_additive_batches() -> None:
+    def batch(session: str, names: dict) -> dict:
+        return {
+            "event_type": TOOL_ACTIVITY_EVENT_TYPE,
+            "metadata": {
+                "client": "claude-code",
+                "client_session_id": session,
+                "tool_names": [{"name": n, "count": c} for n, c in names.items()],
+            },
+        }
+
+    result = build_tool_names_by_session(
+        [
+            batch("s1", {"Bash": 2, "Read": 1}),
+            batch("s1", {"Bash": 3}),
+            # non-positive / boolean counts ignored; a batch with no names contributes nothing
+            batch("s1", {"Read": -1, "Edit": True}),
+            batch("s2", {"mcp__acme__deploy": 4}),
+            {"event_type": "model_usage", "metadata": {"client": "x", "client_session_id": "s1"}},
+        ]
+    )
+    assert result[("claude-code", "s1")] == {"Bash": 5, "Read": 1}
+    assert result[("claude-code", "s2")] == {"mcp__acme__deploy": 4}
 
 
 def test_tool_category_maps_names_only_and_collapses_mcp() -> None:
@@ -103,16 +161,19 @@ def test_build_tool_activity_by_session_sums_batches_and_rejects_junk() -> None:
     assert result[("claude-code", "s2")] == {"execute": 4}
 
 
-def test_capture_tool_activity_records_category_from_raw_event(tmp_path: Path) -> None:
+def test_capture_tool_activity_records_name_and_category_but_never_arguments(tmp_path: Path) -> None:
     raw = json.dumps(
         {"session_id": "hooksess", "tool_name": "Edit", "tool_input": {"file_path": "/secret/path.py"}}
     )
     capture_tool_activity(raw, store_dir=tmp_path)
-    # The captured tick is a category only; the file path/tool_input never lands.
+    # The captured tick carries the tool NAME and its category — but never the
+    # arguments/path (``tool_input``): "secret" must not land, "Edit" now does.
     spool_text = tool_activity_spool_path(tmp_path).read_text(encoding="utf-8")
-    assert "secret" not in spool_text and "Edit" not in spool_text
+    assert "secret" not in spool_text
+    assert '"n":"Edit"' in spool_text
     [event] = drain_tool_activity_spool(tmp_path, now=1.0, token="t")
     assert event["metadata"]["tool_category_counts"] == {"edit": 1}
+    assert event["metadata"]["tool_names"] == [{"name": "Edit", "count": 1}]
     assert event["metadata"]["client"] == "claude-code"
 
 


### PR DESCRIPTION
## What

The Actions dimension recorded only coarse tool **categories** (read/edit/execute/…). It now also captures the tool **NAME** — a builtin (`Read`/`Bash`), an `mcp__server__tool` connector, or a custom command — never arguments, paths, or output. This is the raw material for reasoning "which specific tool/connector did the agent use", toward prescriptive/diagnostic use.

This deliberately moves the `tool_activity.py` capture line from "category only, never the name" to "name too, still never args/paths/output".

## Change

- **Capture** (`tool_activity.py`, `hooks.py`): the PreToolUse hook spools the tool name (`normalize_tool_name` trims + length-bounds it) alongside the category. Args/paths/`tool_input` are never read.
- **Aggregate**: the drain sums per-session tool names into the `tool_activity_observed` event; `work_ledger` and `task_projection` sum them into `task["actions"]`.
- **Surface** (`receipt.py`, CLI, TUI, macOS app): the Actions dimension carries `tool_name_counts` plus a daemon-ranked `tool_names_preview` (top-10 by count) with a disclosed `… +N more` overflow. A `tools: Name×N …` line renders beneath the category counts.

## Honesty / safety

- Tool names ride as **list values** (`[{"name","count"}]`) in the event metadata, not dict keys — so a credential-shaped connector name (`mcp__vault__get_token`, `*_api_key`, …) is **not** blanked by the store's secret redaction and reaches the Receipt (verified end-to-end).
- User-controlled names are escaped on every text surface (a bracket-tag connector name renders literally, never interpreted).
- Names are captured/stored **locally**; redaction for receipts shared **outside** their origin is a separate, later presentation concern.
- Backward compatible: ticks/events recorded before this shipped simply carry no names — an honest undercount, never a fabricated one.

## Verification

- Full suite: 2994 passed, 1 skipped (9 new tests). Swift build clean.
- Adversarial review (find → verify): the aggregation lens found no defects; four confirmed items — the redaction-safety reshape above, a stale hook comment, and two test-coverage gaps (CLI markup-escape and overflow disclosure) — were fixed, the redaction and escape fixes both mutation-verified.
