### PR TITLE
feat(actions): record the files an agent edited in the Receipt's Actions dimension

### DIFF
--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -474,6 +474,52 @@ def capture_claude_code_client_context(raw: str, *, store_dir: Path | str | None
         return None
 
 
+# Keys a file-edit tool uses for its DESTINATION path, across agents (Claude Code
+# Edit/Write use ``file_path`` / ``notebook_path``; others vary). Only the
+# destination path is ever read — never the content, the diff, or any other arg.
+_EDIT_PATH_KEYS = ("file_path", "notebook_path", "filePath", "path", "target_file", "file")
+
+
+def _edit_target_relpath(event: Mapping[str, Any], category: str) -> str | None:
+    """The repo-relative path a file-EDIT tool wrote, or ``None``.
+
+    Reads ONLY the destination path from ``tool_input`` for an ``edit``-category
+    tool and relativizes it to the session ``cwd``, so nothing outside the working
+    tree — and no absolute prefix, home dir, or username — is ever captured. Never
+    reads the file content, the edit/diff, or any other argument. A path that
+    escapes the cwd (``../``) or cannot be relativized is dropped."""
+    if category != "edit":
+        return None
+    tool_input = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else None
+    if not tool_input:
+        return None
+    raw_path = None
+    for key in _EDIT_PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            raw_path = value.strip()
+            break
+    if not raw_path:
+        return None
+    cwd = event.get("cwd")
+    cwd = cwd.strip() if isinstance(cwd, str) and cwd.strip() else None
+    try:
+        if os.path.isabs(raw_path):
+            if not cwd:
+                return None  # never store an absolute path we cannot relativize
+            rel = os.path.relpath(raw_path, cwd)
+        else:
+            rel = raw_path
+    except (ValueError, OSError):
+        return None
+    rel = rel.replace(os.sep, "/")
+    # Drop anything that escapes the working tree or is still absolute — the tick's
+    # _normalize_touched_path re-checks this, but never emit it in the first place.
+    if rel.startswith("/") or rel.split("/", 1)[0] == "..":
+        return None
+    return rel
+
+
 def capture_tool_activity(
     raw: str, *, store_dir: Path | str | None = None, client: str = "claude-code"
 ) -> None:
@@ -481,10 +527,12 @@ def capture_tool_activity(
 
     The PreToolUse hook already receives the tool name (and fails open), so this
     is the cheapest honest place to observe what the agent reached for. The
-    category AND the tool NAME are spooled — never arguments or any payload — so
-    the Receipt's Actions dimension can show both what KIND of tool ran and which
-    SPECIFIC tool/connector. The spool lands in the SAME store as the
-    client-context bridge so the usage importer drains both from one place.
+    category AND the tool NAME are spooled — never arguments or any payload — plus,
+    for a file-EDIT tool, the repo-relative DESTINATION path (see
+    ``_edit_target_relpath``: relativized to cwd, never content/args) so the
+    Receipt's Actions dimension can show which artifacts were touched. The spool
+    lands in the SAME store as the client-context bridge so the usage importer
+    drains both from one place.
 
     ``client`` labels which agent emitted the tick. Codex's PreToolUse hook uses
     the same STDIN shape (``session_id``/``tool_name``), and its ``session_id``
@@ -512,6 +560,7 @@ def capture_tool_activity(
             session_id=session_id,
             category=category,
             name=tool_name,
+            path=_edit_target_relpath(event, category),
             at=time.time(),
         )
     except Exception:  # noqa: BLE001 - activity capture must never affect the hook decision.

--- a/src/agentacct/task_projection.py
+++ b/src/agentacct/task_projection.py
@@ -996,8 +996,17 @@ def build_task_projection(
                             tool_name_counts[label] = tool_name_counts.get(label, 0) + value
         touched_files: list[str] = []
         seen_touched_files: set[str] = set()
-        for item in task_work:
-            files = item.get("files") if isinstance(item.get("files"), list) else []
+        # (a) agent-reported section/check files, and (b) the repo-relative paths a
+        # file-edit tool wrote (hook-captured, per session) — either source alone
+        # routinely misses files the other has. Both are already repo-relative-safe.
+        touched_sources: list[Any] = [
+            item.get("files") if isinstance(item.get("files"), list) else [] for item in task_work
+        ]
+        touched_sources.extend(
+            sessions[key].get("touched_files") if isinstance(sessions[key].get("touched_files"), list) else []
+            for key in ordered_members
+        )
+        for files in touched_sources:
             for candidate in files:
                 path = _text(candidate)
                 if path and path not in seen_touched_files:

--- a/src/agentacct/tool_activity.py
+++ b/src/agentacct/tool_activity.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import uuid
 from collections.abc import Iterable, Mapping
 from pathlib import Path
@@ -115,6 +116,39 @@ def normalize_tool_name(tool_name: Any) -> str | None:
     return name[:_TOOL_NAME_MAX]
 
 
+_TOUCHED_PATH_MAX = 240
+# Hard cap on the number of distinct touched paths carried per drained batch, so a
+# pathological session can never bloat one event. "At least this much", never more.
+_TOUCHED_FILES_PER_BATCH_MAX = 200
+
+
+def _normalize_touched_path(path: Any) -> str | None:
+    """Defensive normalization of a caller-supplied touched-file path.
+
+    The CALLER (the hook) already relativizes the edited file to the session cwd;
+    this is the belt-and-suspenders gate that GUARANTEES the store never holds an
+    absolute path, a Windows drive/UNC path, a ``..`` escape, or an over-long
+    string — so even a buggy caller can never leak an absolute prefix (home dir,
+    username). Blank / unsafe -> ``None`` (nothing recorded)."""
+
+    text = str(path or "").strip()
+    if not text or "\x00" in text:
+        return None
+    if re.match(r"^[A-Za-z]:", text):  # Windows drive (C:\...)
+        return None
+    # A leading slash OR backslash is absolute — one backslash is a Windows
+    # drive-relative absolute (``\Users\bob\...``) that ``os.path.isabs`` misses on
+    # POSIX, so it must be caught here before ``replace("\\","/")`` turns it into a
+    # ``/…`` path whose empty leading segment would be silently dropped.
+    if text.startswith(("\\", "/")):  # single/UNC backslash, or / and //
+        return None
+    normalized = text.replace("\\", "/")
+    parts = [part for part in normalized.split("/") if part not in {"", "."}]
+    if not parts or ".." in parts:
+        return None
+    return "/".join(parts)[:_TOUCHED_PATH_MAX]
+
+
 def tool_activity_spool_path(store_dir: Path | str) -> Path:
     return Path(store_dir) / _SPOOL_RELATIVE_PATH
 
@@ -126,15 +160,20 @@ def record_tool_activity_tick(
     session_id: str,
     category: str,
     name: Any = None,
+    path: Any = None,
     at: float,
 ) -> None:
     """Append ONE tick to the store spool. Best-effort; never raises.
 
     Writes the small scalars ``{c, s, k, t}`` — client, session id, category, and
-    a timestamp — plus ``n``, the tool NAME, when one is given. No arguments, no
-    path, no output: only the name and its category. The line is a single tiny
-    JSON object written with ``O_APPEND`` so concurrent hook processes (many tool
-    calls in flight) never corrupt or interleave lines.
+    a timestamp — plus ``n``, the tool NAME, when one is given, and ``p``, the
+    repo-relative path a file-EDIT tool wrote, when the caller extracted one (the
+    Actions dimension's "which artifacts were touched" — the caller relativizes it
+    to the session cwd and drops anything outside, so no absolute prefix, home dir,
+    or username is ever stored; arguments, content and output are still never
+    recorded). The line is a single tiny JSON object written with ``O_APPEND`` so
+    concurrent hook processes (many tool calls in flight) never corrupt or
+    interleave lines.
     """
 
     try:
@@ -150,6 +189,9 @@ def record_tool_activity_tick(
         normalized_name = normalize_tool_name(name)
         if normalized_name:
             payload["n"] = normalized_name
+        touched = _normalize_touched_path(path)
+        if touched:
+            payload["p"] = touched
         line = json.dumps(
             payload,
             ensure_ascii=False,
@@ -204,6 +246,7 @@ def drain_tool_activity_spool(
 
     counts: dict[tuple[str, str], dict[str, int]] = {}
     name_counts: dict[tuple[str, str], dict[str, int]] = {}
+    touched_paths: dict[tuple[str, str], list[str]] = {}
     latest: dict[tuple[str, str], float] = {}
     for line in raw.splitlines():
         line = line.strip()
@@ -232,6 +275,13 @@ def drain_tool_activity_spool(
         if name:
             name_bucket = name_counts.setdefault(key, {})
             name_bucket[name] = name_bucket.get(name, 0) + 1
+        # Touched file path (present only on edit-tool ticks written after path
+        # capture shipped). Deduped, insertion-ordered, and hard-capped per batch.
+        touched = _normalize_touched_path(row.get("p"))
+        if touched:
+            path_bucket = touched_paths.setdefault(key, [])
+            if touched not in path_bucket and len(path_bucket) < _TOUCHED_FILES_PER_BATCH_MAX:
+                path_bucket.append(touched)
         stamp = row.get("t")
         if isinstance(stamp, (int, float)) and not isinstance(stamp, bool):
             latest[key] = max(latest.get(key, 0.0), float(stamp))
@@ -260,6 +310,12 @@ def drain_tool_activity_spool(
             metadata["tool_names"] = [
                 {"name": name, "count": count} for name, count in sorted(names.items())
             ]
+        touched = touched_paths.get((client, session))
+        if touched:
+            # Paths ride as a plain list of string VALUES (same redaction-safe shape
+            # rationale as tool_names): a path is never a dict KEY, so the store's
+            # secret redaction can never blank it.
+            metadata["touched_files"] = list(touched)
         events.append(
             {
                 "event_id": f"toolact:{digest}",
@@ -382,12 +438,50 @@ def build_tool_names_by_session(
     return {key: value for key, value in result.items() if value}
 
 
+def build_touched_files_by_session(
+    events: Iterable[Mapping[str, Any]],
+) -> dict[tuple[str, str], list[str]]:
+    """Collect ``tool_activity_observed`` touched-file paths per (client, session).
+
+    Mirrors ``build_tool_names_by_session``: reads each event's ``touched_files``
+    list (repo-relative paths a file-edit tool wrote). Batches are additive and the
+    union is deduped (insertion-ordered) across imports. A session recorded before
+    path capture shipped simply has none — an honest gap, never a fabricated entry.
+    Every path is re-run through ``_normalize_touched_path`` here (the third gate,
+    after the tick and the drain), which is safety-equivalent to the projection's
+    ``_safe_relative_posix_path`` — both reject any absolute/drive/UNC/``..``/NUL path.
+    """
+
+    result: dict[tuple[str, str], list[str]] = {}
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        if event.get("event_type") != TOOL_ACTIVITY_EVENT_TYPE:
+            continue
+        metadata = event.get("metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        client = str(metadata.get("client") or "").strip()
+        session = str(metadata.get("client_session_id") or "").strip()
+        if not client or not session:
+            continue
+        paths = metadata.get("touched_files")
+        if not isinstance(paths, list):
+            continue
+        bucket = result.setdefault((client, session), [])
+        for candidate in paths:
+            normalized = _normalize_touched_path(candidate)
+            if normalized and normalized not in bucket:
+                bucket.append(normalized)
+    return {key: value for key, value in result.items() if value}
+
+
 __all__ = [
     "TOOL_ACTIVITY_CAPTURE_BASIS",
     "TOOL_ACTIVITY_EVENT_TYPE",
     "TOOL_CATEGORIES",
     "build_tool_activity_by_session",
     "build_tool_names_by_session",
+    "build_touched_files_by_session",
     "drain_tool_activity_spool",
     "ingest_tool_activity_spool",
     "normalize_tool_name",

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -14,7 +14,11 @@ from .confidence import (
     normalize_usage_confidence,
 )
 from .session_lifecycle import build_session_end_by_session
-from .tool_activity import build_tool_activity_by_session, build_tool_names_by_session
+from .tool_activity import (
+    build_tool_activity_by_session,
+    build_tool_names_by_session,
+    build_touched_files_by_session,
+)
 from .join_rules import (
     JoinCandidateIndex,
     annotate_usage_source_namespace_ambiguity,
@@ -211,7 +215,8 @@ def build_work_ledger(
     # gets NO key, so the Receipt shows an honest Gap, never a fabricated zero.
     tool_activity_by_session = build_tool_activity_by_session(events)
     tool_names_by_session = build_tool_names_by_session(events)
-    if tool_activity_by_session or tool_names_by_session:
+    touched_files_by_session = build_touched_files_by_session(events)
+    if tool_activity_by_session or tool_names_by_session or touched_files_by_session:
         for entry in session_rollup.get("sessions", []):
             entry_key = (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
             counts = tool_activity_by_session.get(entry_key)
@@ -220,6 +225,12 @@ def build_work_ledger(
             names = tool_names_by_session.get(entry_key)
             if names:
                 entry["tool_name_counts"] = dict(names)
+            # Repo-relative paths a file-edit tool wrote (hook-captured). Each was
+            # already gated by _normalize_touched_path at the tick, the drain, and
+            # build_touched_files_by_session (safety-equivalent to _safe_relative_posix_path).
+            touched = touched_files_by_session.get(entry_key)
+            if touched:
+                entry["touched_files"] = list(touched)
     # Ambient session-end (SessionEnd hook): stamp each work item with the end
     # time of its OWN session so the outcome reducer can honestly derive the
     # ``ended_open`` disposition — an open step whose session stopped without a

--- a/tests/test_touched_files.py
+++ b/tests/test_touched_files.py
@@ -1,0 +1,190 @@
+"""Hook-captured touched files (Actions dimension).
+
+A file-EDIT tool's destination path is captured by the tool-activity hook,
+relativized to the session cwd (never an absolute prefix, home dir, or username,
+never the content/diff/args), spooled, drained onto the tool_activity_observed
+event, aggregated per session, and unioned into the Task's Actions touched files
+alongside the agent-reported MCP section/check files.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from agentacct.hooks import _edit_target_relpath, capture_tool_activity
+from agentacct.task_projection import build_task_projection
+from agentacct.tool_activity import (
+    _normalize_touched_path,
+    build_touched_files_by_session,
+    drain_tool_activity_spool,
+    record_tool_activity_tick,
+)
+
+
+def _edit_event(file_path: str, *, cwd: str = "/Users/u/repo", tool: str = "Edit") -> dict[str, Any]:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool,
+        "session_id": "s1",
+        "cwd": cwd,
+        "tool_input": {"file_path": file_path},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _edit_target_relpath — the capture-time extraction + relativization
+# ---------------------------------------------------------------------------
+
+
+def test_relpath_relativizes_absolute_path_under_cwd() -> None:
+    assert _edit_target_relpath(_edit_event("/Users/u/repo/src/foo.py"), "edit") == "src/foo.py"
+
+
+def test_relpath_keeps_already_relative_path() -> None:
+    assert _edit_target_relpath(_edit_event("src/bar.py"), "edit") == "src/bar.py"
+
+
+def test_relpath_drops_path_outside_cwd() -> None:
+    # A path outside the working tree relativizes to ../ and is dropped — never leaks
+    # /etc/passwd or a sibling repo.
+    assert _edit_target_relpath(_edit_event("/etc/passwd"), "edit") is None
+
+
+def test_relpath_drops_absolute_without_cwd() -> None:
+    ev = {"tool_name": "Edit", "tool_input": {"file_path": "/x/y.py"}}
+    assert _edit_target_relpath(ev, "edit") is None
+
+
+def test_relpath_only_for_edit_category() -> None:
+    assert _edit_target_relpath(_edit_event("/Users/u/repo/a.py", tool="Read"), "read") is None
+
+
+def test_relpath_none_when_no_path_arg() -> None:
+    ev = {"tool_name": "Bash", "cwd": "/Users/u/repo", "tool_input": {"command": "ls"}}
+    assert _edit_target_relpath(ev, "execute") is None
+
+
+def test_relpath_reads_notebook_path_key() -> None:
+    ev = {"tool_name": "NotebookEdit", "cwd": "/Users/u/repo", "tool_input": {"notebook_path": "/Users/u/repo/nb.ipynb"}}
+    assert _edit_target_relpath(ev, "edit") == "nb.ipynb"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_touched_path — the tick-time defensive gate
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_rejects_absolute_and_escape_and_drive() -> None:
+    assert _normalize_touched_path("/etc/passwd") is None
+    assert _normalize_touched_path("../../secret") is None
+    assert _normalize_touched_path("C:\\Users\\x") is None
+    assert _normalize_touched_path("\\\\server\\share") is None  # UNC (double backslash)
+    assert _normalize_touched_path("\\Users\\bob\\secret\\id_rsa") is None  # single-backslash Windows absolute
+    assert _normalize_touched_path("a\x00b") is None
+
+
+def test_capture_drops_windows_drive_relative_absolute_end_to_end() -> None:
+    # A single-leading-backslash Windows drive-relative path must never be stored —
+    # it would otherwise leak the username + an out-of-tree location.
+    store = _store()
+    event = {"tool_name": "Edit", "session_id": "s1", "cwd": "C:\\Users\\bob\\proj", "tool_input": {"file_path": "\\Users\\bob\\secret\\id_rsa"}}
+    capture_tool_activity(json.dumps(event), store_dir=store, client="claude-code")
+    events = drain_tool_activity_spool(store)
+    assert events == [] or "touched_files" not in events[0]["metadata"]
+
+
+def test_normalize_keeps_and_cleans_relative() -> None:
+    assert _normalize_touched_path("./src//foo.py") == "src/foo.py"
+    assert _normalize_touched_path("src\\win\\bar.py") == "src/win/bar.py"
+
+
+def test_normalize_length_bounded() -> None:
+    long = "a/" * 300
+    out = _normalize_touched_path(long)
+    assert out is not None and len(out) <= 240
+
+
+# ---------------------------------------------------------------------------
+# pipeline: capture -> tick -> drain -> event.touched_files
+# ---------------------------------------------------------------------------
+
+
+def _store() -> Path:
+    return Path(tempfile.mkdtemp())
+
+
+def test_capture_records_edit_paths_deduped_edit_tools_only() -> None:
+    store = _store()
+    capture_tool_activity(json.dumps(_edit_event("/Users/u/repo/src/auth/login.py")), store_dir=store, client="claude-code")
+    capture_tool_activity(json.dumps(_edit_event("/Users/u/repo/src/auth/login.py")), store_dir=store, client="claude-code")  # dup
+    capture_tool_activity(json.dumps(_edit_event("/Users/u/repo/README.md", tool="Write")), store_dir=store, client="claude-code")
+    capture_tool_activity(json.dumps({"tool_name": "Bash", "session_id": "s1", "cwd": "/Users/u/repo", "tool_input": {"command": "pytest"}}), store_dir=store, client="claude-code")
+    events = drain_tool_activity_spool(store)
+    assert len(events) == 1
+    md = events[0]["metadata"]
+    assert md["touched_files"] == ["src/auth/login.py", "README.md"]  # deduped, edit tools only, cwd-relative
+
+
+def test_pipeline_never_stores_absolute_even_from_a_buggy_tick() -> None:
+    # A tick handed an absolute path directly (bypassing the hook helper) is still
+    # dropped by the tick's own _normalize_touched_path — no absolute path can persist.
+    store = _store()
+    record_tool_activity_tick(store, client="claude-code", session_id="s1", category="edit", name="Edit", path="/Users/secret/home/x.py", at=1.0)
+    events = drain_tool_activity_spool(store)
+    assert events == [] or "touched_files" not in events[0]["metadata"]
+
+
+def test_build_touched_files_by_session_unions_across_batches() -> None:
+    def _event(paths: list[str]) -> dict[str, Any]:
+        return {
+            "event_type": "tool_activity_observed",
+            "metadata": {"client": "hermes", "client_session_id": "20260813_x", "touched_files": paths},
+        }
+
+    result = build_touched_files_by_session([_event(["a.py", "b.py"]), _event(["b.py", "c.py"])])
+    assert result[("hermes", "20260813_x")] == ["a.py", "b.py", "c.py"]  # additive + deduped
+
+
+# ---------------------------------------------------------------------------
+# projection: session touched_files union into the Task Actions dimension
+# ---------------------------------------------------------------------------
+
+
+def _session_with_touched(files: list[str]) -> dict[str, Any]:
+    return {
+        "client": "hermes",
+        "client_session_id": "sess-1",
+        "identity_scope_state": "unscoped",
+        "namespace_fingerprint": None,
+        "session_kind": "root",
+        "last_activity_at": 1.0,
+        "related": {"parent": None},
+        "usage": {"rows": 1, "priced_rows": 1, "unpriced_rows": 0, "fresh_tokens": 5, "total_tokens": 5, "estimated_cost_usd": 0.01, "model_lanes": [{"model": "gpt-5.5"}]},
+        "touched_files": files,
+    }
+
+
+def test_projection_unions_session_touched_files_into_actions() -> None:
+    projection = build_task_projection([_session_with_touched(["src/edited_by_hook.py"])], [])
+    task = projection["tasks"][0]
+    assert "src/edited_by_hook.py" in task["actions"]["touched_files"]
+
+
+def test_projection_unions_hook_and_section_files() -> None:
+    # A section reports one file; the hook captured another. Both reach Actions.
+    session = _session_with_touched(["src/hook_path.py"])
+    work_item = {
+        "client": "hermes",
+        "client_session_id": "sess-1",
+        "section_id": "w1",
+        "run_id": "sess-1",
+        "latest_status": "completed",
+        "files": ["src/section_path.py"],
+    }
+    projection = build_task_projection([session], [work_item])
+    touched = projection["tasks"][0]["actions"]["touched_files"]
+    assert "src/hook_path.py" in touched
+    assert "src/section_path.py" in touched


### PR DESCRIPTION
feat(actions): record the files an agent edited in the Receipt's Actions dimension

The Actions dimension lists which files a Task touched, but those paths came from
a single source — an agent explicitly passing `files=` to an MCP section or check.
An agent that edited files without self-reporting them left the dimension empty
(in a real store: hermes 0/37, opencode 1/5, cursor 0/35 of tasks). The
tool-activity hook already observes every edit; this records the edited file's
path alongside the tool name it already captures, so the Receipt shows what was
changed for every agent — not only the ones that self-report.

- `capture_tool_activity` records the repo-relative destination path of a
  file-edit tool (Edit / Write / NotebookEdit / …), read from the tool's path
  argument and relativized to the session cwd. Only the destination path is read —
  never file content, diffs, commands, or other arguments.
- The path rides the existing tool-activity pipeline: tick → `drain_tool_activity_spool`
  attaches a `touched_files` list to the `tool_activity_observed` event →
  `build_touched_files_by_session` aggregates per session → the Task projection
  unions it into `actions.touched_files` next to any agent-reported section files.
  Deduped, per-batch capped, and idempotent across import batches.
- Agent-agnostic: claude-code, hermes and codex fill immediately (all route
  `tool_input` through `capture_tool_activity`). OpenCode follows in a small plugin
  change (its plugin currently sends only the tool name).

Paths are stored repo-relative. New `tests/test_touched_files.py` covers the
extraction, the pipeline, dedup/caps, and the path handling; full suite green.
