### PR TITLE
feat(hooks): make Hermes self-record via a first-turn record-your-work nudge

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -129,6 +129,7 @@ from .hooks import (
     capture_tool_activity,
     capture_hermes_tool_check,
     capture_hermes_turn_boundary,
+    hermes_first_turn_nudge,
     capture_mechanical_check,
     claude_code_hook_context_status,
     claude_code_hook_doctor_checks,
@@ -2256,20 +2257,24 @@ def _onboard_global_opencode(store_dir: Path, command: str) -> bool:
     return True
 
 
-def _onboard_global_hermes(store_dir: Path, command: str) -> bool:
-    """Configure Hermes at USER scope (zero repo files). Returns readiness.
+def _onboard_global_hermes(store_dir: Path, command: str) -> str | bool:
+    """Configure Hermes at USER scope (zero repo files). Returns a readiness status.
 
     Two layers: the MCP server gives Hermes the agentacct tools (semantic section
-    recording when an agent calls them); the shell hooks add AUTOMATIC observe-only
-    capture — tool activity (pre_tool_call), the harness exit code of recognized
-    checks (post_tool_call), and a turn-boundary heartbeat (on_session_end) — keyed
-    by Hermes' own session_id (which equals the state.db sessions.id the usage
-    importer keys on, so tool activity attributes straight to the session). Hermes
-    gates shell hooks on a one-time consent allowlist, so onboarding installs them
-    and prints the one-time approve + gateway-restart steps. Unlike codex/opencode,
-    Hermes has NO reliable always-on GLOBAL instruction slot (it injects
-    ``AGENTS.md`` only from a project/workspace root, and ``$HOME`` is skipped), so
-    the standing 'record your work' directive is NOT installed here.
+    recording when an agent calls them); the shell hooks add automatic capture —
+    tool activity (pre_tool_call), the harness exit code of recognized checks
+    (post_tool_call), a turn-boundary heartbeat (on_session_end), and — because
+    Hermes has NO always-on global instruction slot ($HOME AGENTS.md is skipped) —
+    the standing 'record your work' directive injected on each session's FIRST turn
+    (pre_llm_call), so the agent actually records its work. All keyed by Hermes' own
+    session_id (which equals the state.db sessions.id the usage importer keys on).
+    Hermes gates shell hooks on a one-time consent allowlist, so onboarding installs
+    them and prints the one-time approve + gateway-restart steps.
+
+    Returns ``"recording"`` when the hooks (incl. the pre_llm_call record-your-work
+    nudge) were wired, ``"tools-only"`` when the MCP server is configured but the
+    hooks block could not be written (so nothing records), or ``False`` when even the
+    MCP server could not be configured.
     """
     home = Path.home()
     config_path = home / ".hermes" / "config.yaml"
@@ -2281,7 +2286,8 @@ def _onboard_global_hermes(store_dir: Path, command: str) -> bool:
         )
         return False
     console.print(f"{action.capitalize()} Hermes MCP server in {path}")
-    # Automatic observe-only tool-activity + exit-code + turn-boundary hooks.
+    # Automatic capture: observe-only tool-activity + exit-code + turn-boundary, plus
+    # the pre_llm_call record-your-work nudge.
     try:
         hooks_action, wrapper_path = _install_hermes_hook(home, store_dir, command)
     except OSError as exc:
@@ -2290,15 +2296,17 @@ def _onboard_global_hermes(store_dir: Path, command: str) -> bool:
         wrapper_path = home / HERMES_HOOK_RELATIVE_PATH
     if hooks_action == "skipped-unparsed":
         console.print(
-            f"Left {config_path} hooks: block unchanged (inline or tab-indented); the automatic "
-            "tool-activity hooks were NOT wired — add the agentacct pre_tool_call / post_tool_call / "
-            "on_session_end entries under hooks: yourself to capture tool activity."
+            f"Left {config_path} hooks: block unchanged (inline or tab-indented); the agentacct hooks "
+            "were NOT wired, so Hermes records nothing — add the agentacct pre_tool_call / post_tool_call / "
+            "on_session_end / pre_llm_call entries under hooks: yourself to capture work, or fix the block and re-run."
         )
         console.print("Hermes auto-reloads config.yaml; its agentacct tools are available now.")
-    else:
-        console.print(f"{hooks_action.capitalize()} Hermes tool-activity hooks in {config_path} ({wrapper_path}).")
-        _print_hermes_hook_consent_steps()
-    return True
+        return "tools-only"
+    console.print(
+        f"{hooks_action.capitalize()} Hermes tool-activity + record-your-work hooks in {config_path} ({wrapper_path})."
+    )
+    _print_hermes_hook_consent_steps()
+    return "recording"
 
 
 def _warn_global_store_mismatches(store_dir: Path, command: str) -> None:
@@ -2491,8 +2499,9 @@ def _onboard_global(*, agent: str, port: int, start_runtime: bool, mcp: bool, as
     # Clients agentacct can configure at USER scope by writing their own config
     # files directly (no client CLI required): claude-code + codex + opencode get
     # full semantic recording (MCP + an always-on global instruction file); hermes
-    # gets MCP tools registered but no standing directive (it has no reliable
-    # global instruction slot — recording is driven by its hook adapter).
+    # has no always-on global instruction slot, so its hook adapter injects the same
+    # standing 'record your work' directive on each session's first turn (pre_llm_call)
+    # — so hermes records too, once its one-time hook consent is granted.
     configurable = ("claude-code", "codex", "opencode", "hermes")
     if agent in {"auto", "all"}:
         targets = [client for client in configurable if client in found] or ["claude-code", "codex"]
@@ -2523,7 +2532,15 @@ def _onboard_global(*, agent: str, port: int, start_runtime: bool, mcp: bool, as
         if _onboard_global_opencode(store_dir, command):
             recording_clients.append("opencode")
     if mcp and "hermes" in targets:
-        if _onboard_global_hermes(store_dir, command):
+        # hermes records via its hook adapter (the pre_llm_call record-your-work nudge
+        # on each session's first turn), so a fully-wired hermes joins the recording
+        # clients (like codex, its capture fires after a one-time hook consent). But if
+        # the hooks block could not be written, ONLY the MCP tools are present and it
+        # records nothing — report that honestly as tools-only, not recording.
+        hermes_status = _onboard_global_hermes(store_dir, command)
+        if hermes_status == "recording":
+            recording_clients.append("hermes")
+        elif hermes_status == "tools-only":
             tools_only_clients.append("hermes")
 
     imported = _local_usage_import_payload(
@@ -4183,6 +4200,35 @@ def hermes_session_end(
         print("{}")
 
 
+@hermes_hooks_app.command("pre-llm-call")
+def hermes_pre_llm_call(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="Unused (accepted for wrapper-arg compatibility; this hook spools nothing)."),
+    ] = None,
+) -> None:
+    """Inject the standing 'record your work' directive into a Hermes session's FIRST
+    turn — the #5 nudge hermes otherwise lacks (no always-on global instruction slot).
+
+    Hermes appends a ``pre_llm_call`` hook's ``{"context": ...}`` return to the current
+    turn's user message (API-call-time only, never persisted). This prints that
+    directive on the first turn and ``{}`` on every later turn, so the agent is nudged
+    once per session to record its work via ``agentacct_record_section``. Fail-open: any
+    error prints ``{}`` so a broken install can never block or alter a hermes LLM call.
+    """
+    from .install_guide import workflow_instruction_body
+
+    try:
+        raw = sys.stdin.read()
+        try:
+            response = hermes_first_turn_nudge(raw, directive=workflow_instruction_body())
+        except Exception:  # noqa: BLE001 - the nudge must never break the LLM call.
+            response = {}
+        print(json.dumps(response))
+    except Exception:  # noqa: BLE001 - FAIL OPEN: never block a hermes LLM call.
+        print("{}")
+
+
 def _hermes_hook_command(wrapper_path: Path, *, python_executable: str | None = None) -> str:
     """The shell command Hermes runs for our wrapper (python + wrapper path).
 
