### PR TITLE
fix(hooks): dedupe the settings hook merge by wrapper file, not full command

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -876,13 +876,58 @@ def _merge_claude_project_settings(project_dir: Path) -> tuple[Path, str]:
     return _merge_claude_settings_from_example(example_path, target)
 
 
+def _command_wrapper_paths(command: Any) -> set[str]:
+    """The agentacct wrapper-script PATH token(s) in ONE hook command string.
+
+    A wrapper token is one whose basename is the frozen wrapper filename
+    (``CLAUDE_HOOK_RELATIVE_PATH.name``). Returning the PATH (not just the
+    basename) is deliberate: the merge treats two commands as the SAME hook only
+    when they run the same wrapper FILE, so a re-install that changed only the
+    python interpreter collapses, while a wrapper at a DIFFERENT location — a stale
+    pre-relocation path — is left for the doctor to flag, not silently rewritten.
+
+    Tokenization is shell-aware (``shlex``) so the quoting the command is BUILT
+    with is undone: the project form ``"$CLAUDE_PROJECT_DIR/.../wrapper.py"`` and a
+    global path that needs quoting (a space in the home dir) both yield the bare
+    wrapper token. A command shlex cannot parse falls back to whitespace split.
+    """
+    text = command if isinstance(command, str) else ""
+    if not text:
+        return set()
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        tokens = text.split()
+    return {
+        token
+        for token in tokens
+        if token.replace("\\", "/").rsplit("/", 1)[-1] == CLAUDE_HOOK_RELATIVE_PATH.name
+    }
+
+
+def _hook_wrapper_paths(row: Any) -> set[str]:
+    """Union of the wrapper paths across every command in a hook row."""
+    paths: set[str] = set()
+    if not isinstance(row, dict):
+        return paths
+    entry_hooks = row.get("hooks")
+    if not isinstance(entry_hooks, list):
+        return paths
+    for hook in entry_hooks:
+        if isinstance(hook, dict):
+            paths |= _command_wrapper_paths(hook.get("command"))
+    return paths
+
+
 def _merge_claude_settings_from_example(example_path: Path, target: Path) -> tuple[Path, str]:
     """Non-destructively merge a generated hook/env example into a settings file.
 
     Shared by the project install (``.claude/settings.local.json``) and the
     default-global install (user-level ``~/.claude/settings.json``): an env key is
-    never overwritten when the user set a different value, hook rows are deduped
-    by fingerprint, and the write is atomic + 0600.
+    never overwritten when the user set a different value, our hook rows are
+    replaced in place (matched by the wrapper FILE they run, so a second install
+    that differs only by interpreter never accrues a duplicate), the user's own
+    hooks are left untouched, and the write is atomic + 0600.
     """
     try:
         generated = json.loads(example_path.read_text(encoding="utf-8"))
@@ -931,17 +976,63 @@ def _merge_claude_settings_from_example(example_path: Path, target: Path) -> tup
             raise RuntimeManagerError(
                 f"Claude Code setting hooks.{event_name} is not an array; agentacct left it unchanged"
             )
-        fingerprints = {
-            json.dumps(row, sort_keys=True, separators=(",", ":"))
-            for row in existing_rows
-            if isinstance(row, dict)
-        }
+        # Replace rows that run the SAME wrapper file as the generated ones in
+        # place; collapse any pre-existing duplicates of that wrapper; leave the
+        # user's own hooks (and a wrapper at a different path) exactly where they
+        # are. Re-running onboard from the same install is a no-op (identical
+        # rows); onboarding from a second install that differs only by interpreter
+        # UPDATES the row instead of appending a near-duplicate that would
+        # double-fire and double-count tool activity.
+        generated_wrapper_paths: set[str] = set()
         for row in rows:
