### PR TITLE
feat(hooks): capture OpenCode check exit codes via tool.execute.after

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -130,6 +130,7 @@ from .hooks import (
     capture_hermes_tool_check,
     capture_hermes_turn_boundary,
     capture_mechanical_check,
+    capture_opencode_tool_check,
     claude_code_hook_context_status,
     claude_code_hook_doctor_checks,
     claude_code_hook_paths,
@@ -4584,6 +4585,32 @@ def opencode_tool_activity(
         try:
             capture_tool_activity(raw, store_dir=store_dir, client="opencode")
         except Exception:  # noqa: BLE001 - activity capture must never affect the tool call.
+            pass
+        print("{}")
+    except Exception:  # noqa: BLE001 - FAIL OPEN: capture must never disturb OpenCode.
+        print("{}")
+
+
+@opencode_hooks_app.command("tool-check")
+def opencode_tool_check(
+    store_dir: Annotated[
+        Optional[Path],
+        typer.Option(help="State directory the mechanical-check tick is spooled to (the OpenCode plugin passes the bound store)."),
+    ] = None,
+) -> None:
+    """Observe an OpenCode ``tool.execute.after`` from stdin (exit-code check).
+
+    The plugin sends ``{tool_name, session_id, command, exit_code}`` for the bash tool.
+    When the command is a recognized test/build/lint runner, the exit code the HARNESS
+    observed is spooled (client ``opencode``) — the local signal that lifts a step to
+    ``independently_checked``. Only a coarse check kind, the runner name, and a sha256
+    command DIGEST are spooled — never the command or its output. Always returns empty.
+    """
+    try:
+        raw = sys.stdin.read()
+        try:
+            capture_opencode_tool_check(raw, store_dir=store_dir)
+        except Exception:  # noqa: BLE001 - capture must never affect the tool call.
             pass
         print("{}")
     except Exception:  # noqa: BLE001 - FAIL OPEN: capture must never disturb OpenCode.

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -1545,12 +1545,15 @@ def capture_hermes_turn_boundary(raw: str, *, store_dir: Path | str | None = Non
 
 OPENCODE_PLUGIN_RELATIVE_PATH = Path("plugins/agentacct.js")
 
-_OPENCODE_PLUGIN_TEMPLATE = '''// agentacct OpenCode tool-activity plugin (observe-only, auto-generated).
+_OPENCODE_PLUGIN_TEMPLATE = '''// agentacct OpenCode capture plugin (observe-only, auto-generated).
 //
-// Records the tool NAME + OpenCode session id for each tool call so the agentacct
-// Receipt's Actions dimension shows what OpenCode reached for. Never reads tool
-// arguments or output. The agentacct CLI is fired fire-and-forget, so a slow or
-// broken install can never add latency to, block, or fail an OpenCode tool call.
+// Two observe-only signals:
+//  - tool.execute.before -> the tool NAME + OpenCode session id (Receipt Actions).
+//  - tool.execute.after  -> for a recognized test/build/lint bash command, the
+//    harness EXIT CODE (lifts a step to independently_checked). The shell command is
+//    read only to classify the runner and is stored ONLY as a sha256 digest, never
+//    raw; tool OUTPUT is never read. The agentacct CLI is fired fire-and-forget, so a
+//    slow or broken install can never add latency to, block, or fail a tool call.
 // Reinstall with: agentacct hooks opencode install --force
 import { existsSync } from "node:fs";
 
@@ -1572,21 +1575,44 @@ function resolveAgentacct() {
   return null;
 }
 
+function spawnCapture(subcommand, payload) {
+  // fire-and-forget: never await — a tool call must not wait on capture, and any
+  // error here must never affect the tool call.
+  try {
+    const executable = resolveAgentacct();
+    if (!executable) return;
+    const args = [executable, "hooks", "opencode", subcommand];
+    if (STORE_DIR) args.push("--store-dir", STORE_DIR);
+    const proc = Bun.spawn(args, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+    proc.stdin.write(JSON.stringify(payload));
+    proc.stdin.end();
+    try { proc.unref(); } catch (e) {}
+  } catch (e) {}
+}
+
 export const AgentacctToolActivity = async () => ({
   "tool.execute.before": async (input) => {
     try {
-      const executable = resolveAgentacct();
-      if (!executable) return;
-      const args = [executable, "hooks", "opencode", "tool-activity"];
-      if (STORE_DIR) args.push("--store-dir", STORE_DIR);
-      const proc = Bun.spawn(args, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
-      proc.stdin.write(JSON.stringify({ tool_name: input.tool, session_id: input.sessionID }));
-      proc.stdin.end();
-      // fire-and-forget: never await — a tool call must not wait on capture.
-      try { proc.unref(); } catch (e) {}
+      if (!input) return;
+      spawnCapture("tool-activity", { tool_name: input.tool, session_id: input.sessionID });
     } catch (e) {
       // observe-only: a plugin error must never affect the tool call.
     }
+  },
+  "tool.execute.after": async (input, output) => {
+    try {
+      // Only the bash/shell tool carries a command + exit code.
+      if (!input || input.tool !== "bash") return;
+      const command = input.args ? input.args.command : undefined;
+      const exit = output && output.metadata ? output.metadata.exit : undefined;
+      if (typeof exit !== "number") return;  // 0 is valid; a missing code is not
+      spawnCapture("tool-check", {
+        tool_name: input.tool,
+        session_id: input.sessionID,
+        command: command,
+        exit_code: exit,
+      });
+    } catch (e) {}
   },
 });
 '''
@@ -1616,6 +1642,63 @@ def render_opencode_plugin(agentacct_executable: str | None = None, *, store_dir
         lambda match: substitutions[match.group(0)],
         _OPENCODE_PLUGIN_TEMPLATE,
     )
+
+
+# opencode's shell/command tool name (its exit-code-bearing tool). The #3 exit-code
+# check only observes this tool, mirroring the Claude Code (bash) / hermes (terminal) paths.
+_OPENCODE_SHELL_TOOL_NAMES = frozenset({"bash"})
+
+
+def capture_opencode_tool_check(raw: str, *, store_dir: Path | str | None = None) -> None:
+    """Record ONE mechanical-check tick for an OpenCode ``tool.execute.after``. Never raises.
+
+    The plugin sends ``{tool_name, session_id, command, exit_code}`` for the bash tool
+    (command from ``input.args.command``, exit from ``output.metadata.exit``). When the
+    command is a recognized test/build/lint runner, the exit code the HARNESS observed is
+    spooled (client ``opencode``) — the local signal that lifts a step to
+    ``independently_checked``. Only a coarse check kind, the runner name, and a sha256
+    command DIGEST are spooled — never the command, arguments, or output.
+    """
+
+    try:
+        from .mechanical_capture import (
+            classify_command,
+            command_digest,
+            record_mechanical_check_tick,
+        )
+
+        event = json.loads(raw or "{}")
+        if not isinstance(event, dict):
+            return
+        tool_name = event.get("tool_name") or event.get("tool")
+        if str(tool_name or "").strip() not in _OPENCODE_SHELL_TOOL_NAMES:
+            return
+        session_id = event.get("session_id")
+        if not isinstance(session_id, str) or not session_id or len(session_id) > _MAX_CONTEXT_ID_LENGTH:
+            return
+        command = event.get("command")
+        classified = classify_command(command)
+        if classified is None:
+            return
+        exit_code = event.get("exit_code")
+        if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+            return  # 0 is valid; a missing/non-int code is not recorded
+        target = Path(store_dir) if store_dir is not None else _hook_store_dir_from_event(event)
+        if target is None:
+            return
+        check_kind, runner = classified
+        record_mechanical_check_tick(
+            target,
+            client="opencode",
+            session_id=session_id,
+            check_kind=check_kind,
+            runner=runner,
+            digest=command_digest(str(command or "")),
+            exit_code=exit_code,
+            at=time.time(),
+        )
+    except Exception:  # noqa: BLE001 - capture must never affect the hook.
+        return
 
 
 def claude_code_settings_example(python_executable: str | None = None, *, hook_path: Path | str | None = None) -> dict[str, Any]:

--- a/src/agentacct/mechanical_capture.py
+++ b/src/agentacct/mechanical_capture.py
@@ -329,10 +329,13 @@ def _build_envelope(tick: Mapping[str, Any]) -> Any | None:
         return None
     if not _SAFE_RUNNER.fullmatch(runner) or not _SHA256.fullmatch(digest):
         return None
-    # Name the wire the check came from honestly, per client: a hermes check
-    # arrives on a hermes post_tool_call, not a Claude Code PostToolUse.
+    # Name the wire the check came from honestly, per client: a hermes check arrives
+    # on a hermes post_tool_call and an opencode check on a tool.execute.after — not a
+    # Claude Code PostToolUse.
     if client == "hermes":
         source_schema, adapter = "hermes_post_tool_call.v1", "hermes_post_tool_call"
+    elif client == "opencode":
+        source_schema, adapter = "opencode_tool_execute_after.v1", "opencode_tool_execute_after"
     else:
         source_schema, adapter = "claude_code_post_tool_use.v1", "claude_code_post_tool_use"
     try:

--- a/tests/test_hooks_opencode.py
+++ b/tests/test_hooks_opencode.py
@@ -20,9 +20,11 @@ from typer.testing import CliRunner
 from agentacct.cli import _install_opencode_plugin, _onboard_global_opencode, app
 from agentacct.hooks import (
     OPENCODE_PLUGIN_RELATIVE_PATH,
+    capture_opencode_tool_check,
     capture_tool_activity,
     render_opencode_plugin,
 )
+from agentacct.mechanical_capture import drain_mechanical_check_spool
 from agentacct.tool_activity import drain_tool_activity_spool
 
 
@@ -86,7 +88,8 @@ def test_render_opencode_plugin_shape() -> None:
     # the agentacct executable + store are bound at install time
     assert "/abs/agentacct" in src
     assert "/store/x" in src
-    assert '"hooks", "opencode", "tool-activity"' in src
+    assert '"hooks", "opencode", subcommand' in src  # invokes `agentacct hooks opencode <sub>`
+    assert 'spawnCapture("tool-activity"' in src
     # fire-and-forget: it must not await the spawned CLI (never add tool-call latency)
     assert "await Bun.spawn" not in src
     assert "Bun.spawn" in src
@@ -187,3 +190,121 @@ def test_onboard_installs_plugin_even_when_mcp_config_is_jsonc(tmp_path: Path, m
     plugin_path = xdg / "opencode" / OPENCODE_PLUGIN_RELATIVE_PATH
     assert plugin_path.exists()
     assert "AgentacctToolActivity" in plugin_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# #3 exit-code mechanical check (tool.execute.after)
+# ---------------------------------------------------------------------------
+
+
+def _after(command, exit_code, *, tool="bash", session="ses_01") -> str:
+    return json.dumps({"tool_name": tool, "session_id": session, "command": command, "exit_code": exit_code})
+
+
+def _drain_checks(tmp_path: Path):
+    return drain_mechanical_check_spool(tmp_path)
+
+
+def test_opencode_tool_check_records_recognized_check(tmp_path: Path) -> None:
+    capture_opencode_tool_check(_after("pytest -q", 0), store_dir=tmp_path)
+    envs = _drain_checks(tmp_path)
+    assert len(envs) == 1
+    env = envs[0]
+    assert env.source_system == "opencode"
+    # Provenance names the opencode wire, not Claude Code's PostToolUse.
+    assert env.source_schema == "opencode_tool_execute_after.v1"
+    assert env.adapter == "opencode_tool_execute_after"
+    attrs = env.payload["attributes"]
+    assert attrs["check_kind"] == "test" and attrs["runner"] == "pytest" and attrs["exit_code"] == 0
+
+
+def test_opencode_tool_check_records_failing_exit(tmp_path: Path) -> None:
+    capture_opencode_tool_check(_after("npm run build", 2), store_dir=tmp_path)
+    env = _drain_checks(tmp_path)[0]
+    assert env.payload["attributes"]["exit_code"] == 2
+    assert env.payload["attributes"]["passed"] is False
+
+
+def test_opencode_tool_check_attributes_input_session(tmp_path: Path) -> None:
+    capture_opencode_tool_check(_after("pytest -q", 0, session="ses_abc123"), store_dir=tmp_path)
+    env = _drain_checks(tmp_path)[0]
+    assert env.source_instance == "ses_abc123"
+
+
+def test_opencode_tool_check_skips_non_check_command(tmp_path: Path) -> None:
+    capture_opencode_tool_check(_after("echo hi", 0), store_dir=tmp_path)
+    assert _drain_checks(tmp_path) == []
+
+
+def test_opencode_tool_check_skips_non_bash_tool(tmp_path: Path) -> None:
+    capture_opencode_tool_check(_after("pytest -q", 0, tool="read"), store_dir=tmp_path)
+    assert _drain_checks(tmp_path) == []
+
+
+def test_opencode_tool_check_skips_missing_or_nonint_exit(tmp_path: Path) -> None:
+    capture_opencode_tool_check(json.dumps({"tool_name": "bash", "session_id": "ses_01", "command": "pytest -q"}), store_dir=tmp_path)
+    capture_opencode_tool_check(_after("pytest -q", True), store_dir=tmp_path)  # bool is not a valid exit code
+    capture_opencode_tool_check(_after("pytest -q", "0"), store_dir=tmp_path)  # string is not an int
+    assert _drain_checks(tmp_path) == []
+
+
+def test_opencode_tool_check_overlong_session_and_garbage(tmp_path: Path) -> None:
+    capture_opencode_tool_check(_after("pytest -q", 0, session="x" * 5000), store_dir=tmp_path)
+    capture_opencode_tool_check("not json", store_dir=tmp_path)
+    capture_opencode_tool_check(json.dumps([1, 2]), store_dir=tmp_path)
+    assert _drain_checks(tmp_path) == []
+
+
+def test_opencode_plugin_has_after_hook_and_is_valid_js(tmp_path: Path) -> None:
+    src = render_opencode_plugin("/abs/agentacct", store_dir=str(tmp_path / "store"))
+    assert "tool.execute.after" in src
+    assert "tool-check" in src and "spawnCapture" in src
+    assert 'input.tool !== "bash"' in src  # gated on the shell tool
+    if shutil.which("node"):
+        plugin = tmp_path / "p.mjs"
+        plugin.write_text(src, encoding="utf-8")
+        result = subprocess.run(["node", "--check", str(plugin)], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+
+def test_tool_check_subcommand_spools_check(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app, ["hooks", "opencode", "tool-check", "--store-dir", str(tmp_path)], input=_after("pytest -q", 0)
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "{}"
+    assert len(drain_mechanical_check_spool(tmp_path)) == 1
+
+
+def test_tool_check_subcommand_fail_open_on_garbage(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app, ["hooks", "opencode", "tool-check", "--store-dir", str(tmp_path)], input="}{not json"
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "{}"
+
+
+def test_before_and_after_hooks_survive_null_input(tmp_path: Path) -> None:
+    # A null/undefined `input` from OpenCode must not make a hook reject (observe-only
+    # must never throw into OpenCode's dispatch). The before-hook guards input the same
+    # way the after-hook does.
+    src = render_opencode_plugin("/abs/agentacct", store_dir=None)
+    assert "if (!input) return;" in src  # before-hook null guard
+    if shutil.which("node") is None:
+        pytest.skip("node not available to run the plugin hooks")
+    plugin = tmp_path / "p.mjs"
+    plugin.write_text(src, encoding="utf-8")
+    harness = tmp_path / "h.mjs"
+    harness.write_text(
+        "import { AgentacctToolActivity } from './p.mjs';\n"
+        "const h = await AgentacctToolActivity();\n"
+        "await h['tool.execute.before'](null);\n"
+        "await h['tool.execute.before'](undefined);\n"
+        "await h['tool.execute.after'](null, null);\n"
+        "await h['tool.execute.after'](undefined, undefined);\n"
+        "console.log('NO_THROW');\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(["node", str(harness)], capture_output=True, text=True, cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "NO_THROW" in result.stdout


### PR DESCRIPTION
feat(hooks): capture OpenCode check exit codes via tool.execute.after

OpenCode recorded tool activity but not the harness exit code of its checks, so
its steps could never reach independently_checked. This adds the #3 signal:
a tool.execute.after hook that records the exit code of recognized test/build/lint
commands, the same independent-check evidence Claude Code and Hermes already emit.

Verified OpenCode plugin API (@opencode-ai/plugin 1.18.8): tool.execute.after
receives `input.tool`, `input.args.command`, and `output.metadata.exit` (an
integer). For the bash tool the plugin sends `{tool_name, session_id, command,
exit_code}` to a new `hooks opencode tool-check` subcommand, which classifies
recognized runners and records a mechanical check (client=opencode). The session
id is the `ses_...` session-table id the usage importer keys on, so the check
attributes straight to the OpenCode session.

- Plugin refactored to a shared `spawnCapture` helper; both hooks are
  fire-and-forget (never awaited) and guard null input, so a plugin error can
  never add latency to, block, or fail an OpenCode tool call. The generated JS is
  `node --check`-validated in CI.
- `capture_opencode_tool_check`: only the bash tool is observed, only a real
  integer exit code records (0 valid; missing/bool/string skipped), and only
  recognized test/build/lint commands record.
- Provenance is labeled opencode (`opencode_tool_execute_after.v1`), never the
  Claude Code wire.

Privacy: the shell command is read only to classify the runner and is spooled ONLY
as a sha256 digest — never the raw command, its arguments, or tool output.

Adversarial review; the confirmed defects fixed (the spawnCapture refactor had
moved the before-hook's input dereference out of its try/catch, so a null input
could reject into OpenCode — restored the guard). Full suite green.

Deploy note: CLI/hook-side only — git pull is enough; re-run `agentacct onboard`
(or `agentacct hooks opencode install --force`) to update an existing plugin.
