### PR TITLE
feat(hooks): capture OpenCode tool activity via an observe-only plugin

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -121,6 +121,7 @@ from .hooks import (
     CLAUDE_HOOK_RELATIVE_PATH,
     CODEX_HOOK_RELATIVE_PATH,
     CODEX_HOOKS_JSON_RELATIVE_PATH,
+    OPENCODE_PLUGIN_RELATIVE_PATH,
     capture_claude_code_client_context,
     capture_tool_activity,
     capture_mechanical_check,
@@ -132,6 +133,7 @@ from .hooks import (
     evaluate_stdin_json,
     install_claude_code_hook,
     render_codex_hook_wrapper,
+    render_opencode_plugin,
 )
 from .log_evidence import build_log_evidence_index, summarize_log_evidence_donor_rows
 from . import install_guide
@@ -256,6 +258,7 @@ mcp_app = typer.Typer(help="MCP server commands for agent integrations.")
 setup_app = typer.Typer(help="Setup helpers for coding agents and local integrations.")
 claude_code_hooks_app = typer.Typer(help="Claude Code hook helpers.")
 codex_hooks_app = typer.Typer(help="Codex hook helpers (observe-only tool-activity + session-end).")
+opencode_hooks_app = typer.Typer(help="OpenCode hook helpers (observe-only tool-activity plugin).")
 canonical_app = typer.Typer(
     help="Canonical SQLite store operations: health, maintenance, promotion, and cutover verification."
 )
@@ -549,6 +552,7 @@ def finding_dispose(
 app.add_typer(setup_app, name="setup")
 hooks_app.add_typer(claude_code_hooks_app, name="claude-code")
 hooks_app.add_typer(codex_hooks_app, name="codex")
+hooks_app.add_typer(opencode_hooks_app, name="opencode")
 app.add_typer(hooks_app, name="hooks")
 app.add_typer(canonical_app, name="canonical")
 app.add_typer(smoke_app, name="smoke")
@@ -2205,13 +2209,24 @@ def _onboard_global_opencode(store_dir: Path, command: str) -> bool:
     OpenCode's GLOBAL rules file (``AGENTS.md`` under the XDG config dir, injected
     into every session, project or not) AND supports MCP servers in
     ``opencode.jsonc``, so both the standing 'record your work' directive and the
-    agentacct tools are installed the same way codex gets them.
+    agentacct tools are installed the same way codex gets them. The observe-only
+    tool-activity plugin is installed independently of the MCP config, so a config
+    that agentacct can't safely rewrite (e.g. JSONC comments) still gets capture.
     """
     # 1. standing "record your work" instructions -> <xdg>/opencode/AGENTS.md
     setup_instructions(
         agent="opencode", user=True, path=None, remove=False, dry_run=False, store_dir=store_dir
     )
-    # 2. native user-scope MCP registration -> <xdg>/opencode/opencode.jsonc
+    # 2. automatic observe-only tool-activity plugin -> <config>/plugins/agentacct.js.
+    # Installed BEFORE the MCP write: it only writes its own file and must not be
+    # gated out by an unrelated MCP-config parse skip below.
+    config_dir = _opencode_config_dir()
+    try:
+        plugin_action, plugin_path = _install_opencode_plugin(config_dir, store_dir, command)
+        console.print(f"{plugin_action.capitalize()} OpenCode tool-activity plugin ({plugin_path}).")
+    except (OSError, UnicodeError) as exc:
+        console.print(f"OpenCode rules configured, but the tool-activity plugin could not be written ({exc}).")
+    # 3. native user-scope MCP registration -> <xdg>/opencode/opencode.jsonc
     config_path = _resolve_opencode_config_path()
     path, action = _write_opencode_mcp_config_at(config_path, store_dir, command=command)
     if action in {"skipped-unparsed", "skipped-mcp-not-object"}:
@@ -2229,7 +2244,7 @@ def _onboard_global_opencode(store_dir: Path, command: str) -> bool:
         )
         return False
     console.print(f"{action.capitalize()} OpenCode MCP server in {path}")
-    console.print("Start a NEW OpenCode session so it loads the server + rules.")
+    console.print("Start a NEW OpenCode session so it loads the server + rules + plugin.")
     return True
 
 
@@ -4063,6 +4078,81 @@ def codex_hooks_install(
         "Codex needs the hook TRUSTED before it fires — start a new Codex session and approve it "
         "(or vet the wrapper and use --dangerously-bypass-hook-trust)."
     )
+
+
+@opencode_hooks_app.command("tool-activity")
+def opencode_tool_activity(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory the tick is spooled to (the OpenCode plugin passes the bound store)."),
+    ] = None,
+) -> None:
+    """Observe an OpenCode tool call from stdin (observe-only).
+
+    The OpenCode plugin's ``tool.execute.before`` hook fires the agentacct CLI with
+    ``{tool_name, session_id}`` on stdin. OpenCode's ``session_id`` is the ``ses_...``
+    ``session`` table id the usage importer keys on, so the tick attributes straight
+    to the OpenCode session with no log pairing. Records the tool name + category
+    (never arguments); always returns an empty no-op response.
+    """
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_tool_activity(raw, store_dir=store_dir, client="opencode")
+        except Exception:  # noqa: BLE001 - activity capture must never affect the tool call.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: capture must never disturb OpenCode.
+        print("{}")
+
+
+def _install_opencode_plugin(config_dir: Path, store_dir: Path, command: str, *, force: bool = False) -> tuple[str, Path]:
+    """Write the OpenCode tool-activity plugin into ``<config>/plugins/agentacct.js``.
+    Returns (action, plugin_path). Idempotent: an already-correct file is left
+    byte-untouched. OpenCode auto-loads named-export plugins from that directory."""
+    plugin_path = config_dir / OPENCODE_PLUGIN_RELATIVE_PATH
+    plugin_bytes = render_opencode_plugin(command, store_dir=store_dir).encode("utf-8")
+    existing: bytes | None = None
+    if plugin_path.exists():
+        try:
+            # Compare bytes, not decoded text: a pre-existing non-UTF-8 file at the
+            # path would make read_text raise UnicodeDecodeError (a UnicodeError, not
+            # OSError) and escape the callers' guards. Bytes never decode-fail; a
+            # non-matching file is simply overwritten below.
+            existing = plugin_path.read_bytes()
+        except OSError:
+            existing = None
+    if not force and existing == plugin_bytes:
+        return "unchanged", plugin_path
+    action = "updated" if plugin_path.exists() else "wrote"
+    plugin_path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(plugin_path, plugin_bytes.decode("utf-8"), mode=0o644)
+    return action, plugin_path
+
+
+@opencode_hooks_app.command("install")
+def opencode_hooks_install(
+    home: Annotated[
+        Optional[Path],
+        typer.Option(help="Home dir whose XDG config holds OpenCode's config (defaults to the user's home)."),
+    ] = None,
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="Store the plugin spools ticks to. Required so a GUI/gateway-launched OpenCode binds the right store."),
+    ] = None,
+    force: Annotated[bool, typer.Option(help="Rewrite the plugin even if it already matches.")] = False,
+) -> None:
+    """Install the OpenCode tool-activity plugin into <config>/plugins/agentacct.js."""
+    resolved_store = store_dir if store_dir is not None else onboard_global_store_dir()[0]
+    command = _resolve_absolute_mcp_command()
+    config_dir = _opencode_config_dir(Path(home) if home is not None else None)
+    try:
+        action, plugin_path = _install_opencode_plugin(config_dir, Path(resolved_store), command, force=force)
+    except (OSError, UnicodeError) as exc:
+        console.print(f"The OpenCode plugin could not be written ({exc}).")
+        raise typer.Exit(1) from exc
+    console.print(f"OpenCode tool-activity plugin: {action} ({plugin_path})")
+    console.print("Start a NEW OpenCode session so it loads the plugin (auto-loaded from the plugins/ directory).")
 
 
 @claude_code_hooks_app.command("install")

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -1246,6 +1246,93 @@ def codex_hooks_json_block(wrapper_path: Path | str, *, python_executable: str |
     }
 
 
+# ---------------------------------------------------------------------------
+# OpenCode tool-activity plugin (observe-only)
+# ---------------------------------------------------------------------------
+#
+# OpenCode (sst/opencode, a Bun runtime) auto-loads named-export plugins from
+# ``<config>/plugins/*.js``. Its ``tool.execute.before`` hook receives the tool
+# name and the OpenCode session id (``ses_...``), which is exactly the ``session``
+# table id the agentacct usage importer keys on — so a tick attributes straight to
+# the OpenCode session with no log pairing. The plugin only ever spools the tool
+# NAME + session id (never arguments or output), and it fires the agentacct CLI
+# fire-and-forget so it can never add latency to, block, or fail a tool call.
+
+OPENCODE_PLUGIN_RELATIVE_PATH = Path("plugins/agentacct.js")
+
+_OPENCODE_PLUGIN_TEMPLATE = '''// agentacct OpenCode tool-activity plugin (observe-only, auto-generated).
+//
+// Records the tool NAME + OpenCode session id for each tool call so the agentacct
+// Receipt's Actions dimension shows what OpenCode reached for. Never reads tool
+// arguments or output. The agentacct CLI is fired fire-and-forget, so a slow or
+// broken install can never add latency to, block, or fail an OpenCode tool call.
+// Reinstall with: agentacct hooks opencode install --force
+import { existsSync } from "node:fs";
+
+const AGENTACCT_CANDIDATES = __AGENTACCT_CANDIDATES__;
+const STORE_DIR = __STORE_DIR__;
+
+function resolveAgentacct() {
+  for (const candidate of AGENTACCT_CANDIDATES) {
+    if (!candidate) continue;
+    if (candidate.includes("/")) {
+      if (existsSync(candidate)) return candidate;
+    } else {
+      try {
+        const found = Bun.which(candidate);
+        if (found) return found;
+      } catch (e) {}
+    }
+  }
+  return null;
+}
+
+export const AgentacctToolActivity = async () => ({
+  "tool.execute.before": async (input) => {
+    try {
+      const executable = resolveAgentacct();
+      if (!executable) return;
+      const args = [executable, "hooks", "opencode", "tool-activity"];
+      if (STORE_DIR) args.push("--store-dir", STORE_DIR);
+      const proc = Bun.spawn(args, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+      proc.stdin.write(JSON.stringify({ tool_name: input.tool, session_id: input.sessionID }));
+      proc.stdin.end();
+      // fire-and-forget: never await — a tool call must not wait on capture.
+      try { proc.unref(); } catch (e) {}
+    } catch (e) {
+      // observe-only: a plugin error must never affect the tool call.
+    }
+  },
+});
+'''
+
+
+def render_opencode_plugin(agentacct_executable: str | None = None, *, store_dir: Path | str | None = None) -> str:
+    """Render the OpenCode tool-activity plugin JS with the agentacct executable
+    candidates and the store dir bound at install time (OpenCode plugins run in the
+    OpenCode process, which sees neither agentacct's env nor a predictable cwd)."""
+    candidates: list[str] = []
+    if agentacct_executable:
+        candidates.append(str(agentacct_executable))
+    for bare_name in ("agentacct", "agent-chronicle", "agent-sentinel"):
+        if bare_name not in candidates:
+            candidates.append(bare_name)
+    store_literal = json.dumps(str(store_dir)) if store_dir is not None else "null"
+    # Single-pass substitution: a sequential str.replace would rescan the text it
+    # just inserted, so an agentacct path that happened to contain the literal
+    # ``__STORE_DIR__`` token would corrupt the candidates array. re.sub replaces
+    # each sentinel once, left to right, and never revisits substituted text.
+    substitutions = {
+        "__AGENTACCT_CANDIDATES__": json.dumps(candidates),
+        "__STORE_DIR__": store_literal,
+    }
+    return re.sub(
+        r"__AGENTACCT_CANDIDATES__|__STORE_DIR__",
+        lambda match: substitutions[match.group(0)],
+        _OPENCODE_PLUGIN_TEMPLATE,
+    )
+
+
 def claude_code_settings_example(python_executable: str | None = None, *, hook_path: Path | str | None = None) -> dict[str, Any]:
     """Example Claude Code settings block invoking the agentacct hook wrapper.
 

--- a/tests/test_hooks_opencode.py
+++ b/tests/test_hooks_opencode.py
@@ -1,0 +1,189 @@
+"""OpenCode observe-only tool-activity plugin: the capture subcommand, the plugin
+renderer, and the installer.
+
+OpenCode auto-loads named-export plugins from ``<config>/plugins/*.js``. Its
+``tool.execute.before`` hook carries the tool name and the OpenCode ``session_id``
+(``ses_...``), which is the ``session`` table id the usage importer keys on — so a
+tick attributes straight to the OpenCode session with no log pairing.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from agentacct.cli import _install_opencode_plugin, _onboard_global_opencode, app
+from agentacct.hooks import (
+    OPENCODE_PLUGIN_RELATIVE_PATH,
+    capture_tool_activity,
+    render_opencode_plugin,
+)
+from agentacct.tool_activity import drain_tool_activity_spool
+
+
+def _tool_event(session_id: str, tool: str) -> str:
+    return json.dumps({"tool_name": tool, "session_id": session_id})
+
+
+# ---------------------------------------------------------------------------
+# capture subcommand
+# ---------------------------------------------------------------------------
+
+
+def test_capture_tool_activity_labels_opencode_client(tmp_path: Path) -> None:
+    capture_tool_activity(_tool_event("ses_0097fe8daffeJ2Recg87jKR2rc", "bash"), store_dir=tmp_path, client="opencode")
+    events = drain_tool_activity_spool(tmp_path)
+    assert len(events) == 1
+    meta = events[0]["metadata"]
+    assert events[0]["source"] == "opencode"
+    assert meta["client_session_id"] == "ses_0097fe8daffeJ2Recg87jKR2rc"
+    assert {"name": "bash", "count": 1} in meta["tool_names"]
+
+
+def test_tool_activity_subcommand_spools_tick(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["hooks", "opencode", "tool-activity", "--store-dir", str(tmp_path)],
+        input=_tool_event("ses_abc", "write"),
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "{}"
+    events = drain_tool_activity_spool(tmp_path)
+    assert len(events) == 1
+    assert events[0]["source"] == "opencode"
+    assert events[0]["metadata"]["client_session_id"] == "ses_abc"
+
+
+def test_tool_activity_subcommand_fails_open_on_garbage(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["hooks", "opencode", "tool-activity", "--store-dir", str(tmp_path)],
+        input="}{not json",
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "{}"
+    assert drain_tool_activity_spool(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# plugin renderer
+# ---------------------------------------------------------------------------
+
+
+def test_render_opencode_plugin_shape() -> None:
+    src = render_opencode_plugin("/abs/agentacct", store_dir="/store/x")
+    # named export (OpenCode requires a named-export plugin, not a default export)
+    assert "export const AgentacctToolActivity" in src
+    assert "export default" not in src
+    # the tool-activity hook and the two fields it forwards
+    assert '"tool.execute.before"' in src
+    assert "input.tool" in src and "input.sessionID" in src
+    # the agentacct executable + store are bound at install time
+    assert "/abs/agentacct" in src
+    assert "/store/x" in src
+    assert '"hooks", "opencode", "tool-activity"' in src
+    # fire-and-forget: it must not await the spawned CLI (never add tool-call latency)
+    assert "await Bun.spawn" not in src
+    assert "Bun.spawn" in src
+
+
+def test_render_opencode_plugin_no_store_binding() -> None:
+    src = render_opencode_plugin("/abs/agentacct", store_dir=None)
+    assert "const STORE_DIR = null;" in src
+
+
+def test_render_opencode_plugin_escapes_paths_with_spaces() -> None:
+    src = render_opencode_plugin("/a b/agentacct", store_dir="/x y/store")
+    # JSON-encoded, so a path with spaces round-trips as a valid JS string literal
+    assert '"/a b/agentacct"' in src
+    assert '"/x y/store"' in src
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available to syntax-check the generated plugin")
+def test_generated_plugin_is_valid_javascript(tmp_path: Path) -> None:
+    plugin = tmp_path / "agentacct.mjs"
+    plugin.write_text(render_opencode_plugin("/abs/agentacct", store_dir="/store/x"), encoding="utf-8")
+    result = subprocess.run(["node", "--check", str(plugin)], capture_output=True, text=True)
+    assert result.returncode == 0, f"generated plugin is not valid JS:\n{result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# installer
+# ---------------------------------------------------------------------------
+
+
+def test_install_opencode_plugin_writes_and_is_idempotent(tmp_path: Path) -> None:
+    config_dir = tmp_path / "opencode"
+    store = tmp_path / "store"
+    action, plugin_path = _install_opencode_plugin(config_dir, store, "/abs/agentacct")
+    assert action == "wrote"
+    assert plugin_path == config_dir / OPENCODE_PLUGIN_RELATIVE_PATH
+    assert plugin_path.exists()
+    assert plugin_path.parent.name == "plugins"
+    body = plugin_path.read_text(encoding="utf-8")
+    assert str(store) in body
+
+    # second run with the same inputs is a byte-identical no-op
+    before = plugin_path.read_bytes()
+    action2, _ = _install_opencode_plugin(config_dir, store, "/abs/agentacct")
+    assert action2 == "unchanged"
+    assert plugin_path.read_bytes() == before
+
+
+def test_install_opencode_plugin_updates_on_change(tmp_path: Path) -> None:
+    config_dir = tmp_path / "opencode"
+    store = tmp_path / "store"
+    _install_opencode_plugin(config_dir, store, "/abs/agentacct")
+    action, plugin_path = _install_opencode_plugin(config_dir, tmp_path / "store2", "/abs/agentacct")
+    assert action == "updated"
+    assert str(tmp_path / "store2") in plugin_path.read_text(encoding="utf-8")
+
+
+def test_install_opencode_plugin_overwrites_non_utf8_file(tmp_path: Path) -> None:
+    # A pre-existing non-UTF-8 agentacct.js must not crash the idempotency check
+    # (a bytes compare, not read_text) — it is simply overwritten.
+    config_dir = tmp_path / "opencode"
+    plugin_path = config_dir / OPENCODE_PLUGIN_RELATIVE_PATH
+    plugin_path.parent.mkdir(parents=True)
+    plugin_path.write_bytes(b"\xff\xfe not utf-8 \x80\x81")
+    action, _ = _install_opencode_plugin(config_dir, tmp_path / "store", "/abs/agentacct")
+    assert action == "updated"
+    body = plugin_path.read_text(encoding="utf-8")  # now valid UTF-8
+    assert "AgentacctToolActivity" in body
+
+
+def test_render_opencode_plugin_survives_sentinel_in_path(tmp_path: Path) -> None:
+    # An agentacct path containing the literal template sentinel must not corrupt
+    # the candidates array (single-pass substitution).
+    weird = "/home/u/__STORE_DIR__/bin/agentacct"
+    src = render_opencode_plugin(weird, store_dir="/store/x")
+    assert json.dumps(weird) in src  # the literal path survives intact
+    assert 'const STORE_DIR = "/store/x";' in src
+    if shutil.which("node"):
+        plugin = tmp_path / "p.mjs"
+        plugin.write_text(src, encoding="utf-8")
+        result = subprocess.run(["node", "--check", str(plugin)], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+
+def test_onboard_installs_plugin_even_when_mcp_config_is_jsonc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A JSONC config with comments makes the MCP write skip; the observe-only plugin
+    # must still be installed (it is independent of that JSON file).
+    xdg = tmp_path / "xdg"
+    (xdg / "opencode").mkdir(parents=True)
+    (xdg / "opencode" / "opencode.jsonc").write_text(
+        '{\n  // a comment makes this un-writable strict JSON\n  "mcp": {}\n}\n', encoding="utf-8"
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    ready = _onboard_global_opencode(tmp_path / "store", "/abs/agentacct")
+    # MCP couldn't be rewritten (JSONC) -> not fully ready ...
+    assert ready is False
+    # ... but the tool-activity plugin WAS installed anyway.
+    plugin_path = xdg / "opencode" / OPENCODE_PLUGIN_RELATIVE_PATH
+    assert plugin_path.exists()
+    assert "AgentacctToolActivity" in plugin_path.read_text(encoding="utf-8")


### PR DESCRIPTION
feat(hooks): capture OpenCode tool activity via an observe-only plugin

OpenCode sessions recorded semantic sections (MCP) but no tool activity — its
Actions dimension was empty. This adds an observe-only tool-activity plugin,
bringing OpenCode to the same #1 capture the codex and hermes hooks provide.

OpenCode (a Bun runtime) auto-loads named-export plugins from
`<config>/plugins/*.js`. The installed plugin's `tool.execute.before` hook fires
the agentacct CLI fire-and-forget with the tool name and the OpenCode session id,
so it never adds latency to, blocks, or fails a tool call. The session id is the
`ses_...` session-table id the usage importer keys on, so a tick attributes
straight to the OpenCode session with no log pairing.

- `render_opencode_plugin` renders the plugin JS with the agentacct executable and
  store bound at install time (OpenCode plugins see neither agentacct's env nor a
  predictable cwd). Only the tool NAME + session id ever leave the plugin — never
  arguments, output, or conversation content.
- New `hooks opencode tool-activity` subcommand records the tick
  (`capture_tool_activity(client="opencode")`); fail-open, prints `{}`.
- New `hooks opencode install` and `onboard --agent opencode` write
  `<config>/plugins/agentacct.js` idempotently. The plugin is installed
  independently of the MCP config, so a config agentacct can't safely rewrite
  (e.g. JSONC comments) still gets capture.

Tests: the capture subcommand, the renderer shape, install idempotency, and a
`node --check` that the generated plugin is valid JavaScript. Full suite 3105
passed, 1 skipped.

---

Verification:
- Two adversarial review passes (a six-dimension find→verify, then targeted); three
  confirmed defects fixed: the onboard install was gated behind the MCP-config skip
  (JSONC-comment configs got no plugin); the idempotency check crashed on a
  pre-existing non-UTF-8 plugin file (UnicodeError escaped an OSError-only guard);
  and the two-pass template substitution could corrupt the candidates array if the
  install path contained the store sentinel. Each has a regression test.
- Real-machine end-to-end (plugin installed into a live ~/.config/opencode via a
  worktree-code shim, real `opencode run`, then removed): a `client=opencode`
  tool_activity tick landed in the store for both the `bash` tool and the MCP tool,
  keyed to session `ses_0083...` — equal to the opencode.db `session` row the usage
  importer keys on.

Deploy note: CLI/hook-side only — no daemon restart; git pull is enough.
