### PR TITLE
feat(usage): pair OpenCode-recorded agentacct sections to their session

### DIFF
--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -22,12 +22,14 @@ from .confidence import COST_BASIS_CLIENT_SESSION, COST_BASIS_PRICING_TABLE, COS
 from .env_compat import read_env_alias
 from .cost import estimate_model_cost_breakdown_usd, has_model_price, model_pricing_entry
 from .log_evidence import (
+    ACCEPTED_SERVER_KEYS,
     LogEvidenceAccumulator,
     classify_claude_tool_use,
     classify_codex_function_call,
     classify_codex_mcp_invocation,
     claude_tool_use_creation_tool,
     extract_created_event_id,
+    opencode_tool_creation_tool,
     refused_recording_rows,
     unwrap_codex_mcp_error,
     unwrap_codex_mcp_result,
@@ -3190,18 +3192,94 @@ def _opencode_model_fields(raw_model: Any) -> tuple[str | None, str | None]:
     return None, None
 
 
+def _scan_opencode_part_evidence(
+    con: sqlite3.Connection, session_ids: list[str]
+) -> dict[str, LogEvidenceAccumulator]:
+    """Client-log evidence for the OpenCode sessions being imported.
+
+    Scans the ``part`` table for the agentacct MCP creation-tool calls those
+    sessions made and returns one accumulator per session, so the recorded
+    events (sections, checks) can be attributed back to the session that created
+    them — the OpenCode analogue of the codex/claude client-log pairing.
+
+    Privacy + cost boundary (identical in spirit to the codex/claude readers over
+    their own transcripts): the ``part`` table is read ONLY for the
+    ≤``limit_sessions`` sessions being imported AND ONLY for rows whose ``data``
+    names an agentacct MCP server — a cheap SQL prefilter (``session_id`` set +
+    a server-name ``LIKE``) keeps every other tool's payload, every prompt, and
+    every message body out of the process entirely; they are never SELECTed,
+    parsed, read, or retained. Rows are streamed (no ``fetchall`` of the part
+    table). From each matching row ONLY an agentacct ``evt_`` id is extracted,
+    and ONLY out of an agentacct CREATION-tool response (allowlist + strict
+    single-event shape check in ``log_evidence``). Read/list tools that echo
+    other sessions' ids are structurally excluded; a tool's INPUT args are never
+    read. A part still in flight (no string output) donates nothing and is
+    counted as an honest skip.
+    """
+
+    evidence: dict[str, LogEvidenceAccumulator] = {}
+    if not session_ids:
+        return evidence
+    if not {"session_id", "data"} <= _sqlite_table_columns(con, "part"):
+        return evidence
+    session_placeholders = ", ".join("?" for _ in session_ids)
+    # Coarse SQL prefilter: only rows whose data references an agentacct-family
+    # server name reach Python. The server keys carry no LIKE metacharacters, so
+    # a bare ``%key%`` is exact-enough; the strict Python allowlist below is the
+    # real gate (a stray non-agentacct row that merely mentions the name is
+    # dropped without ever being retained). This bounds the scan to the handful
+    # of agentacct parts even on the 500-session dashboard path and lets SQLite
+    # apply the filter without materializing every tool payload in memory.
+    server_keys = sorted(ACCEPTED_SERVER_KEYS)
+    server_like = " or ".join("data like ?" for _ in server_keys)
+    params = [*session_ids, *(f"%{key}%" for key in server_keys)]
+    cursor = con.execute(
+        f"select session_id, data from part "
+        f"where session_id in ({session_placeholders}) and ({server_like})",
+        params,
+    )
+    for prow in cursor:
+        sid = str(prow["session_id"] or "").strip()
+        if not sid:
+            continue
+        raw = prow["data"]
+        if not isinstance(raw, str):
+            continue
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(data, dict) or data.get("type") != "tool":
+            continue
+        tool = opencode_tool_creation_tool(data.get("tool"))
+        if tool is None:
+            continue
+        state = data.get("state")
+        output = state.get("output") if isinstance(state, dict) else None
+        acc = evidence.get(sid)
+        if acc is None:
+            acc = LogEvidenceAccumulator()
+            evidence[sid] = acc
+        acc.add_output_text(output if isinstance(output, str) else None, tool=tool)
+    return evidence
+
+
 def _read_opencode_session_db_usage(
     db_source: _RegularSourceFile,
     *,
     limit_sessions: int,
-) -> tuple[int, list[dict[str, Any]]]:
+) -> tuple[int, list[dict[str, Any]], dict[str, LogEvidenceAccumulator]]:
     """Read the authoritative ``session`` rollup from one ``opencode*.db``.
 
-    Returns ``(discovered_rows, selected_rows)``. Only the per-session token,
-    cost, model, lineage, directory, and timestamp columns are read; message
-    bodies, prompts, and tool payloads are never touched. Raises on a corrupt
-    or unreadable database so discovery fails closed rather than reporting the
-    store as silently absent.
+    Returns ``(discovered_rows, selected_rows, evidence_by_session)``. Only the
+    per-session token, cost, model, lineage, directory, and timestamp columns of
+    the ``session`` table are read for usage; the ``part`` table is read
+    SEPARATELY and, via a server-name SQL prefilter, ONLY for rows that name the
+    agentacct MCP server — to pair the session's own agentacct creation-tool
+    event ids (see ``_scan_opencode_part_evidence`` for the boundary). Other
+    tools' payloads, prompts, and message bodies are never SELECTed or parsed.
+    Raises on a corrupt or unreadable database so discovery fails closed rather
+    than reporting the store as silently absent.
     """
 
     con = _connect_regular_source_sqlite_read_only(db_source)