@@ -4541,9 +4587,9 @@ def hermes_hooks_install(
     ] = None,
     force: Annotated[bool, typer.Option(help="Rewrite the wrapper even if it already matches.")] = False,
 ) -> None:
-    """Install the Hermes observe-only hooks: the wrapper + config.yaml ``hooks:``
-    entries (pre_tool_call tool-activity, post_tool_call exit-code, on_session_end
-    turn-boundary) pointing at it."""
+    """Install the Hermes hooks: the wrapper + config.yaml ``hooks:`` entries
+    (pre_tool_call tool-activity, post_tool_call exit-code, on_session_end
+    turn-boundary, pre_llm_call record-your-work nudge) pointing at it."""
     resolved_store = store_dir if store_dir is not None else onboard_global_store_dir()[0]
     command = _resolve_absolute_mcp_command()
     try:
@@ -4557,7 +4603,8 @@ def hermes_hooks_install(
         console.print(
             f"Hermes config.yaml: LEFT UNCHANGED ({config_path}) — its hooks: block is not a safely "
             "editable block mapping (inline hooks: {{...}} or tab-indented). No hook was wired. Add the "
-            "agentacct pre_tool_call / post_tool_call / on_session_end entries under hooks: yourself, then re-run."
+            "agentacct pre_tool_call / post_tool_call / on_session_end / pre_llm_call entries under hooks: "
+            "yourself, then re-run."
         )
         raise typer.Exit(1)
     console.print(f"Hermes config.yaml hooks: {action} ({config_path})")

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -1267,11 +1267,13 @@ def codex_hooks_json_block(wrapper_path: Path | str, *, python_executable: str |
 # sessions.id the usage importer keys on — so hermes ticks attribute straight to
 # the session with no log pairing (verified on the real machine 2026-08-13).
 #
-# Three events are wired, all observe-only (agentacct never blocks a hermes tool
-# call — hermes owns its own approval layer):
+# Four events are wired. The first three are observe-only (agentacct never blocks a
+# hermes tool call — hermes owns its own approval layer); pre_llm_call is the ONE
+# event that returns content (a first-turn nudge, see below), not a block:
 #   pre_tool_call  -> tool NAME + category (Receipt Actions dimension)          [#1]
 #   post_tool_call -> the harness exit code of a recognized check command       [#3]
 #   on_session_end -> a TURN-boundary heartbeat (see below)                     [#4]
+#   pre_llm_call   -> first-turn 'record your work' directive (see below)       [#5]
 #
 # NOTE on #4: hermes fires ``on_session_end`` at the end of EVERY turn
 # (``run_conversation`` runs once per user message), NOT at real session close.
@@ -1284,10 +1286,19 @@ HERMES_CONFIG_RELATIVE_PATH = Path(".hermes/config.yaml")
 
 # The hermes shell-hook event names this adapter wires, mapped to the agentacct
 # CLI subcommand each dispatches to. The wrapper routes on ``hook_event_name``.
+#
+# ``pre_llm_call`` is the ONE non-observe-only event: hermes has no always-on global
+# instruction slot (no $HOME AGENTS.md), so the agent never learns to record its
+# work the way codex/opencode do. This hook injects the standing 'record your work'
+# directive into the FIRST turn's user message (hermes appends a pre_llm_call hook's
+# ``{"context": ...}`` return to the user message, API-call-time only, never
+# persisted — see agent/turn_context.py), giving hermes the same #5 nudge. It fires
+# only when ``is_first_turn`` is set, so it injects once per session, not every turn.
 HERMES_HOOK_EVENT_SUBCOMMANDS: dict[str, str] = {
     "pre_tool_call": "pre-tool-call",
     "post_tool_call": "post-tool-call",
     "on_session_end": "session-end",
+    "pre_llm_call": "pre-llm-call",
 }
 
 # hermes's shell/terminal tool name (its exit-code-bearing command tool). The #3
@@ -1296,20 +1307,25 @@ HERMES_HOOK_EVENT_SUBCOMMANDS: dict[str, str] = {
 _HERMES_SHELL_TOOL_NAMES = frozenset({"terminal"})
 
 _HERMES_HOOK_WRAPPER_TEMPLATE = '''#!/usr/bin/env python3
-"""Hermes shell-hook wrapper for agentacct (observe-only).
+"""Hermes shell-hook wrapper for agentacct.
 
 One wrapper serves the installed Hermes hook events (dispatch on the event's own
 `hook_event_name`):
 - pre_tool_call:  spool the tool NAME + category for the Receipt's Actions dimension.
 - post_tool_call: spool the harness exit code of a recognized check command.
 - on_session_end: spool a content-free turn-boundary heartbeat.
+- pre_llm_call:   on the FIRST turn only, return the standing 'record your work'
+                  directive as `{"context": ...}` so Hermes injects it into the user
+                  message (Hermes has no always-on instruction slot). Later turns are
+                  short-circuited here WITHOUT spawning the CLI, so this hook adds no
+                  per-turn latency to the LLM call.
 
-All observe-only — agentacct never makes an allow/block decision for Hermes
-(Hermes owns its own approval layer). Shells out to the installed `agentacct`
-CLI. Fail-open: on any error, a hung child, or an unknown event, this wrapper
-writes an empty JSON object `{}` (Hermes reads that as "hook contributed nothing")
-and exits 0, so a broken or moved install can never block a Hermes tool call.
-Reinstall with: agentacct hooks hermes install --force
+Every event EXCEPT the pre_llm_call first-turn nudge is observe-only — agentacct
+never makes an allow/block decision for Hermes (Hermes owns its own approval layer).
+Shells out to the installed `agentacct` CLI. Fail-open: on any error, a hung child,
+or an unknown event, this wrapper writes an empty JSON object `{}` (Hermes reads that
+as "hook contributed nothing") and exits 0, so a broken or moved install can never
+block a Hermes tool call. Reinstall with: agentacct hooks hermes install --force
 """
 
 import json
@@ -1346,9 +1362,19 @@ def no_op(reason=""):
     return 0
 
 
+def _is_first_turn(event):
+    if not isinstance(event, dict):
+        return None
+    value = event.get("is_first_turn")
+    if value is None and isinstance(event.get("extra"), dict):
+        value = event["extra"].get("is_first_turn")
+    return value
+
+
 def main():
     raw = sys.stdin.buffer.read().decode("utf-8", "replace")
     hook_event = ""
+    event = None
     try:
         event = json.loads(raw)
         if isinstance(event, dict):
@@ -1360,6 +1386,11 @@ def main():
     subcommand = EVENT_SUBCOMMANDS.get(hook_event)
     if subcommand is None:
         return no_op()  # not one of ours (or unparseable): silent no-op
+    # pre_llm_call fires before EVERY inference but only the FIRST turn needs the CLI
+    # (to inject the record-your-work nudge). Short-circuit later turns here so the
+    # LLM critical path never pays a per-turn CLI cold-start for a {} result.
+    if hook_event == "pre_llm_call" and _is_first_turn(event) is not True:
+        return no_op()
     executable = resolve_agentacct()
     if executable is None:
         return no_op("agentacct executable not found (re-run: agentacct hooks hermes install --force)")
@@ -1529,6 +1560,41 @@ def capture_hermes_turn_boundary(raw: str, *, store_dir: Path | str | None = Non
         )
     except Exception:  # noqa: BLE001 - capture must never affect the hook.
         return
+
+
+def hermes_first_turn_nudge(raw: str, *, directive: str) -> dict[str, Any]:
+    """Return the hermes ``pre_llm_call`` response that gives hermes the #5 nudge.
+
+    Hermes appends a ``pre_llm_call`` hook's ``{"context": ...}`` return to the
+    current turn's user message (API-call-time only, never persisted — see
+    ``agent/turn_context.py``). On the FIRST turn of a session this returns the
+    standing 'record your work' ``directive`` (framed as ambient setup context, not
+    a user request) so the hermes agent learns to call ``agentacct_record_section``,
+    the same way codex/opencode learn it from an always-on AGENTS.md. Every later
+    turn returns ``{}`` so the nudge fires once per session. Never raises: on any
+    error it returns ``{}`` (no nudge, never blocks the LLM call).
+    """
+    try:
+        event = json.loads(raw or "{}")
+        if not isinstance(event, dict):
+            return {}
+        extra = event.get("extra") if isinstance(event.get("extra"), dict) else {}
+        # hermes nests non-top-level payload keys under ``extra``; tolerate both.
+        is_first = event.get("is_first_turn")
+        if is_first is None:
+            is_first = extra.get("is_first_turn")
+        if is_first is not True:
+            return {}
+        text = str(directive or "").strip()
+        if not text:
+            return {}
+        framed = (
+            "[agentacct — standing setup instruction for this session, not a message from the user]\n"
+            + text
+        )
+        return {"context": framed}
+    except Exception:  # noqa: BLE001 - a nudge must never block or break the LLM call.
+        return {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks_hermes.py
+++ b/tests/test_hooks_hermes.py
@@ -34,6 +34,7 @@ from agentacct.hooks import (
     capture_hermes_tool_check,
     capture_hermes_turn_boundary,
     capture_tool_activity,
+    hermes_first_turn_nudge,
     render_hermes_hook_wrapper,
 )
 from agentacct.mechanical_capture import drain_mechanical_check_spool
@@ -544,7 +545,7 @@ def test_session_end_subcommand_spools_turn_boundary(tmp_path: Path) -> None:
     assert len(drain_turn_boundary_spool(tmp_path)) == 1
 
 
-@pytest.mark.parametrize("subcommand", ["pre-tool-call", "post-tool-call", "session-end"])
+@pytest.mark.parametrize("subcommand", ["pre-tool-call", "post-tool-call", "session-end", "pre-llm-call"])
 def test_subcommands_fail_open_on_garbage(subcommand: str, tmp_path: Path) -> None:
     result = CliRunner().invoke(
         app,
@@ -553,3 +554,83 @@ def test_subcommands_fail_open_on_garbage(subcommand: str, tmp_path: Path) -> No
     )
     assert result.exit_code == 0
     assert result.stdout.strip() == "{}"
+
+
+# ---------------------------------------------------------------------------
+# #5 first-turn record-your-work nudge (pre_llm_call)
+# ---------------------------------------------------------------------------
+
+_DIRECTIVE = "## agentacct — record your work\n\ncall agentacct_record_section to record work."
+
+
+def _pre_llm(is_first: object, *, top_level: bool = False) -> str:
+    payload: dict = {"hook_event_name": "pre_llm_call", "session_id": "s1"}
+    if top_level:
+        payload["is_first_turn"] = is_first
+    else:
+        payload["extra"] = {"is_first_turn": is_first}
+    return json.dumps(payload)
+
+
+def test_nudge_injects_directive_on_first_turn() -> None:
+    resp = hermes_first_turn_nudge(_pre_llm(True), directive=_DIRECTIVE)
+    assert "context" in resp
+    assert _DIRECTIVE in resp["context"]
+    assert "not a message from the user" in resp["context"]  # framed as ambient
+
+
+def test_nudge_tolerates_top_level_is_first_turn() -> None:
+    assert "context" in hermes_first_turn_nudge(_pre_llm(True, top_level=True), directive=_DIRECTIVE)
+
+
+def test_nudge_empty_on_later_turns() -> None:
+    assert hermes_first_turn_nudge(_pre_llm(False), directive=_DIRECTIVE) == {}
+
+
+def test_nudge_empty_when_is_first_turn_absent() -> None:
+    payload = json.dumps({"hook_event_name": "pre_llm_call", "session_id": "s1", "extra": {}})
+    assert hermes_first_turn_nudge(payload, directive=_DIRECTIVE) == {}
+
+
+def test_nudge_empty_on_blank_directive() -> None:
+    assert hermes_first_turn_nudge(_pre_llm(True), directive="   ") == {}
+
+
+def test_nudge_never_raises_on_garbage() -> None:
+    assert hermes_first_turn_nudge("not json", directive=_DIRECTIVE) == {}
+    assert hermes_first_turn_nudge(json.dumps([1, 2]), directive=_DIRECTIVE) == {}
+
+
+def test_pre_llm_call_subcommand_injects_on_first_turn() -> None:
+    result = CliRunner().invoke(app, ["hooks", "hermes", "pre-llm-call", "--store-dir", "/tmp/x"], input=_pre_llm(True))
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert "context" in payload
+    assert "agentacct_record_section" in payload["context"]  # the real directive
+
+
+def test_pre_llm_call_subcommand_empty_on_later_turn() -> None:
+    result = CliRunner().invoke(app, ["hooks", "hermes", "pre-llm-call", "--store-dir", "/tmp/x"], input=_pre_llm(False))
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {}
+
+
+def test_pre_llm_call_is_wired_into_events_wrapper_and_writer(tmp_path: Path) -> None:
+    assert HERMES_HOOK_EVENT_SUBCOMMANDS.get("pre_llm_call") == "pre-llm-call"
+    wrapper = render_hermes_hook_wrapper("/abs/agentacct", store_dir="/store")
+    assert "pre_llm_call" in wrapper and "pre-llm-call" in wrapper
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(_BASE_CONFIG, encoding="utf-8")
+    _write_hermes_hooks_config_at(cfg, _COMMAND, WRAPPER_BASENAME)
+    assert "pre_llm_call" in _load(cfg)["hooks"]
+
+
+def test_wrapper_short_circuits_later_pre_llm_call_without_spawning() -> None:
+    # pre_llm_call fires before EVERY inference; the wrapper must read is_first_turn
+    # itself and skip the CLI subprocess on later turns (no per-turn LLM-path latency).
+    src = render_hermes_hook_wrapper("/abs/agentacct", store_dir="/store")
+    import ast
+
+    ast.parse(src)  # still valid python
+    assert "_is_first_turn" in src
+    assert 'hook_event == "pre_llm_call"' in src  # gated before resolve/spawn

--- a/tests/test_onboard_global.py
+++ b/tests/test_onboard_global.py
@@ -220,7 +220,7 @@ def test_onboard_global_agent_opencode_writes_mcp_and_global_rules(
         assert not (repo / leaked).exists()
 
 
-def test_onboard_global_agent_hermes_registers_mcp_only_no_directive(
+def test_onboard_global_agent_hermes_installs_record_your_work_hook(
     tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import yaml
@@ -235,11 +235,40 @@ def test_onboard_global_agent_hermes_registers_mcp_only_no_directive(
     store = isolated_home / ".local" / "state" / "agentacct" / "state"
     hermes_cfg = yaml.safe_load((isolated_home / ".hermes" / "config.yaml").read_text())
     assert hermes_cfg["mcp_servers"]["agentacct"]["args"][-1] == str(store)
-    # Hermes has no reliable global instruction slot, so NO standing directive is
-    # installed here (recording rides its hook adapter, added separately).
+    # Hermes has no reliable global instruction slot, so the standing directive is not
+    # a FILE — it rides the pre_llm_call hook (injected on each session's first turn).
     assert not (isolated_home / "AGENTS.md").exists()
-    assert "tools registered" in result.output
-    assert "hook adapter" in result.output
+    assert "pre_llm_call" in hermes_cfg["hooks"]  # the record-your-work nudge hook is wired
+    normalized = " ".join(result.output.split())
+    assert "record-your-work" in normalized  # hermes now records, not tools-only
+    assert "tools registered" not in normalized
+
+
+def test_onboard_global_hermes_reported_tools_only_when_hooks_block_uneditable(
+    tmp_path: Path, isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import yaml
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    # A pre-existing inline (flow-style) hooks block agentacct cannot safely edit: the
+    # MCP server is still added, but the record-your-work nudge hook is NOT wired.
+    hermes_dir = isolated_home / ".hermes"
+    hermes_dir.mkdir(parents=True)
+    (hermes_dir / "config.yaml").write_text("hooks: {pre_tool_call: []}\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["onboard", "--scope", "global", "--agent", "hermes", "--no-start"])
+    assert result.exit_code == 0, result.output
+
+    cfg = yaml.safe_load((hermes_dir / "config.yaml").read_text())
+    assert "agentacct" in cfg["mcp_servers"]  # MCP got configured
+    assert "pre_llm_call" not in (cfg.get("hooks") or {})  # but the nudge was NOT wired
+    normalized = " ".join(result.output.split())
+    # Honest: NOT reported as recording — it says the hooks were not wired and records
+    # nothing, and the tools-only caveat is shown instead of a false "recording" claim.
+    assert "records nothing" in normalized
+    assert "MCP tools registered" in normalized
 
 
 def test_onboard_global_agent_codex_installs_tool_activity_hooks(


### PR DESCRIPTION
feat(hooks): make Hermes self-record via a first-turn record-your-work nudge

Hermes captured tool activity and exit codes but never recorded semantic sections
on its own: unlike codex/opencode, it has no always-on global instruction slot
($HOME AGENTS.md is skipped), so the agent was never told to call
agentacct_record_section. This closes that gap (the #5 signal) so Hermes reaches
the same recording parity as the other clients.

Mechanism (verified from Hermes source): agent/turn_context.py invokes the
pre_llm_call plugin hook with is_first_turn, and appends each hook's
`{"context": ...}` return to the current turn's user message (API-call-time only,
never persisted). This wires a pre_llm_call hook that returns the standing
'record your work' directive — the same text codex/opencode get from AGENTS.md,
framed as ambient setup context, not a user request — on a session's FIRST turn.

- New `hermes_first_turn_nudge` + `hooks hermes pre-llm-call` subcommand;
  `pre_llm_call` added to the wrapper's event map and the config.yaml `hooks:`
  block. onboard/install wire it automatically (one command, no extra steps).
- The wrapper reads `is_first_turn` itself and short-circuits every later turn
  WITHOUT spawning the CLI, so this hook — which fires before every inference —
  adds no per-turn latency to the LLM call. Fail-open on any error: it can never
  block or corrupt a Hermes LLM call.
- onboard now reports Hermes as a recording client when the hooks were actually
  wired, and honestly falls back to "tools-only, records nothing" when the config's
  hooks block can't be edited (inline/tab-indented) — never a false "recording is
  live" claim.

Two adversarial review rounds; seven findings across this and the opencode change,
all fixed (the false tools-only/recording classification, the per-turn CLI spawn,
the stale wrapper/section docstrings, the recovery-message omission of pre_llm_call).
Behavioral check: a later-turn pre_llm_call short-circuits to `{}` with no
subprocess; a first-turn pre_llm_call resolves agentacct and returns the directive.
Full suite green.

Deploy note: CLI/hook-side only — git pull is enough; re-run `agentacct onboard`
(or `agentacct hooks hermes install --force`) to add the pre_llm_call entry to an
existing hermes install.
