### PR TITLE
feat(hooks): add Hermes observe-only shell hooks for tool-activity, exit-code, and turn-boundary capture

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -121,8 +121,13 @@ from .hooks import (
     CLAUDE_HOOK_RELATIVE_PATH,
     CODEX_HOOK_RELATIVE_PATH,
     CODEX_HOOKS_JSON_RELATIVE_PATH,
+    HERMES_CONFIG_RELATIVE_PATH,
+    HERMES_HOOK_EVENT_SUBCOMMANDS,
+    HERMES_HOOK_RELATIVE_PATH,
     capture_claude_code_client_context,
     capture_tool_activity,
+    capture_hermes_tool_check,
+    capture_hermes_turn_boundary,
     capture_mechanical_check,
     claude_code_hook_context_status,
     claude_code_hook_doctor_checks,
@@ -132,6 +137,7 @@ from .hooks import (
     evaluate_stdin_json,
     install_claude_code_hook,
     render_codex_hook_wrapper,
+    render_hermes_hook_wrapper,
 )
 from .log_evidence import build_log_evidence_index, summarize_log_evidence_donor_rows
 from . import install_guide
@@ -256,6 +262,7 @@ mcp_app = typer.Typer(help="MCP server commands for agent integrations.")
 setup_app = typer.Typer(help="Setup helpers for coding agents and local integrations.")
 claude_code_hooks_app = typer.Typer(help="Claude Code hook helpers.")
 codex_hooks_app = typer.Typer(help="Codex hook helpers (observe-only tool-activity + session-end).")
+hermes_hooks_app = typer.Typer(help="Hermes hook helpers (observe-only tool-activity + exit-code + turn-boundary).")
 canonical_app = typer.Typer(
     help="Canonical SQLite store operations: health, maintenance, promotion, and cutover verification."
 )
@@ -549,6 +556,7 @@ def finding_dispose(
 app.add_typer(setup_app, name="setup")
 hooks_app.add_typer(claude_code_hooks_app, name="claude-code")
 hooks_app.add_typer(codex_hooks_app, name="codex")
+hooks_app.add_typer(hermes_hooks_app, name="hermes")
 app.add_typer(hooks_app, name="hooks")
 app.add_typer(canonical_app, name="canonical")
 app.add_typer(smoke_app, name="smoke")
@@ -2234,16 +2242,19 @@ def _onboard_global_opencode(store_dir: Path, command: str) -> bool:
 
 
 def _onboard_global_hermes(store_dir: Path, command: str) -> bool:
-    """Register the agentacct MCP server for Hermes at USER scope. Returns readiness.
+    """Configure Hermes at USER scope (zero repo files). Returns readiness.
 
-    Hermes reads external MCP servers from the top-level ``mcp_servers`` block of
-    ``~/.hermes/config.yaml`` and auto-reloads on that file's mtime change, so the
-    agentacct tools become available in Hermes sessions. Unlike codex/opencode,
+    Two layers: the MCP server gives Hermes the agentacct tools (semantic section
+    recording when an agent calls them); the shell hooks add AUTOMATIC observe-only
+    capture — tool activity (pre_tool_call), the harness exit code of recognized
+    checks (post_tool_call), and a turn-boundary heartbeat (on_session_end) — keyed
+    by Hermes' own session_id (which equals the state.db sessions.id the usage
+    importer keys on, so tool activity attributes straight to the session). Hermes
+    gates shell hooks on a one-time consent allowlist, so onboarding installs them
+    and prints the one-time approve + gateway-restart steps. Unlike codex/opencode,
     Hermes has NO reliable always-on GLOBAL instruction slot (it injects
     ``AGENTS.md`` only from a project/workspace root, and ``$HOME`` is skipped), so
-    the standing 'record your work' directive is NOT installed here — Hermes
-    recording is driven by its own hook system in a separate step. This makes the
-    tools present now; the directive lands with the hooks.
+    the standing 'record your work' directive is NOT installed here.
     """
     home = Path.home()
     config_path = home / ".hermes" / "config.yaml"
@@ -2255,10 +2266,23 @@ def _onboard_global_hermes(store_dir: Path, command: str) -> bool:
         )
         return False
     console.print(f"{action.capitalize()} Hermes MCP server in {path}")
-    console.print(
-        "Hermes auto-reloads config.yaml; its agentacct tools are available now. "
-        "Semantic recording still needs the Hermes hook adapter (installed separately)."
-    )
+    # Automatic observe-only tool-activity + exit-code + turn-boundary hooks.
+    try:
+        hooks_action, wrapper_path = _install_hermes_hook(home, store_dir, command)
+    except OSError as exc:
+        console.print(f"Hermes MCP configured, but the hook could not be written ({exc}).")
+        hooks_action = "skipped-unparsed"
+        wrapper_path = home / HERMES_HOOK_RELATIVE_PATH
+    if hooks_action == "skipped-unparsed":
+        console.print(
+            f"Left {config_path} hooks: block unchanged (inline or tab-indented); the automatic "
+            "tool-activity hooks were NOT wired — add the agentacct pre_tool_call / post_tool_call / "
+            "on_session_end entries under hooks: yourself to capture tool activity."
+        )
+        console.print("Hermes auto-reloads config.yaml; its agentacct tools are available now.")
+    else:
+        console.print(f"{hooks_action.capitalize()} Hermes tool-activity hooks in {config_path} ({wrapper_path}).")
+        _print_hermes_hook_consent_steps()
     return True
 
 
@@ -4063,6 +4087,466 @@ def codex_hooks_install(
         "Codex needs the hook TRUSTED before it fires — start a new Codex session and approve it "
         "(or vet the wrapper and use --dangerously-bypass-hook-trust)."
     )
+
+
+@hermes_hooks_app.command("pre-tool-call")
+def hermes_pre_tool_call(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory the tick is spooled to (the hermes wrapper passes the bound store)."),
+    ] = None,
+) -> None:
+    """Observe a Hermes ``pre_tool_call`` JSON event from stdin (observe-only).
+
+    Hermes' shell-hook STDIN carries the same ``session_id``/``tool_name`` shape as
+    Claude Code + Codex, and its ``session_id`` equals the ``state.db`` sessions.id
+    the usage importer keys on, so the tick attributes straight to the Hermes
+    session. OBSERVE-ONLY: agentacct never makes an allow/block decision for Hermes
+    (Hermes owns its own approval layer) — it records the tool name + category
+    (never arguments) and returns an empty no-op response.
+    """
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_tool_activity(raw, store_dir=store_dir, client="hermes")
+        except Exception:  # noqa: BLE001 - activity capture must never affect the tool call.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: a pre_tool_call hook must never block a Hermes tool call.
+        print("{}")
+
+
+@hermes_hooks_app.command("post-tool-call")
+def hermes_post_tool_call(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory the mechanical-check tick is spooled to (the hermes wrapper passes the bound store)."),
+    ] = None,
+) -> None:
+    """Observe a Hermes ``post_tool_call`` JSON event from stdin (exit-code check).
+
+    When the terminal tool ran a recognized test/build/lint command, spool the exit
+    code the HARNESS observed (from ``extra.result``) — the independent signal that
+    lifts a step to ``independently_checked``. Only a coarse check kind, the runner
+    name, and a sha256 command DIGEST are spooled — never the command or its output.
+    Always returns an empty no-op response.
+    """
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_hermes_tool_check(raw, store_dir=store_dir)
+        except Exception:  # noqa: BLE001 - capture must never affect the tool call.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: a post_tool_call hook must never disturb Hermes.
+        print("{}")
+
+
+@hermes_hooks_app.command("session-end")
+def hermes_session_end(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory the turn-boundary fact is spooled to (the hermes wrapper passes the bound store)."),
+    ] = None,
+) -> None:
+    """Observe a Hermes ``on_session_end`` JSON event from stdin (turn heartbeat).
+
+    Hermes fires ``on_session_end`` at the end of EVERY turn (once per user
+    message), not at real session close, so this spools a content-free
+    ``turn_boundary_observed`` liveness fact — never fed into the ``ended_open``
+    inference (a per-turn end would falsely close a still-live session between
+    turns). Never reads conversation content; always returns empty.
+    """
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_hermes_turn_boundary(raw, store_dir=store_dir)
+        except Exception:  # noqa: BLE001 - capture must never affect anything.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: a session-end hook must never disturb shutdown.
+        print("{}")
+
+
+def _hermes_hook_command(wrapper_path: Path, *, python_executable: str | None = None) -> str:
+    """The shell command Hermes runs for our wrapper (python + wrapper path).
+
+    Shell-quoted so Hermes' ``shlex.split`` keeps paths-with-spaces as single
+    tokens (mirrors ``codex_hooks_json_block``'s command)."""
+    python_command = python_executable or sys.executable or "python3"
+    return f"{shlex.quote(python_command)} {shlex.quote(str(wrapper_path))}"
+
+
+def _hermes_command_runs_wrapper(command: object, wrapper_basename: str) -> bool:
+    """True when a config.yaml hook command RUNS the agentacct Hermes wrapper as its
+    script — the bare wrapper (``<wrapper>``) or a python interpreter invoking it
+    (``python3 <wrapper>``, our own form). A command that merely names the wrapper
+    file as an ARGUMENT to some other program (``watchdog --watch <wrapper>``) is NOT
+    ours and must be left alone."""
+    text = command if isinstance(command, str) else ""
+    if not text:
+        return False
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        tokens = text.split()
+    if not tokens:
+        return False
+
+    def _base(token: str) -> str:
+        return token.replace("\\", "/").rsplit("/", 1)[-1]
+
+    if _base(tokens[0]) == wrapper_basename:
+        return True  # bare wrapper as the executable
+    if len(tokens) >= 2 and _base(tokens[1]) == wrapper_basename and _base(tokens[0]).startswith("python"):
+        return True  # a python interpreter running the wrapper as its script
+    return False
+
+
+def _hermes_item_command_text(span: list[str]) -> str | None:
+    """Extract the ``command`` value from a YAML list-item span, tolerating any scalar
+    form (plain, quoted, folded ``>-``, literal ``|-``, multi-line). The span is
+    parsed as YAML so this textual matcher agrees with the parser used for the
+    idempotency decision. Returns None if the span is not a single ``{command: ...}``
+    item."""
+    import textwrap
+
+    import yaml
+
+    try:
+        loaded = yaml.safe_load(textwrap.dedent("\n".join(span)))
+    except yaml.YAMLError:
+        return None
+    if isinstance(loaded, list) and len(loaded) == 1 and isinstance(loaded[0], dict):
+        cmd = loaded[0].get("command")
+        return cmd if isinstance(cmd, str) else None
+    return None
+
+
+def _hermes_hooks_yaml_block(command: str, events: list[str], *, timeout: int, child_indent: str) -> str:
+    """A fresh top-level ``hooks:`` block wiring every event to our wrapper command.
+
+    The command is written as a JSON-encoded (double-quoted) YAML scalar so a path
+    with spaces or YAML-special characters round-trips exactly and Hermes'
+    ``shlex.split`` still recovers the individual tokens."""
+    lines = ["hooks:"]
+    for event in events:
+        lines.append(f"{child_indent}{event}:")
+        lines.append(f"{child_indent}- command: {json.dumps(command)}")
+        lines.append(f"{child_indent}  timeout: {int(timeout)}")
+    return "\n".join(lines) + "\n"
+
+
+def _write_hermes_hooks_config_at(
+    config_path: Path, command: str, wrapper_basename: str, *, timeout: int = 10
+) -> tuple[Path, str]:
+    """Upsert the observe-only hook entries into Hermes' config.yaml ``hooks:`` block.
+
+    TEXTUAL upsert (mirrors ``_write_hermes_mcp_config_at``): the file is large and
+    heavily commented and only PyYAML (no round-trip) is available, so it is never
+    reflowed. For each of the three events, ONLY our own prior entry — matched by the
+    wrapper FILE it runs, so a reinstall differing by interpreter updates in place
+    instead of double-firing — is replaced; the user's own entries under those events
+    and every other event are preserved. A read-only parse decides idempotency. An
+    inline/flow ``hooks: {...}`` or tab-indented children are left untouched
+    (``skipped-unparsed``)."""
+    import yaml
+
+    events = list(HERMES_HOOK_EVENT_SUBCOMMANDS.keys())
+
+    def _event_is_current(existing_list: object) -> bool:
+        if not isinstance(existing_list, list):
+            return False
+        ours = [
+            entry for entry in existing_list
+            if isinstance(entry, dict) and _hermes_command_runs_wrapper(entry.get("command"), wrapper_basename)
+        ]
+        return len(ours) == 1 and ours[0].get("command") == command
+
+    if not config_path.exists():
+        block = _hermes_hooks_yaml_block(command, events, timeout=timeout, child_indent="  ")
+        _atomic_write_text(config_path, block, mode=0o600)
+        return config_path, "wrote"
+
+    # Read RAW bytes (not read_text): universal-newline translation would rewrite
+    # CRLF to LF before we could detect it, defeating the never-reflow promise.
+    text = config_path.read_bytes().decode("utf-8")
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        data = None
+    if isinstance(data, dict):
+        hooks = data.get("hooks")
+        if isinstance(hooks, dict) and all(_event_is_current(hooks.get(event)) for event in events):
+            return config_path, "unchanged"
+
+    mode = (config_path.stat().st_mode & 0o777) or 0o600
+    newline = "\r\n" if "\r\n" in text else "\n"
+    lines = text.splitlines()
+
+    def _indent_width(line: str) -> int:
+        return len(line) - len(line.lstrip())
+
+    header_re = re.compile(r"^hooks:[ \t]*(#.*)?$")
+    inline_re = re.compile(r"^hooks:[ \t]*\S")
+
+    def _region_end(header_index: int) -> int:
+        for j in range(header_index + 1, len(lines)):
+            stripped = lines[j].strip()
+            if stripped == "" or stripped.startswith("#"):
+                continue
+            if _indent_width(lines[j]) == 0:
+                return j
+        return len(lines)
+
+    header_idx = next((i for i, ln in enumerate(lines) if header_re.match(ln)), None)
+    if header_idx is None:
+        # A hooks: key we cannot locate textually still parses as a top-level hooks
+        # mapping: an inline ``hooks: {...}``, a space before the colon (``hooks :``),
+        # or a quoted ``"hooks":`` all load as ``hooks`` but do not match header_re.
+        # Appending a second ``hooks:`` block would create a duplicate top-level key
+        # that clobbers the user's hooks (last-wins) — refuse instead of corrupting.
+        if any(inline_re.match(ln) for ln in lines) or (isinstance(data, dict) and "hooks" in data):
+            return config_path, "skipped-unparsed"
+        block = _hermes_hooks_yaml_block(command, events, timeout=timeout, child_indent="  ")
+        if newline != "\n":
+            block = block.replace("\n", newline)
+        separator = "" if text == "" or text.endswith(("\n", "\r")) else newline
+        _atomic_write_text(config_path, text + separator + block, mode=mode)
+        return config_path, "updated"
+
+    # Child indent is read from the first existing hooks child; default two spaces.
+    region_end = _region_end(header_idx)
+    child_indent = "  "
+    for j in range(header_idx + 1, region_end):
+        stripped = lines[j].strip()
+        if stripped == "" or stripped.startswith("#"):
+            continue
+        child_indent = lines[j][: _indent_width(lines[j])]
+        break
+    if "\t" in child_indent:
+        # Tab-indented YAML: a space-based block would misalign (or land the key
+        # outside hooks:, where Hermes silently ignores it). Refuse rather than
+        # emit a config that reads as installed but is not.
+        return config_path, "skipped-unparsed"
+    child_depth = len(child_indent)
+    # Default entry style for a brand-new event: the block-list dash sits at the
+    # key's own indent (``  - ...``).
+    default_entry = [
+        f"{child_indent}- command: {json.dumps(command)}",
+        f"{child_indent}  timeout: {int(timeout)}",
+    ]
+    at_key_item_re = re.compile(rf"^{re.escape(child_indent)}-[ \t]")
+    parsed_hooks = data.get("hooks") if isinstance(data, dict) else None
+
+    # One event at a time; the header/region are re-derived each pass because a
+    # prior event's insert shifts every later index. Nothing is written until the
+    # whole pass succeeds, so an early ``skipped-unparsed`` leaves the file untouched.
+    for event in events:
+        header_idx = next((i for i, ln in enumerate(lines) if header_re.match(ln)), None)
+        if header_idx is None:  # defensive: cannot happen once found above
+            break
+        region_end = _region_end(header_idx)
+        event_re = re.compile(rf"^{re.escape(child_indent)}{re.escape(event)}:[ \t]*(#.*)?$")
+        event_idx = next((j for j in range(header_idx + 1, region_end) if event_re.match(lines[j])), None)
+        if event_idx is None:
+            # The parse says this event already exists but we cannot find it as an
+            # editable block key (an inline ``event: [...]`` value, a quoted key, or
+            # a space before the colon): inserting our own key would duplicate it.
+            # Refuse rather than corrupt — nothing has been written yet.
+            if isinstance(parsed_hooks, dict) and event in parsed_hooks:
+                return config_path, "skipped-unparsed"
+            insert = [f"{child_indent}{event}:"] + default_entry
+            lines = lines[: header_idx + 1] + insert + lines[header_idx + 1 :]
+            continue
+        # The event is located as a block key, but its VALUE must be a sequence for
+        # our list upsert to be safe. A block MAPPING or scalar value (e.g. an event
+        # holding ``mode: strict``) would have its children misread as our list-item
+        # continuations and corrupt the file — refuse it. ``None`` (an empty event)
+        # is safe to populate. File untouched; nothing written yet.
+        existing_value = parsed_hooks.get(event) if isinstance(parsed_hooks, dict) else None
+        if existing_value is not None and not isinstance(existing_value, list):
+            return config_path, "skipped-unparsed"
+        # The event exists as a block key. Its region runs until the next sibling
+        # KEY at the child indent (or shallower); block-list items (at the child
+        # indent OR indented deeper) and their continuations stay in the region.
+        event_end = region_end
+        for j in range(event_idx + 1, region_end):
+            stripped = lines[j].strip()
+            if stripped == "" or stripped.startswith("#"):
+                continue
+            if _indent_width(lines[j]) > child_depth or at_key_item_re.match(lines[j]):
+                continue
+            event_end = j
+            break
+        # A YAML block sequence may be written with the dash AT the key indent
+        # (``  - ...``) or one level DEEPER (``    - ...``); both are valid and must
+        # not be mixed under one key. Detect the indent this event actually uses and
+        # write our entry — and match the user's items — at that SAME indent, so we
+        # never emit an inconsistent sequence that PyYAML would reject.
+        item_indent = child_indent
+        for j in range(event_idx + 1, event_end):
+            match = re.match(r"^(\s*)-[ \t]", lines[j])
+            if match and len(match.group(1)) >= child_depth:
+                item_indent = match.group(1)
+                break
+        item_depth = len(item_indent)
+        item_re = re.compile(rf"^{re.escape(item_indent)}-[ \t]")
+        event_entry = [
+            f"{item_indent}- command: {json.dumps(command)}",
+            f"{item_indent}  timeout: {int(timeout)}",
+        ]
+        # Keep every list item EXCEPT our own prior entries; a user's co-located
+        # entry under the same event is preserved verbatim at its own indent.
+        kept: list[str] = []
+        j = event_idx + 1
+        while j < event_end:
+            line = lines[j]
+            if item_re.match(line):
+                span = [line]
+                k = j + 1
+                while k < event_end and lines[k].strip() != "" and _indent_width(lines[k]) > item_depth:
+                    span.append(lines[k])
+                    k += 1
+                if not _hermes_command_runs_wrapper(_hermes_item_command_text(span), wrapper_basename):
+                    kept.extend(span)  # the user's own entry — keep it
+                j = k
+            else:
+                kept.append(line)  # blank/comment inside the event list — preserve
+                j += 1
+        new_region = [lines[event_idx]] + event_entry + kept
+        lines = lines[:event_idx] + new_region + lines[event_end:]
+
+    result = newline.join(lines)
+    if text.endswith(("\n", "\r")):
+        result += newline
+    # Safety net over the whole textual edit: never write a result we cannot prove
+    # preserves the user's data. Re-parse and verify the file still parses, every
+    # non-hooks section and non-agentacct event is semantically unchanged, and each
+    # of our events carries exactly our command plus every entry the user already had.
+    # Any textual-editing bug (present or future) fails this and refuses instead of
+    # corrupting the user's live config.
+    if not _hermes_hooks_result_is_safe(text, result, command=command, events=events, wrapper_basename=wrapper_basename):
+        return config_path, "skipped-unparsed"
+    _atomic_write_text(config_path, result, mode=mode)
+    return config_path, "updated"
+
+
+def _hermes_hooks_result_is_safe(
+    before_text: str, after_text: str, *, command: str, events: list[str], wrapper_basename: str
+) -> bool:
+    """Semantic guard for the config.yaml hooks upsert: True only when the edit
+    preserves everything it must and wired exactly our entries."""
+    import yaml
+
+    try:
+        before = yaml.safe_load(before_text)
+        after = yaml.safe_load(after_text)
+    except yaml.YAMLError:
+        return False
+    if not isinstance(after, dict):
+        return False
+    before = before if isinstance(before, dict) else {}
+    before_hooks = before.get("hooks") if isinstance(before.get("hooks"), dict) else {}
+    after_hooks = after.get("hooks")
+    if not isinstance(after_hooks, dict):
+        return False
+    ours = set(events)
+
+    # (a) every non-hooks top-level key is byte-for-byte semantically unchanged.
+    if (set(before.keys()) - {"hooks"}) != (set(after.keys()) - {"hooks"}):
+        return False
+    for key in before.keys():
+        if key != "hooks" and after.get(key) != before.get(key):
+            return False
+
+    # (b) no non-agentacct event is added, dropped, or changed.
+    if (set(before_hooks.keys()) - ours) != (set(after_hooks.keys()) - ours):
+        return False
+    for event in set(before_hooks.keys()) - ours:
+        if after_hooks.get(event) != before_hooks.get(event):
+            return False
+
+    # (c) each of our events carries exactly our command once, and every entry the
+    # user already had under it (that was not a prior agentacct entry) still survives.
+    for event in ours:
+        entries = after_hooks.get(event)
+        if not isinstance(entries, list):
+            return False
+        mine = [
+            entry for entry in entries
+            if isinstance(entry, dict) and _hermes_command_runs_wrapper(entry.get("command"), wrapper_basename)
+        ]
+        if len(mine) != 1 or mine[0].get("command") != command:
+            return False
+        prior = before_hooks.get(event)
+        for entry in prior if isinstance(prior, list) else []:
+            if isinstance(entry, dict) and _hermes_command_runs_wrapper(entry.get("command"), wrapper_basename):
+                continue  # a prior agentacct entry — legitimately replaced
+            if entry not in entries:
+                return False
+    return True
+
+
+def _install_hermes_hook(home: Path, store_dir: Path, command: str, *, force: bool = False) -> tuple[str, Path]:
+    """Write the Hermes hook wrapper + upsert config.yaml ``hooks:``. Returns
+    (config_action, wrapper_path). ``command`` is the absolute agentacct executable
+    embedded in the wrapper's candidate list."""
+    wrapper_path = home / HERMES_HOOK_RELATIVE_PATH
+    wrapper_path.parent.mkdir(parents=True, exist_ok=True)
+    wrapper_source = render_hermes_hook_wrapper(command, store_dir=store_dir)
+    if force or not wrapper_path.exists() or wrapper_path.read_text(encoding="utf-8") != wrapper_source:
+        _atomic_write_text(wrapper_path, wrapper_source, mode=0o755)
+    hook_command = _hermes_hook_command(wrapper_path)
+    config_path = home / HERMES_CONFIG_RELATIVE_PATH
+    _path, action = _write_hermes_hooks_config_at(config_path, hook_command, HERMES_HOOK_RELATIVE_PATH.name)
+    return action, wrapper_path
+
+
+def _print_hermes_hook_consent_steps() -> None:
+    """The one-time consent + restart steps Hermes shell hooks require."""
+    console.print(
+        "Hermes gates shell hooks on a one-time consent allowlist "
+        "(~/.hermes/shell-hooks-allowlist.json): approve the agentacct hook ONCE — run a hermes "
+        "CLI/TUI session with --accept-hooks (or export HERMES_ACCEPT_HOOKS=1), or set "
+        "hooks_auto_accept: true in config.yaml (needed for the non-interactive gateway)."
+    )
+    console.print(
+        "RESTART the running gateway so it registers the new hook: a long-running gateway keeps its "
+        "old hooks until it restarts (hermes gateway run --replace)."
+    )
+
+
+@hermes_hooks_app.command("install")
+def hermes_hooks_install(
+    home: Annotated[Path, typer.Option(help="Home dir to install into (~/.hermes/*). Defaults to the user's home.")] = Path.home(),
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="Store the hooks spool ticks to. Required so gateway/GUI-launched Hermes binds the right store on the command line."),
+    ] = None,
+    force: Annotated[bool, typer.Option(help="Rewrite the wrapper even if it already matches.")] = False,
+) -> None:
+    """Install the Hermes observe-only hooks: the wrapper + config.yaml ``hooks:``
+    entries (pre_tool_call tool-activity, post_tool_call exit-code, on_session_end
+    turn-boundary) pointing at it."""
+    resolved_store = store_dir if store_dir is not None else onboard_global_store_dir()[0]
+    command = _resolve_absolute_mcp_command()
+    try:
+        action, wrapper_path = _install_hermes_hook(Path(home), Path(resolved_store), command, force=force)
+    except OSError as exc:
+        console.print(f"The Hermes hook could not be written ({exc}).")
+        raise typer.Exit(1) from exc
+    console.print(f"Hermes hook wrapper: {wrapper_path}")
+    config_path = Path(home) / HERMES_CONFIG_RELATIVE_PATH
+    if action == "skipped-unparsed":
+        console.print(
+            f"Hermes config.yaml: LEFT UNCHANGED ({config_path}) — its hooks: block is not a safely "
+            "editable block mapping (inline hooks: {{...}} or tab-indented). No hook was wired. Add the "
+            "agentacct pre_tool_call / post_tool_call / on_session_end entries under hooks: yourself, then re-run."
+        )
+        raise typer.Exit(1)
+    console.print(f"Hermes config.yaml hooks: {action} ({config_path})")
+    _print_hermes_hook_consent_steps()
 
 
 @claude_code_hooks_app.command("install")
