### PR TITLE
fix(hooks): bound the Claude Code hook wrapper subprocess with a timeout

### DIFF
--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -1053,7 +1053,15 @@ def main():
             input=raw,
             text=True,
             capture_output=True,
+            # A bounded wait is part of the never-block contract: fail-open covers
+            # the CLI RETURNING an error, but a hung child (stalled store mount,
+            # held SQLite lock, cold-import stall) would otherwise block the tool
+            # call up to Claude Code's own hook timeout. 5s turns that into a
+            # fail-open no-op first (matches the codex + hermes wrappers).
+            timeout=5,
         )
+    except subprocess.TimeoutExpired:
+        return fail_open("agentacct timed out", HOOK_EVENT)
     except OSError as exc:
         return fail_open("agentacct failed to start (%s)" % exc, HOOK_EVENT)
     if proc.stderr:

--- a/tests/test_hooks_claude_code.py
+++ b/tests/test_hooks_claude_code.py
@@ -948,6 +948,40 @@ def test_wrapper_fails_open_when_cli_crashes_or_returns_no_decision(tmp_path):
     assert json.loads(result.stdout)["agent_sentinel"]["decision"] == "allow"
 
 
+def test_claude_wrapper_bounds_subprocess_with_timeout():
+    # A hung CLI must not block a Claude Code tool call forever (matches the codex +
+    # hermes wrappers): the wrapper bounds the subprocess and catches the timeout.
+    from agentacct.hooks import render_claude_hook_wrapper
+
+    src = render_claude_hook_wrapper("/abs/agentacct")
+    assert "timeout=5" in src
+    assert "TimeoutExpired" in src
+
+
+def test_wrapper_fails_open_when_cli_hangs(tmp_path):
+    # Behavioral proof: a hung CLI is killed at the 5s bound and the wrapper fails
+    # open (allow) rather than blocking the tool call.
+    from agentacct.hooks import render_claude_hook_wrapper
+
+    hanging = tmp_path / "hang" / "agent-chronicle"
+    hanging.parent.mkdir(parents=True)
+    # Absolute /bin/sleep: the wrapper is run with an empty PATH, so a bare `sleep`
+    # would not resolve and the stub would never actually hang.
+    hanging.write_text("#!/bin/sh\n/bin/sleep 30\nprintf '%s' '{}'\n")
+    hanging.chmod(0o755)
+    empty_bin = tmp_path / "emptybin_hang"
+    empty_bin.mkdir()
+    wrapper = tmp_path / "hang_wrapper.py"
+    wrapper.write_text(render_claude_hook_wrapper(str(hanging)))
+
+    result = _run_wrapper(
+        wrapper, {"tool_name": "Bash", "tool_input": {"command": "echo ok"}}, path_env=str(empty_bin)
+    )
+    assert result.returncode == 0  # fail-open, tool call not blocked
+    assert json.loads(result.stdout)["agent_sentinel"]["decision"] == "allow"
+    assert "timed out" in result.stderr
+
+
 def test_installed_wrapper_end_to_end_without_shell_path(tmp_path):
     """The exact dogfood scenario: a fresh install must survive a PATH-less hook environment."""
     from agentacct.hooks import resolve_agentacct_executable


### PR DESCRIPTION
fix(hooks): bound the Claude Code hook wrapper subprocess with a timeout

The Claude Code hook wrapper shelled out to the agentacct CLI with no timeout, so
a hung child (a stalled store mount, a held SQLite lock, a cold-import stall)
could block a Claude Code tool call until Claude Code's own hook timeout. The
codex and hermes wrappers already bound their subprocess at 5s and fail open on
TimeoutExpired; this brings the Claude Code wrapper to the same contract.

- Add `timeout=5` to the wrapper's `subprocess.run(...)` and an
  `except subprocess.TimeoutExpired` handler that fails open (a PreToolUse
  timeout emits the same allow decision as the existing OSError path; every other
  event emits its content-free no-op). Exit code stays 0 — a hang can never block
  the tool call.
- The event is parsed before the subprocess call, so the timeout fail-open picks
  the correct decision shape for each of PreToolUse / PostToolUse / SessionStart /
  SessionEnd.

Tests: a static assertion that the rendered wrapper carries the bound, plus a
behavioral test that runs the wrapper against a hanging stub (absolute /bin/sleep
so it hangs under the empty-PATH hook environment) and asserts it fails open
(returncode 0, allow decision, "timed out" in stderr) within the bound. Full
suite 3095 passed, 1 skipped.
