### PR TITLE
feat(receipt): infer an ended_open disposition when a session stops with a step open

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -3435,6 +3435,34 @@ def claude_code_post_tool_use(
         print("{}")
 
 
+@claude_code_hooks_app.command("session-end")
+def claude_code_session_end(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory for the hook context bridge. Defaults to the nearest existing .agent-sentinel/state above the hook event cwd."),
+    ] = None,
+) -> None:
+    """Observe a Claude Code SessionEnd JSON event from stdin.
+
+    Spools a content-free session-end fact (client, session id, the end reason, a
+    timestamp) so the reducer can infer an ``ended_open`` disposition for a step
+    whose session stopped without a recorded terminal. Never reads conversation
+    content; SessionEnd output is ignored by Claude Code, so this always returns
+    an empty response and never blocks anything.
+    """
+    from .hooks import capture_session_end
+
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_session_end(raw, store_dir=store_dir)
+        except Exception:  # noqa: BLE001 - capture must never affect anything.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: a SessionEnd hook must never disturb shutdown.
+        print("{}")
+
+
 @claude_code_hooks_app.command("session-start")
 def claude_code_session_start(
     store_dir: Annotated[
@@ -6851,6 +6879,20 @@ def _local_usage_import_payload(
                 ingest_mechanical_check_spool(
                     effective_store_dir,
                     evidence=service.evidence,
+                    now=time.time(),
+                )
+            except Exception:  # noqa: BLE001 - draining the spool must never fail the import.
+                pass
+            # Drain the SessionEnd spool into content-free session_end_observed
+            # events. The reducer stamps each work item with its session's end
+            # time to derive the honest ``ended_open`` disposition. Best-effort,
+            # additive + content-idded, same as the two spools above.
+            from .session_lifecycle import ingest_session_end_spool
+
+            try:
+                ingest_session_end_spool(
+                    effective_store_dir,
+                    record=service.record_event,
                     now=time.time(),
                 )
             except Exception:  # noqa: BLE001 - draining the spool must never fail the import.

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -511,6 +511,39 @@ def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> N
         return
 
 
+def capture_session_end(raw: str, *, store_dir: Path | str | None = None) -> None:
+    """Record ONE session-end tick for this SessionEnd hook. Never raises.
+
+    Spools only content-free identity + timing — client, session id, the end
+    ``reason`` (a short enum like ``clear``/``logout``), and a timestamp — so the
+    reducer can infer an ``ended_open`` disposition for a step whose session
+    stopped without a recorded terminal. Never reads conversation content. The
+    SessionEnd hook fires only for a ROOT session, so no subagent-end noise.
+    """
+
+    try:
+        from .session_lifecycle import record_session_end_tick
+
+        event = json.loads(raw or "{}")
+        if not isinstance(event, dict):
+            return
+        session_id = event.get("session_id")
+        if not isinstance(session_id, str) or not session_id or len(session_id) > _MAX_CONTEXT_ID_LENGTH:
+            return
+        target = Path(store_dir) if store_dir is not None else _hook_store_dir_from_event(event)
+        if target is None:
+            return
+        record_session_end_tick(
+            target,
+            client="claude-code",
+            session_id=session_id,
+            reason=event.get("reason"),
+            at=time.time(),
+        )
+    except Exception:  # noqa: BLE001 - session-end capture must never affect the hook.
+        return
+
+
 def _hook_exit_code(event: dict[str, Any]) -> int | None:
     """Read the Bash exit code from a PostToolUse event, tolerant of the
     tool_output/tool_response key and exit_code/exitCode/code spellings. 0 is a
@@ -621,10 +654,21 @@ def claude_session_start_response(raw: str) -> dict[str, Any]:
         return {}
     if is_subagent_session_start(event):
         return {}
+    context = session_start_additional_context()
+    # On a resumed/compacted start — the moment work is most likely mid-handoff —
+    # append a targeted reminder to close the loop with a terminal status. This is
+    # the injection-capable hook (SessionEnd/PreCompact cannot inject); it lifts
+    # the AGENT-asserted quality, while SessionEnd's inferred ``ended_open`` is the
+    # safety net for when the reminder is not acted on.
+    source = event.get("source")
+    if isinstance(source, str) and source in ("resume", "compact"):
+        from .install_guide import session_resume_additional_context
+
+        context = f"{context}\n\n{session_resume_additional_context()}"
     return {
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
-            "additionalContext": session_start_additional_context(),
+            "additionalContext": context,
         }
     }
 
@@ -954,9 +998,10 @@ def resolve_agentacct():
 
 def fail_open(reason, hook_event=""):
     sys.stderr.write("agentacct hook: %s; failing open\\n" % reason)
-    if hook_event in ("SessionStart", "PostToolUse"):
-        # SessionStart / PostToolUse no-op: an empty object. PostToolUse in
-        # particular must never block or edit the tool result on failure.
+    if hook_event in ("SessionStart", "PostToolUse", "SessionEnd"):
+        # SessionStart / PostToolUse / SessionEnd no-op: an empty object.
+        # PostToolUse in particular must never block or edit the tool result on
+        # failure; SessionEnd output is ignored by Claude Code either way.
         sys.stdout.write("{}\\n")
     else:
         # "agent_sentinel" is a frozen wire key (pre-rename): consumers parse it.
@@ -982,6 +1027,7 @@ def main():
     subcommand = {
         "SessionStart": "session-start",
         "PostToolUse": "post-tool-use",
+        "SessionEnd": "session-end",
     }.get(HOOK_EVENT, "pre-tool-use")
     executable = resolve_agentacct()
     if executable is None:
@@ -1124,6 +1170,21 @@ def claude_code_settings_example(python_executable: str | None = None, *, hook_p
             "PostToolUse": [
                 {
                     "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": command,
+                        }
+                    ],
+                }
+            ],
+            # SessionEnd fires once when a root session terminates. The wrapper
+            # spools a content-free session-end fact (client, session id, reason,
+            # time); the reducer later infers an ``ended_open`` disposition for a
+            # step whose session stopped without a recorded terminal. Fire-and-
+            # forget: Claude Code ignores the output, so it never blocks anything.
+            "SessionEnd": [
+                {
                     "hooks": [
                         {
                             "type": "command",

--- a/src/agentacct/install_guide.py
+++ b/src/agentacct/install_guide.py
@@ -341,6 +341,25 @@ def session_start_additional_context() -> str:
     return SESSION_START_ADDITIONAL_CONTEXT
 
 
+# Appended to the SessionStart context ONLY when the session resumed or just
+# compacted (source in {resume, compact}) — the moment work is most likely being
+# handed off/rolled over. It nudges the agent to close the loop itself
+# (agent-asserted, the highest-quality record); the SessionEnd hook's inferred
+# ``ended_open`` is only the safety net for when this reminder is not acted on.
+SESSION_RESUME_ADDITIONAL_CONTEXT = (
+    "This session resumed or just compacted (its context rolled over — a common "
+    "handoff point). If you are mid-task, record the current section's status now "
+    "so the work state is not lost, and record the TERMINAL status "
+    "(completed / handed_off) when you finish or hand off — a section left open "
+    "reads as unfinished."
+)
+
+
+def session_resume_additional_context() -> str:
+    """The extra directive appended on a resumed/compacted SessionStart."""
+    return SESSION_RESUME_ADDITIONAL_CONTEXT
+
+
 # --- Standing workflow instructions (per-session, user or project level) -------
 # In global mode agentacct installs the MCP server, hooks, and store but NOT any
 # standing "record your work" instruction, so agents never open sections and the

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -69,6 +69,10 @@ SOURCE_HOOK = "hook"
 SOURCE_CI = "ci"
 SOURCE_GIT = "git"
 SOURCE_HUMAN = "human"
+# agentacct's OWN inference from an ambient signal (e.g. a SessionEnd event) —
+# not the agent's word, not a check, not a person. The weakest source: it may
+# fill a gap honestly but never claims the certainty of a report or a check.
+SOURCE_INFERRED = "inferred"
 SOURCE_NONE = "none"
 
 PROVENANCE_LEGEND: dict[str, str] = {
@@ -78,6 +82,7 @@ PROVENANCE_LEGEND: dict[str, str] = {
     SOURCE_CI: "Reported by external CI or the model provider.",
     SOURCE_GIT: "Derived from the git repository.",
     SOURCE_HUMAN: "Asserted by a person (review, approval, or finding disposition).",
+    SOURCE_INFERRED: "Inferred by agentacct from an ambient signal (e.g. the session ended); not the agent's word.",
     SOURCE_NONE: "Not captured by any source — recorded here as a gap, never guessed.",
 }
 
@@ -96,6 +101,9 @@ _DECISION_ASSERTED_BY: dict[str, str] = {
     "resolved": "agent_report",
     "mostly_done": "agent_report",
     "handed_off": "agent_report",
+    # Inferred by agentacct from an ambient SessionEnd event — the weakest
+    # provenance, deliberately NOT agent_report (the agent never said this).
+    "ended_open": "inferred",
     "in_progress": "agent_report",
     "observed": "none",
     "unknown": "none",
@@ -113,6 +121,10 @@ _DECISION_STATEMENTS: dict[str, str] = {
     "resolved": "A later passed check reports the exact blocker resolved; this is not a verified completion.",
     "reported": "The agent reported completing work; no linked passing check verifies it yet.",
     "handed_off": "The work was cleanly handed off (continued elsewhere); a deliberate stop, not a completion.",
+    "ended_open": (
+        "The session ended with this step still open; agentacct inferred a stop from the session-end "
+        "event — not a recorded completion or a deliberate handoff."
+    ),
     "mostly_done": "Recorded steps completed while one or more were left open; not a claim the Task is finished.",
     "in_progress": "This Task is still in progress.",
     "observed": "agentacct observed this Task but no outcome was recorded.",
@@ -506,6 +518,8 @@ def _asserted_by_source(asserted_by: str, checks: list[Mapping[str, Any]]) -> st
         return SOURCE_MCP
     if asserted_by == "agent_report":
         return SOURCE_MCP
+    if asserted_by == "inferred":
+        return SOURCE_INFERRED
     return SOURCE_NONE
 
 

--- a/src/agentacct/session_lifecycle.py
+++ b/src/agentacct/session_lifecycle.py
@@ -1,0 +1,269 @@
+"""Ambient session-lifecycle capture for the Receipt's semantic layer.
+
+The semantic layer (a section and its lifecycle: started/checkpoint/completed/
+handed_off) is otherwise 100% agent-cooperative — it exists only if the agent
+calls ``agentacct_record_section``. That makes the NORMAL end of a session — the
+agent just stops without recording a terminal — leave its section open forever,
+so the Task reads as perpetually in-progress.
+
+This module adds the one AMBIENT fact needed to close that loop honestly: the
+Claude Code ``SessionEnd`` hook fires when a root session terminates, and this
+records a single ``session_end_observed`` event carrying only content-free
+identity + timing (client, session id, the end ``reason``, a timestamp) — never
+any conversation content. The reducer then DERIVES an ``ended_open`` disposition
+for a still-open step whose session has ended (see ``task_outcome``); nothing is
+fabricated as "completed", and the derived state is marked ``asserted_by:
+inferred`` so it never claims the agent's or a check's certainty.
+
+Capture mirrors ``tool_activity``: the fail-open hook appends one tiny line to a
+per-store spool, and ``usage import-local`` later drains it into the store — no
+daemon required, O(1), best-effort. A lost line is an honest undercount (a
+missed auto-close leaves the section open, exactly as today), never an overcount.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+
+# frozen: stored ``session_end_observed`` events carry this event_type forever.
+SESSION_END_EVENT_TYPE = "session_end_observed"
+SESSION_END_CAPTURE_BASIS = "client_hook_session_end"
+_SPOOL_RELATIVE_PATH = Path("spool") / "claude-session-end.jsonl"
+
+# A hard bound on the captured reason (a short enum like ``clear``/``logout``).
+_REASON_MAX = 64
+
+
+def _normalize_reason(reason: Any) -> str | None:
+    text = str(reason or "").strip()
+    if not text:
+        return None
+    return text[:_REASON_MAX]
+
+
+def session_end_spool_path(store_dir: Path | str) -> Path:
+    return Path(store_dir) / _SPOOL_RELATIVE_PATH
+
+
+def record_session_end_tick(
+    store_dir: Path | str,
+    *,
+    client: str,
+    session_id: str,
+    reason: Any = None,
+    at: float,
+) -> None:
+    """Append ONE session-end tick to the store spool. Best-effort; never raises.
+
+    Writes only the scalars ``{c, s, t}`` — client, session id, timestamp — plus
+    ``r``, the end reason (a short enum), when given. No conversation content, no
+    path, no payload. ``O_APPEND`` so concurrent hook processes never interleave.
+    """
+
+    try:
+        client = str(client or "").strip()
+        session_id = str(session_id or "").strip()
+        if not client or not session_id:
+            return
+        target = session_end_spool_path(store_dir)
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        payload: dict[str, Any] = {"c": client, "s": session_id, "t": float(at)}
+        normalized_reason = _normalize_reason(reason)
+        if normalized_reason:
+            payload["r"] = normalized_reason
+        line = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, (line + "\n").encode("utf-8"))
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001 - capture must never affect the hook.
+        return
+
+
+def drain_session_end_spool(
+    store_dir: Path | str,
+    *,
+    now: float | None = None,
+    token: str | None = None,
+) -> list[dict[str, Any]]:
+    """Consume the spool and return additive ``session_end_observed`` events.
+
+    The spool is atomically renamed aside before being read, so ticks that land
+    during the drain go to a freshly recreated spool and are picked up next time.
+    One event per (client, session): the LATEST end timestamp wins (a session can
+    legitimately end more than once across resume cycles — the most recent end is
+    the one that matters for the disposition). Each event carries a deterministic
+    id so re-reducing the event log is idempotent and re-importing never doubles.
+    """
+
+    spool = session_end_spool_path(store_dir)
+    if not spool.exists():
+        return []
+    batch_token = token or uuid.uuid4().hex
+    consuming = spool.with_name(f".{spool.name}.consuming-{os.getpid()}-{batch_token}")
+    try:
+        os.replace(spool, consuming)
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return []
+    try:
+        raw = consuming.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    finally:
+        try:
+            consuming.unlink()
+        except OSError:
+            pass
+
+    latest: dict[tuple[str, str], float] = {}
+    reasons: dict[tuple[str, str], str] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, Mapping):
+            continue
+        client = str(row.get("c") or "").strip()
+        session = str(row.get("s") or "").strip()
+        if not client or not session:
+            continue
+        stamp = row.get("t")
+        if not isinstance(stamp, (int, float)) or isinstance(stamp, bool):
+            continue
+        key = (client, session)
+        stamp = float(stamp)
+        if stamp >= latest.get(key, float("-inf")):
+            latest[key] = stamp
+            reason = _normalize_reason(row.get("r"))
+            if reason:
+                reasons[key] = reason
+            elif key in reasons:
+                del reasons[key]
+
+    events: list[dict[str, Any]] = []
+    for (client, session), ended_at in sorted(latest.items()):
+        digest = uuid.uuid5(uuid.NAMESPACE_URL, f"{batch_token}\0{client}\0{session}").hex
+        metadata: dict[str, Any] = {
+            "client": client,
+            "client_session_id": session,
+            "ended_at": ended_at,
+            "capture_basis": SESSION_END_CAPTURE_BASIS,
+            "sentinel_semantic_kind": "session_lifecycle",
+        }
+        reason = reasons.get((client, session))
+        if reason:
+            metadata["reason"] = reason
+        events.append(
+            {
+                "event_id": f"sessend:{digest}",
+                "created_at": ended_at,
+                "source": client,
+                "event_type": SESSION_END_EVENT_TYPE,
+                "run_id": None,
+                "metadata": metadata,
+            }
+        )
+    return events
+
+
+def _event_session_key(event: Mapping[str, Any]) -> tuple[str, str] | None:
+    meta = event.get("metadata")
+    meta = meta if isinstance(meta, Mapping) else {}
+    session = str(meta.get("client_session_id") or "").strip()
+    if not session:
+        return None
+    client = str(meta.get("client") or event.get("source") or "").strip()
+    if not client:
+        return None
+    return (client, session)
+
+
+def build_session_end_by_session(events: Any) -> dict[tuple[str, str], float]:
+    """Map ``(client, client_session_id)`` -> the session's end timestamp, but ONLY
+    when that end is the session's LAST word.
+
+    A Claude Code session that ends and is later resumed keeps the SAME
+    ``client_session_id`` (``claude --resume`` reuses the id), so a stored
+    ``session_end_observed`` alone does not mean the session is dead. We therefore
+    treat an end as authoritative only when NO other event for that session
+    postdates it: the resumed session's own work (tool activity, usage, a fresh
+    section) carries a later timestamp and supersedes the stale end, so a live
+    resumed session is never inferred ``ended_open``. The end contributes its OWN
+    ``ended_at`` (the real session-end time, not the later import/record time) to
+    the activity comparison, so a normal end that truly IS the last event still
+    counts. The latest end wins across resume cycles.
+    """
+
+    ends: dict[tuple[str, str], float] = {}
+    latest_activity: dict[tuple[str, str], float] = {}
+    for event in events or []:
+        if not isinstance(event, Mapping):
+            continue
+        key = _event_session_key(event)
+        if key is None:
+            continue
+        is_end = event.get("event_type") == SESSION_END_EVENT_TYPE
+        if is_end:
+            meta = event.get("metadata")
+            meta = meta if isinstance(meta, Mapping) else {}
+            ended = meta.get("ended_at")
+            if not isinstance(ended, (int, float)) or isinstance(ended, bool):
+                ended = event.get("created_at")
+            try:
+                ts = float(ended)
+            except (TypeError, ValueError):
+                continue
+            ends[key] = max(ends.get(key, float("-inf")), ts)
+        else:
+            created = event.get("created_at")
+            if not isinstance(created, (int, float)) or isinstance(created, bool):
+                continue
+            ts = float(created)
+        latest_activity[key] = max(latest_activity.get(key, float("-inf")), ts)
+
+    # An end is authoritative only when nothing else for its session is newer.
+    return {
+        key: ended_at
+        for key, ended_at in ends.items()
+        if ended_at >= latest_activity.get(key, ended_at)
+    }
+
+
+def ingest_session_end_spool(
+    store_dir: Path | str,
+    *,
+    record: Callable[[dict[str, Any]], Any],
+    now: float | None = None,
+    token: str | None = None,
+) -> int:
+    """Drain the spool and hand each event to ``record``. Never raises.
+
+    Mirrors ``tool_activity.ingest_tool_activity_spool`` so the usage importer
+    drains session-end the same way it drains tool activity and mechanical checks.
+    """
+
+    try:
+        events = drain_session_end_spool(store_dir, now=now, token=token)
+    except Exception:  # noqa: BLE001 - a spool drain must never fail the import.
+        return 0
+    written = 0
+    for event in events:
+        try:
+            record(event)
+            written += 1
+        except Exception:  # noqa: BLE001 - one bad event must not abort the rest.
+            continue
+    return written

--- a/src/agentacct/task_intelligence.py
+++ b/src/agentacct/task_intelligence.py
@@ -126,6 +126,7 @@ def _state_axes(
             "reported",
             "resolved",
             "handed_off",
+            "ended_open",
             "mostly_done",
         }
         else "unknown"
@@ -178,6 +179,7 @@ def _decision_brief(
         "resolved": "A later passed check explicitly reports the exact blocker resolved; this is not a verified completion.",
         "reported": "The agent reported completing work; no linked passing check verifies it yet.",
         "handed_off": "The work was cleanly handed off (continued elsewhere or in a new session); this is a deliberate stop, not a completed or verified outcome.",
+        "ended_open": "The session ended with a step still open; agentacct inferred a stop from the session-end event — this is not a recorded completion or a deliberate handoff.",
         "mostly_done": "Recorded steps completed while one or more were left open without a terminal record; this is not a claim the Task is finished.",
         "unknown": "agentacct observed this Task but no outcome was recorded.",
     }[outcome]

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -487,6 +487,28 @@ def reduce_task_outcome(
     handoff_current = newest_handoff_at is not None and (
         not _open_times or newest_handoff_at >= max(_open_times)
     )
+    # ENDED-OPEN DISPOSITION (inferred). A still-open step (started/checkpoint)
+    # whose SESSION has ended — a ``session_ended_at`` at/after the step's own last
+    # activity, stamped by the projection from an ambient SessionEnd event — is not
+    # "in progress": the session stopped without the agent recording a terminal.
+    # The Task is ``ended_open`` only when EVERY open step is in an ended session
+    # (if any open step is still in a LIVE session, work genuinely continues
+    # somewhere, so the Task stays in progress) — the same "no live frontier" shape
+    # as the handoff rule. This is agentacct's own inference, not the agent's word,
+    # so it is the weakest disposition (ranked below an agent-asserted handoff) and
+    # never claims completion. A resumed step lands in a newer, still-live session,
+    # so its open step keeps the Task ``in_progress`` here automatically.
+    _open_items = [item for item, status in zip(items, statuses) if status in _ACTIVE_STATUSES]
+
+    def _session_ended_at(item: Mapping[str, Any]) -> float | None:
+        ended = _number(item.get("session_ended_at"))
+        return ended if ended > 0.0 else None
+
+    ended_open_current = bool(_open_items) and all(
+        (_session_ended_at(item) is not None)
+        and (_session_ended_at(item) >= _number(item.get("updated_at") or item.get("started_at")))
+        for item in _open_items
+    )
     checks = latest_task_checks(task)
     # Explicit work state is the product's user-action contract. A current
     # failed check may explain the blocker, but it must never demote a
@@ -593,6 +615,15 @@ def reduce_task_outcome(
         # deliberate stop — never a completed/verified claim, never a
         # blocker/failure.
         key = "handed_off"
+    elif ended_open_current:
+        # INFERRED: every still-open step is in a session that has ended without a
+        # recorded terminal. Ranked BELOW an agent-asserted handoff (the agent's
+        # own word wins) and below blocked/finding (a red check still leads), but
+        # ABOVE plain in_progress: the session stopped, so "in progress" would be a
+        # lie. Not a completion, not a deliberate handoff — agentacct inferred the
+        # stop from the ambient SessionEnd event (asserted_by=inferred, see
+        # receipt). Never fabricates ``completed``.
+        key = "ended_open"
     elif open_step_count:
         # DECISION 3a: one un-closed step must not drag a mostly-finished Task to
         # plain "in progress" — but silence is NOT evidence of abandonment. The

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -13,6 +13,7 @@ from .confidence import (
     normalize_cost_confidence,
     normalize_usage_confidence,
 )
+from .session_lifecycle import build_session_end_by_session
 from .tool_activity import build_tool_activity_by_session, build_tool_names_by_session
 from .join_rules import (
     JoinCandidateIndex,
@@ -219,6 +220,18 @@ def build_work_ledger(
             names = tool_names_by_session.get(entry_key)
             if names:
                 entry["tool_name_counts"] = dict(names)
+    # Ambient session-end (SessionEnd hook): stamp each work item with the end
+    # time of its OWN session so the outcome reducer can honestly derive the
+    # ``ended_open`` disposition — an open step whose session stopped without a
+    # recorded terminal. A step with no session-end simply carries no key (its
+    # session is still live / never observed ending), so nothing is inferred.
+    session_end_by_session = build_session_end_by_session(events)
+    if session_end_by_session:
+        for item in work_items:
+            item_key = (str(item.get("client") or ""), str(item.get("client_session_id") or ""))
+            ended_at = session_end_by_session.get(item_key)
+            if ended_at is not None:
+                item["session_ended_at"] = ended_at
     rollup_summary = session_rollup.get("summary")
     if isinstance(rollup_summary, dict):
         rollup_summary["mechanical_projection"] = dict(session_observation_diagnostics or {})

--- a/tests/test_hooks_claude_code.py
+++ b/tests/test_hooks_claude_code.py
@@ -770,13 +770,74 @@ def test_render_wrapper_embeds_absolute_path_with_bare_name_fallback():
     # fails open with the event-appropriate shape too.
     assert '"SessionStart": "session-start"' in text
     assert '"PostToolUse": "post-tool-use"' in text
+    assert '"SessionEnd": "session-end"' in text
     assert '.get(HOOK_EVENT, "pre-tool-use")' in text
-    # PostToolUse (like SessionStart) fails open to an empty object, never a
-    # blocking decision.
-    assert 'hook_event in ("SessionStart", "PostToolUse")' in text
+    # PostToolUse / SessionEnd (like SessionStart) fail open to an empty object,
+    # never a blocking decision.
+    assert 'hook_event in ("SessionStart", "PostToolUse", "SessionEnd")' in text
     assert '[executable, "hooks", "claude-code", subcommand, *AGENT_CHRONICLE_HOOK_ARGS]' in text
     # Bytes + replace: undecodable stdin can never raise before the event is known.
     assert 'sys.stdin.buffer.read().decode("utf-8", "replace")' in text
+
+
+def test_settings_example_wires_session_end() -> None:
+    from agentacct.hooks import claude_code_settings_example
+
+    hooks = claude_code_settings_example(python_executable="/usr/bin/python3")["hooks"]
+    assert "SessionEnd" in hooks
+    # one entry, no matcher (fires once on any root-session termination)
+    assert len(hooks["SessionEnd"]) == 1 and "matcher" not in hooks["SessionEnd"][0]
+
+
+def test_session_start_nudge_only_on_resume_or_compact() -> None:
+    import json
+
+    from agentacct.hooks import claude_session_start_response
+
+    def ctx(source):
+        r = claude_session_start_response(json.dumps({"hook_event_name": "SessionStart", "source": source}))
+        return r["hookSpecificOutput"]["additionalContext"]
+
+    startup, compact, resume = ctx("startup"), ctx("compact"), ctx("resume")
+    # the terminal-status reminder is appended only when work is likely mid-handoff
+    assert "handoff point" in compact and "handoff point" in resume
+    assert "handoff point" not in startup
+    assert len(compact) > len(startup) and len(resume) > len(startup)
+    # the base record-your-work directive is still present in every case
+    assert startup and startup in compact
+
+
+def test_capture_session_end_is_content_free(tmp_path) -> None:
+    import json
+
+    from agentacct.hooks import capture_session_end
+    from agentacct.session_lifecycle import drain_session_end_spool
+
+    raw = json.dumps(
+        {
+            "hook_event_name": "SessionEnd",
+            "session_id": "sess-xyz",
+            "reason": "logout",
+            "transcript_path": "/secret/transcript.jsonl",
+            "cwd": "/secret/project",
+        }
+    )
+    capture_session_end(raw, store_dir=tmp_path)
+    [event] = drain_session_end_spool(tmp_path, now=1.0)
+    assert event["metadata"]["client_session_id"] == "sess-xyz"
+    assert event["metadata"]["reason"] == "logout"
+    blob = json.dumps(event)
+    assert "secret" not in blob and "transcript" not in blob and "cwd" not in blob
+
+
+def test_session_end_with_no_session_id_is_a_noop(tmp_path) -> None:
+    import json
+
+    from agentacct.hooks import capture_session_end
+    from agentacct.session_lifecycle import session_end_spool_path
+
+    capture_session_end(json.dumps({"hook_event_name": "SessionEnd", "reason": "clear"}), store_dir=tmp_path)
+    assert not session_end_spool_path(tmp_path).exists()
 
 
 def test_install_embeds_resolved_executable_and_python_paths(tmp_path, monkeypatch):

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -150,6 +150,32 @@ def test_blocked_receipt_still_carries_the_handoff_marker() -> None:
     assert receipt["axes"]["handoff"]["handed_off"] is True
 
 
+def test_ended_open_is_inferred_and_never_claims_completion() -> None:
+    # A still-open step whose session ended surfaces as the ``ended_open``
+    # decision word, asserted_by=inferred (weaker than the agent's word), with a
+    # statement that never claims completion or a deliberate handoff. The outcome
+    # dimension's provenance must be the inferred source, not mcp/machine/human.
+    task = _task(
+        [
+            {
+                "work_id": "a",
+                "latest_status": "started",
+                "updated_at": 100.0,
+                "client": "claude-code",
+                "client_session_id": "s1",
+                "session_ended_at": 200.0,
+            }
+        ]
+    )
+    receipt = _receipt(task)
+    decision = receipt["axes"]["decision_status"]
+    assert decision["key"] == "ended_open"
+    assert decision["asserted_by"] == "inferred"
+    assert "inferred" in decision["statement"].lower()
+    assert "complet" not in decision["statement"].lower() or "not a recorded completion" in decision["statement"].lower()
+    assert receipt["dimensions"]["outcome"]["provenance"] == ["inferred"]
+
+
 def test_resumed_task_receipt_shows_no_handoff_marker() -> None:
     # A later open step postdates the handoff: the Task resumed, so neither the
     # decision word nor the marker report a handoff. Assert BOTH the detail axis

--- a/tests/test_receipt_cli.py
+++ b/tests/test_receipt_cli.py
@@ -283,6 +283,66 @@ def test_receipt_detail_discloses_tool_name_overflow(tmp_path: Path) -> None:
     assert "… +4 more" in detail.output  # overflow disclosed
 
 
+def _record_session_end(store: Path, *, session_id: str, at: float, reason: str = "logout") -> None:
+    SentinelService(store).record_event(
+        {
+            "event_id": f"sessend:{session_id}:{int(at)}",
+            "created_at": at,
+            "source": "claude-code",
+            "event_type": "session_end_observed",
+            "run_id": None,
+            "metadata": {
+                "client": "claude-code",
+                "client_session_id": session_id,
+                "ended_at": at,
+                "reason": reason,
+                "sentinel_semantic_kind": "session_lifecycle",
+            },
+        }
+    )
+
+
+def test_open_section_in_an_ended_session_reads_ended_open_end_to_end(tmp_path: Path) -> None:
+    # End-to-end: a started (open) section whose session then ends (an ambient
+    # session_end_observed event) flows through the store projection — the work
+    # ledger stamps session_ended_at, and the reducer infers ``ended_open``
+    # instead of a perpetual ``in_progress``. This is the dogfood gap the feature
+    # closes: the normal end of a session (agent stops without a terminal record).
+    _seed(tmp_path)  # session s1 + one completed section
+    _add_section(tmp_path, section_id="sec-open", status="started", at=150.0)
+    # The section events are stamped with the store's record time; the SessionEnd
+    # fires AFTER them (its real time.time()), so use a timestamp comfortably after
+    # the record time to express "the session ended after this step's last work".
+    _record_session_end(tmp_path, session_id="s1", at=4_000_000_000.0)
+
+    task_id = json.loads(
+        runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)]).output
+    )["tasks"][0]["task_id"]
+    receipt = json.loads(
+        runner.invoke(app, ["receipt", task_id, "--json", "--store-dir", str(tmp_path)]).output
+    )
+    decision = receipt["axes"]["decision_status"]
+    assert decision["key"] == "ended_open"
+    assert decision["asserted_by"] == "inferred"  # not the agent's word
+
+
+def test_session_end_cli_command_is_fire_and_forget(tmp_path: Path) -> None:
+    # Invariant: the SessionEnd hook path always emits {} and exits 0 — never a
+    # decision, never a non-zero exit — for both well-formed and malformed stdin.
+    ok = runner.invoke(
+        app,
+        ["hooks", "claude-code", "session-end", "--store-dir", str(tmp_path)],
+        input=json.dumps({"hook_event_name": "SessionEnd", "session_id": "s1", "reason": "logout"}),
+    )
+    assert ok.exit_code == 0 and ok.output.strip() == "{}"
+    bad = runner.invoke(
+        app,
+        ["hooks", "claude-code", "session-end", "--store-dir", str(tmp_path)],
+        input="not json at all",
+    )
+    assert bad.exit_code == 0 and bad.output.strip() == "{}"
+
+
 def test_receipts_list_json(tmp_path: Path) -> None:
     _seed(tmp_path)
     result = runner.invoke(app, ["receipts", "--json", "--store-dir", str(tmp_path)])

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -1,0 +1,111 @@
+"""Ambient session-end capture: spool -> drain -> event, and the join helper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agentacct.session_lifecycle import (
+    SESSION_END_EVENT_TYPE,
+    build_session_end_by_session,
+    drain_session_end_spool,
+    ingest_session_end_spool,
+    record_session_end_tick,
+    session_end_spool_path,
+)
+
+
+def test_spool_drain_roundtrip_latest_end_wins(tmp_path: Path) -> None:
+    record_session_end_tick(tmp_path, client="claude-code", session_id="s1", reason="logout", at=100.0)
+    record_session_end_tick(tmp_path, client="claude-code", session_id="s1", reason="clear", at=200.0)
+    record_session_end_tick(tmp_path, client="claude-code", session_id="s2", at=150.0)
+    events = drain_session_end_spool(tmp_path, now=300.0)
+    by = {e["metadata"]["client_session_id"]: e for e in events}
+    assert by["s1"]["event_type"] == SESSION_END_EVENT_TYPE
+    assert by["s1"]["metadata"]["ended_at"] == 200.0  # latest wins
+    assert by["s1"]["metadata"]["reason"] == "clear"  # the latest end's reason
+    assert by["s2"]["metadata"]["ended_at"] == 150.0
+    assert "reason" not in by["s2"]["metadata"]  # honest gap, no fabricated reason
+    # spool is consumed; a second drain sees nothing.
+    assert drain_session_end_spool(tmp_path) == []
+
+
+def test_capture_is_content_free(tmp_path: Path) -> None:
+    record_session_end_tick(tmp_path, client="claude-code", session_id="s", reason="other", at=1.0)
+    spool_text = session_end_spool_path(tmp_path).read_text(encoding="utf-8")
+    # only the tiny scalars {c,s,t}[,r] — never any payload
+    assert set(json.loads(spool_text.strip())) <= {"c", "s", "t", "r"}
+    [event] = drain_session_end_spool(tmp_path, now=2.0)
+    blob = json.dumps(event)
+    for forbidden in ("prompt", "message", "tool_input", "transcript", "content", "cwd"):
+        assert forbidden not in blob
+
+
+def test_missing_client_or_session_is_dropped(tmp_path: Path) -> None:
+    record_session_end_tick(tmp_path, client="", session_id="s", at=1.0)
+    record_session_end_tick(tmp_path, client="claude-code", session_id="", at=1.0)
+    assert drain_session_end_spool(tmp_path) == []
+
+
+def test_build_session_end_by_session_latest_wins() -> None:
+    events = [
+        {"event_type": SESSION_END_EVENT_TYPE, "created_at": 100.0, "source": "claude-code",
+         "metadata": {"client": "claude-code", "client_session_id": "s1", "ended_at": 100.0}},
+        {"event_type": SESSION_END_EVENT_TYPE, "created_at": 200.0, "source": "claude-code",
+         "metadata": {"client": "claude-code", "client_session_id": "s1", "ended_at": 200.0}},
+        {"event_type": "model_usage", "metadata": {"client": "claude-code", "client_session_id": "s1"}},
+        # falls back to created_at when ended_at is absent
+        {"event_type": SESSION_END_EVENT_TYPE, "created_at": 150.0,
+         "metadata": {"client": "claude-code", "client_session_id": "s2"}},
+    ]
+    result = build_session_end_by_session(events)
+    assert result[("claude-code", "s1")] == 200.0
+    assert result[("claude-code", "s2")] == 150.0
+    assert ("claude-code", "nope") not in result
+
+
+def _end(sid, t):
+    # created_at (record/import time) deliberately later than ended_at, as in the
+    # real store, to prove the activity comparison uses ended_at, not created_at.
+    return {"event_type": SESSION_END_EVENT_TYPE, "created_at": t + 999,
+            "metadata": {"client": "claude-code", "client_session_id": sid, "ended_at": t}}
+
+
+def _act(sid, t, typ="model_usage"):
+    return {"event_type": typ, "created_at": t, "metadata": {"client": "claude-code", "client_session_id": sid}}
+
+
+def test_end_that_is_the_sessions_last_word_is_authoritative() -> None:
+    assert build_session_end_by_session([_act("s1", 100), _end("s1", 200)]) == {("claude-code", "s1"): 200.0}
+
+
+def test_post_end_activity_supersedes_a_stale_end_so_a_resumed_session_is_live() -> None:
+    # THE HONESTY GUARD (review finding): claude --resume reuses the session id, so
+    # a stored end alone is not death. Any activity AFTER the end (the resumed
+    # session's own usage/tool work) supersedes the end -> not returned -> the
+    # reducer never infers ended_open for a live, resumed session.
+    assert build_session_end_by_session([_act("s1", 100), _end("s1", 200), _act("s1", 300)]) == {}
+    # tool activity (not just usage) also supersedes
+    assert build_session_end_by_session([_end("s1", 200), _act("s1", 300, typ="tool_activity_observed")]) == {}
+
+
+def test_a_session_that_ends_again_after_resuming_keeps_the_later_end() -> None:
+    got = build_session_end_by_session([_end("s1", 200), _act("s1", 300), _end("s1", 400)])
+    assert got == {("claude-code", "s1"): 400.0}
+
+
+def test_an_end_for_one_session_never_appears_for_another(tmp_path: Path) -> None:
+    # Cross-session: session A ended; session B is live (only activity, no end).
+    # The map must key strictly on (client, session) so B is never stamped.
+    got = build_session_end_by_session([_end("A", 200), _act("B", 300)])
+    assert got == {("claude-code", "A"): 200.0}
+    assert ("claude-code", "B") not in got
+
+
+def test_ingest_records_each_event(tmp_path: Path) -> None:
+    record_session_end_tick(tmp_path, client="claude-code", session_id="s1", at=1.0)
+    record_session_end_tick(tmp_path, client="claude-code", session_id="s2", at=2.0)
+    recorded: list[dict] = []
+    n = ingest_session_end_spool(tmp_path, record=recorded.append, now=3.0)
+    assert n == 2 and len(recorded) == 2
+    assert all(e["event_type"] == SESSION_END_EVENT_TYPE for e in recorded)

--- a/tests/test_task_outcome.py
+++ b/tests/test_task_outcome.py
@@ -583,3 +583,79 @@ def test_task_without_any_handoff_step_carries_handoff_current_false() -> None:
     for status in ("started", "completed", "checkpoint", "resolved", "blocked"):
         outcome = reduce_task_outcome(_multi_task([_step(status)]))
         assert outcome["handoff_current"] is False, status
+
+
+# --- ended_open: inferred disposition when a session stops with a step open ----
+
+
+def _sitem(status, t, *, ended=None, sid="s1"):
+    d = {
+        "latest_status": status,
+        "updated_at": t,
+        "started_at": t,
+        "client": "claude-code",
+        "client_session_id": sid,
+        "kind": "implementation",
+    }
+    if ended is not None:
+        d["session_ended_at"] = ended
+    return d
+
+
+def test_open_step_in_ended_session_reads_ended_open() -> None:
+    # THE FIX: a still-open step whose session ended (SessionEnd at/after the
+    # step) is not "in progress" — the session stopped without a terminal.
+    o = reduce_task_outcome(_multi_task([_sitem("started", 100, ended=200)]))
+    assert o["key"] == "ended_open"
+
+
+def test_open_step_in_a_live_session_stays_in_progress() -> None:
+    # No session-end signal (session still live / never observed ending): the
+    # inference never fires; behavior is byte-identical to before this feature.
+    assert reduce_task_outcome(_multi_task([_sitem("started", 100)]))["key"] == "in_progress"
+
+
+def test_one_live_open_step_keeps_the_task_in_progress() -> None:
+    # ended_open requires EVERY open step to be in an ended session; a single
+    # still-live open step means work genuinely continues somewhere.
+    task = _multi_task([_sitem("started", 100, ended=200, sid="s1"), _sitem("checkpoint", 150, sid="s2")])
+    assert reduce_task_outcome(task)["key"] == "in_progress"
+
+
+def test_resumed_after_session_end_reads_in_progress() -> None:
+    # A newer, still-live open step (a later session resumed the work) keeps the
+    # Task in progress; the earlier ended session is history.
+    task = _multi_task([_sitem("started", 100, ended=150, sid="s1"), _sitem("started", 200, sid="s2")])
+    assert reduce_task_outcome(task)["key"] == "in_progress"
+
+
+def test_agent_handoff_outranks_inferred_ended_open() -> None:
+    # The agent's own word (handed_off) beats agentacct's inference (ended_open).
+    task = _multi_task([_step("handed_off", updated_at=200), _sitem("started", 100, ended=150, sid="s2")])
+    assert reduce_task_outcome(task)["key"] == "handed_off"
+
+
+def test_blocked_and_finding_outrank_ended_open() -> None:
+    assert reduce_task_outcome(_multi_task([_sitem("blocked", 100, ended=200)]))["key"] == "blocked"
+    finding = _multi_task([_sitem("started", 100, ended=200)])
+    finding["task_evidence_events"] = [_check("failed", created_at=300, event_id="f")]
+    assert reduce_task_outcome(finding)["key"] == "finding"
+
+
+def test_completed_step_in_ended_session_is_never_ended_open() -> None:
+    # ended_open is only for OPEN steps; a completed step whose session ended is
+    # reported/verified, never dressed down to ended_open or fabricated done.
+    assert reduce_task_outcome(_multi_task([_sitem("completed", 100, ended=200)]))["key"] == "reported"
+
+
+def test_stale_session_end_before_the_step_does_not_fire() -> None:
+    # A session-end that PREDATES the step's last activity is not the step's end
+    # (the step was touched afterward) — stays in progress.
+    assert reduce_task_outcome(_multi_task([_sitem("started", 200, ended=100)]))["key"] == "in_progress"
+
+
+def test_session_end_at_the_exact_step_time_reads_ended_open() -> None:
+    # The documented "at/after" boundary: a SessionEnd stamped at exactly the
+    # step's last-activity time still infers ended_open (>= not >). Pins the tie
+    # so a >=-to-> regression is caught.
+    assert reduce_task_outcome(_multi_task([_sitem("started", 100, ended=100)]))["key"] == "ended_open"


### PR DESCRIPTION
## Problem

agentacct's semantic layer (a section and its lifecycle: started/checkpoint/completed/handed_off) was recorded only when the agent called the MCP tools. The *ambient* layer (tools, exit codes, tokens, session identity) records itself from hooks, but the semantic layer depended entirely on the agent's cooperation. So the normal end of a session — the agent stops without recording a terminal — left its section open forever, and the Task read as perpetually `in_progress`. Nothing in the codebase ever auto-closed a dangling section.

## Change

- **`session_lifecycle.py` (new):** spool → drain → ingest for a content-free `session_end_observed` event, plus `build_session_end_by_session`. The SessionEnd hook fire-and-forgets a tiny fact (client, session id, end reason, timestamp) — never any conversation content.
- **Reducer (`task_outcome`):** derives an inferred `ended_open` disposition for a still-open step whose session ended. It fires only when every open step is in an ended session, ranks **below** an agent-asserted `handed_off` and below `blocked`/`finding`, and never fabricates `completed`.
- **Honesty (`receipt` / `task_intelligence`):** new `asserted_by: inferred` (the weakest provenance, below `agent_report`) + `SOURCE_INFERRED`; `ended_open` carries a statement that says the stop was *inferred from the session-end event*, not the agent's word.
- **Resume safety:** `claude --resume <id>` reuses the session id, so a stored end alone is not death. An end is authoritative only when nothing for that session postdates it — any later activity (the resumed session's own work) supersedes the stale end, so a live resumed session is never mislabeled `ended_open`.
- **Nudge (`SessionStart`):** on `resume`/`compact` (the injection-capable hook — SessionEnd/PreCompact cannot inject), appends a reminder to record the terminal status, lifting the quality of the agent's own record. The inferred close is the safety net.

## Verification

- Full suite **3053 passed, 1 skipped** (baseline 3028 + 25 new tests). No Swift change (the new keys decode as strings and default to a muted tint).
- One adversarial-review round (find → verify → synth) across reducer honesty, hook safety, privacy, projection join, and tests. Hook-safety + privacy: zero findings. It caught a real over-fire (a resumed same-id session reading `ended_open` while live) — fixed by the supersede rule above and covered by a unit test; the remaining findings were test-coverage gaps, all closed.

## Deploy note

This re-wires the Claude Code hook (adds `SessionEnd` to settings.json), so deploy regenerates the wrapper and merges settings — safe now that #91 dedupes the hook merge by wrapper file.
