### PR TITLE
feat(hooks): capture OpenCode edit target paths for the Receipt Actions dimension

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -4622,10 +4622,12 @@ def opencode_tool_activity(
     """Observe an OpenCode tool call from stdin (observe-only).
 
     The OpenCode plugin's ``tool.execute.before`` hook fires the agentacct CLI with
-    ``{tool_name, session_id}`` on stdin. OpenCode's ``session_id`` is the ``ses_...``
-    ``session`` table id the usage importer keys on, so the tick attributes straight
-    to the OpenCode session with no log pairing. Records the tool name + category
-    (never arguments); always returns an empty no-op response.
+    ``{tool_name, session_id}`` on stdin — plus, for a file-edit tool, ``tool_input``
+    (the destination path only) and ``cwd`` (the project/worktree root), so the shared
+    extractor can relativize the touched path. OpenCode's ``session_id`` is the
+    ``ses_...`` ``session`` table id the usage importer keys on, so the tick attributes
+    straight to the OpenCode session with no log pairing. Records the tool name +
+    category + destination path (never other arguments); always returns an empty no-op.
     """
     try:
         raw = sys.stdin.read()

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -1654,16 +1654,19 @@ def hermes_first_turn_nudge(raw: str, *, directive: str) -> dict[str, Any]:
 # ``<config>/plugins/*.js``. Its ``tool.execute.before`` hook receives the tool
 # name and the OpenCode session id (``ses_...``), which is exactly the ``session``
 # table id the agentacct usage importer keys on — so a tick attributes straight to
-# the OpenCode session with no log pairing. The plugin only ever spools the tool
-# NAME + session id (never arguments or output), and it fires the agentacct CLI
-# fire-and-forget so it can never add latency to, block, or fail a tool call.
+# the OpenCode session with no log pairing. The plugin spools the tool NAME + session
+# id and, for a file-edit tool, the destination path it wrote (never the file content,
+# the diff, or any other argument), and it fires the agentacct CLI fire-and-forget so
+# it can never add latency to, block, or fail a tool call.
 
 OPENCODE_PLUGIN_RELATIVE_PATH = Path("plugins/agentacct.js")
 
 _OPENCODE_PLUGIN_TEMPLATE = '''// agentacct OpenCode capture plugin (observe-only, auto-generated).
 //
 // Two observe-only signals:
-//  - tool.execute.before -> the tool NAME + OpenCode session id (Receipt Actions).
+//  - tool.execute.before -> the tool NAME + OpenCode session id, plus (for a file-edit
+//    tool) the DESTINATION path it wrote — never the content, the diff, or any other
+//    argument; the CLI relativizes it to the project/worktree root (Receipt Actions).
 //  - tool.execute.after  -> for a recognized test/build/lint bash command, the
 //    harness EXIT CODE (lifts a step to independently_checked). The shell command is
 //    read only to classify the runner and is stored ONLY as a sha256 digest, never
@@ -1705,11 +1708,45 @@ function spawnCapture(subcommand, payload) {
   } catch (e) {}
 }
 
-export const AgentacctToolActivity = async () => ({
-  "tool.execute.before": async (input) => {
+// Keys an OpenCode file-edit tool uses for its DESTINATION path (edit/write use
+// ``filePath``). Only the destination path is read — never the content or the diff.
+const EDIT_PATH_KEYS = ["filePath", "file_path", "path", "notebook_path", "target_file", "file"];
+
+// Tool names the CLI counts as a file EDIT (mirrors _CATEGORY_BY_TOOL_NAME's edit set),
+// so a path is forwarded ONLY for these — a read/search tool's target path is never
+// sent, and the CLI's category gate is a second, independent check.
+const EDIT_TOOLS = new Set(["edit", "write", "multiedit", "notebookedit"]);
+
+function editTargetPath(args) {
+  if (!args || typeof args !== "object") return undefined;
+  for (const key of EDIT_PATH_KEYS) {
+    const value = args[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}
+
+export const AgentacctToolActivity = async ({ directory, worktree } = {}) => {
+  // The project/worktree root, so the CLI can relativize an absolute edit path to a
+  // repo-relative one (it never stores an absolute prefix, home dir, or username).
+  const PROJECT_CWD = worktree || directory || null;
+  return {
+  "tool.execute.before": async (input, output) => {
     try {
       if (!input) return;
-      spawnCapture("tool-activity", { tool_name: input.tool, session_id: input.sessionID });
+      const payload = { tool_name: input.tool, session_id: input.sessionID };
+      // For a file-EDIT tool ONLY, forward the DESTINATION path (never content or any
+      // other arg) as tool_input, so the CLI's shared extractor relativizes it. Gating
+      // on the same tool set the CLI counts as 'edit' keeps the wire edit-only (a
+      // read/search tool's target path is never sent) and mirrors the Claude Code path.
+      if (EDIT_TOOLS.has(String(input.tool || "").toLowerCase())) {
+        const editPath = editTargetPath(output && output.args);
+        if (editPath) {
+          payload.tool_input = { filePath: editPath };
+          if (PROJECT_CWD) payload.cwd = PROJECT_CWD;
+        }
+      }
+      spawnCapture("tool-activity", payload);
     } catch (e) {
       // observe-only: a plugin error must never affect the tool call.
     }
@@ -1729,7 +1766,8 @@ export const AgentacctToolActivity = async () => ({
       });
     } catch (e) {}
   },
-});
+  };
+};
 '''
 
 

--- a/src/agentacct/tool_activity.py
+++ b/src/agentacct/tool_activity.py
@@ -1,12 +1,12 @@
 """Tool-activity capture for the Receipt's Actions dimension.
 
 The Actions question a Receipt must answer is "what did the agent reach for".
-This records, per tool call, a COARSE CATEGORY (read/edit/execute/…) AND the
+This records, per tool call, a COARSE CATEGORY (read/edit/execute/…), the
 tool's NAME — a builtin like ``Read``/``Bash``, an ``mcp__server__tool`` name, or
-a custom command. It never records a tool's ARGUMENTS, its output, or any PATH:
-only the name and the category derived from it. The taxonomy is derivable from
-the name ALONE — we do not tell ``git commit`` from ``ls`` inside ``execute``,
-because that would require reading arguments.
+a custom command — and, for a file-EDIT tool, the repo-relative DESTINATION PATH it
+wrote. It never records a tool's OTHER arguments, the file content or diff, or the
+tool's output. The CATEGORY is derivable from the name ALONE — we do not tell ``git
+commit`` from ``ls`` inside ``execute``, because that would require reading arguments.
 
 Capturing the NAME (a deliberate move from the earlier category-only line) is
 what lets the Receipt answer "which specific tool / connector did the agent

--- a/tests/test_hooks_opencode.py
+++ b/tests/test_hooks_opencode.py
@@ -47,6 +47,39 @@ def test_capture_tool_activity_labels_opencode_client(tmp_path: Path) -> None:
     assert {"name": "bash", "count": 1} in meta["tool_names"]
 
 
+def test_capture_tool_activity_opencode_records_edit_path(tmp_path: Path) -> None:
+    # The plugin forwards an edit's DESTINATION path as ``tool_input`` plus the project
+    # ``cwd``, so the shared extractor relativizes it exactly as it does for Claude Code.
+    event = {
+        "tool_name": "edit",
+        "session_id": "ses_x",
+        "cwd": "/proj",
+        "tool_input": {"filePath": "/proj/src/a.py"},
+    }
+    capture_tool_activity(json.dumps(event), store_dir=tmp_path, client="opencode")
+    meta = drain_tool_activity_spool(tmp_path)[0]["metadata"]
+    assert meta["touched_files"] == ["src/a.py"]
+    assert {"name": "edit", "count": 1} in meta["tool_names"]
+
+
+def test_capture_tool_activity_opencode_drops_non_edit_carried_path(tmp_path: Path) -> None:
+    # Defense in depth: even if a non-edit tool's path reached the CLI, the shared
+    # extractor gates on CATEGORY, so a ``read`` carrying a filePath records no touched
+    # file. (The plugin also gates in JS, so this payload should not arrive — but the
+    # CLI must drop it regardless, and this exercises a non-edit tool that DOES carry a
+    # path rather than a bash tick that carries none.)
+    event = {
+        "tool_name": "read",
+        "session_id": "ses_x",
+        "cwd": "/proj",
+        "tool_input": {"filePath": "/proj/src/secret.py"},
+    }
+    capture_tool_activity(json.dumps(event), store_dir=tmp_path, client="opencode")
+    meta = drain_tool_activity_spool(tmp_path)[0]["metadata"]
+    assert "touched_files" not in meta
+    assert {"name": "read", "count": 1} in meta["tool_names"]
+
+
 def test_tool_activity_subcommand_spools_tick(tmp_path: Path) -> None:
     result = CliRunner().invoke(
         app,
@@ -93,6 +126,64 @@ def test_render_opencode_plugin_shape() -> None:
     # fire-and-forget: it must not await the spawned CLI (never add tool-call latency)
     assert "await Bun.spawn" not in src
     assert "Bun.spawn" in src
+
+
+def test_render_opencode_plugin_forwards_edit_path() -> None:
+    src = render_opencode_plugin("/abs/agentacct", store_dir="/store/x")
+    # OpenCode puts a tool's args in the SECOND before-hook param (``output.args``);
+    # the plugin reads the edit destination from there and forwards it + the cwd.
+    assert "output.args" in src
+    assert "editTargetPath" in src and '"filePath"' in src
+    # the path is forwarded only for edit-category tools (a read/search target is not)
+    assert "EDIT_TOOLS" in src
+    # cwd comes from the plugin factory's worktree/directory context
+    assert "PROJECT_CWD" in src
+    assert "worktree" in src and "directory" in src
+    # the destination path rides as tool_input (the shared extractor relativizes it)
+    assert "tool_input" in src
+
+
+def test_before_hook_forwards_edit_path_and_drops_content(tmp_path: Path) -> None:
+    # Drive the real generated JS under node. The before-hook must: forward an EDIT
+    # tool's destination path (as tool_input) + the project cwd, never the file content;
+    # forward NOTHING extra for a non-edit tool that CARRIES a path (read); and omit cwd
+    # when the plugin factory received no directory/worktree.
+    if shutil.which("node") is None:
+        pytest.skip("node not available to run the plugin hook")
+    exe = tmp_path / "agentacct"
+    exe.write_text("#!/bin/sh\n", encoding="utf-8")  # a real path so resolveAgentacct() resolves
+    plugin = tmp_path / "p.mjs"
+    plugin.write_text(render_opencode_plugin(str(exe), store_dir=str(tmp_path / "store")), encoding="utf-8")
+    harness = tmp_path / "h.mjs"
+    harness.write_text(
+        "let captured = [];\n"
+        "globalThis.Bun = { which: () => null, spawn: () => ({ stdin: { write: (s) => captured.push(s), end: () => {} }, unref: () => {} }) };\n"
+        "const { AgentacctToolActivity } = await import('./p.mjs');\n"
+        "const h = await AgentacctToolActivity({ directory: '/proj', worktree: '/proj' });\n"
+        "await h['tool.execute.before']({ tool: 'edit', sessionID: 'ses_x' }, { args: { filePath: '/proj/src/a.py', content: 'SECRET' } });\n"
+        "await h['tool.execute.before']({ tool: 'read', sessionID: 'ses_x' }, { args: { filePath: '/proj/src/secret.py' } });\n"
+        "await h['tool.execute.before']({ tool: 'bash', sessionID: 'ses_x' }, { args: { command: 'pytest -q' } });\n"
+        "const hNoCwd = await AgentacctToolActivity();\n"
+        "await hNoCwd['tool.execute.before']({ tool: 'write', sessionID: 'ses_x' }, { args: { filePath: 'rel/b.py' } });\n"
+        "console.log(JSON.stringify(captured.map((s) => JSON.parse(s))));\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(["node", str(harness)], capture_output=True, text=True, cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+    edit_p, read_p, bash_p, nocwd_p = json.loads(result.stdout.strip())
+    # edit tool: destination path + cwd, never the file content sitting beside it
+    assert edit_p["tool_name"] == "edit" and edit_p["session_id"] == "ses_x"
+    assert edit_p["tool_input"] == {"filePath": "/proj/src/a.py"}
+    assert edit_p["cwd"] == "/proj"
+    assert "SECRET" not in result.stdout  # the file content is never forwarded
+    # read tool CARRIES a filePath but is not an edit -> the JS gate forwards no path
+    assert read_p["tool_name"] == "read"
+    assert "tool_input" not in read_p and "cwd" not in read_p
+    # bash: no path key at all
+    assert "tool_input" not in bash_p
+    # no factory cwd -> path still forwarded (relativized later), but cwd omitted
+    assert nocwd_p["tool_input"] == {"filePath": "rel/b.py"}
+    assert "cwd" not in nocwd_p
 
 
 def test_render_opencode_plugin_no_store_binding() -> None:


### PR DESCRIPTION
## What

The OpenCode capture plugin now records the destination path of each file edit, feeding the Receipt's Actions "touched files" for OpenCode sessions the same way the Claude Code and Codex paths already do.

## Why

Previously the plugin's `tool.execute.before` hook forwarded only the tool name and session id, so an OpenCode session's Actions dimension showed which tools were used but never which files were edited — leaving OpenCode receipts short of the touched-files coverage the other agents have.

## How

- The hook reads the edit destination from its second argument (`output.args`, where OpenCode passes tool arguments) and forwards it as `tool_input` plus the project `cwd` (from the plugin factory's `worktree`/`directory` context). The existing `capture_tool_activity` extractor relativizes it to a repo-relative path — no Python change needed.
- The path is forwarded only for edit-category tools, and only the destination path travels — never the file content, the diff, or any other argument. The CLI's category gate is a second, independent check.
- Corrects the `tool_activity` module docstring, which still described capture as name-and-category-only after edit-path capture landed.

## Tests

- Python: an OpenCode edit event records the relativized touched path; a non-edit tool carrying a path records none.
- Node (runs the generated plugin under `node`): the before-hook forwards an edit's path + cwd and never the content, forwards nothing for a non-edit tool that carries a path, and omits cwd when the factory received no directory/worktree.

Full suite: 3187 passed, 1 skipped.
