### PR TITLE
feat(hooks): add Codex automatic tool-activity and session-end hooks

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -119,6 +119,8 @@ from .cost import (
 from .context_bridge import build_client_context_join_health
 from .hooks import (
     CLAUDE_HOOK_RELATIVE_PATH,
+    CODEX_HOOK_RELATIVE_PATH,
+    CODEX_HOOKS_JSON_RELATIVE_PATH,
     capture_claude_code_client_context,
     capture_tool_activity,
     capture_mechanical_check,
@@ -126,8 +128,10 @@ from .hooks import (
     claude_code_hook_doctor_checks,
     claude_code_hook_paths,
     claude_session_start_response,
+    codex_hooks_json_block,
     evaluate_stdin_json,
     install_claude_code_hook,
+    render_codex_hook_wrapper,
 )
 from .log_evidence import build_log_evidence_index, summarize_log_evidence_donor_rows
 from . import install_guide
@@ -251,6 +255,7 @@ usage_app = typer.Typer(help="Import local client-reported usage from coding age
 mcp_app = typer.Typer(help="MCP server commands for agent integrations.")
 setup_app = typer.Typer(help="Setup helpers for coding agents and local integrations.")
 claude_code_hooks_app = typer.Typer(help="Claude Code hook helpers.")
+codex_hooks_app = typer.Typer(help="Codex hook helpers (observe-only tool-activity + session-end).")
 canonical_app = typer.Typer(
     help="Canonical SQLite store operations: health, maintenance, promotion, and cutover verification."
 )
@@ -543,6 +548,7 @@ def finding_dispose(
 
 app.add_typer(setup_app, name="setup")
 hooks_app.add_typer(claude_code_hooks_app, name="claude-code")
+hooks_app.add_typer(codex_hooks_app, name="codex")
 app.add_typer(hooks_app, name="hooks")
 app.add_typer(canonical_app, name="canonical")
 app.add_typer(smoke_app, name="smoke")
@@ -1731,6 +1737,110 @@ def _write_hermes_mcp_config_at(
     return config_path, "updated"
 
 
+def _codex_command_runs_wrapper(command: object, wrapper_basename: str) -> bool:
+    """True when a hooks.json command token IS the agentacct Codex wrapper file."""
+    text = command if isinstance(command, str) else ""
+    if not text:
+        return False
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        tokens = text.split()
+    return any(token.replace("\\", "/").rsplit("/", 1)[-1] == wrapper_basename for token in tokens)
+
+
+def _codex_row_runs_wrapper(row: object, wrapper_basename: str) -> bool:
+    if not isinstance(row, dict):
+        return False
+    return any(
+        _codex_command_runs_wrapper(hook.get("command"), wrapper_basename)
+        for hook in (row.get("hooks") or [])
+        if isinstance(hook, dict)
+    )
+
+
+def _write_codex_hooks_json_at(
+    hooks_json_path: Path, block: dict[str, Any], *, wrapper_basename: str
+) -> tuple[Path, str]:
+    """Merge the agentacct Codex hook rows into ``~/.codex/hooks.json``.
+
+    Codex uses the SAME hooks.json schema as Claude Code settings. Our rows are
+    matched by the wrapper FILE they run (so a second install differing only by
+    interpreter updates in place instead of duplicating — a duplicate would
+    double-fire and double-count tool activity); the user's own hooks under the
+    same event are preserved; a non-object hooks.json is refused rather than
+    clobbered. Idempotent: an already-correct file is left byte-untouched.
+    """
+    existing: dict[str, Any] = {}
+    if hooks_json_path.exists():
+        try:
+            loaded = json.loads(hooks_json_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return hooks_json_path, "skipped-unparsed"
+        if not isinstance(loaded, dict):
+            return hooks_json_path, "skipped-unparsed"
+        existing = loaded
+    hooks = existing.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        return hooks_json_path, "skipped-unparsed"
+    before = json.dumps(existing, sort_keys=True)
+    for event_name, rows in (block.get("hooks") or {}).items():
+        existing_rows = hooks.setdefault(event_name, [])
+        if not isinstance(existing_rows, list):
+            return hooks_json_path, "skipped-unparsed"
+        # Dedupe our prior rows at HOOK-ENTRY granularity, mirroring the Claude
+        # settings merge: drop only the wrapper command(s) from a row, keep any
+        # user command co-located under the same matcher, and insert our fresh
+        # row once where the first of ours stood. A row that carries none of ours
+        # is the user's and is left exactly as-is.
+        rebuilt: list[Any] = []
+        inserted = False
+        for row in existing_rows:
+            if not isinstance(row, dict):
+                rebuilt.append(row)
+                continue
+            row_hooks = row.get("hooks") if isinstance(row.get("hooks"), list) else []
+            survivors = [
+                hook
+                for hook in row_hooks
+                if not (isinstance(hook, dict) and _codex_command_runs_wrapper(hook.get("command"), wrapper_basename))
+            ]
+            if len(survivors) == len(row_hooks):
+                rebuilt.append(row)  # no agentacct entry in this row — the user's own
+                continue
+            if not inserted:
+                rebuilt.extend(rows)
+                inserted = True
+            if survivors:
+                trimmed = dict(row)
+                trimmed["hooks"] = survivors
+                rebuilt.append(trimmed)  # a co-located user command, kept
+        if not inserted:
+            rebuilt = list(existing_rows) + list(rows)  # first install: append
+        hooks[event_name] = rebuilt
+    if json.dumps(existing, sort_keys=True) == before and hooks_json_path.exists():
+        return hooks_json_path, "unchanged"
+    action = "updated" if hooks_json_path.exists() else "wrote"
+    _atomic_write_text(hooks_json_path, json.dumps(existing, indent=2) + "\n", mode=0o600)
+    return hooks_json_path, action
+
+
+def _install_codex_hook(home: Path, store_dir: Path, command: str, *, force: bool = False) -> tuple[str, Path]:
+    """Write the Codex hook wrapper + merge ~/.codex/hooks.json. Returns
+    (hooks_json_action, wrapper_path)."""
+    wrapper_path = home / CODEX_HOOK_RELATIVE_PATH
+    wrapper_path.parent.mkdir(parents=True, exist_ok=True)
+    wrapper_source = render_codex_hook_wrapper(command, store_dir=store_dir)
+    if force or not wrapper_path.exists() or wrapper_path.read_text(encoding="utf-8") != wrapper_source:
+        _atomic_write_text(wrapper_path, wrapper_source, mode=0o755)
+    block = codex_hooks_json_block(wrapper_path)
+    hooks_json_path = home / CODEX_HOOKS_JSON_RELATIVE_PATH
+    _path, action = _write_codex_hooks_json_at(
+        hooks_json_path, block, wrapper_basename=CODEX_HOOK_RELATIVE_PATH.name
+    )
+    return action, wrapper_path
+
+
 def _print_claude_mcp_setup(config_store_dir: Path | str, *, command: str = "agentacct") -> None:
     quoted_store_dir = shlex.quote(str(config_store_dir))
     quoted_command = shlex.quote(command)
@@ -2040,7 +2150,16 @@ def _onboard_global_claude(store_dir: Path, command: str, *, assume_yes: bool) -
 
 
 def _onboard_global_codex(store_dir: Path, command: str) -> bool:
-    """Configure Codex at USER scope (zero repo files). Returns readiness."""
+    """Configure Codex at USER scope (zero repo files). Returns readiness.
+
+    Two layers: the MCP server + AGENTS.md directive give Codex SEMANTIC section
+    recording (as before); the hooks add AUTOMATIC observe-only capture of every
+    tool call (PreToolUse) and session end (SessionEnd), keyed by Codex's own
+    session_id (which equals the rollout id the usage importer keys on, so tool
+    activity attributes straight to the session). Codex requires the user to
+    TRUST the hook before it fires, so onboarding installs it and prints the
+    one-time trust step.
+    """
     home = Path.home()
     setup_instructions(
         agent="codex", user=True, path=None, remove=False, dry_run=False, store_dir=store_dir
@@ -2049,7 +2168,33 @@ def _onboard_global_codex(store_dir: Path, command: str) -> bool:
     if action == "skipped":
         return False
     console.print(f"{action.capitalize()} Codex MCP server block in {path}")
-    console.print("Start a NEW Codex session so it loads the server.")
+    # Automatic tool-activity + session-end hooks (observe-only).
+    try:
+        hooks_action, wrapper_path = _install_codex_hook(home, store_dir, command)
+    except OSError as exc:
+        console.print(f"Codex MCP configured, but the hook could not be written ({exc}).")
+        hooks_action = "skipped-unparsed"
+        wrapper_path = home / CODEX_HOOK_RELATIVE_PATH
+    if hooks_action == "skipped-unparsed":
+        console.print(
+            f"Left {home / CODEX_HOOKS_JSON_RELATIVE_PATH} unchanged (not a JSON object); the "
+            "automatic tool-activity hook was NOT wired — add the agentacct PreToolUse + SessionEnd "
+            "hooks yourself to capture tool activity."
+        )
+        # MCP still works, so the session still records semantic sections; just no
+        # automatic tool-activity/session-end capture. Say exactly that.
+        console.print("Start a NEW Codex session so it loads the server.")
+    else:
+        console.print(
+            f"{hooks_action.capitalize()} Codex tool-activity + session-end hooks "
+            f"({home / CODEX_HOOKS_JSON_RELATIVE_PATH})."
+        )
+        console.print(
+            "Codex requires trusting a hook before it runs: start a NEW Codex session and approve "
+            "the agentacct hook when prompted (or run codex once with --dangerously-bypass-hook-trust "
+            "if you vet the wrapper yourself)."
+        )
+        console.print("Start a NEW Codex session so it loads the server + hooks.")
     return True
 
 
@@ -3831,6 +3976,93 @@ def claude_code_session_start(
         print(json.dumps(response, ensure_ascii=False))
     except Exception:  # noqa: BLE001 - FAIL OPEN: a SessionStart error must never break session startup; emit the empty no-op response and exit 0.
         print("{}")
+
+
+@codex_hooks_app.command("pre-tool-use")
+def codex_pre_tool_use(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory the tick is spooled to (the codex wrapper passes the global store)."),
+    ] = None,
+) -> None:
+    """Observe a Codex PreToolUse JSON event from stdin (observe-only).
+
+    Codex's PreToolUse STDIN carries the same ``session_id``/``tool_name`` shape
+    as Claude Code, and its ``session_id`` equals the rollout id the usage
+    importer keys on, so the tick attributes straight to the Codex session. This
+    is OBSERVE-ONLY: agentacct never makes an allow/block decision for Codex
+    (Codex owns its own sandbox/approval layer) — it records the tool name +
+    category (never arguments) and returns an empty no-op response.
+    """
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_tool_activity(raw, store_dir=store_dir, client="codex")
+        except Exception:  # noqa: BLE001 - activity capture must never affect the tool call.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: a PreToolUse hook must never block a Codex tool call.
+        print("{}")
+
+
+@codex_hooks_app.command("session-end")
+def codex_session_end(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory the session-end fact is spooled to (the codex wrapper passes the global store)."),
+    ] = None,
+) -> None:
+    """Observe a Codex SessionEnd JSON event from stdin.
+
+    Spools the same content-free ``(client, session_id, reason, time)`` fact as
+    the Claude Code path (client ``codex``) so the reducer can infer an
+    ``ended_open`` disposition for a Codex step whose session stopped without a
+    recorded terminal. Never reads conversation content; always returns empty.
+    """
+    from .hooks import capture_session_end
+
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_session_end(raw, store_dir=store_dir, client="codex")
+        except Exception:  # noqa: BLE001 - capture must never affect anything.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: a SessionEnd hook must never disturb shutdown.
+        print("{}")
+
+
+@codex_hooks_app.command("install")
+def codex_hooks_install(
+    home: Annotated[Path, typer.Option(help="Home dir to install into (~/.codex/hooks*). Defaults to the user's home.")] = Path.home(),
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="Store the hooks spool ticks to. Required so GUI-launched Codex binds the right store on the command line."),
+    ] = None,
+    force: Annotated[bool, typer.Option(help="Rewrite the wrapper even if it already matches.")] = False,
+) -> None:
+    """Install the Codex observe-only hooks: the wrapper + ~/.codex/hooks.json
+    entries (PreToolUse tool-activity, SessionEnd) pointing at it."""
+    resolved_store = store_dir if store_dir is not None else onboard_global_store_dir()[0]
+    command = _resolve_absolute_mcp_command()
+    action, wrapper_path = _install_codex_hook(Path(home), Path(resolved_store), command, force=force)
+    console.print(f"Codex hook wrapper: {wrapper_path}")
+    hooks_json = Path(home) / CODEX_HOOKS_JSON_RELATIVE_PATH
+    if action == "skipped-unparsed":
+        # The wrapper is on disk but nothing references it: be honest that no
+        # hook was wired, and do NOT tell the user to "trust it" (there is
+        # nothing to fire). Non-zero exit so scripts see the skip.
+        console.print(
+            f"Codex hooks.json: LEFT UNCHANGED ({hooks_json}) — it is not a JSON object. "
+            "No hook was wired. Fix or remove that file, or add the agentacct PreToolUse + "
+            "SessionEnd entries yourself, then re-run."
+        )
+        raise typer.Exit(1)
+    console.print(f"Codex hooks.json: {action} ({hooks_json})")
+    console.print(
+        "Codex needs the hook TRUSTED before it fires — start a new Codex session and approve it "
+        "(or vet the wrapper and use --dangerously-bypass-hook-trust)."
+    )
 
 
 @claude_code_hooks_app.command("install")

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -474,7 +474,9 @@ def capture_claude_code_client_context(raw: str, *, store_dir: Path | str | None
         return None
 
 
-def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> None:
+def capture_tool_activity(
+    raw: str, *, store_dir: Path | str | None = None, client: str = "claude-code"
+) -> None:
     """Record ONE tool-activity tick for this PreToolUse. Never raises.
 
     The PreToolUse hook already receives the tool name (and fails open), so this
@@ -483,6 +485,11 @@ def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> N
     the Receipt's Actions dimension can show both what KIND of tool ran and which
     SPECIFIC tool/connector. The spool lands in the SAME store as the
     client-context bridge so the usage importer drains both from one place.
+
+    ``client`` labels which agent emitted the tick. Codex's PreToolUse hook uses
+    the same STDIN shape (``session_id``/``tool_name``), and its ``session_id``
+    equals the rollout id the usage importer keys on, so a ``codex`` tick
+    attributes straight to the Codex session with no log pairing.
     """
 
     try:
@@ -501,7 +508,7 @@ def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> N
         category = tool_category(tool_name)
         record_tool_activity_tick(
             target,
-            client="claude-code",
+            client=client,
             session_id=session_id,
             category=category,
             name=tool_name,
@@ -511,7 +518,9 @@ def capture_tool_activity(raw: str, *, store_dir: Path | str | None = None) -> N
         return
 
 
-def capture_session_end(raw: str, *, store_dir: Path | str | None = None) -> None:
+def capture_session_end(
+    raw: str, *, store_dir: Path | str | None = None, client: str = "claude-code"
+) -> None:
     """Record ONE session-end tick for this SessionEnd hook. Never raises.
 
     Spools only content-free identity + timing — client, session id, the end
@@ -519,6 +528,10 @@ def capture_session_end(raw: str, *, store_dir: Path | str | None = None) -> Non
     reducer can infer an ``ended_open`` disposition for a step whose session
     stopped without a recorded terminal. Never reads conversation content. The
     SessionEnd hook fires only for a ROOT session, so no subagent-end noise.
+
+    ``client`` labels the emitting agent. Codex's SessionEnd hook carries the
+    same ``session_id`` (equal to the rollout id), so a ``codex`` end fact keys
+    to the right Codex session for the ``ended_open`` inference.
     """
 
     try:
@@ -535,7 +548,7 @@ def capture_session_end(raw: str, *, store_dir: Path | str | None = None) -> Non
             return
         record_session_end_tick(
             target,
-            client="claude-code",
+            client=client,
             session_id=session_id,
             reason=event.get("reason"),
             at=time.time(),
@@ -1098,6 +1111,139 @@ def render_claude_hook_wrapper(agentacct_executable: str | None = None, *, store
 
 # PATH-lookup-only rendering, kept for callers that used the old constant.
 CLAUDE_HOOK_WRAPPER = render_claude_hook_wrapper()
+
+
+# Codex reads a user-level ``~/.codex/hooks.json``; its wrapper lives beside it
+# under ``~/.codex/hooks/`` (NOT the store), so a store move can never vanish the
+# wrapper and brick Codex tool calls — the same lesson as the Claude Code path.
+CODEX_HOOK_RELATIVE_PATH = Path(".codex/hooks/agentacct_codex_hook.py")
+CODEX_HOOKS_JSON_RELATIVE_PATH = Path(".codex/hooks.json")
+
+_CODEX_HOOK_WRAPPER_TEMPLATE = '''#!/usr/bin/env python3
+"""Codex hook wrapper for agentacct (observe-only).
+
+One wrapper serves the installed Codex hook events (dispatch on the event's own
+`hook_event_name`):
+- PreToolUse: spool the tool NAME + category for the Receipt's Actions dimension
+  (observe-only — agentacct never makes an allow/block decision for Codex; Codex
+  owns its own sandbox/approval layer).
+- SessionEnd: spool a content-free session-end fact for the ended_open inference.
+
+Shells out to the installed `agentacct` CLI. Fail-open: if no agentacct
+executable can be started, or the CLI exits without output, this wrapper prints
+an empty no-op response `{}` and exits 0, so a broken or moved install can never
+block a Codex tool call. Reinstall with: agentacct hooks codex install --force
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+AGENTACCT_CANDIDATES = __AGENTACCT_CANDIDATES__
+AGENTACCT_HOOK_ARGS = __AGENTACCT_HOOK_ARGS__
+
+
+def resolve_agentacct():
+    for candidate in AGENTACCT_CANDIDATES:
+        if not candidate:
+            continue
+        if os.path.basename(candidate) != candidate:
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        else:
+            found = shutil.which(candidate)
+            if found:
+                return found
+    return None
+
+
+def no_op(reason=""):
+    if reason:
+        sys.stderr.write("agentacct codex hook: %s; failing open\\n" % reason)
+    sys.stdout.write("{}\\n")
+    return 0
+
+
+def main():
+    raw = sys.stdin.buffer.read().decode("utf-8", "replace")
+    hook_event = ""
+    try:
+        event = json.loads(raw)
+        if isinstance(event, dict):
+            value = event.get("hook_event_name")
+            if isinstance(value, str):
+                hook_event = value
+    except ValueError:
+        pass
+    subcommand = "session-end" if hook_event == "SessionEnd" else "pre-tool-use"
+    executable = resolve_agentacct()
+    if executable is None:
+        return no_op("agentacct executable not found (re-run: agentacct hooks codex install --force)")
+    try:
+        proc = subprocess.run(
+            [executable, "hooks", "codex", subcommand, *AGENTACCT_HOOK_ARGS],
+            input=raw,
+            text=True,
+            capture_output=True,
+            # A bounded wait is part of the never-block contract: fail-open covers
+            # the CLI RETURNING an error, but a hung child (stalled store mount,
+            # held SQLite lock, cold-import stall) would otherwise block the Codex
+            # tool call forever. A timeout turns that into a no-op {} instead.
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return no_op("agentacct timed out")
+    except OSError as exc:
+        return no_op("agentacct failed to start (%s)" % exc)
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
+    if proc.returncode == 0 and proc.stdout.strip():
+        sys.stdout.write(proc.stdout)
+        return 0
+    return no_op("agentacct exited with code %s without output" % proc.returncode)
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = main()
+    except Exception as exc:  # fail-open: a wrapper bug must never break Codex sessions.
+        exit_code = no_op("unexpected codex hook wrapper error (%s: %s)" % (type(exc).__name__, exc))
+    raise SystemExit(exit_code)
+'''
+
+
+def render_codex_hook_wrapper(agentacct_executable: str | None = None, *, store_dir: Path | str | None = None) -> str:
+    candidates: list[str] = []
+    if agentacct_executable:
+        candidates.append(str(agentacct_executable))
+    for bare_name in ("agentacct", "agent-chronicle", "agent-sentinel"):
+        if bare_name not in candidates:
+            candidates.append(bare_name)
+    hook_args: list[str] = []
+    if store_dir is not None:
+        # GUI-launched Codex (ChatGPT.app) sees neither shell env vars nor a
+        # predictable cwd, so the store binds on the command line.
+        hook_args = ["--store-dir", str(store_dir)]
+    rendered = _CODEX_HOOK_WRAPPER_TEMPLATE.replace("__AGENTACCT_CANDIDATES__", repr(candidates))
+    return rendered.replace("__AGENTACCT_HOOK_ARGS__", repr(hook_args))
+
+
+def codex_hooks_json_block(wrapper_path: Path | str, *, python_executable: str | None = None) -> dict[str, Any]:
+    """The ``~/.codex/hooks.json`` content wiring PreToolUse + SessionEnd to the
+    agentacct Codex wrapper. Codex uses the SAME hooks.json schema as Claude Code
+    (``{"hooks": {"<Event>": [{"matcher"?, "hooks": [{"type": "command", ...}]}]}}``),
+    so this mirrors the Claude settings block shape. One wrapper serves both
+    events (it dispatches on ``hook_event_name``)."""
+    python_command = python_executable or sys.executable or "python3"
+    command = f"{shlex.quote(python_command)} {shlex.quote(str(wrapper_path))}"
+    return {
+        "hooks": {
+            "PreToolUse": [{"matcher": "*", "hooks": [{"type": "command", "command": command}]}],
+            "SessionEnd": [{"hooks": [{"type": "command", "command": command}]}],
+        }
+    }
 
 
 def claude_code_settings_example(python_executable: str | None = None, *, hook_path: Path | str | None = None) -> dict[str, Any]:

--- a/tests/test_hooks_codex.py
+++ b/tests/test_hooks_codex.py
@@ -165,9 +165,12 @@ def test_codex_hooks_install_command_fails_honestly_on_non_object(tmp_path: Path
         app, ["hooks", "codex", "install", "--home", str(home), "--store-dir", str(tmp_path / "store")]
     )
     assert result.exit_code == 1
-    assert "LEFT UNCHANGED" in result.output
-    assert "No hook was wired" in result.output
-    assert "trust" not in result.output.lower()  # no false "approve it" line
+    # Normalize: the rich console soft-wraps at ~80 cols with no TTY (CI), which
+    # would split these multi-word phrases across a newline.
+    normalized = " ".join(result.output.split())
+    assert "LEFT UNCHANGED" in normalized
+    assert "No hook was wired" in normalized
+    assert "trust" not in normalized.lower()  # no false "approve it" line
     assert hj.read_text() == "[]"  # never clobbered
 
 

--- a/tests/test_hooks_codex.py
+++ b/tests/test_hooks_codex.py
@@ -1,0 +1,178 @@
+"""Codex observe-only hooks: client-parameterized capture, the hooks.json
+writer, the wrapper, and the CLI subcommands.
+
+Codex's PreToolUse/SessionEnd hook STDIN uses the SAME snake_case shape as
+Claude Code (hook_event_name/session_id/tool_name), and its session_id equals
+the rollout id the usage importer keys on — verified on a real Codex 0.146
+build — so the tool ticks and session-end facts attribute straight to the Codex
+session with no log pairing.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agentacct import cli
+from agentacct.cli import app
+from agentacct.hooks import (
+    CODEX_HOOK_RELATIVE_PATH,
+    CODEX_HOOKS_JSON_RELATIVE_PATH,
+    capture_session_end,
+    capture_tool_activity,
+    codex_hooks_json_block,
+    render_codex_hook_wrapper,
+)
+from agentacct.session_lifecycle import drain_session_end_spool
+from agentacct.tool_activity import drain_tool_activity_spool
+
+
+def _codex_pre_tool_event(session_id: str, tool_name: str) -> str:
+    return json.dumps({"hook_event_name": "PreToolUse", "session_id": session_id, "tool_name": tool_name, "cwd": "/x"})
+
+
+def test_capture_tool_activity_labels_codex_client(tmp_path: Path) -> None:
+    capture_tool_activity(_codex_pre_tool_event("019ff6ee-a", "Bash"), store_dir=tmp_path, client="codex")
+    capture_tool_activity(
+        _codex_pre_tool_event("019ff6ee-a", "mcp__agentacct__agentacct_record_section"),
+        store_dir=tmp_path, client="codex",
+    )
+    [event] = drain_tool_activity_spool(tmp_path, now=100.0, token="t")
+    md = event["metadata"]
+    assert md["client"] == "codex"
+    assert md["client_session_id"] == "019ff6ee-a"
+    assert {row["name"]: row["count"] for row in md["tool_names"]} == {
+        "Bash": 1,
+        "mcp__agentacct__agentacct_record_section": 1,
+    }
+    assert md["tool_category_counts"] == {"execute": 1, "mcp": 1}
+
+
+def test_capture_session_end_labels_codex_client(tmp_path: Path) -> None:
+    capture_session_end(
+        json.dumps({"hook_event_name": "SessionEnd", "session_id": "019ff6ee-a", "reason": "other"}),
+        store_dir=tmp_path, client="codex",
+    )
+    [event] = drain_session_end_spool(tmp_path, now=100.0, token="t")
+    assert event["source"] == "codex"
+    assert event["metadata"]["client"] == "codex"
+    assert event["metadata"]["client_session_id"] == "019ff6ee-a"
+
+
+def test_codex_wrapper_renders_valid_python_shelling_to_hooks_codex(tmp_path: Path) -> None:
+    src = render_codex_hook_wrapper("/abs/agentacct", store_dir="/global/store")
+    ast.parse(src)  # must be valid python
+    assert '"hooks", "codex"' in src or "'hooks', 'codex'" in src
+    assert "/abs/agentacct" in src
+    assert "/global/store" in src  # store bound on the command line
+    # Never makes an allow/block decision for codex: fail-open is an empty {}.
+    assert "sys.stdout.write" in src
+
+
+def test_codex_hooks_json_writer_fresh_idempotent_and_merge(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    store = tmp_path / "store"
+    action, wrapper = cli._install_codex_hook(home, store, "/abs/agentacct")
+    assert action == "wrote"
+    assert wrapper.exists()
+    assert (wrapper.stat().st_mode & 0o777) == 0o755
+    hooks = json.loads((home / CODEX_HOOKS_JSON_RELATIVE_PATH).read_text())
+    assert set(hooks["hooks"].keys()) == {"PreToolUse", "SessionEnd"}
+    assert CODEX_HOOK_RELATIVE_PATH.name in hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+
+    before = (home / CODEX_HOOKS_JSON_RELATIVE_PATH).read_text()
+    action2, _ = cli._install_codex_hook(home, store, "/abs/agentacct")
+    assert action2 == "unchanged"
+    assert (home / CODEX_HOOKS_JSON_RELATIVE_PATH).read_text() == before  # byte-identical
+
+
+def test_codex_hooks_json_writer_preserves_user_hook(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    hj = home / CODEX_HOOKS_JSON_RELATIVE_PATH
+    hj.parent.mkdir(parents=True)
+    hj.write_text(json.dumps({"hooks": {"PreToolUse": [
+        {"matcher": "Bash", "hooks": [{"type": "command", "command": "/usr/bin/user-hook"}]}
+    ]}}))
+    cli._install_codex_hook(home, tmp_path / "store", "/abs/agentacct")
+    merged = json.loads(hj.read_text())
+    commands = [h["command"] for row in merged["hooks"]["PreToolUse"] for h in row["hooks"]]
+    assert "/usr/bin/user-hook" in commands  # user's own hook survives
+    assert any(CODEX_HOOK_RELATIVE_PATH.name in c for c in commands)  # ours added
+
+
+def test_codex_hooks_json_writer_refuses_non_object(tmp_path: Path) -> None:
+    hj = tmp_path / "hooks.json"
+    hj.write_text("[]")
+    _path, action = cli._write_codex_hooks_json_at(
+        hj, codex_hooks_json_block("/w/wrap.py"), wrapper_basename="wrap.py"
+    )
+    assert action == "skipped-unparsed"
+    assert hj.read_text() == "[]"  # never clobbered
+
+
+def test_codex_pre_tool_use_subcommand_spools_codex_tick(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["hooks", "codex", "pre-tool-use", "--store-dir", str(tmp_path)],
+        input=_codex_pre_tool_event("019ff6ee-b", "Bash"),
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "{}"  # observe-only no-op response
+    [event] = drain_tool_activity_spool(tmp_path, now=100.0, token="t")
+    assert event["metadata"]["client"] == "codex"
+    assert event["metadata"]["client_session_id"] == "019ff6ee-b"
+
+
+# --- Regression tests for adversarial-review findings --------------------------
+
+
+def test_codex_hooks_json_preserves_co_located_user_command(tmp_path: Path) -> None:
+    # FINDING #1: a user command co-located in the SAME matcher row as ours must
+    # survive re-install; ours must not accrue a duplicate.
+    home = tmp_path / "home"
+    hj = home / CODEX_HOOKS_JSON_RELATIVE_PATH
+    hj.parent.mkdir(parents=True)
+    wrapper_cmd = f"python3 {home / CODEX_HOOK_RELATIVE_PATH}"
+    hj.write_text(json.dumps({"hooks": {"PreToolUse": [
+        {"matcher": "*", "hooks": [
+            {"type": "command", "command": wrapper_cmd},
+            {"type": "command", "command": "/usr/bin/user-audit"},
+        ]}
+    ]}}))
+    cli._install_codex_hook(home, tmp_path / "store", str(home / "bin/agentacct"))
+    merged = json.loads(hj.read_text())
+    commands = [h["command"] for row in merged["hooks"]["PreToolUse"] for h in row["hooks"]]
+    assert "/usr/bin/user-audit" in commands  # co-located user command survives
+    assert sum(CODEX_HOOK_RELATIVE_PATH.name in c for c in commands) == 1  # no duplicate
+
+    before = hj.read_text()
+    cli._install_codex_hook(home, tmp_path / "store", str(home / "bin/agentacct"))
+    assert hj.read_text() == before  # idempotent on the co-located shape
+
+
+def test_codex_hooks_install_command_fails_honestly_on_non_object(tmp_path: Path) -> None:
+    # FINDING #2: the standalone install must NOT print "trust it and it fires"
+    # when the writer skipped a non-object hooks.json.
+    home = tmp_path / "home"
+    hj = home / CODEX_HOOKS_JSON_RELATIVE_PATH
+    hj.parent.mkdir(parents=True)
+    hj.write_text("[]")
+    result = CliRunner().invoke(
+        app, ["hooks", "codex", "install", "--home", str(home), "--store-dir", str(tmp_path / "store")]
+    )
+    assert result.exit_code == 1
+    assert "LEFT UNCHANGED" in result.output
+    assert "No hook was wired" in result.output
+    assert "trust" not in result.output.lower()  # no false "approve it" line
+    assert hj.read_text() == "[]"  # never clobbered
+
+
+def test_codex_wrapper_bounds_subprocess_with_timeout() -> None:
+    # FINDING #4: a hung CLI must not block a Codex tool call forever.
+    src = render_codex_hook_wrapper("/abs/agentacct", store_dir="/store")
+    assert "timeout=5" in src
+    assert "TimeoutExpired" in src

--- a/tests/test_onboard_global.py
+++ b/tests/test_onboard_global.py
@@ -240,3 +240,49 @@ def test_onboard_global_agent_hermes_registers_mcp_only_no_directive(
     assert not (isolated_home / "AGENTS.md").exists()
     assert "tools registered" in result.output
     assert "hook adapter" in result.output
+
+
+def test_onboard_global_agent_codex_installs_tool_activity_hooks(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--agent", "codex", "--no-start"])
+    assert result.exit_code == 0, result.output
+
+    store = isolated_home / ".local" / "state" / "agentacct" / "state"
+    # MCP block still written (the semantic layer).
+    assert "[mcp_servers.agentacct]" in (isolated_home / ".codex" / "config.toml").read_text()
+    # Automatic hook layer: wrapper + hooks.json wiring PreToolUse + SessionEnd.
+    wrapper = isolated_home / ".codex" / "hooks" / "agentacct_codex_hook.py"
+    assert wrapper.exists()
+    assert str(store) in wrapper.read_text()  # store bound on the command line
+    hooks = json.loads((isolated_home / ".codex" / "hooks.json").read_text())
+    assert set(hooks["hooks"].keys()) == {"PreToolUse", "SessionEnd"}
+    assert "agentacct_codex_hook.py" in hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    # The one-time trust step is surfaced.
+    assert "trust" in result.output.lower()
+    # Zero files leaked into the repo.
+    for leaked in ("hooks.json", ".codex", "AGENTS.md"):
+        assert not (repo / leaked).exists()
+
+
+def test_onboard_global_agent_codex_non_object_hooks_json_is_honest(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A pre-existing non-object ~/.codex/hooks.json is left untouched, and the
+    # summary must NOT claim the session loads hooks that were never wired.
+    codex_dir = isolated_home / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "hooks.json").write_text("[]")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--agent", "codex", "--no-start"])
+    assert result.exit_code == 0, result.output
+    assert (codex_dir / "hooks.json").read_text() == "[]"  # never clobbered
+    assert "NOT wired" in result.output
+    assert "loads the server + hooks" not in result.output  # no false "+ hooks" claim

--- a/tests/test_onboard_global.py
+++ b/tests/test_onboard_global.py
@@ -289,5 +289,8 @@ def test_onboard_global_agent_codex_is_honest_when_hooks_skip(
 
     result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--agent", "codex", "--no-start"])
     assert result.exit_code == 0, result.output
-    assert "NOT wired" in result.output
-    assert "loads the server + hooks" not in result.output  # no false "+ hooks" claim
+    # Normalize whitespace: the rich console soft-wraps at ~80 cols with no TTY
+    # (CI), which would split a multi-word phrase across a newline.
+    normalized = " ".join(result.output.split())
+    assert "NOT wired" in normalized
+    assert "loads the server + hooks" not in normalized  # no false "+ hooks" claim

--- a/tests/test_onboard_global.py
+++ b/tests/test_onboard_global.py
@@ -269,20 +269,25 @@ def test_onboard_global_agent_codex_installs_tool_activity_hooks(
         assert not (repo / leaked).exists()
 
 
-def test_onboard_global_agent_codex_non_object_hooks_json_is_honest(
+def test_onboard_global_agent_codex_is_honest_when_hooks_skip(
     tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A pre-existing non-object ~/.codex/hooks.json is left untouched, and the
-    # summary must NOT claim the session loads hooks that were never wired.
-    codex_dir = isolated_home / ".codex"
-    codex_dir.mkdir(parents=True)
-    (codex_dir / "hooks.json").write_text("[]")
+    # When the hook install skips (e.g. a non-object ~/.codex/hooks.json), the
+    # onboard summary must NOT claim the session loads hooks that were never
+    # wired. Forcing the skip return keeps this deterministic (independent of the
+    # global-store resolution and the real hooks.json path).
+    import agentacct.cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module,
+        "_install_codex_hook",
+        lambda *args, **kwargs: ("skipped-unparsed", isolated_home / ".codex" / "hooks" / "agentacct_codex_hook.py"),
+    )
     repo = tmp_path / "repo"
     repo.mkdir()
     monkeypatch.chdir(repo)
 
     result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--agent", "codex", "--no-start"])
     assert result.exit_code == 0, result.output
-    assert (codex_dir / "hooks.json").read_text() == "[]"  # never clobbered
     assert "NOT wired" in result.output
     assert "loads the server + hooks" not in result.output  # no false "+ hooks" claim


### PR DESCRIPTION
## What

Codex records semantic sections via MCP + AGENTS.md (#5), but captured no tool activity — its Actions dimension was always empty. This adds the automatic, observe-only hook layer Claude Code already has, bringing Codex to parity:

- **PreToolUse** records the tool name + category of every call (never arguments).
- **SessionEnd** records a content-free end fact for the `ended_open` inference.

Verified on a real Codex 0.146 build: its PreToolUse/SessionEnd hook STDIN uses the same snake_case shape as Claude Code (`hook_event_name`, `session_id`, `tool_name`), and the hook `session_id` equals the rollout id the usage importer keys on, so a Codex tick attributes straight to the session with no log pairing. A real end-to-end run produced `client=codex` tool-activity events.

## Safety

Observe-only: agentacct makes **no** allow/block decision for Codex (Codex owns its own sandbox/approval layer). The wrapper fails open on every path — agentacct missing, crash, empty output, bad STDIN, or a CLI that hangs past a bounded `timeout` — printing an empty response so it can **never** block a Codex tool call.

## Merge-safety

The `~/.codex/hooks.json` writer (Codex uses the same hooks.json schema) is idempotent and dedupes agentacct rows at hook-entry granularity, so a user command co-located under the same matcher is preserved; a non-object file is refused rather than clobbered. Wired into `onboard --agent codex` (which surfaces the one-time hook-trust step Codex requires) and a `hooks codex install` command.

## Tests

12 new tests: client-parameterized capture, the wrapper, the hooks.json writer (fresh/idempotent/user-hook preservation/non-object refusal/co-located dedupe), the CLI subcommands, honest skipped-unparsed messaging, the wrapper timeout, and the onboard wiring. Full suite: 3093 passed, 1 skipped.