-            fingerprint = json.dumps(row, sort_keys=True, separators=(",", ":"))
-            if fingerprint not in fingerprints:
-                existing_rows.append(row)
-                fingerprints.add(fingerprint)
-                changed = True
+            generated_wrapper_paths |= _hook_wrapper_paths(row)
+        rebuilt: list[Any]
+        if generated_wrapper_paths:
+            rebuilt = []
+            inserted = False
+            for row in existing_rows:
+                if not (_hook_wrapper_paths(row) & generated_wrapper_paths):
+                    rebuilt.append(row)  # user's own hook / a wrapper elsewhere
+                    continue
+                # This row runs our wrapper. Drop our command(s) from it — but at
+                # COMMAND granularity, so a user command co-located under the same
+                # matcher survives. Insert our canonical rows once, at the first
+                # such position; keep the row only if a non-wrapper command remains.
+                if not inserted:
+                    rebuilt.extend(rows)
+                    inserted = True
+                survivors = [
+                    hook
+                    for hook in (row.get("hooks") or [])
+                    if not (
+                        isinstance(hook, dict)
+                        and _command_wrapper_paths(hook.get("command")) & generated_wrapper_paths
+                    )
+                ]
+                if survivors:
+                    trimmed = dict(row)
+                    trimmed["hooks"] = survivors
+                    rebuilt.append(trimmed)  # the user's co-located command, kept
+            if not inserted:
+                rebuilt = list(existing_rows) + list(rows)  # first install: append
+        else:
+            # A generated hook row that carries no agentacct wrapper path (a
+            # non-standard example) has no stable identity to replace by, so fall
+            # back to exact-fingerprint dedup — enough to keep re-merge idempotent.
+            rebuilt = list(existing_rows)
+            seen = {
+                json.dumps(row, sort_keys=True, separators=(",", ":"))
+                for row in rebuilt
+                if isinstance(row, dict)
+            }
+            for row in rows:
+                fingerprint = json.dumps(row, sort_keys=True, separators=(",", ":"))
+                if fingerprint not in seen:
+                    rebuilt.append(row)
+                    seen.add(fingerprint)
+        if rebuilt != existing_rows:
+            changed = True
+        hooks[event_name] = rebuilt
     target.parent.mkdir(parents=True, exist_ok=True)
     if changed or not target.exists():
         payload = (json.dumps(current, indent=2) + "\n").encode("utf-8")

--- a/tests/test_statusline_hook.py
+++ b/tests/test_statusline_hook.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+from pathlib import Path
 
 from typer.testing import CliRunner
 
@@ -212,3 +213,204 @@ def test_user_statusline_is_preserved_and_never_blocks_core_recording(tmp_path):
     assert merged["statusLine"]["command"] == "my-own-bar"  # theirs kept
     assert merged["env"]["ENABLE_TOOL_SEARCH"] == "auto"  # core env still merged
     assert "PreToolUse" in merged["hooks"]  # core recording hooks still merged