@@ -3247,6 +3325,10 @@ def _read_opencode_session_db_usage(
             """,
             (max(0, limit_sessions),),
         ).fetchall()
+        session_ids = [
+            sid for sid in (str(row["id"] or "").strip() for row in rows) if sid
+        ]
+        evidence_by_session = _scan_opencode_part_evidence(con, session_ids)
     finally:
         con.close()
     selected: list[dict[str, Any]] = []
@@ -3261,7 +3343,7 @@ def _read_opencode_session_db_usage(
         usage["cache_read_tokens_reported"] = "tokens_cache_read" in columns
         usage["cache_write_tokens_reported"] = "tokens_cache_write" in columns
         selected.append(usage)
-    return max(0, discovered_rows), selected
+    return max(0, discovered_rows), selected, evidence_by_session
 
 
 def discover_opencode_usage_from_db(
@@ -3283,7 +3365,7 @@ def discover_opencode_usage_from_db(
     seen_sessions: set[tuple[str, str]] = set()
     for db_source in db_sources:
         namespace = _source_home_namespace(db_source.root)
-        _discovered, selected_rows = _read_opencode_session_db_usage(
+        _discovered, selected_rows, evidence_by_session = _read_opencode_session_db_usage(
             db_source,
             limit_sessions=limit_sessions,
         )
@@ -3291,6 +3373,11 @@ def discover_opencode_usage_from_db(
             session_id = str(usage.get("id") or "").strip()
             if not session_id:
                 continue
+            evidence_fields = (
+                evidence_by_session[session_id].as_usage_fields()
+                if session_id in evidence_by_session
+                else {}
+            )
             identity = (namespace, session_id)
             if identity in seen_sessions:
                 continue
@@ -3344,8 +3431,16 @@ def discover_opencode_usage_from_db(
                 source_revision_at=source_revision_ms * 1000 if source_revision_ms is not None else None,
                 source_revision_basis="opencode_session_time_updated_us" if source_revision_ms is not None else None,
                 source_namespace_fingerprint=namespace,
+                evidenced_event_ids=tuple(evidence_fields.get("evidenced_event_ids", ())),
+                evidenced_event_id_total=int(evidence_fields.get("evidenced_event_id_total", 0)),
+                evidenced_outputs_skipped=int(evidence_fields.get("evidenced_outputs_skipped", 0)),
             )
-            if _event_has_usage_or_cost(event):
+            # A session that recorded agentacct work is worth emitting even if the
+            # session table carries no token/cost yet (the recorded work IS the
+            # signal), so evidence counts as a reason to keep the row alongside
+            # usage/cost. Without this an evidenced-but-tokenless session would be
+            # dropped and its sections would never attach.
+            if _event_has_usage_or_cost(event) or event.evidenced_event_id_total:
                 seen_sessions.add(identity)
                 events.append(event)
     return events

--- a/src/agentacct/log_evidence.py
+++ b/src/agentacct/log_evidence.py
@@ -521,6 +521,30 @@ def claude_tool_use_creation_tool(name: Any) -> str | None:
     return tool
 
 
+def opencode_tool_creation_tool(name: Any) -> str | None:
+    """Bare creation-tool name of an OpenCode ``part.data.tool`` string, else None.
+
+    OpenCode names an MCP tool ``<server>_<tool>`` (single-underscore join), so
+    the agentacct record tools arrive as e.g.
+    ``agentacct_agentacct_record_section``. Accept ONLY when the name is exactly
+    an allowlisted server key joined to an allowlisted creation tool — the
+    remainder after the server prefix must equal a creation tool, never merely
+    contain one. Read/list tools (which echo OTHER sessions' ids) and any
+    non-creation name return None and are structurally excluded, exactly as the
+    codex/claude classifiers exclude them.
+    """
+
+    if not isinstance(name, str):
+        return None
+    for server in ACCEPTED_SERVER_KEYS:
+        prefix = f"{server}_"
+        if name.startswith(prefix):
+            tool = name[len(prefix):]
+            if tool in SENTINEL_CREATION_TOOLS:
+                return tool
+    return None
+
+
 def classify_codex_mcp_invocation(server: Any, tool: Any) -> str | None:
     """"accepted" / "rejected" / None for a codex mcp_tool_call_end invocation.
 

--- a/tests/test_client_usage.py
+++ b/tests/test_client_usage.py
@@ -440,6 +440,117 @@ def test_discover_opencode_usage_reads_native_session_db(tmp_path):
     assert payload["metadata"]["usage_update_semantics"] == "opencode_session_rollup"
 
 
+def _agentacct_record_output(event_id: str, *, event_type: str = "section_started") -> str:
+    """The JSON string OpenCode stores as an agentacct tool ``state.output``."""
+    return json.dumps(
+        {"event": {"created_at": 1.0, "event_id": event_id, "event_type": event_type,
+                   "metadata": {"section_id": "s1"}}}
+    )
+
+
+def _add_opencode_parts(opencode_home: Path, parts: list[dict[str, object]], *, db_name: str = "opencode.db") -> None:
+    """Add a ``part`` table (OpenCode's tool-call log) to an existing db home.
+
+    Each entry is ``{"session_id": ..., "tool": ..., "output": <str|None>,
+    "status": ...}``; the row's ``data`` is assembled into OpenCode's real
+    ``{"type":"tool","tool":...,"state":{...}}`` shape.
+    """
+    con = sqlite3.connect(opencode_home / db_name)
+    try:
+        con.execute(
+            "create table part (id text primary key, message_id text, session_id text, "
+            "time_created integer, time_updated integer, data text)"
+        )
+        for index, part in enumerate(parts):
+            state: dict[str, object] = {"status": part.get("status", "completed")}
+            if "output" in part:
+                state["output"] = part["output"]
+            data = {"type": part.get("type", "tool"), "tool": part.get("tool"), "state": state}
+            con.execute(
+                "insert into part (id, message_id, session_id, time_created, time_updated, data) "
+                "values (?, ?, ?, ?, ?, ?)",
+                (f"prt_{index}", f"msg_{index}", part.get("session_id"), index, index, json.dumps(data)),
+            )
+        con.commit()
+    finally:
+        con.close()
+
+
+def test_discover_opencode_usage_pairs_recorded_section_to_session(tmp_path):
+    # An agentacct record_section call in the opencode part log donates its
+    # created event id to the session that made it (the observed->reported fix).
+    opencode_home = _make_opencode_db_home(tmp_path)
+    _add_opencode_parts(
+        opencode_home,
+        [
+            {"session_id": "ses_alpha", "tool": "agentacct_agentacct_record_section",
+             "output": _agentacct_record_output("evt_aaaaaaaaaaaa")},
+            {"session_id": "ses_alpha", "tool": "agentacct_agentacct_record_machine_check",
+             "output": _agentacct_record_output("evt_bbbbbbbbbbbb", event_type="machine_check")},
+        ],
+    )
+
+    events = discover_opencode_usage(opencode_home=opencode_home, limit_sessions=10)
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.client_session_id == "ses_alpha"
+    assert set(event.evidenced_event_ids) == {"evt_aaaaaaaaaaaa", "evt_bbbbbbbbbbbb"}
+    assert event.evidenced_event_id_total == 2
+    # And it rides into the emitted event metadata for the reducer to consume.
+    payload = event.to_sentinel_event()
+    assert set(payload["metadata"]["evidenced_event_ids"]) == {"evt_aaaaaaaaaaaa", "evt_bbbbbbbbbbbb"}
+
+
+def test_discover_opencode_usage_read_tool_and_inflight_donate_nothing(tmp_path):
+    # A READ tool echoes OTHER sessions' ids and must never donate; an in-flight
+    # call (no output) donates nothing and is counted as an honest skip.
+    opencode_home = _make_opencode_db_home(tmp_path)
+    _add_opencode_parts(
+        opencode_home,
+        [
+            {"session_id": "ses_alpha", "tool": "agentacct_agentacct_list_events",
+             "output": json.dumps({"events": [{"event_id": "evt_ffffffffffff"}]})},
+            {"session_id": "ses_alpha", "tool": "agentacct_agentacct_record_section",
+             "status": "running"},  # no output key at all
+        ],
+    )
+
+    events = discover_opencode_usage(opencode_home=opencode_home, limit_sessions=10)
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.evidenced_event_ids == ()  # read-tool echo excluded, in-flight skipped
+    assert "evt_ffffffffffff" not in event.evidenced_event_ids
+    assert event.evidenced_outputs_skipped >= 1
+    # No evidence -> metadata stays byte-clean (no evidenced_event_ids key).
+    assert "evidenced_event_ids" not in event.to_sentinel_event()["metadata"]
+
+
+def test_discover_opencode_usage_ignores_non_agentacct_tool_payloads(tmp_path):
+    # A foreign tool's payload (bash output, file reads) that never names the
+    # agentacct server is excluded by the SQL prefilter — it is not SELECTed,
+    # not parsed, and cannot donate an id even if its text happens to contain an
+    # evt_-shaped string. It is not even counted as a skip (never reaches Python).
+    opencode_home = _make_opencode_db_home(tmp_path)
+    _add_opencode_parts(
+        opencode_home,
+        [
+            {"session_id": "ses_alpha", "tool": "bash",
+             "output": "ran a command; log line evt_deadbeefcafe here"},
+            {"session_id": "ses_alpha", "type": "text",
+             "output": "user prompt mentioning nothing relevant"},
+        ],
+    )
+
+    events = discover_opencode_usage(opencode_home=opencode_home, limit_sessions=10)
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.evidenced_event_ids == ()
+    assert event.evidenced_outputs_skipped == 0  # foreign rows never reached the scanner
+
+
 def test_discover_opencode_usage_recomputes_cost_from_tokens_when_stored_zero(tmp_path):
     opencode_home = _make_opencode_db_home(tmp_path)
 

--- a/tests/test_log_evidenced_linking.py
+++ b/tests/test_log_evidenced_linking.py
@@ -1270,6 +1270,41 @@ def test_multi_session_evidence_refuses_with_counter() -> None:
     assert ledger["session_rollup"]["summary"]["unassigned_work_items"] == 1
 
 
+def test_opencode_evidenced_section_attaches_to_its_session() -> None:
+    # End-to-end: an opencode section recorded via MCP carries no session id of
+    # its own (session=None), but the opencode usage row evidences its event id
+    # from the part log, so it attaches to that session — the flip from a task
+    # with NO items (observed) to a task with a real step (reported).
+    target = "evt_0bc0de000001"
+    events = [
+        _usage_row(event_id="evt_usage_oc", session="ses_oc_a", client="opencode", evidenced=[target]),
+        _section_event(event_id=target, section_id="notes", client="opencode", session=None),
+    ]
+
+    ledger = build_work_ledger(events)
+
+    item = ledger["work_items"][0]
+    assert item["client_session_id"] == "ses_oc_a"
+    assert item.get("log_evidence_ambiguous") is None
+
+
+def test_opencode_multi_session_evidence_refuses() -> None:
+    # The generic >1-donor guard reaches opencode too: one event evidenced by two
+    # opencode sessions links to neither (no guessed session).
+    target = "evt_0bc0de000002"
+    events = [
+        _usage_row(event_id="evt_usage_a", session="ses_oc_a", client="opencode", evidenced=[target]),
+        _usage_row(event_id="evt_usage_b", session="ses_oc_b", client="opencode", evidenced=[target], created_at=105.0),
+        _section_event(event_id=target, section_id="sec-1", client="opencode", session=None),
+    ]
+
+    ledger = build_work_ledger(events)
+
+    item = ledger["work_items"][0]
+    assert item["client_session_id"] is None  # >1 donor -> links to none
+    assert item["log_evidence_ambiguous"] == {"session_count": 2}
+
+
 def test_cross_session_idless_section_id_collision_item_level_refusal() -> None:
     events = [
         _usage_row(event_id="evt_usage_a", session=SESSION, evidenced=["evt_5a4ed000000a"]),


### PR DESCRIPTION
## What

OpenCode records agentacct work via MCP, but those events floated unattributed — the session's task showed no steps (`decision_status: observed`) — because the OpenCode importer never linked them to the session that created them. This mirrors the existing codex/claude client-log evidence pairing for OpenCode, completing the OpenCode instrumentation from #93.

The importer now scans the `opencode.db` `part` table for the session's own agentacct creation-tool calls and attaches their created event ids as the session's `evidenced_event_ids`. The generic reducer then attributes those recorded sections to the session, so its task flips from `observed` to `reported`.

## Honesty

All existing pairing guards apply unchanged (they are client-agnostic): one event evidenced by two sessions links to neither, source-namespace fail-closed, and the local-usage-import trust gate. The codex-specific replay/time-skew guards are deliberately not copied. A session that recorded work is kept even when the session table carries no token/cost total yet.

## Privacy + cost

The part scan is bounded and privacy-preserving: a server-name SQL prefilter plus session-scoped cursor streaming reads only the rows that name the agentacct MCP server, so other tools' payloads, prompts, and message bodies are never selected or parsed. Only an agentacct `evt_` id is extracted, and only out of an agentacct creation-tool response; read/list tools that echo other sessions' ids are structurally excluded.

## Tests

5 new tests: producer extract + read-tool/in-flight exclusion, the prefilter keeping foreign payloads out of the scanner, the `observed -> reported` attribution flip, and the multi-session ambiguity refusal. Full suite: 3081 passed, 1 skipped.
