### PR TITLE
feat(hooks): capture out-of-tree file edits in the Receipt Actions dimension

### DIFF
--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -480,14 +480,89 @@ def capture_claude_code_client_context(raw: str, *, store_dir: Path | str | None
 _EDIT_PATH_KEYS = ("file_path", "notebook_path", "filePath", "path", "target_file", "file")
 
 
-def _edit_target_relpath(event: Mapping[str, Any], category: str) -> str | None:
-    """The repo-relative path a file-EDIT tool wrote, or ``None``.
+def _clean_touched_rel(rel: str) -> str | None:
+    """POSIX-normalize a relative touched path; drop it if it is somehow STILL
+    absolute — an absolute prefix (home dir, username) must never reach the store. A
+    leading ``/`` OR ``\\`` (a Windows drive-relative absolute ``os.path`` misses on
+    POSIX) is treated as absolute; the tick's _normalize_touched_path re-checks this."""
+    rel = rel.replace(os.sep, "/")
+    if rel.startswith(("/", "\\")):
+        return None
+    return rel
 
-    Reads ONLY the destination path from ``tool_input`` for an ``edit``-category
-    tool and relativizes it to the session ``cwd``, so nothing outside the working
-    tree — and no absolute prefix, home dir, or username — is ever captured. Never
-    reads the file content, the edit/diff, or any other argument. A path that
-    escapes the cwd (``../``) or cannot be relativized is dropped."""
+
+def _path_is_under(path: str, base: str) -> bool:
+    """True if ``path`` is at or under ``base`` (both absolute, normalized). Uses
+    ``commonpath`` so ``/home/bob-evil`` is NOT mistaken for under ``/home/bob``."""
+    try:
+        return os.path.commonpath([path, base]) == base
+    except (ValueError, OSError):
+        return False
+
+
+# Well-known parents of user home directories. When the home dir is UNKNOWN we cannot
+# detect a home boundary, so a cwd-relative descent from one of these (or from the
+# filesystem root, the parent of ``/root`` etc.) can retain a ``/Users/<user>/`` or
+# ``/home/<user>/`` segment. A normal project dir (``/app``, ``/workspace``, ``/srv``)
+# is NOT one, so its in-tree edits are still captured under a degenerate HOME.
+_HOME_PARENT_DIRS = frozenset({"/Users", "/home"})
+
+
+def _cwd_may_hide_home(path: str) -> bool:
+    """True if a cwd-relative descent from ``path`` could retain a home dir / username
+    when the home dir is UNKNOWN — i.e. ``path`` is the filesystem ROOT or a well-known
+    parent of user homes (``/Users``, ``/home``). A normal project cwd returns False so
+    its in-tree edits stay captured under a degenerate HOME (containerized CI)."""
+    if os.path.dirname(path) == path:  # the filesystem root — parent of every home
+        return True
+    return path in _HOME_PARENT_DIRS
+
+
+def _user_home_abs() -> str | None:
+    """The user's home directory as an absolute, normalized path — or ``None`` when it
+    cannot be determined SAFELY. Reads ``$HOME`` (with ``expanduser``'s passwd-database
+    fallback); it never stats a path, so the hook stays fast and side-effect free.
+
+    Returns ``None`` for a home that is unusable as a privacy boundary: unset /
+    unresolvable (``expanduser`` returns ``~``), relative, or the filesystem ROOT
+    (``/`` — what ``expanduser`` yields for ``HOME=""`` or ``HOME="/"``, common in
+    root/daemon/container contexts). A root "home" is not a boundary — EVERY absolute
+    path is "under" it, so treating it as home would tag every edit ``~/…`` and
+    re-embed the username. A ``None`` home makes the caller DROP out-of-tree edits
+    rather than risk a leak."""
+    try:
+        home = os.path.expanduser("~")
+    except Exception:  # noqa: BLE001
+        return None
+    if not home or home == "~" or not os.path.isabs(home):
+        return None
+    home = os.path.normpath(home)
+    if os.path.dirname(home) == home:  # the filesystem root is its own parent — not a home
+        return None
+    return home
+
+
+def _edit_target_relpath(event: Mapping[str, Any], category: str) -> str | None:
+    """The path a file-EDIT tool wrote, relative and free of any home dir/username, or ``None``.
+
+    Reads ONLY the destination path from ``tool_input`` for an ``edit``-category tool
+    and represents it in the LEAST-revealing form that still identifies the file:
+      * under the session ``cwd`` (and cwd not above home) -> a clean cwd-relative path
+        (``src/foo.py``);
+      * under the user's HOME -> a ``~``-relative path (``~/.claude/x``) that names a
+        home-file edit WITHOUT the home dir or username. This form WINS over the
+        cwd-relative one whenever cwd sits AT OR ABOVE home (a daemon/container cwd of
+        ``/`` or ``/Users``), where the cwd-relative form would re-descend through
+        ``/Users/<username>/`` and embed the username;
+      * else (out-of-tree, non-home) -> a cwd-relative ``../`` path (``../sib/x.py``),
+        emitted only when the home dir is KNOWN. When home cannot be determined
+        (unset/root/relative HOME) an out-of-tree edit is DROPPED rather than risk a leak.
+    An absolute prefix, the home dir, or the username is NEVER captured. All resolution
+    is pure string math on the LITERAL path — the hook never touches the filesystem, so
+    aliasing it cannot see without I/O (a symlink into home, a non-canonically CASED path
+    on a case-insensitive FS, or a Unicode NFC/NFD variant) may fall through to the
+    ``../`` form; the result is still a relative path, never an absolute prefix. Never
+    reads the file content, the edit/diff, or any other argument."""
     if category != "edit":
         return None
     tool_input = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else None
@@ -503,21 +578,53 @@ def _edit_target_relpath(event: Mapping[str, Any], category: str) -> str | None:
         return None
     cwd = event.get("cwd")
     cwd = cwd.strip() if isinstance(cwd, str) and cwd.strip() else None
+    cwd_abs = os.path.normpath(cwd) if cwd and os.path.isabs(cwd) else None
     try:
+        # Resolve to an absolute target with pure string ops (never touches the fs).
         if os.path.isabs(raw_path):
-            if not cwd:
-                return None  # never store an absolute path we cannot relativize
-            rel = os.path.relpath(raw_path, cwd)
+            target_abs = os.path.normpath(raw_path)
+        elif cwd_abs:
+            target_abs = os.path.normpath(os.path.join(cwd_abs, raw_path))
         else:
-            rel = raw_path
+            # A relative path with no absolute cwd carries no absolute prefix — keep it.
+            return _clean_touched_rel(raw_path)
+        home_abs = _user_home_abs()
+        under_home = home_abs is not None and _path_is_under(target_abs, home_abs)
+        # The cwd-relative form re-descends through the home dir (leaking the username)
+        # exactly when the target is under home AND cwd sits AT OR ABOVE home — e.g. a
+        # daemon/container cwd of "/" or "/Users" editing ~/.claude/x. There the ``~``
+        # form (step 2) must WIN over the cwd-relative form (step 1).
+        cwd_at_or_above_home = (
+            home_abs is not None and cwd_abs is not None and _path_is_under(home_abs, cwd_abs)
+        )
+        # 1. In-tree (under cwd) — with two guards. (a) If cwd is at/above home, step 2's
+        #    ``~`` form is the only leak-free representation of a home target. (b) If home
+        #    is UNKNOWN, a cwd-relative path from a home-PARENT cwd (``/``, ``/Users``,
+        #    ``/home``) can retain a ``/Users/<username>/`` segment — so drop there. A normal
+        #    project cwd (``/app``, ``/workspace``, ``/workspace/repo``) is still captured,
+        #    so the feature is not silently lost in containerized CI with a degenerate HOME.
+        if (
+            cwd_abs
+            and _path_is_under(target_abs, cwd_abs)
+            and not (under_home and cwd_at_or_above_home)
+            and (home_abs is not None or not _cwd_may_hide_home(cwd_abs))
+        ):
+            return _clean_touched_rel(os.path.relpath(target_abs, cwd_abs))
+        # 2. Under the user's HOME: a ``~``-relative path — captures a home-file edit
+        #    WITHOUT the home dir/username, and closes the relpath re-descent leak.
+        if under_home:
+            rel_home = os.path.relpath(target_abs, home_abs)
+            return "~" if rel_home == "." else _clean_touched_rel(os.path.join("~", rel_home))
+        # 3. Out-of-tree, non-home: a cwd-relative ``../`` path. Emit it ONLY when the
+        #    home dir is KNOWN — step 2 has then proven the target is not under home, so
+        #    the relpath cannot re-descend through ``/Users/<username>/``. If home is
+        #    UNKNOWN we cannot rule out that re-descent, so we DROP rather than risk
+        #    embedding the username (in-tree step-1 edits, which need no home, are unaffected).
+        if cwd_abs and home_abs is not None:
+            return _clean_touched_rel(os.path.relpath(target_abs, cwd_abs))
+        return None
     except (ValueError, OSError):
         return None
-    rel = rel.replace(os.sep, "/")
-    # Drop anything that escapes the working tree or is still absolute — the tick's
-    # _normalize_touched_path re-checks this, but never emit it in the first place.
-    if rel.startswith("/") or rel.split("/", 1)[0] == "..":
-        return None
-    return rel
 
 
 def capture_tool_activity(
@@ -528,8 +635,9 @@ def capture_tool_activity(
     The PreToolUse hook already receives the tool name (and fails open), so this
     is the cheapest honest place to observe what the agent reached for. The
     category AND the tool NAME are spooled — never arguments or any payload — plus,
-    for a file-EDIT tool, the repo-relative DESTINATION path (see
-    ``_edit_target_relpath``: relativized to cwd, never content/args) so the
+    for a file-EDIT tool, the cwd-relative destination path (see
+    ``_edit_target_relpath``: relativized to cwd — or ``~/…`` for a home file — never
+    an absolute prefix/home dir/username, never content/args) so the
     Receipt's Actions dimension can show which artifacts were touched. The spool
     lands in the SAME store as the client-context bridge so the usage importer
     drains both from one place.

--- a/src/agentacct/task_projection.py
+++ b/src/agentacct/task_projection.py
@@ -974,9 +974,10 @@ def build_task_projection(
         supporting_keys = member_keys - root_keys
         # Actions dimension: which KINDS of tools ran (hook-captured category
         # counts), which SPECIFIC tools/connectors (hook-captured tool names), and
-        # which repo-relative artifacts were touched (union of every step's
-        # files) — each summed over the Task's sessions. All are pure aggregates
-        # of already-recorded data; tool NAMES are captured, arguments never are.
+        # which artifacts were touched (union of every step's files — each path
+        # relative: cwd-relative, or ``~/…``/``../`` for a home/out-of-tree edit)
+        # — each summed over the Task's sessions. All are pure aggregates of
+        # already-recorded data; tool NAMES are captured, arguments never are.
         tool_category_counts: dict[str, int] = {}
         tool_name_counts: dict[str, int] = {}
         for key in ordered_members:
@@ -996,9 +997,10 @@ def build_task_projection(
                             tool_name_counts[label] = tool_name_counts.get(label, 0) + value
         touched_files: list[str] = []
         seen_touched_files: set[str] = set()
-        # (a) agent-reported section/check files, and (b) the repo-relative paths a
-        # file-edit tool wrote (hook-captured, per session) — either source alone
-        # routinely misses files the other has. Both are already repo-relative-safe.
+        # (a) agent-reported section/check files, and (b) the paths a file-edit tool
+        # wrote (hook-captured, per session; cwd-relative, or ``~/…``/``../`` for a
+        # home/out-of-tree edit) — either source alone routinely misses files the
+        # other has. Both are already relative, free of any absolute prefix.
         touched_sources: list[Any] = [
             item.get("files") if isinstance(item.get("files"), list) else [] for item in task_work
         ]

--- a/src/agentacct/tool_activity.py
+++ b/src/agentacct/tool_activity.py
@@ -127,9 +127,11 @@ def _normalize_touched_path(path: Any) -> str | None:
 
     The CALLER (the hook) already relativizes the edited file to the session cwd;
     this is the belt-and-suspenders gate that GUARANTEES the store never holds an
-    absolute path, a Windows drive/UNC path, a ``..`` escape, or an over-long
-    string — so even a buggy caller can never leak an absolute prefix (home dir,
-    username). Blank / unsafe -> ``None`` (nothing recorded)."""
+    absolute path, a Windows drive/UNC path, or an over-long string — so even a buggy
+    caller can never leak an absolute prefix (home dir, username). A ``..`` escape and
+    a ``~/`` home path are KEPT: the hook writes an out-of-tree edit as a ``../``-relative
+    path and a home-file edit as ``~/…`` (no username), and neither carries an absolute
+    prefix. Blank / unsafe -> ``None``."""
 
     text = str(path or "").strip()
     if not text or "\x00" in text:
@@ -143,8 +145,10 @@ def _normalize_touched_path(path: Any) -> str | None:
     if text.startswith(("\\", "/")):  # single/UNC backslash, or / and //
         return None
     normalized = text.replace("\\", "/")
+    # ``..`` segments are kept (an out-of-tree edit is a legitimate ``../`` path); the
+    # absolute/drive/UNC guards above already blocked every absolute-prefix leak.
     parts = [part for part in normalized.split("/") if part not in {"", "."}]
-    if not parts or ".." in parts:
+    if not parts:
         return None
     return "/".join(parts)[:_TOUCHED_PATH_MAX]
 
@@ -167,11 +171,11 @@ def record_tool_activity_tick(
 
     Writes the small scalars ``{c, s, k, t}`` — client, session id, category, and
     a timestamp — plus ``n``, the tool NAME, when one is given, and ``p``, the
-    repo-relative path a file-EDIT tool wrote, when the caller extracted one (the
+    cwd-relative path a file-EDIT tool wrote, when the caller extracted one (the
     Actions dimension's "which artifacts were touched" — the caller relativizes it
-    to the session cwd and drops anything outside, so no absolute prefix, home dir,
-    or username is ever stored; arguments, content and output are still never
-    recorded). The line is a single tiny JSON object written with ``O_APPEND`` so
+    to the session cwd, keeping an out-of-tree edit as a ``../`` path, so no absolute
+    prefix, home dir, or username is ever stored; arguments, content and output are
+    still never recorded). The line is a single tiny JSON object written with ``O_APPEND`` so
     concurrent hook processes (many tool calls in flight) never corrupt or
     interleave lines.
     """
@@ -444,12 +448,15 @@ def build_touched_files_by_session(
     """Collect ``tool_activity_observed`` touched-file paths per (client, session).
 
     Mirrors ``build_tool_names_by_session``: reads each event's ``touched_files``
-    list (repo-relative paths a file-edit tool wrote). Batches are additive and the
+    list (cwd-relative paths a file-edit tool wrote, or ``~/…`` for a home file).
+    Batches are additive and the
     union is deduped (insertion-ordered) across imports. A session recorded before
     path capture shipped simply has none — an honest gap, never a fabricated entry.
     Every path is re-run through ``_normalize_touched_path`` here (the third gate,
-    after the tick and the drain), which is safety-equivalent to the projection's
-    ``_safe_relative_posix_path`` — both reject any absolute/drive/UNC/``..``/NUL path.
+    after the tick and the drain): it rejects any absolute/drive/UNC/NUL path (never an
+    absolute prefix), but KEEPS a ``../`` escape so an out-of-tree edit survives — the
+    projection's ``_safe_relative_posix_path`` is stricter and drops ``..`` (it guards a
+    different, section-reported input).
     """
 
     result: dict[tuple[str, str], list[str]] = {}

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -225,9 +225,12 @@ def build_work_ledger(
             names = tool_names_by_session.get(entry_key)
             if names:
                 entry["tool_name_counts"] = dict(names)
-            # Repo-relative paths a file-edit tool wrote (hook-captured). Each was
-            # already gated by _normalize_touched_path at the tick, the drain, and
-            # build_touched_files_by_session (safety-equivalent to _safe_relative_posix_path).
+            # Paths a file-edit tool wrote (hook-captured), cwd-relative — an out-of-tree
+            # edit rides as ``../`` and a home-file edit as ``~/…`` (no username). Each was
+            # gated by _normalize_touched_path at the tick, the drain, and
+            # build_touched_files_by_session (which blocks every absolute-prefix leak;
+            # unlike _safe_relative_posix_path it additionally keeps a ``..`` escape —
+            # both keep a ``~`` home segment).
             touched = touched_files_by_session.get(entry_key)
             if touched:
                 entry["touched_files"] = list(touched)

--- a/tests/test_touched_files.py
+++ b/tests/test_touched_files.py
@@ -1,19 +1,26 @@
 """Hook-captured touched files (Actions dimension).
 
-A file-EDIT tool's destination path is captured by the tool-activity hook,
-relativized to the session cwd (never an absolute prefix, home dir, or username,
-never the content/diff/args), spooled, drained onto the tool_activity_observed
-event, aggregated per session, and unioned into the Task's Actions touched files
-alongside the agent-reported MCP section/check files.
+A file-EDIT tool's destination path is captured by the tool-activity hook and
+represented in its least-revealing relative form — under the cwd it is cwd-relative
+(``src/foo.py``); a file under the user's HOME is ``~``-relative (``~/.claude/x``, no
+username); anything else out-of-tree is a cwd-relative ``../`` path. An absolute
+prefix, the home dir, and the username are NEVER stored (never the content/diff/args
+either). The path is spooled, drained onto the tool_activity_observed event,
+aggregated per session, and unioned into the Task's Actions touched files alongside
+the agent-reported MCP section/check files.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+import agentacct.hooks as hooks
 from agentacct.hooks import _edit_target_relpath, capture_tool_activity
 from agentacct.task_projection import build_task_projection
 from agentacct.tool_activity import (
@@ -22,6 +29,20 @@ from agentacct.tool_activity import (
     drain_tool_activity_spool,
     record_tool_activity_tick,
 )
+
+# The real _user_home_abs, captured before the autouse fixture below patches the module
+# attribute — so a test can exercise the genuine HOME-resolution guard.
+_REAL_USER_HOME_ABS = hooks._user_home_abs
+
+
+@pytest.fixture(autouse=True)
+def _fixed_home(monkeypatch: pytest.MonkeyPatch) -> str:
+    # Pin the user's home so relativization is deterministic regardless of the runner's
+    # real home (otherwise a runner whose home contained a test path would reclassify
+    # it, e.g. a /Users/u/... target under a /Users/u home). Disjoint from the
+    # /Users/u paths used by the out-of-tree cases below.
+    monkeypatch.setattr(hooks, "_user_home_abs", lambda: "/Users/owner")
+    return "/Users/owner"
 
 
 def _edit_event(file_path: str, *, cwd: str = "/Users/u/repo", tool: str = "Edit") -> dict[str, Any]:
@@ -39,7 +60,7 @@ def _edit_event(file_path: str, *, cwd: str = "/Users/u/repo", tool: str = "Edit
 # ---------------------------------------------------------------------------
 
 
-def test_relpath_relativizes_absolute_path_under_cwd() -> None:
+def test_relpath_in_tree_is_cwd_relative() -> None:
     assert _edit_target_relpath(_edit_event("/Users/u/repo/src/foo.py"), "edit") == "src/foo.py"
 
 
@@ -47,15 +68,108 @@ def test_relpath_keeps_already_relative_path() -> None:
     assert _edit_target_relpath(_edit_event("src/bar.py"), "edit") == "src/bar.py"
 
 
-def test_relpath_drops_path_outside_cwd() -> None:
-    # A path outside the working tree relativizes to ../ and is dropped — never leaks
-    # /etc/passwd or a sibling repo.
-    assert _edit_target_relpath(_edit_event("/etc/passwd"), "edit") is None
+def test_relpath_out_of_tree_non_home_is_dotdot() -> None:
+    # A file edited OUTSIDE the tree and NOT under home rides as a ``../`` path (Actions
+    # spans out-of-tree edits) — the absolute prefix never survives.
+    assert _edit_target_relpath(_edit_event("/etc/passwd"), "edit") == "../../../etc/passwd"
+    assert _edit_target_relpath(_edit_event("/srv/data/x.py", cwd="/opt/app"), "edit") == "../../srv/data/x.py"
 
 
-def test_relpath_drops_absolute_without_cwd() -> None:
+def test_relpath_home_file_is_tilde_relative() -> None:
+    # A file under the user's HOME is ``~``-relative — captured WITHOUT the username,
+    # whether the cwd is under home (../ would strip it) or a sibling of it.
+    assert (
+        _edit_target_relpath(_edit_event("/Users/owner/.claude/settings.json", cwd="/Users/owner/repo"), "edit")
+        == "~/.claude/settings.json"
+    )
+    assert _edit_target_relpath(_edit_event("/Users/owner/other/x.py", cwd="/Users/owner/repo"), "edit") == "~/other/x.py"
+
+
+def test_relpath_out_of_home_cwd_home_file_never_leaks_username() -> None:
+    # THE RE-DESCENT LEAK CASE: cwd OUTSIDE home editing a home file. A plain
+    # os.path.relpath would climb above home and back down through /Users/owner/...,
+    # embedding the username as ordinary relative segments; the ``~`` form does not.
+    got = _edit_target_relpath(_edit_event("/Users/owner/.claude/settings.json", cwd="/private/tmp/build"), "edit")
+    assert got == "~/.claude/settings.json"
+    assert "owner" not in got
+
+
+def test_relpath_cwd_at_or_above_home_uses_tilde_no_username() -> None:
+    # cwd AT or ABOVE home (a daemon/container cwd of "/" or "/Users") editing a home
+    # file: the cwd-relative form would descend through /Users/owner/ and store the
+    # username, so the ``~`` form must win. HOME is pinned to /Users/owner by the fixture.
+    assert (
+        _edit_target_relpath(_edit_event("/Users/owner/.claude/settings.json", cwd="/"), "edit")
+        == "~/.claude/settings.json"
+    )
+    assert _edit_target_relpath(_edit_event("/Users/owner/.ssh/id_rsa", cwd="/Users"), "edit") == "~/.ssh/id_rsa"
+    # a NON-home file from cwd="/" is still a safe cwd-relative path (no username).
+    assert _edit_target_relpath(_edit_event("/etc/hosts", cwd="/"), "edit") == "etc/hosts"
+
+
+def test_relpath_absolute_home_without_cwd_is_tilde() -> None:
+    # An absolute home path with no cwd is still safe to capture as ``~/…`` (no username).
+    ev = {"tool_name": "Edit", "tool_input": {"file_path": "/Users/owner/.zshrc"}}
+    assert _edit_target_relpath(ev, "edit") == "~/.zshrc"
+
+
+def test_relpath_drops_absolute_without_cwd_not_under_home() -> None:
+    # An absolute path we cannot relativize (no cwd) and NOT under home is dropped —
+    # an absolute prefix is never stored.
     ev = {"tool_name": "Edit", "tool_input": {"file_path": "/x/y.py"}}
     assert _edit_target_relpath(ev, "edit") is None
+
+
+def test_user_home_abs_rejects_degenerate_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A home that is unset/unresolvable ("~"), relative, or the filesystem ROOT ("/",
+    # what expanduser yields for HOME="" or HOME="/") is not a usable privacy boundary
+    # and must resolve to None (so the caller drops rather than leaks).
+    for raw in ("/", "", "~", "relative/home"):
+        monkeypatch.setattr(os.path, "expanduser", lambda p, _r=raw: _r if p == "~" else p)
+        assert _REAL_USER_HOME_ABS() is None, f"expected None for expanduser->{raw!r}"
+    monkeypatch.setattr(os.path, "expanduser", lambda p: "/Users/owner" if p == "~" else p)
+    assert _REAL_USER_HOME_ABS() == "/Users/owner"
+
+
+def test_cwd_may_hide_home() -> None:
+    # The filesystem root and well-known home parents can hide a home when HOME is
+    # unknown; a normal project dir (even at depth 1) cannot.
+    assert hooks._cwd_may_hide_home("/") is True
+    assert hooks._cwd_may_hide_home("/Users") is True
+    assert hooks._cwd_may_hide_home("/home") is True
+    assert hooks._cwd_may_hide_home("/app") is False
+    assert hooks._cwd_may_hide_home("/workspace") is False
+    assert hooks._cwd_may_hide_home("/Users/owner") is False
+
+
+def test_relpath_drops_out_of_tree_when_home_undetectable(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When home cannot be determined safely (_user_home_abs -> None, e.g. a degenerate
+    # HOME of "/" or an unresolvable/relative HOME), an out-of-tree edit is DROPPED —
+    # step 3 must not emit a ``../`` path that could re-descend through /Users/<user>/
+    # (nor a ``~/Users/<user>/`` path from a root home). In-tree edits are unaffected.
+    monkeypatch.setattr(hooks, "_user_home_abs", lambda: None)
+    assert _edit_target_relpath(_edit_event("/Users/owner/.claude/x", cwd="/private/tmp/build"), "edit") is None
+    assert _edit_target_relpath(_edit_event("/etc/hosts", cwd="/opt/app"), "edit") is None
+    # in-tree still works with no resolvable home (a DEEP, non-shallow cwd)
+    assert _edit_target_relpath(_edit_event("/Users/u/repo/src/a.py"), "edit") == "src/a.py"
+
+
+def test_relpath_home_parent_cwd_dropped_but_project_cwd_kept_when_home_undetectable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # With home UNKNOWN, an in-tree edit from a home-PARENT cwd ("/", "/Users", "/home")
+    # is DROPPED (its cwd-relative form would retain /Users/<user>/). A normal project
+    # cwd ("/app", "/workspace") — even at depth 1 — still captures in-tree edits, so the
+    # feature is not silently lost in containerized CI (Cloud Build/Tekton /workspace,
+    # Docker WORKDIR /app) that also has a degenerate HOME.
+    monkeypatch.setattr(hooks, "_user_home_abs", lambda: None)
+    assert _edit_target_relpath(_edit_event("/Users/owner/repo/src/a.py", cwd="/"), "edit") is None
+    assert _edit_target_relpath(_edit_event("/Users/owner/.ssh/id_rsa", cwd="/Users"), "edit") is None
+    assert _edit_target_relpath(_edit_event("/home/u/proj/x.py", cwd="/home"), "edit") is None
+    assert _edit_target_relpath(_edit_event("/app/src/main.py", cwd="/app"), "edit") == "src/main.py"
+    assert _edit_target_relpath(_edit_event("/workspace/src/main.py", cwd="/workspace"), "edit") == "src/main.py"
+    # a deep project cwd also still captures
+    assert _edit_target_relpath(_edit_event("/workspace/repo/src/a.py", cwd="/workspace/repo"), "edit") == "src/a.py"
 
 
 def test_relpath_only_for_edit_category() -> None:
@@ -77,13 +191,20 @@ def test_relpath_reads_notebook_path_key() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_normalize_rejects_absolute_and_escape_and_drive() -> None:
+def test_normalize_rejects_absolute_and_drive() -> None:
     assert _normalize_touched_path("/etc/passwd") is None
-    assert _normalize_touched_path("../../secret") is None
     assert _normalize_touched_path("C:\\Users\\x") is None
     assert _normalize_touched_path("\\\\server\\share") is None  # UNC (double backslash)
     assert _normalize_touched_path("\\Users\\bob\\secret\\id_rsa") is None  # single-backslash Windows absolute
     assert _normalize_touched_path("a\x00b") is None
+
+
+def test_normalize_keeps_dotdot_and_tilde() -> None:
+    # A ``../`` escape and a ``~/…`` home path carry no absolute prefix, so both are
+    # KEPT (only absolute/drive/UNC paths are rejected).
+    assert _normalize_touched_path("../../other/file.py") == "../../other/file.py"
+    assert _normalize_touched_path("./../sib/x.py") == "../sib/x.py"
+    assert _normalize_touched_path("~/.claude/settings.json") == "~/.claude/settings.json"
 
 
 def test_capture_drops_windows_drive_relative_absolute_end_to_end() -> None:
@@ -126,6 +247,29 @@ def test_capture_records_edit_paths_deduped_edit_tools_only() -> None:
     assert len(events) == 1
     md = events[0]["metadata"]
     assert md["touched_files"] == ["src/auth/login.py", "README.md"]  # deduped, edit tools only, cwd-relative
+
+
+def test_capture_records_out_of_tree_edit_as_relative() -> None:
+    # An absolute edit OUTSIDE the cwd (and not under home) is captured as a ``../``
+    # relative touched path — the out-of-repo file is no longer silently dropped.
+    store = _store()
+    capture_tool_activity(json.dumps(_edit_event("/Users/u/other-project/mod.py")), store_dir=store, client="claude-code")
+    md = drain_tool_activity_spool(store)[0]["metadata"]
+    assert md["touched_files"] == ["../other-project/mod.py"]
+
+
+def test_capture_records_home_edit_as_tilde_no_username() -> None:
+    # End-to-end: an out-of-home cwd editing a HOME file stores ``~/…`` — the username
+    # never lands in the spooled touched path (the re-descent leak is closed).
+    store = _store()
+    capture_tool_activity(
+        json.dumps(_edit_event("/Users/owner/.claude/settings.json", cwd="/private/tmp/build")),
+        store_dir=store,
+        client="claude-code",
+    )
+    md = drain_tool_activity_spool(store)[0]["metadata"]
+    assert md["touched_files"] == ["~/.claude/settings.json"]
+    assert not any("owner" in path for path in md["touched_files"])
 
 
 def test_pipeline_never_stores_absolute_even_from_a_buggy_tick() -> None:
@@ -171,6 +315,16 @@ def test_projection_unions_session_touched_files_into_actions() -> None:
     projection = build_task_projection([_session_with_touched(["src/edited_by_hook.py"])], [])
     task = projection["tasks"][0]
     assert "src/edited_by_hook.py" in task["actions"]["touched_files"]
+
+
+def test_projection_binds_out_of_tree_and_home_paths_into_actions() -> None:
+    # A ``../`` out-of-tree path and a ``~/…`` home path flow UNCHANGED from the hook
+    # into the Actions dimension — no downstream gate drops them (the projection unions
+    # session touched files without re-normalizing).
+    projection = build_task_projection([_session_with_touched(["../sibling/mod.py", "~/.claude/x"])], [])
+    touched = projection["tasks"][0]["actions"]["touched_files"]
+    assert "../sibling/mod.py" in touched
+    assert "~/.claude/x" in touched
 
 
 def test_projection_unions_hook_and_section_files() -> None:


### PR DESCRIPTION
## What

A file edited **outside** the session's working tree is now recorded in the Receipt's Actions "touched files". Previously the hook relativized the destination path to the cwd and dropped anything that escaped it, so an agent that edited a sibling project, a parent-directory config, or a file under the user's home left no trace of those artifacts.

## How

`_edit_target_relpath` represents an edit in the least-revealing relative form that still identifies the file:

- under the session cwd → a cwd-relative path (`src/foo.py`)
- under the user's home → a `~`-relative path (`~/.claude/x`) that names the file **without the home directory or username**
- else out-of-tree → a cwd-relative `../` path (`../sib/x.py`)

An absolute prefix, the home directory, and the username are never stored. Resolution is pure string math — the hook never touches the filesystem.

## Safety

The touched-path invariant is that the store never holds an absolute path, the home directory, or the username. Two degenerate boundaries are handled so the `../` and cwd-relative forms cannot re-embed a username:

- **Unknown home** (an unset, root `/`, or relative `HOME`, e.g. a daemon/container): `_user_home_abs()` returns `None`, and an out-of-tree edit is dropped rather than relativized through an undetectable home boundary.
- **Home-parent cwd** (`/`, `/Users`, `/home`): with an unknown home, an in-tree cwd-relative path from one of these would retain a `/Users/<user>/` segment, so it is dropped. A normal project cwd (`/app`, `/workspace`, …) still captures in-tree edits, so the feature is not lost in containerized CI.
- When cwd sits **at or above** home, the `~` form wins over the cwd-relative one (the cwd-relative form would re-descend through `/Users/<user>/`).

Path aliasing the hook cannot resolve without filesystem I/O (a symlink into home, a non-canonically cased path on a case-insensitive FS, or a Unicode NFC/NFD variant) falls through to the `../` form; the result is still relative, never an absolute prefix.

The tick/drain gate (`_normalize_touched_path`) keeps `../` and `~` relative segments while still rejecting any absolute/drive/UNC/NUL path. The projection's `_safe_relative_posix_path` (which guards the separate agent-reported section/check files) is unchanged.

## Tests

Deterministic coverage (home pinned via a fixture) for: in-tree, home-file (`~/…`) from an in-home and an out-of-home cwd, out-of-tree (`../`), cwd at/above home, degenerate-HOME drop, home-parent-cwd drop vs project-cwd capture, and the three absolute-rejection safety cases. An exhaustive 792-combination probe (6 HOME values × 11 cwds × 12 targets) stores no absolute prefix and no owner username.

Full suite: 3195 passed, 1 skipped.