@@ -7470,6 +7954,21 @@ def _local_usage_import_payload(
 
             try:
                 ingest_session_end_spool(
+                    effective_store_dir,
+                    record=service.record_event,
+                    now=time.time(),
+                )
+            except Exception:  # noqa: BLE001 - draining the spool must never fail the import.
+                pass
+            # Drain the Hermes turn-boundary spool into content-free
+            # turn_boundary_observed liveness events. Distinct from SessionEnd:
+            # hermes fires on_session_end per TURN, so these are NEVER consumed as
+            # a session close (no ended_open) — they only contribute to a session's
+            # latest activity. Best-effort, additive + content-idded, same as above.
+            from .session_lifecycle import ingest_turn_boundary_spool
+
+            try:
+                ingest_turn_boundary_spool(
                     effective_store_dir,
                     record=service.record_event,
                     now=time.time(),

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -1246,6 +1246,283 @@ def codex_hooks_json_block(wrapper_path: Path | str, *, python_executable: str |
     }
 
 
+# ---------------------------------------------------------------------------
+# Hermes shell-hook adapter (observe-only)
+# ---------------------------------------------------------------------------
+#
+# Hermes (Nous Research personal agent) dispatches shell hooks from the
+# ``hooks:`` block of ``~/.hermes/config.yaml`` for both its CLI/TUI and its
+# gateway. Its wire STDIN is a single serialization point
+# (``agent/shell_hooks.py:_serialize_payload``) whose top-level keys
+# ``hook_event_name`` / ``tool_name`` / ``session_id`` are the SAME snake_case as
+# Claude Code + Codex, and its hook ``session_id`` EQUALS the ``state.db``
+# sessions.id the usage importer keys on — so hermes ticks attribute straight to
+# the session with no log pairing (verified on the real machine 2026-08-13).
+#
+# Three events are wired, all observe-only (agentacct never blocks a hermes tool
+# call — hermes owns its own approval layer):
+#   pre_tool_call  -> tool NAME + category (Receipt Actions dimension)          [#1]
+#   post_tool_call -> the harness exit code of a recognized check command       [#3]
+#   on_session_end -> a TURN-boundary heartbeat (see below)                     [#4]
+#
+# NOTE on #4: hermes fires ``on_session_end`` at the end of EVERY turn
+# (``run_conversation`` runs once per user message), NOT at real session close.
+# So it is captured as a distinct ``turn_boundary_observed`` liveness heartbeat,
+# never fed into the ``ended_open`` inference (a per-turn end would falsely close
+# a still-live session between turns). See session_lifecycle.record_turn_boundary_tick.
+
+HERMES_HOOK_RELATIVE_PATH = Path(".hermes/hooks/agentacct_hermes_hook.py")
+HERMES_CONFIG_RELATIVE_PATH = Path(".hermes/config.yaml")
+
+# The hermes shell-hook event names this adapter wires, mapped to the agentacct
+# CLI subcommand each dispatches to. The wrapper routes on ``hook_event_name``.
+HERMES_HOOK_EVENT_SUBCOMMANDS: dict[str, str] = {
+    "pre_tool_call": "pre-tool-call",
+    "post_tool_call": "post-tool-call",
+    "on_session_end": "session-end",
+}
+
+# hermes's shell/terminal tool name (its exit-code-bearing command tool). The #3
+# exit-code check only observes this tool, mirroring the Claude Code path gating
+# on ``bash``.
+_HERMES_SHELL_TOOL_NAMES = frozenset({"terminal"})
+
+_HERMES_HOOK_WRAPPER_TEMPLATE = '''#!/usr/bin/env python3
+"""Hermes shell-hook wrapper for agentacct (observe-only).
+
+One wrapper serves the installed Hermes hook events (dispatch on the event's own
+`hook_event_name`):
+- pre_tool_call:  spool the tool NAME + category for the Receipt's Actions dimension.
+- post_tool_call: spool the harness exit code of a recognized check command.
+- on_session_end: spool a content-free turn-boundary heartbeat.
+
+All observe-only — agentacct never makes an allow/block decision for Hermes
+(Hermes owns its own approval layer). Shells out to the installed `agentacct`
+CLI. Fail-open: on any error, a hung child, or an unknown event, this wrapper
+writes an empty JSON object `{}` (Hermes reads that as "hook contributed nothing")
+and exits 0, so a broken or moved install can never block a Hermes tool call.
+Reinstall with: agentacct hooks hermes install --force
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+AGENTACCT_CANDIDATES = __AGENTACCT_CANDIDATES__
+AGENTACCT_HOOK_ARGS = __AGENTACCT_HOOK_ARGS__
+EVENT_SUBCOMMANDS = __EVENT_SUBCOMMANDS__
+
+
+def resolve_agentacct():
+    for candidate in AGENTACCT_CANDIDATES:
+        if not candidate:
+            continue
+        if os.path.basename(candidate) != candidate:
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        else:
+            found = shutil.which(candidate)
+            if found:
+                return found
+    return None
+
+
+def no_op(reason=""):
+    if reason:
+        sys.stderr.write("agentacct hermes hook: %s; failing open\\n" % reason)
+    # Hermes observe-only contract: an empty JSON object contributes nothing to
+    # the dispatcher (never a block, never injected context).
+    sys.stdout.write("{}\\n")
+    return 0
+
+
+def main():
+    raw = sys.stdin.buffer.read().decode("utf-8", "replace")
+    hook_event = ""
+    try:
+        event = json.loads(raw)
+        if isinstance(event, dict):
+            value = event.get("hook_event_name")
+            if isinstance(value, str):
+                hook_event = value
+    except ValueError:
+        pass
+    subcommand = EVENT_SUBCOMMANDS.get(hook_event)
+    if subcommand is None:
+        return no_op()  # not one of ours (or unparseable): silent no-op
+    executable = resolve_agentacct()
+    if executable is None:
+        return no_op("agentacct executable not found (re-run: agentacct hooks hermes install --force)")
+    try:
+        proc = subprocess.run(
+            [executable, "hooks", "hermes", subcommand, *AGENTACCT_HOOK_ARGS],
+            input=raw,
+            text=True,
+            capture_output=True,
+            # A bounded wait is part of the never-block contract: a hung child
+            # (stalled store mount, held SQLite lock, cold-import stall) would
+            # otherwise stall the Hermes tool call up to hermes's own hook
+            # timeout. 5s < the installed per-hook timeout, so we fail-open first.
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return no_op("agentacct timed out")
+    except OSError as exc:
+        return no_op("agentacct failed to start (%s)" % exc)
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
+    if proc.returncode == 0 and proc.stdout.strip():
+        sys.stdout.write(proc.stdout)
+        return 0
+    return no_op("agentacct exited with code %s without output" % proc.returncode)
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = main()
+    except Exception as exc:  # fail-open: a wrapper bug must never break Hermes sessions.
+        exit_code = no_op("unexpected hermes hook wrapper error (%s: %s)" % (type(exc).__name__, exc))
+    raise SystemExit(exit_code)
+'''
+
+
+def render_hermes_hook_wrapper(agentacct_executable: str | None = None, *, store_dir: Path | str | None = None) -> str:
+    candidates: list[str] = []
+    if agentacct_executable:
+        candidates.append(str(agentacct_executable))
+    for bare_name in ("agentacct", "agent-chronicle", "agent-sentinel"):
+        if bare_name not in candidates:
+            candidates.append(bare_name)
+    hook_args: list[str] = []
+    if store_dir is not None:
+        # Hermes hooks fire from the CLI/TUI and the gateway, neither of which
+        # guarantees agentacct's env vars or cwd, so the store binds on the
+        # command line (mirrors the Codex wrapper).
+        hook_args = ["--store-dir", str(store_dir)]
+    rendered = _HERMES_HOOK_WRAPPER_TEMPLATE.replace("__AGENTACCT_CANDIDATES__", repr(candidates))
+    rendered = rendered.replace("__AGENTACCT_HOOK_ARGS__", repr(hook_args))
+    return rendered.replace("__EVENT_SUBCOMMANDS__", repr(dict(HERMES_HOOK_EVENT_SUBCOMMANDS)))
+
+
+def _hermes_tool_exit_code(event: dict[str, Any]) -> int | None:
+    """Read the terminal exit code from a hermes ``post_tool_call`` payload.
+
+    Hermes nests the result under ``extra.result`` — a dict
+    ``{"output", "exit_code", "error"}`` for the terminal tool, or a JSON string
+    for some tools. 0 is a valid value, so a missing/unusable code returns None
+    (kept distinct from success) so the check is only recorded when real."""
+
+    extra = event.get("extra")
+    result = extra.get("result") if isinstance(extra, dict) else None
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except ValueError:
+            return None
+    if not isinstance(result, dict):
+        return None
+    value = result.get("exit_code")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def capture_hermes_tool_check(raw: str, *, store_dir: Path | str | None = None) -> None:
+    """Record ONE mechanical-check tick for a hermes ``post_tool_call``. Never raises.
+
+    Mirrors ``capture_mechanical_check`` for hermes's wire shape: the check runs
+    only for the terminal tool, the command comes from top-level ``tool_input``,
+    and the harness exit code from ``extra.result`` (see ``_hermes_tool_exit_code``).
+    When the command is a recognized test/build/lint runner, the exit code the
+    HARNESS observed is spooled (client ``hermes``) — the local signal that lifts a
+    step to ``independently_checked``. Only a coarse check kind, the runner name,
+    and a sha256 command DIGEST are spooled — never the command, arguments, or output.
+    """
+
+    try:
+        from .mechanical_capture import (
+            classify_command,
+            command_digest,
+            record_mechanical_check_tick,
+        )
+
+        event = json.loads(raw or "{}")
+        if not isinstance(event, dict):
+            return
+        tool_name = event.get("tool_name") or event.get("tool")
+        if str(tool_name or "").strip() not in _HERMES_SHELL_TOOL_NAMES:
+            return
+        session_id = event.get("session_id")
+        if not isinstance(session_id, str) or not session_id or len(session_id) > _MAX_CONTEXT_ID_LENGTH:
+            return
+        tool_input = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else {}
+        command = tool_input.get("command")
+        classified = classify_command(command)
+        if classified is None:
+            return
+        exit_code = _hermes_tool_exit_code(event)
+        if exit_code is None:
+            return
+        target = Path(store_dir) if store_dir is not None else _hook_store_dir_from_event(event)
+        if target is None:
+            return
+        check_kind, runner = classified
+        record_mechanical_check_tick(
+            target,
+            client="hermes",
+            session_id=session_id,
+            check_kind=check_kind,
+            runner=runner,
+            digest=command_digest(str(command or "")),
+            exit_code=exit_code,
+            at=time.time(),
+        )
+    except Exception:  # noqa: BLE001 - capture must never affect the hook.
+        return
+
+
+def capture_hermes_turn_boundary(raw: str, *, store_dir: Path | str | None = None) -> None:
+    """Record ONE turn-boundary heartbeat for a hermes ``on_session_end``. Never raises.
+
+    Hermes fires ``on_session_end`` at the end of EVERY turn, not at session
+    close, so this is spooled as a content-free ``turn_boundary_observed``
+    liveness fact — client, session id, timestamp, and the terminal ``completed`` /
+    ``interrupted`` flags — and is NEVER consumed as a session close (the reducer
+    would otherwise falsely infer ``ended_open`` between turns). No conversation
+    content. Latest-per-session wins on drain.
+    """
+
+    try:
+        from .session_lifecycle import record_turn_boundary_tick
+
+        event = json.loads(raw or "{}")
+        if not isinstance(event, dict):
+            return
+        session_id = event.get("session_id")
+        if not isinstance(session_id, str) or not session_id or len(session_id) > _MAX_CONTEXT_ID_LENGTH:
+            return
+        target = Path(store_dir) if store_dir is not None else _hook_store_dir_from_event(event)
+        if target is None:
+            return
+        extra = event.get("extra") if isinstance(event.get("extra"), dict) else {}
+        completed = extra.get("completed")
+        interrupted = extra.get("interrupted")
+        record_turn_boundary_tick(
+            target,
+            client="hermes",
+            session_id=session_id,
+            at=time.time(),
+            completed=completed if isinstance(completed, bool) else None,
+            interrupted=interrupted if isinstance(interrupted, bool) else None,
+        )
+    except Exception:  # noqa: BLE001 - capture must never affect the hook.
+        return
+
+
 def claude_code_settings_example(python_executable: str | None = None, *, hook_path: Path | str | None = None) -> dict[str, Any]:
     """Example Claude Code settings block invoking the agentacct hook wrapper.
 

--- a/src/agentacct/mechanical_capture.py
+++ b/src/agentacct/mechanical_capture.py
@@ -329,6 +329,12 @@ def _build_envelope(tick: Mapping[str, Any]) -> Any | None:
         return None
     if not _SAFE_RUNNER.fullmatch(runner) or not _SHA256.fullmatch(digest):
         return None
+    # Name the wire the check came from honestly, per client: a hermes check
+    # arrives on a hermes post_tool_call, not a Claude Code PostToolUse.
+    if client == "hermes":
+        source_schema, adapter = "hermes_post_tool_call.v1", "hermes_post_tool_call"
+    else:
+        source_schema, adapter = "claude_code_post_tool_use.v1", "claude_code_post_tool_use"
     try:
         return EvidenceEnvelope.create(
             assertion="observed",
@@ -336,8 +342,8 @@ def _build_envelope(tick: Mapping[str, Any]) -> Any | None:
             source_type="client_hook",
             source_system=client,
             source_instance=session,
-            source_schema="claude_code_post_tool_use.v1",
-            adapter="claude_code_post_tool_use",
+            source_schema=source_schema,
+            adapter=adapter,
             event_timestamp=float(at),
             dimensions=["machine_check"],
             measurement_basis="hook_exit_code",

--- a/src/agentacct/session_lifecycle.py
+++ b/src/agentacct/session_lifecycle.py
@@ -36,6 +36,17 @@ SESSION_END_EVENT_TYPE = "session_end_observed"
 SESSION_END_CAPTURE_BASIS = "client_hook_session_end"
 _SPOOL_RELATIVE_PATH = Path("spool") / "claude-session-end.jsonl"
 
+# frozen: stored ``turn_boundary_observed`` events carry this event_type forever.
+# Distinct from SESSION_END because a hermes ``on_session_end`` fires per TURN
+# (once per user message), not at real session close. It is a pure liveness
+# heartbeat: ``build_session_end_by_session`` never treats it as an end (that
+# check keys on SESSION_END_EVENT_TYPE), so it contributes to a session's latest
+# activity but can NEVER derive an ``ended_open`` disposition. Mapping a per-turn
+# end to ``ended_open`` would falsely close a still-live session between turns.
+TURN_BOUNDARY_EVENT_TYPE = "turn_boundary_observed"
+TURN_BOUNDARY_CAPTURE_BASIS = "client_hook_turn_boundary"
+_TURN_BOUNDARY_SPOOL_RELATIVE_PATH = Path("spool") / "hermes-turn-boundary.jsonl"
+
 # A hard bound on the captured reason (a short enum like ``clear``/``logout``).
 _REASON_MAX = 64
 
@@ -257,6 +268,171 @@ def ingest_session_end_spool(
 
     try:
         events = drain_session_end_spool(store_dir, now=now, token=token)
+    except Exception:  # noqa: BLE001 - a spool drain must never fail the import.
+        return 0
+    written = 0
+    for event in events:
+        try:
+            record(event)
+            written += 1
+        except Exception:  # noqa: BLE001 - one bad event must not abort the rest.
+            continue
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Turn-boundary heartbeat (hermes on_session_end — a per-turn liveness fact)
+# ---------------------------------------------------------------------------
+
+
+def turn_boundary_spool_path(store_dir: Path | str) -> Path:
+    return Path(store_dir) / _TURN_BOUNDARY_SPOOL_RELATIVE_PATH
+
+
+def record_turn_boundary_tick(
+    store_dir: Path | str,
+    *,
+    client: str,
+    session_id: str,
+    at: float,
+    completed: bool | None = None,
+    interrupted: bool | None = None,
+) -> None:
+    """Append ONE turn-boundary tick to the store spool. Best-effort; never raises.
+
+    Writes only the scalars ``{c, s, t}`` — client, session id, timestamp — plus
+    the terminal ``co`` (completed) / ``ir`` (interrupted) booleans when known. No
+    conversation content, no path, no payload. ``O_APPEND`` so concurrent hook
+    processes never interleave.
+    """
+
+    try:
+        client = str(client or "").strip()
+        session_id = str(session_id or "").strip()
+        if not client or not session_id:
+            return
+        target = turn_boundary_spool_path(store_dir)
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        payload: dict[str, Any] = {"c": client, "s": session_id, "t": float(at)}
+        if isinstance(completed, bool):
+            payload["co"] = completed
+        if isinstance(interrupted, bool):
+            payload["ir"] = interrupted
+        line = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, (line + "\n").encode("utf-8"))
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001 - capture must never affect the hook.
+        return
+
+
+def drain_turn_boundary_spool(
+    store_dir: Path | str,
+    *,
+    now: float | None = None,
+    token: str | None = None,
+) -> list[dict[str, Any]]:
+    """Consume the spool and return additive ``turn_boundary_observed`` events.
+
+    The spool is atomically renamed aside before being read, so ticks that land
+    during the drain go to a freshly recreated spool and are picked up next time.
+    One event per (client, session): the LATEST turn-boundary timestamp wins (a
+    session fires this every turn — only the most recent boundary matters for
+    liveness). Each event carries a deterministic id so re-reducing is idempotent.
+    """
+
+    spool = turn_boundary_spool_path(store_dir)
+    if not spool.exists():
+        return []
+    batch_token = token or uuid.uuid4().hex
+    consuming = spool.with_name(f".{spool.name}.consuming-{os.getpid()}-{batch_token}")
+    try:
+        os.replace(spool, consuming)
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return []
+    try:
+        raw = consuming.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    finally:
+        try:
+            consuming.unlink()
+        except OSError:
+            pass
+
+    latest: dict[tuple[str, str], float] = {}
+    flags: dict[tuple[str, str], dict[str, bool]] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, Mapping):
+            continue
+        client = str(row.get("c") or "").strip()
+        session = str(row.get("s") or "").strip()
+        if not client or not session:
+            continue
+        stamp = row.get("t")
+        if not isinstance(stamp, (int, float)) or isinstance(stamp, bool):
+            continue
+        key = (client, session)
+        stamp = float(stamp)
+        if stamp >= latest.get(key, float("-inf")):
+            latest[key] = stamp
+            row_flags: dict[str, bool] = {}
+            if isinstance(row.get("co"), bool):
+                row_flags["completed"] = row["co"]
+            if isinstance(row.get("ir"), bool):
+                row_flags["interrupted"] = row["ir"]
+            flags[key] = row_flags
+
+    events: list[dict[str, Any]] = []
+    for (client, session), observed_at in sorted(latest.items()):
+        digest = uuid.uuid5(uuid.NAMESPACE_URL, f"{batch_token}\0{client}\0{session}").hex
+        metadata: dict[str, Any] = {
+            "client": client,
+            "client_session_id": session,
+            "observed_at": observed_at,
+            "capture_basis": TURN_BOUNDARY_CAPTURE_BASIS,
+            "sentinel_semantic_kind": "session_lifecycle",
+        }
+        metadata.update(flags.get((client, session), {}))
+        events.append(
+            {
+                "event_id": f"turnboundary:{digest}",
+                "created_at": observed_at,
+                "source": client,
+                "event_type": TURN_BOUNDARY_EVENT_TYPE,
+                "run_id": None,
+                "metadata": metadata,
+            }
+        )
+    return events
+
+
+def ingest_turn_boundary_spool(
+    store_dir: Path | str,
+    *,
+    record: Callable[[dict[str, Any]], Any],
+    now: float | None = None,
+    token: str | None = None,
+) -> int:
+    """Drain the turn-boundary spool and hand each event to ``record``. Never raises.
+
+    Mirrors ``ingest_session_end_spool`` so the usage importer drains turn
+    boundaries the same way it drains session-end and tool activity.
+    """
+
+    try:
+        events = drain_turn_boundary_spool(store_dir, now=now, token=token)
     except Exception:  # noqa: BLE001 - a spool drain must never fail the import.
         return 0
     written = 0

--- a/tests/test_hooks_hermes.py
+++ b/tests/test_hooks_hermes.py
@@ -1,0 +1,555 @@
+"""Hermes observe-only shell hooks: the three capture paths, the turn-boundary
+heartbeat, the config.yaml ``hooks:`` writer, the wrapper, and the CLI subcommands.
+
+Hermes' shell-hook STDIN is a single serialization point whose top-level keys
+``hook_event_name`` / ``tool_name`` / ``session_id`` are the SAME snake_case as
+Claude Code + Codex, and its ``session_id`` equals the ``state.db`` sessions.id
+the usage importer keys on — verified on the real machine — so tool ticks and
+checks attribute straight to the Hermes session with no log pairing. Unlike a
+Claude Code / Codex ``SessionEnd`` (once, at real close), a hermes
+``on_session_end`` fires per TURN, so it is captured as a distinct
+``turn_boundary_observed`` liveness heartbeat that is NEVER consumed as a session
+close (no false ``ended_open`` between turns).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agentacct.cli import (
+    _hermes_hook_command,
+    _install_hermes_hook,
+    _write_hermes_hooks_config_at,
+    app,
+)
+from agentacct.hooks import (
+    HERMES_CONFIG_RELATIVE_PATH,
+    HERMES_HOOK_EVENT_SUBCOMMANDS,
+    HERMES_HOOK_RELATIVE_PATH,
+    capture_hermes_tool_check,
+    capture_hermes_turn_boundary,
+    capture_tool_activity,
+    render_hermes_hook_wrapper,
+)
+from agentacct.mechanical_capture import drain_mechanical_check_spool
+from agentacct.session_lifecycle import (
+    TURN_BOUNDARY_EVENT_TYPE,
+    build_session_end_by_session,
+    drain_turn_boundary_spool,
+    record_turn_boundary_tick,
+)
+from agentacct.tool_activity import drain_tool_activity_spool
+
+WRAPPER_BASENAME = HERMES_HOOK_RELATIVE_PATH.name
+_COMMAND = f"/usr/bin/python3 /home/u/.hermes/hooks/{WRAPPER_BASENAME}"
+
+
+def _pre(session_id: str, tool_name: str = "terminal", command: str = "echo hi") -> str:
+    return json.dumps(
+        {
+            "hook_event_name": "pre_tool_call",
+            "tool_name": tool_name,
+            "tool_input": {"command": command},
+            "session_id": session_id,
+            "cwd": "/x",
+            "extra": {"task_id": "t1", "tool_call_id": "c1", "turn_id": "tt"},
+        }
+    )
+
+
+def _post(session_id: str, command: str, *, exit_code: int = 0, result_as_string: bool = False, tool_name: str = "terminal") -> str:
+    result: object = {"output": "x", "exit_code": exit_code, "error": None}
+    if result_as_string:
+        result = json.dumps(result)
+    return json.dumps(
+        {
+            "hook_event_name": "post_tool_call",
+            "tool_name": tool_name,
+            "tool_input": {"command": command},
+            "session_id": session_id,
+            "cwd": "/x",
+            "extra": {"result": result, "status": "success", "duration_ms": 42},
+        }
+    )
+
+
+def _end(session_id: str, *, completed: bool = True, interrupted: bool = False) -> str:
+    return json.dumps(
+        {
+            "hook_event_name": "on_session_end",
+            "session_id": session_id,
+            "cwd": "/x",
+            "extra": {"completed": completed, "interrupted": interrupted, "turn_id": "tt"},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1 tool activity
+# ---------------------------------------------------------------------------
+
+
+def test_capture_tool_activity_labels_hermes_client(tmp_path: Path) -> None:
+    capture_tool_activity(_pre("20260813_031424_2b0e74", "terminal"), store_dir=tmp_path, client="hermes")
+    events = drain_tool_activity_spool(tmp_path)
+    assert len(events) == 1
+    meta = events[0]["metadata"]
+    assert events[0]["source"] == "hermes"
+    assert meta["client_session_id"] == "20260813_031424_2b0e74"
+    assert {"name": "terminal", "count": 1} in meta["tool_names"]
+
+
+# ---------------------------------------------------------------------------
+# #3 exit-code mechanical check
+# ---------------------------------------------------------------------------
+
+
+def _drain_checks(tmp_path: Path) -> list:
+    envelopes = drain_mechanical_check_spool(tmp_path)
+    return envelopes
+
+
+def test_hermes_tool_check_records_recognized_check(tmp_path: Path) -> None:
+    capture_hermes_tool_check(_post("s1", "pytest -q", exit_code=0), store_dir=tmp_path)
+    envelopes = _drain_checks(tmp_path)
+    assert len(envelopes) == 1
+    env = envelopes[0]
+    assert env.source_system == "hermes"
+    # Provenance names the hermes wire, not Claude Code's PostToolUse.
+    assert env.source_schema == "hermes_post_tool_call.v1"
+    assert env.adapter == "hermes_post_tool_call"
+
+
+def test_hermes_tool_check_reads_exit_from_string_result(tmp_path: Path) -> None:
+    # Some hermes tools carry extra.result as a JSON STRING, not a dict.
+    capture_hermes_tool_check(_post("s1", "npm run build", exit_code=2, result_as_string=True), store_dir=tmp_path)
+    envelopes = _drain_checks(tmp_path)
+    assert len(envelopes) == 1
+    attrs = envelopes[0].payload["attributes"]
+    assert attrs["exit_code"] == 2
+    assert attrs["passed"] is False
+
+
+def test_hermes_tool_check_skips_non_check_command(tmp_path: Path) -> None:
+    capture_hermes_tool_check(_post("s1", "echo hi", exit_code=0), store_dir=tmp_path)
+    assert _drain_checks(tmp_path) == []
+
+
+def test_hermes_tool_check_skips_non_terminal_tool(tmp_path: Path) -> None:
+    capture_hermes_tool_check(_post("s1", "pytest -q", tool_name="web_search"), store_dir=tmp_path)
+    assert _drain_checks(tmp_path) == []
+
+
+def test_hermes_tool_check_skips_missing_exit_code(tmp_path: Path) -> None:
+    event = {
+        "hook_event_name": "post_tool_call",
+        "tool_name": "terminal",
+        "tool_input": {"command": "pytest -q"},
+        "session_id": "s1",
+        "extra": {"result": {"output": "x", "error": None}},  # no exit_code
+    }
+    capture_hermes_tool_check(json.dumps(event), store_dir=tmp_path)
+    assert _drain_checks(tmp_path) == []
+
+
+def test_hermes_tool_check_never_raises_on_garbage(tmp_path: Path) -> None:
+    capture_hermes_tool_check("not json", store_dir=tmp_path)
+    capture_hermes_tool_check(json.dumps([1, 2, 3]), store_dir=tmp_path)
+    assert _drain_checks(tmp_path) == []
+
+
+def test_hermes_tool_check_attributes_input_session(tmp_path: Path) -> None:
+    # Invariant 6: the check must key to the session it came from, unmodified.
+    capture_hermes_tool_check(_post("20260813_031424_2b0e74", "pytest -q"), store_dir=tmp_path)
+    env = _drain_checks(tmp_path)[0]
+    assert env.source_instance == "20260813_031424_2b0e74"
+    assert getattr(env.subjects, "client_session_id", None) == "20260813_031424_2b0e74"
+
+
+def test_hermes_captures_reject_overlong_session_id(tmp_path: Path) -> None:
+    # Invariant 6: a session id past the bound (241+ chars) is dropped, never spooled.
+    overlong = "x" * 5000
+    capture_hermes_tool_check(_post(overlong, "pytest -q"), store_dir=tmp_path)
+    capture_hermes_turn_boundary(_end(overlong), store_dir=tmp_path)
+    capture_tool_activity(_pre(overlong), store_dir=tmp_path, client="hermes")
+    assert _drain_checks(tmp_path) == []
+    assert drain_turn_boundary_spool(tmp_path) == []
+    assert drain_tool_activity_spool(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# #4 turn-boundary heartbeat (NEVER ended_open)
+# ---------------------------------------------------------------------------
+
+
+def test_turn_boundary_records_liveness_with_flags(tmp_path: Path) -> None:
+    capture_hermes_turn_boundary(_end("s1", completed=True, interrupted=False), store_dir=tmp_path)
+    events = drain_turn_boundary_spool(tmp_path)
+    assert len(events) == 1
+    assert events[0]["event_type"] == TURN_BOUNDARY_EVENT_TYPE
+    meta = events[0]["metadata"]
+    assert meta["client"] == "hermes"
+    assert meta["client_session_id"] == "s1"
+    assert meta["completed"] is True
+    assert meta["interrupted"] is False
+
+
+def test_turn_boundary_latest_per_session_wins(tmp_path: Path) -> None:
+    record_turn_boundary_tick(tmp_path, client="hermes", session_id="s1", at=100.0, completed=False)
+    record_turn_boundary_tick(tmp_path, client="hermes", session_id="s1", at=200.0, completed=True)
+    events = drain_turn_boundary_spool(tmp_path)
+    assert len(events) == 1
+    assert events[0]["created_at"] == 200.0
+    assert events[0]["metadata"]["completed"] is True
+
+
+def test_turn_boundary_never_derives_ended_open(tmp_path: Path) -> None:
+    capture_hermes_turn_boundary(_end("s1"), store_dir=tmp_path)
+    events = drain_turn_boundary_spool(tmp_path)
+    # A turn-boundary event is pure liveness: build_session_end_by_session (which
+    # keys ended_open on SESSION_END_EVENT_TYPE) must return NO end for it.
+    assert build_session_end_by_session(events) == {}
+
+
+# ---------------------------------------------------------------------------
+# wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_hermes_wrapper_renders_valid_python_with_event_map(tmp_path: Path) -> None:
+    source = render_hermes_hook_wrapper("/abs/agentacct", store_dir=tmp_path)
+    ast.parse(source)  # valid python
+    assert "hooks" in source and "hermes" in source
+    # dispatch map is embedded so the wrapper routes on hook_event_name
+    for event, subcommand in HERMES_HOOK_EVENT_SUBCOMMANDS.items():
+        assert event in source
+        assert subcommand in source
+    assert "--store-dir" in source and str(tmp_path) in source
+    assert "timeout=5" in source
+
+
+# ---------------------------------------------------------------------------
+# config.yaml hooks: writer
+# ---------------------------------------------------------------------------
+
+_BASE_CONFIG = (
+    "model:\n"
+    "  default: gpt-5.5\n"
+    "hooks:\n"
+    "  post_llm_call:\n"
+    "  - command: /home/u/.hermes/scripts/lark.py\n"
+    "    timeout: 30\n"
+    "hooks_auto_accept: false\n"
+    "mcp_servers:\n"
+    "  agentacct:\n"
+    "    command: agentacct\n"
+)
+
+
+def _load(path: Path) -> dict:
+    import yaml
+
+    return yaml.safe_load(path.read_bytes().decode("utf-8"))
+
+
+def test_hooks_writer_fresh_insert_preserves_everything(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_CONFIG, encoding="utf-8")
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "updated"
+    data = _load(cfg)
+    for event in HERMES_HOOK_EVENT_SUBCOMMANDS:
+        entries = data["hooks"][event]
+        assert entries[0]["command"] == _COMMAND
+        assert entries[0]["timeout"] == 10
+    # the user's lark hook and every non-hooks section survive untouched
+    assert data["hooks"]["post_llm_call"] == [{"command": "/home/u/.hermes/scripts/lark.py", "timeout": 30}]
+    assert data["hooks_auto_accept"] is False
+    assert data["mcp_servers"] == {"agentacct": {"command": "agentacct"}}
+
+
+def test_hooks_writer_is_idempotent(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_CONFIG, encoding="utf-8")
+    _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    first = cfg.read_bytes()
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "unchanged"
+    assert cfg.read_bytes() == first  # byte-identical on re-run
+
+
+def test_hooks_writer_reinstall_replaces_in_place_no_duplicate(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_CONFIG, encoding="utf-8")
+    _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    other = f"/opt/py/python3 /home/u/.hermes/hooks/{WRAPPER_BASENAME}"
+    _, action = _write_hermes_hooks_config_at(cfg, other, WRAPPER_BASENAME)
+    assert action == "updated"
+    data = _load(cfg)
+    for event in HERMES_HOOK_EVENT_SUBCOMMANDS:
+        ours = [e for e in data["hooks"][event] if WRAPPER_BASENAME in (e.get("command") or "")]
+        assert len(ours) == 1  # the stale interpreter entry was replaced, not duplicated
+        assert ours[0]["command"] == other
+
+
+def test_hooks_writer_preserves_bytes_outside_hooks_region(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_CONFIG, encoding="utf-8")
+    _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    text = cfg.read_bytes().decode("utf-8")
+    # Everything before the hooks: header and after the hooks region is verbatim.
+    assert text.startswith("model:\n  default: gpt-5.5\n")
+    assert "hooks_auto_accept: false\nmcp_servers:\n  agentacct:\n    command: agentacct\n" in text
+
+
+def test_hooks_writer_preserves_user_entry_under_shared_event(tmp_path: Path) -> None:
+    config = (
+        "hooks:\n"
+        "  pre_tool_call:\n"
+        "  - command: /home/u/.hermes/scripts/user_gate.py\n"
+        "    timeout: 15\n"
+        "other: 1\n"
+    )
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(config, encoding="utf-8")
+    _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    data = _load(cfg)
+    commands = [e["command"] for e in data["hooks"]["pre_tool_call"]]
+    assert _COMMAND in commands
+    assert "/home/u/.hermes/scripts/user_gate.py" in commands  # user's own entry kept
+    assert data["other"] == 1
+
+
+def test_hooks_writer_appends_block_when_no_hooks_key(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("model:\n  default: gpt-5.5\n", encoding="utf-8")
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "updated"
+    data = _load(cfg)
+    assert set(HERMES_HOOK_EVENT_SUBCOMMANDS).issubset(data["hooks"].keys())
+
+
+def test_hooks_writer_creates_fresh_file(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "wrote"
+    data = _load(cfg)
+    assert set(HERMES_HOOK_EVENT_SUBCOMMANDS).issubset(data["hooks"].keys())
+
+
+def test_hooks_writer_refuses_inline_hooks_mapping(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("hooks: {}\nother: 1\n", encoding="utf-8")
+    before = cfg.read_bytes()
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "skipped-unparsed"
+    assert cfg.read_bytes() == before  # left untouched
+
+
+def test_hooks_writer_refuses_tab_indented_children(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("hooks:\n\tpost_llm_call:\n\t- command: x\n", encoding="utf-8")
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "skipped-unparsed"
+
+
+def test_hooks_writer_preserves_crlf(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_bytes(_BASE_CONFIG.replace("\n", "\r\n").encode("utf-8"))
+    _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    raw = cfg.read_bytes()
+    assert b"\r\n" in raw
+    assert b"\n" not in raw.replace(b"\r\n", b"")  # no bare LF introduced
+
+
+def test_hooks_writer_handles_deeper_indented_sequence_style(tmp_path: Path) -> None:
+    # A user config whose list items are indented one level DEEPER than the key
+    # (equally valid YAML). Our entry must be written at the SAME indent so the
+    # sequence stays consistent (mixed indents would make PyYAML reject the file).
+    config = (
+        "hooks:\n"
+        "  pre_tool_call:\n"
+        "    - command: /home/u/user_gate.py\n"
+        "      timeout: 15\n"
+        "other: 1\n"
+    )
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(config, encoding="utf-8")
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "updated"
+    data = _load(cfg)  # must not raise — the sequence indent stayed consistent
+    commands = [e["command"] for e in data["hooks"]["pre_tool_call"]]
+    assert _COMMAND in commands
+    assert "/home/u/user_gate.py" in commands  # user's deeper-indented entry kept
+    assert data["other"] == 1
+    # re-run is idempotent even in the deeper style (no duplicate, no corruption)
+    _, action2 = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action2 == "unchanged"
+
+
+def test_hooks_writer_refuses_space_before_colon_hooks_key(tmp_path: Path) -> None:
+    # `hooks :` parses as the hooks mapping but header_re does not match it;
+    # appending a second hooks: block would clobber the user's hooks, so refuse.
+    config = "hooks :\n  pre_tool_call:\n  - command: /home/u/user_gate.py\n    timeout: 15\n"
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(config, encoding="utf-8")
+    before = cfg.read_bytes()
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "skipped-unparsed"
+    assert cfg.read_bytes() == before  # user's hooks untouched, not duplicated
+
+
+def test_hooks_writer_refuses_inline_event_value(tmp_path: Path) -> None:
+    # An event present as an inline value (`pre_tool_call: []`) cannot be edited
+    # textually without duplicating the key, so the writer refuses rather than corrupt.
+    config = "hooks:\n  pre_tool_call: []\nother: 1\n"
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(config, encoding="utf-8")
+    before = cfg.read_bytes()
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "skipped-unparsed"
+    assert cfg.read_bytes() == before
+
+
+def test_hooks_writer_refuses_block_mapping_event(tmp_path: Path) -> None:
+    # An event whose value is a block MAPPING (not a sequence) must be refused, not
+    # rewritten as a list — otherwise its children corrupt into our list item.
+    config = (
+        "hooks:\n"
+        "  pre_tool_call:\n"
+        "    command: /bin/user-hook\n"
+        "    timeout: 5\n"
+        "other:\n"
+        "  keep: yes\n"
+    )
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(config, encoding="utf-8")
+    before = cfg.read_bytes()
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "skipped-unparsed"
+    assert cfg.read_bytes() == before  # user's mapping + data untouched
+
+
+def test_hooks_writer_keeps_user_entry_naming_wrapper_as_argument(tmp_path: Path) -> None:
+    # A user hook that merely NAMES the wrapper file as an argument (running a
+    # different executable) is not ours and must be preserved on reinstall.
+    user_cmd = f"/usr/bin/watchdog --watch {WRAPPER_BASENAME} --restart"
+    config = f'hooks:\n  pre_tool_call:\n  - command: "{user_cmd}"\n    timeout: 30\n'
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(config, encoding="utf-8")
+    _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    data = _load(cfg)
+    commands = [e["command"] for e in data["hooks"]["pre_tool_call"]]
+    assert _COMMAND in commands
+    assert user_cmd in commands  # the watchdog entry was NOT misclassified as ours
+
+
+def test_hooks_writer_dedupes_folded_scalar_prior_entry(tmp_path: Path) -> None:
+    # A prior agentacct entry a formatter rewrote as a folded scalar must still be
+    # recognized and replaced on reinstall (no duplicate wrapper entry). Our command
+    # is always <python-interpreter> <wrapper>, so the prior interpreter is python-named.
+    old = f"/old/python3 /home/u/.hermes/hooks/{WRAPPER_BASENAME}"
+    config = (
+        "hooks:\n"
+        "  pre_tool_call:\n"
+        "  - command: >-\n"
+        f"      {old}\n"
+        "    timeout: 10\n"
+    )
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(config, encoding="utf-8")
+    _, action = _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert action == "updated"
+    data = _load(cfg)
+    ours = [e for e in data["hooks"]["pre_tool_call"] if WRAPPER_BASENAME in (e.get("command") or "")]
+    assert len(ours) == 1  # the folded prior entry was replaced, not duplicated
+    assert ours[0]["command"] == _COMMAND
+
+
+# ---------------------------------------------------------------------------
+# installer
+# ---------------------------------------------------------------------------
+
+
+def test_install_hermes_hook_writes_wrapper_and_config(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".hermes").mkdir()
+    (home / ".hermes" / "config.yaml").write_text(_BASE_CONFIG, encoding="utf-8")
+    store = tmp_path / "store"
+    action, wrapper_path = _install_hermes_hook(home, store, "/abs/agentacct")
+    assert action == "updated"
+    assert wrapper_path == home / HERMES_HOOK_RELATIVE_PATH
+    assert wrapper_path.exists()
+    # wrapper is executable
+    assert wrapper_path.stat().st_mode & 0o111
+    data = _load(home / HERMES_CONFIG_RELATIVE_PATH)
+    expected = _hermes_hook_command(wrapper_path)
+    for event in HERMES_HOOK_EVENT_SUBCOMMANDS:
+        assert data["hooks"][event][0]["command"] == expected
+
+
+def test_install_hermes_hook_idempotent(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".hermes").mkdir(parents=True)
+    (home / ".hermes" / "config.yaml").write_text(_BASE_CONFIG, encoding="utf-8")
+    store = tmp_path / "store"
+    _install_hermes_hook(home, store, "/abs/agentacct")
+    config_bytes = (home / HERMES_CONFIG_RELATIVE_PATH).read_bytes()
+    action, _ = _install_hermes_hook(home, store, "/abs/agentacct")
+    assert action == "unchanged"
+    assert (home / HERMES_CONFIG_RELATIVE_PATH).read_bytes() == config_bytes
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommands (fail-open, spool)
+# ---------------------------------------------------------------------------
+
+
+def test_pre_tool_call_subcommand_spools_tick(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["hooks", "hermes", "pre-tool-call", "--store-dir", str(tmp_path)],
+        input=_pre("s1", "terminal"),
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "{}"
+    assert len(drain_tool_activity_spool(tmp_path)) == 1
+
+
+def test_post_tool_call_subcommand_spools_check(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["hooks", "hermes", "post-tool-call", "--store-dir", str(tmp_path)],
+        input=_post("s1", "pytest -q"),
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "{}"
+    assert len(drain_mechanical_check_spool(tmp_path)) == 1
+
+
+def test_session_end_subcommand_spools_turn_boundary(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["hooks", "hermes", "session-end", "--store-dir", str(tmp_path)],
+        input=_end("s1"),
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "{}"
+    assert len(drain_turn_boundary_spool(tmp_path)) == 1
+
+
+@pytest.mark.parametrize("subcommand", ["pre-tool-call", "post-tool-call", "session-end"])
+def test_subcommands_fail_open_on_garbage(subcommand: str, tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["hooks", "hermes", subcommand, "--store-dir", str(tmp_path)],
+        input="}{not json",
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "{}"


### PR DESCRIPTION
feat(hooks): add Hermes observe-only shell hooks for tool-activity, exit-code, and turn-boundary capture

Instruments the Hermes agent to Claude Code work-capture parity via its
`config.yaml` `hooks:` block, mirroring the existing Codex hook adapter.

Contract verified on the real machine (a temporary dump-STDIN hook + a one-shot
`hermes -z ... --accept-hooks --yolo` run): Hermes' shell-hook STDIN is a single
serialization point whose top-level keys `hook_event_name` / `tool_name` /
`session_id` are the same snake_case as Claude Code and Codex, and the hook
`session_id` equals the `~/.hermes/state.db` sessions.id the usage importer keys
on — so ticks attribute straight to the Hermes session with no log pairing.

Three observe-only events (agentacct never blocks a Hermes tool call):

- `pre_tool_call` -> tool name + category (Receipt Actions dimension), reusing
  `capture_tool_activity(client="hermes")`.
- `post_tool_call` -> the harness exit code of a recognized test/build/lint
  command (`extra.result.exit_code`, dict or JSON string), which lifts a step to
  `independently_checked`. Hermes exposes a discrete exit code, so this is a real
  signal (unlike Codex, whose exit code needs text parsing).
- `on_session_end` -> a `turn_boundary_observed` liveness heartbeat. Hermes fires
  this per turn (once per user message), NOT at session close, so it is a
  distinct event type that is never fed into the `ended_open` inference — a
  per-turn end mapped to `ended_open` would falsely close a still-live session
  between turns.

Details:

- New `hooks hermes` CLI group (`pre-tool-call` / `post-tool-call` / `session-end`
  / `install`) and a fail-open wrapper at `~/.hermes/hooks/agentacct_hermes_hook.py`
  that dispatches on `hook_event_name` and prints `{}` on any error, timeout, or
  unknown event so it can never block a tool call.
- `_write_hermes_hooks_config_at`: a textual merge-safe upsert into the
  `config.yaml` `hooks:` block that never reflows the file, preserves the user's
  own hook entries and every other section, is idempotent, replaces our prior
  entry in place on reinstall (matched by wrapper file, not interpreter), and
  refuses an inline or tab-indented `hooks:` block rather than corrupt it.
- `onboard --agent hermes` now installs the hooks alongside the MCP server and
  prints the one-time consent (`--accept-hooks` / `HERMES_ACCEPT_HOOKS=1` /
  `hooks_auto_accept: true`) and gateway-restart steps Hermes requires.
- Mechanical-check provenance is labeled by client, so a Hermes check reads as
  `hermes_post_tool_call.v1` rather than the Claude Code wire.
- The usage importer drains the new turn-boundary spool next to tool-activity and
  session-end.

Privacy unchanged: spools carry only the tool name, tool category, check kind,
runner name, a sha256 command digest, exit code, session id, timestamps, and the
completed/interrupted booleans — never a command string, arguments, output, or
any conversation content.

---

Verification:
- Full suite: 3130 passed, 1 skipped. New tests/test_hooks_hermes.py (35 tests) cover the three capture paths, the config.yaml writer across every branch (fresh insert, idempotency, reinstall dedupe, deeper-indent style, block-mapping refuse, argument-token preservation, folded-scalar dedupe, inline/tab/space-before-colon refusal, CRLF), the wrapper, the installer, and fail-open subcommands.
- Two adversarial review rounds (six-dimension + a focused writer pass) surfaced seven defects, all fixed. The writer now carries a re-parse safety net (_hermes_hooks_result_is_safe): it refuses to write any result it cannot prove preserves every non-hooks section, every non-agentacct event, and each user entry — so a config-corrupting edit is structurally impossible (worst case is a byte-untouched skip).
- Real-machine end-to-end (installed into a live ~/.hermes via a worktree-code shim, real hermes run, then reverted byte-identical): a client=hermes tool_activity tick and a turn-boundary tick both landed in the store keyed to the run's session id (equal to the state.db sessions.id), and a pytest post_tool_call driven through the installed wrapper recorded a hermes_post_tool_call.v1 machine-check envelope (kind=test, runner=pytest, exit=0, passed).

Deploy note: CLI/hook-side only — no daemon restart needed; git pull is enough (editable venv). The usage importer drains the new turn-boundary spool on the next import once this is deployed.