+
+
+def _example_with(interp: str, wrap):
+    from agentacct.hooks import claude_code_settings_example
+
+    return claude_code_settings_example(python_executable=interp, hook_path=wrap)
+
+
+def _rows(merged, event):
+    return merged["hooks"][event]
+
+
+def _cmds(merged, event):
+    return [h["command"] for r in merged["hooks"][event] for h in r.get("hooks", [])]
+
+
+def test_merge_collapses_a_preexisting_duplicate_agentacct_hook(tmp_path):
+    """The dogfood double-count bug: a machine onboarded twice (same wrapper file,
+    two different python interpreters) has two hook rows and double-fires. The
+    next onboard must COLLAPSE them to one, not leave the duplicate."""
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    wrap = tmp_path / "hooks" / "claude_pre_tool_use.py"
+    ex_a = _example_with("/interp-a/bin/python", wrap)
+    ex_b = _example_with("/interp-b/bin/python3", wrap)
+    # existing = BOTH interpreters wired (the double-count state)
+    existing = {"hooks": {}}
+    for ex in (ex_a, ex_b):
+        for event, rows in ex["hooks"].items():
+            existing["hooks"].setdefault(event, []).extend(rows)
+    target = tmp_path / "settings.json"
+    target.write_text(json.dumps(existing), encoding="utf-8")
+    assert len(existing["hooks"]["PreToolUse"]) == 2  # precondition: doubled
+
+    example_path = tmp_path / "ex.json"
+    example_path.write_text(json.dumps(ex_a), encoding="utf-8")
+    _merge_claude_settings_from_example(example_path, target)
+
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    for event in ex_a["hooks"]:
+        assert len(_rows(merged, event)) == 1, (event, _rows(merged, event))
+        assert _cmds(merged, event) == _cmds({"hooks": ex_a["hooks"]}, event)
+
+
+def test_merge_is_idempotent_never_doubles_the_hook(tmp_path):
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    wrap = tmp_path / "hooks" / "claude_pre_tool_use.py"
+    example_path = tmp_path / "ex.json"
+    example_path.write_text(json.dumps(_example_with("/interp/bin/python", wrap)), encoding="utf-8")
+    target = tmp_path / "settings.json"
+    _merge_claude_settings_from_example(example_path, target)
+    _, action = _merge_claude_settings_from_example(example_path, target)  # second run
+    assert action == "unchanged"
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    for event in ("PreToolUse", "SessionStart", "PostToolUse"):
+        assert len(_rows(merged, event)) == 1  # never doubled on repeat
+
+
+def test_merge_replaces_hook_in_place_when_interpreter_changes(tmp_path):
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    wrap = tmp_path / "hooks" / "claude_pre_tool_use.py"
+    target = tmp_path / "settings.json"
+    old = tmp_path / "old.json"
+    old.write_text(json.dumps(_example_with("/old/bin/python", wrap)), encoding="utf-8")
+    _merge_claude_settings_from_example(old, target)
+    new = tmp_path / "new.json"
+    new.write_text(json.dumps(_example_with("/new/bin/python", wrap)), encoding="utf-8")
+    _merge_claude_settings_from_example(new, target)
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    for event in ("PreToolUse", "SessionStart", "PostToolUse"):
+        assert len(_rows(merged, event)) == 1  # replaced, not appended
+        assert all("/new/bin/python" in c and "/old/bin/python" not in c for c in _cmds(merged, event))
+
+
+def test_merge_preserves_a_users_own_hook_while_collapsing_a_real_duplicate(tmp_path):
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    wrap = tmp_path / "hooks" / "claude_pre_tool_use.py"
+    user_hook = {"matcher": "*", "hooks": [{"type": "command", "command": "/usr/bin/my-linter.sh"}]}
+    ex_x = _example_with("/interp-x/bin/python", wrap)
+    ex_y = _example_with("/interp-y/bin/python3", wrap)
+    # existing: the user's own hook, then TWO of ours (a genuine duplicate — this
+    # is what forces the collapse branch; a single copy would pass under the old
+    # append code too).
+    existing = {
+        "hooks": {
+            "PreToolUse": [user_hook]
+            + list(ex_x["hooks"]["PreToolUse"])
+            + list(ex_y["hooks"]["PreToolUse"])
+        }
+    }
+    target = tmp_path / "settings.json"
+    target.write_text(json.dumps(existing), encoding="utf-8")
+    example_path = tmp_path / "ex.json"
+    example_path.write_text(json.dumps(ex_x), encoding="utf-8")
+    _merge_claude_settings_from_example(example_path, target)
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    rows = _rows(merged, "PreToolUse")
+    cmds = _cmds(merged, "PreToolUse")
+    assert cmds[0] == "/usr/bin/my-linter.sh"  # user's own hook untouched, at front
+    assert sum(1 for c in cmds if "claude_pre_tool_use.py" in c) == 1  # collapsed to one
+    assert len(rows) == 2  # [user_hook, single our row], not three
+
+
+def test_merge_preserves_a_user_hook_sharing_our_basename_at_a_different_path(tmp_path):
+    """The dedup matches by wrapper FILE (full path), NOT basename — so a user's
+    own unrelated hook that merely shares the filename claude_pre_tool_use.py at a
+    different location must never be mistaken for ours and deleted. Locks the
+    full-path invariant against a future 'compare basenames' simplification."""
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    our_wrap = tmp_path / "hooks" / "claude_pre_tool_use.py"
+    ex = _example_with("/interp/bin/python", our_wrap)
+    user_same_name = {
+        "matcher": "*",
+        "hooks": [{"type": "command", "command": "python /home/me/tools/claude_pre_tool_use.py"}],
+    }
+    target = tmp_path / "settings.json"
+    target.write_text(
+        json.dumps({"hooks": {"PreToolUse": [user_same_name] + list(ex["hooks"]["PreToolUse"])}}),
+        encoding="utf-8",
+    )
+    example_path = tmp_path / "ex.json"
+    example_path.write_text(json.dumps(ex), encoding="utf-8")
+    _merge_claude_settings_from_example(example_path, target)
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    cmds = _cmds(merged, "PreToolUse")
+    assert "python /home/me/tools/claude_pre_tool_use.py" in cmds  # user's same-named hook preserved
+    assert sum(1 for c in cmds if str(our_wrap) in c) == 1  # ours present exactly once
+
+
+def test_merge_dedups_project_form_hook_across_interpreters(tmp_path):
+    """The project-install command double-quotes the wrapper for $CLAUDE_PROJECT_DIR
+    expansion; shell-aware tokenizing must still recognize it so a re-onboard from a
+    different interpreter collapses instead of double-firing."""
+    from agentacct.cli import _merge_claude_settings_from_example
+    from agentacct.hooks import claude_code_settings_example
+
+    ex_a = claude_code_settings_example(python_executable="/venvA/bin/python", hook_path=None)
+    ex_b = claude_code_settings_example(python_executable="/venvB/bin/python3", hook_path=None)
+    existing = {"hooks": {}}
+    for ex in (ex_a, ex_b):
+        for event, rows in ex["hooks"].items():
+            existing["hooks"].setdefault(event, []).extend(rows)
+    target = tmp_path / "settings.json"
+    target.write_text(json.dumps(existing), encoding="utf-8")
+    example_path = tmp_path / "ex.json"
+    example_path.write_text(json.dumps(ex_a), encoding="utf-8")
+    _merge_claude_settings_from_example(example_path, target)
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    for event in ("PreToolUse", "SessionStart", "PostToolUse"):
+        assert len(_rows(merged, event)) == 1, (event, _cmds(merged, event))
+
+
+def test_merge_dedups_when_the_wrapper_path_contains_a_space(tmp_path):
+    """A home dir with a space (common on macOS/Windows) makes the command
+    shlex-quote the wrapper path; the dedup must still collapse across interpreters."""
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    wrap = Path("/Users/John Smith") / ".claude" / "hooks" / "claude_pre_tool_use.py"
+    ex_a = _example_with("/pyA/bin/python", wrap)
+    ex_b = _example_with("/pyB/bin/python3", wrap)
+    existing = {"hooks": {}}
+    for ex in (ex_a, ex_b):
+        for event, rows in ex["hooks"].items():
+            existing["hooks"].setdefault(event, []).extend(rows)
+    target = tmp_path / "settings.json"
+    target.write_text(json.dumps(existing), encoding="utf-8")
+    example_path = tmp_path / "ex.json"
+    example_path.write_text(json.dumps(ex_a), encoding="utf-8")
+    _merge_claude_settings_from_example(example_path, target)
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    assert len(_rows(merged, "PreToolUse")) == 1, _cmds(merged, "PreToolUse")
+
+
+def test_merge_keeps_a_user_command_colocated_in_our_matcher_row(tmp_path):
+    """If a user adds their own command to the SAME matcher entry as our wrapper,
+    the merge must drop only OUR command from that row, never the user's."""
+    from agentacct.cli import _merge_claude_settings_from_example
+
+    wrap = tmp_path / "hooks" / "claude_pre_tool_use.py"
+    ex = _example_with("/interp/bin/python", wrap)
+    our_cmd = ex["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    mixed = {
+        "matcher": "*",
+        "hooks": [
+            {"type": "command", "command": our_cmd},
+            {"type": "command", "command": "/usr/bin/my-audit.sh"},
+        ],
+    }
+    target = tmp_path / "settings.json"
+    target.write_text(json.dumps({"hooks": {"PreToolUse": [mixed]}}), encoding="utf-8")
+    example_path = tmp_path / "ex.json"
+    example_path.write_text(json.dumps(ex), encoding="utf-8")
+    _merge_claude_settings_from_example(example_path, target)
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    cmds = _cmds(merged, "PreToolUse")
+    assert "/usr/bin/my-audit.sh" in cmds  # user's co-located command NEVER dropped
+    assert sum(1 for c in cmds if "claude_pre_tool_use.py" in c) == 1  # ours deduped


### PR DESCRIPTION
## What

Re-onboarding Claude Code from a second agentacct install — or after the python interpreter path changed (a venv relocation, a python upgrade) — appended a near-duplicate hook row that differed only by the interpreter. Both rows ran the same wrapper, so it fired **twice per tool call** and tool activity was **double-counted**. The old merge deduped by the exact full command string, which an interpreter change defeats.

## Change

`_merge_claude_settings_from_example` now recognizes an agentacct hook by the **wrapper FILE** it runs (the frozen `claude_pre_tool_use.py` path) and replaces it in place instead of appending:

- **Shell-aware matching** (`shlex.split`, with a whitespace fallback on unbalanced quotes): recognizes the wrapper in the project-install form (`"$CLAUDE_PROJECT_DIR/…/claude_pre_tool_use.py"`, double-quoted for env expansion) and when the home path contains a space (shlex-quoted) — the two forms the first cut missed.
- **Command-granularity collapse**: a user command co-located in the same matcher row as our wrapper is preserved (only our command is trimmed); a matched row is dropped only if nothing of theirs remains.
- **Full-path (not basename) identity**: a user's own unrelated hook that merely shares the filename at a different path is never mistaken for ours.
- A generated example carrying no wrapper path falls back to the prior exact-fingerprint dedup, so re-merge stays idempotent.

Re-running onboard from the same install is a no-op; onboarding from a second install collapses to one row.

## Verification

- Full suite: 3025 passed, 1 skipped (8 new tests: collapse-duplicate, idempotent, interpreter-change, project-form, spaced-path, co-located user command, same-basename-different-path, genuine-duplicate-with-user-hook).
- Adversarial review, two rounds: round 1 found three real defects (shell-unaware tokenizing, row-granularity user-command loss, a weak test) — all fixed; round 2's correctness lens found no code defects and one further test-coverage gap, now closed. The shell-aware, command-granularity, and full-path invariants each have a mutation-verified test.
