### PR TITLE
feat(actions): capture the commands an execute tool ran in the Receipt Actions dimension

### DIFF
--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -259,6 +259,22 @@ struct ReceiptCards: View {
                 }
                 .padding(.leading, 82)  // align under the summary column (74 label + 8 spacing)
             }
+            let commands = actionsCommandsPreview
+            if !commands.shown.isEmpty {
+                VStack(alignment: .leading, spacing: 1) {
+                    ForEach(commands.shown, id: \.self) { cmd in
+                        // verbatim: a command is untrusted text — never interpret it as
+                        // markdown (Text's default LocalizedStringKey init would).
+                        Text(verbatim: "$ \(cmd)").font(.caption).foregroundStyle(Theme.textFaint)
+                            .lineLimit(1).truncationMode(.middle)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    if commands.elided > 0 {
+                        Text("… +\(commands.elided) more").font(.caption).foregroundStyle(Theme.textFaint)
+                    }
+                }
+                .padding(.leading, 82)  // align the commands under the summary column
+            }
         }
     }
 
@@ -271,6 +287,16 @@ struct ReceiptCards: View {
             return (preview, dim.touchedFilesElided ?? 0)
         }
         return (dim.touchedFiles ?? [], 0)
+    }
+
+    // Same daemon-capped preview + disclosed overflow for the commands an execute tool
+    // ran (fallback to the full list for an older payload without the preview fields).
+    private var actionsCommandsPreview: (shown: [String], elided: Int) {
+        let dim = receipt.dimensions.actions
+        if let preview = dim.commandsPreview {
+            return (preview, dim.commandsElided ?? 0)
+        }
+        return (dim.commands ?? [], 0)
     }
 
     @ViewBuilder
@@ -339,6 +365,9 @@ struct ReceiptCards: View {
             ? "not instrumented"
             : counts.sorted { $0.key < $1.key }.map { "\($0.key)×\($0.value)" }.joined(separator: " ")
         var summary = "\(categories) · touched \(dim.touchedFileCount ?? 0) file(s)"
+        if let commandCount = dim.commandCount, commandCount > 0 {
+            summary += " · ran \(commandCount) command(s)"
+        }
         // The specific tools/connectors the agent used (daemon-ranked), with the
         // disclosed overflow — surfaced beneath the coarse category counts.
         if let preview = dim.toolNamesPreview, !preview.isEmpty {

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -711,6 +711,12 @@ struct ReceiptActionsDim: Decodable {
     // them still decodes (the app then falls back to slicing touchedFiles).
     let touchedFilesPreview: [String]?
     let touchedFilesElided: Int?
+    // The commands an execute tool ran (daemon-capped preview + disclosed overflow;
+    // single-line, credential-scrubbed). Optional so an older payload still decodes.
+    let commands: [String]?
+    let commandCount: Int?
+    let commandsPreview: [String]?
+    let commandsElided: Int?
     // The specific tools the agent used (daemon-ranked, most-used first) + the
     // disclosed overflow. Optional so an older payload without them still decodes.
     let toolNamesPreview: [ReceiptToolName]?
@@ -725,6 +731,10 @@ struct ReceiptActionsDim: Decodable {
         case touchedFileCount = "touched_file_count"
         case touchedFilesPreview = "touched_files_preview"
         case touchedFilesElided = "touched_files_elided"
+        case commands
+        case commandCount = "command_count"
+        case commandsPreview = "commands_preview"
+        case commandsElided = "commands_elided"
         case toolNamesPreview = "tool_names_preview"
         case toolNamesElided = "tool_names_elided"
         case provenance, gaps

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -10483,6 +10483,9 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
     actions = dims.get("actions", {})
     actions_summary = _receipt_category_text(actions.get("tool_category_counts") or {})
     actions_summary += f"  · touched {int(actions.get('touched_file_count') or 0)} file(s)"
+    _command_count = int(actions.get("command_count") or 0)
+    if _command_count:
+        actions_summary += f"  · ran {_command_count} command(s)"
     names_preview = actions.get("tool_names_preview") or []
     if names_preview:
         # The SPECIFIC tools/connectors the agent used (most-used first). Names are
@@ -10502,6 +10505,15 @@ def _render_receipt_text(receipt: dict[str, Any]) -> None:
         if elided_files:
             lines += f"\n… +{elided_files} more"
         actions_summary += f"\n[dim]{_rich_escape(lines)}[/dim]"
+    shown_commands = actions.get("commands_preview") or []
+    elided_commands = int(actions.get("commands_elided") or 0)
+    if shown_commands:
+        # The actual commands the agent ran (single-line, credential-scrubbed), not just
+        # the count. The daemon capped the slice and disclosed the overflow.
+        cmd_lines = "\n".join(f"$ {cmd}" for cmd in shown_commands)
+        if elided_commands:
+            cmd_lines += f"\n… +{elided_commands} more"
+        actions_summary += f"\n[dim]{_rich_escape(cmd_lines)}[/dim]"
     table.add_row("Actions", actions_summary, ", ".join(actions.get("provenance") or []))
 
     cost = dims.get("cost", {})

--- a/src/agentacct/hooks.py
+++ b/src/agentacct/hooks.py
@@ -520,19 +520,36 @@ def _edit_target_relpath(event: Mapping[str, Any], category: str) -> str | None:
     return rel
 
 
+def _execute_command(event: Mapping[str, Any], category: str) -> str | None:
+    """The raw command an EXECUTE-category tool ran, or ``None``.
+
+    Reads ONLY the ``command`` arg from ``tool_input`` (a Bash/shell tool), never any
+    other argument or the output. The raw command is returned as-is; the tick's
+    ``_normalize_command`` single-lines it, best-effort scrubs obvious credential values,
+    and bounds its length before it is ever stored."""
+    if category != "execute":
+        return None
+    tool_input = event.get("tool_input") if isinstance(event.get("tool_input"), dict) else None
+    if not tool_input:
+        return None
+    command = tool_input.get("command")
+    return command if isinstance(command, str) and command.strip() else None
+
+
 def capture_tool_activity(
     raw: str, *, store_dir: Path | str | None = None, client: str = "claude-code"
 ) -> None:
     """Record ONE tool-activity tick for this PreToolUse. Never raises.
 
     The PreToolUse hook already receives the tool name (and fails open), so this
-    is the cheapest honest place to observe what the agent reached for. The
-    category AND the tool NAME are spooled — never arguments or any payload — plus,
-    for a file-EDIT tool, the repo-relative DESTINATION path (see
-    ``_edit_target_relpath``: relativized to cwd, never content/args) so the
-    Receipt's Actions dimension can show which artifacts were touched. The spool
-    lands in the SAME store as the client-context bridge so the usage importer
-    drains both from one place.
+    is the cheapest honest place to observe what the agent reached for. The category
+    AND the tool NAME are spooled — plus, for a file-EDIT tool, the repo-relative
+    DESTINATION path (see ``_edit_target_relpath``: relativized to cwd, never
+    content), and for an EXECUTE tool, the COMMAND it ran (see ``_execute_command``:
+    single-lined, best-effort scrubbed of obvious credential values, length-bounded).
+    Non-command arguments and tool output are never spooled. The spool lands in the
+    SAME store as the client-context bridge so the usage importer drains both from
+    one place.
 
     ``client`` labels which agent emitted the tick. Codex's PreToolUse hook uses
     the same STDIN shape (``session_id``/``tool_name``), and its ``session_id``
@@ -561,6 +578,7 @@ def capture_tool_activity(
             category=category,
             name=tool_name,
             path=_edit_target_relpath(event, category),
+            command=_execute_command(event, category),
             at=time.time(),
         )
     except Exception:  # noqa: BLE001 - activity capture must never affect the hook decision.

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -180,6 +180,24 @@ def touched_files_preview(
     return shown, max(0, len(files) - len(shown))
 
 
+# The Actions dimension captures every command an execute tool ran; surfaces preview a
+# capped slice and disclose the remainder (same honesty rule + single-source-of-truth as
+# the touched-file preview). Commands are already single-line + best-effort scrubbed.
+RECEIPT_COMMANDS_PREVIEW = 12
+
+
+def commands_preview(
+    actions: Mapping[str, Any], *, limit: int = RECEIPT_COMMANDS_PREVIEW
+) -> tuple[list[str], int]:
+    """Return (commands to show, count elided). Called ONCE, in ``_actions_dimension``,
+    which bakes the result into the receipt as ``commands_preview`` / ``commands_elided``
+    so every surface (CLI, TUI, macOS app) renders the same daemon-provided slice."""
+
+    commands = [str(cmd) for cmd in (actions.get("commands") or []) if str(cmd).strip()]
+    shown = commands if limit is None or limit < 0 else commands[:limit]
+    return shown, max(0, len(commands) - len(shown))
+
+
 # Tool NAMES are an OPEN set (unlike the 9 fixed categories), so the Actions
 # dimension previews the most-used and discloses the remainder — computed ONCE
 # here so every surface renders the same ranking, the same way the touched-file
@@ -644,6 +662,8 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
     name_counts = _mapping(actions.get("tool_name_counts"))
     names_preview, names_elided = tool_names_preview({"tool_name_counts": name_counts})
     section_files = actions.get("touched_files") if isinstance(actions.get("touched_files"), list) else []
+    # Commands an execute tool ran (hook-captured; single-line, best-effort scrubbed).
+    commands = [cmd for cmd in (_text(x) for x in (actions.get("commands") or [])) if cmd]
     # Union the section-recorded files with the paths the Task's machine checks
     # named: either source alone routinely misses files the other has.
     touched: list[str] = []
@@ -659,7 +679,7 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
         provenance.append(SOURCE_MCP)
     else:
         gaps.append("No touched files were recorded for this Task's steps.")
-    if counts or name_counts:
+    if counts or name_counts or commands:
         provenance.append(SOURCE_HOOK)
     else:
         gaps.append(
@@ -669,6 +689,7 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
     # (CLI, TUI, and the macOS app) renders the daemon-provided slice and never
     # re-derives the cap client-side — the single source of truth for the cap.
     preview, elided = touched_files_preview({"touched_files": touched})
+    commands_shown, commands_elided = commands_preview({"commands": commands})
     return {
         "tool_category_counts": dict(counts),
         "tool_category_total": int(actions.get("tool_category_total") or 0),
@@ -680,6 +701,10 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
         "touched_file_count": len(touched),
         "touched_files_preview": preview,
         "touched_files_elided": elided,
+        "commands": commands,
+        "command_count": len(commands),
+        "commands_preview": commands_shown,
+        "commands_elided": commands_elided,
         "provenance": sorted(set(provenance)) or [SOURCE_NONE],
         "gaps": gaps,
     }

--- a/src/agentacct/task_projection.py
+++ b/src/agentacct/task_projection.py
@@ -1012,6 +1012,20 @@ def build_task_projection(
                 if path and path not in seen_touched_files:
                     seen_touched_files.add(path)
                     touched_files.append(path)
+        # Commands an execute tool ran (hook-captured, per session; single-line and
+        # best-effort scrubbed of obvious credential values) — the union across the
+        # Task's sessions, deduped and insertion-ordered.
+        commands: list[str] = []
+        seen_commands: set[str] = set()
+        for key in ordered_members:
+            session_commands = sessions[key].get("commands")
+            if not isinstance(session_commands, list):
+                continue
+            for candidate in session_commands:
+                command = _text(candidate)
+                if command and command not in seen_commands:
+                    seen_commands.add(command)
+                    commands.append(command)
         actions = {
             "tool_category_counts": dict(sorted(tool_category_counts.items())),
             "tool_category_total": sum(tool_category_counts.values()),
@@ -1019,6 +1033,8 @@ def build_task_projection(
             "tool_name_total": sum(tool_name_counts.values()),
             "touched_files": touched_files,
             "touched_file_count": len(touched_files),
+            "commands": commands,
+            "command_count": len(commands),
         }
         tasks.append(
             {

--- a/src/agentacct/tool_activity.py
+++ b/src/agentacct/tool_activity.py
@@ -149,6 +149,125 @@ def _normalize_touched_path(path: Any) -> str | None:
     return "/".join(parts)[:_TOUCHED_PATH_MAX]
 
 
+# A captured command is length-bounded (a pathological one-liner should not bloat the
+# spool) and the number of DISTINCT commands per drained batch is capped — "at least
+# this much", never more.
+_COMMAND_MAX = 400
+_COMMANDS_PER_BATCH_MAX = 100
+
+_REDACTED = "‹redacted›"  # ‹redacted›
+# Control / ANSI-escape bytes are stripped from a captured command so a crafted command
+# cannot inject terminal escapes into the CLI/TUI Receipt render (\x00 already drops the
+# whole command earlier). Whitespace is collapsed separately, so only non-space controls
+# remain here to remove.
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")  # C0 controls, DEL, and the C1 range (CSI/OSC)
+
+
+def _is_nonsecret_value(value: str) -> bool:
+    """A value that is definitionally NOT an inline secret: a shell variable reference
+    (``$FOO`` / ``${FOO}``) is an indirection, never a literal token."""
+    return value.startswith("$")
+
+
+# Env-var NAMES that contain a credential keyword but whose VALUE is definitionally a
+# path/handle (``GOOGLE_APPLICATION_CREDENTIALS``, ``*_TOKEN_FILE``, …), so must not be
+# redacted — masking the path hides what the agent ran and protects nothing.
+_NONSECRET_NAME_SUFFIXES = ("_FILE", "_PATH", "_DIR", "_CREDENTIALS", "_CREDENTIAL")
+# A credential keyword must be a WHOLE ``_``-delimited name segment (``GITHUB_TOKEN``) —
+# NOT a substring of a config name (``MAX_TOKENS``, ``TOKENIZERS_PARALLELISM``).
+# (``PWD`` is deliberately excluded — it collides with the shell working-dir env ``PWD``/
+# ``OLDPWD``; the common ``*_PASSWORD``/``PASSWD`` forms are covered instead.)
+_CREDENTIAL_SEGMENTS = frozenset({"PASSWORD", "PASSWD", "TOKEN", "SECRET", "APIKEY", "CREDENTIAL", "CREDENTIALS"})
+_CREDENTIAL_NAME_PARTS = ("API_KEY", "ACCESS_KEY", "AUTH_TOKEN", "SECRET_KEY", "SECRET_ACCESS_KEY")
+# A value that is a config SCALAR (number/bool/null) is not a secret — masking it would
+# corrupt common config like ``MAX_TOKENS=4096`` or ``token_count=5``.
+_SCALAR_VALUE = re.compile(r"(?i)(?:\d+|true|false|none|null|yes|no)$")
+
+
+def _redact_flag(match: re.Match[str]) -> str:
+    flag, value = match.group(1), match.group(2)
+    return match.group(0) if _is_nonsecret_value(value) else flag + _REDACTED
+
+
+def _redact_env(match: re.Match[str]) -> str:
+    name, value = match.group(1), match.group(2)  # name includes the trailing '='
+    bare = name[:-1].upper()
+    if bare.endswith(_NONSECRET_NAME_SUFFIXES) or _is_nonsecret_value(value) or _SCALAR_VALUE.match(value):
+        return match.group(0)
+    # A real credential name has the keyword as a whole ``_`` segment (GITHUB_TOKEN),
+    # as a name SUFFIX (PGPASSWORD), or as a known two-word part (API_KEY) — not merely a
+    # substring of a config name (MAX_TOKENS, TOKENIZERS_PARALLELISM).
+    is_credential = (
+        any(bare.endswith(kw) for kw in _CREDENTIAL_SEGMENTS)
+        or bool(_CREDENTIAL_SEGMENTS & set(bare.split("_")))
+        or any(part in bare for part in _CREDENTIAL_NAME_PARTS)
+    )
+    return name + _REDACTED if is_credential else match.group(0)
+
+
+# Best-effort credential masking for a captured command. LOCAL capture keeps the command
+# for readability (the owner's model: capture detailed locally, redact when a Receipt is
+# SHARED); this only masks obvious secret VALUES in RECOGNIZABLE positions so a live token
+# is not persisted verbatim. It is NOT a guarantee — share-time redaction is the real
+# safety net — and it deliberately errs toward keeping the command legible. Each sub runs
+# once; a ``repl`` may be a string or a function (to skip a non-secret value).
+_SECRET_SUBS: tuple[tuple[re.Pattern[str], Any], ...] = (
+    # Known token shapes (prefix-anchored), masked whole.
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{12,}"), _REDACTED),
+    (re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9]{12,}"), _REDACTED),
+    (re.compile(r"\bgh[posru]_[A-Za-z0-9]{20,}"), _REDACTED),  # ghp/gho/ghr/ghs/ghu
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}"), _REDACTED),
+    (re.compile(r"\bglpat-[A-Za-z0-9_-]{16,}"), _REDACTED),
+    (re.compile(r"\bpypi-[A-Za-z0-9_-]{16,}"), _REDACTED),
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}"), _REDACTED),
+    (re.compile(r"\bAKIA[A-Z0-9]{16}\b"), _REDACTED),
+    (re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b"), _REDACTED),
+    (re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{6,}"), _REDACTED),  # JWT
+    # A credential in an inline JSON/quoted body ({"password": "…"} / {"api_key":"…"}).
+    (re.compile(r'(?i)("(?:password|passwd|pwd|secret|token|api[-_]?key|access[-_]?key|auth[-_]?token|credential)"\s*:\s*")[^"]*'), r"\1" + _REDACTED),
+    # An Authorization / api-key header VALUE passed via curl ``-H``/``--header`` (quoted,
+    # non-empty). Anchoring on the header FLAG + quote avoids corrupting a bare
+    # ``authorization:`` grep pattern or an echoed header NAME, and the ``+`` (non-empty
+    # value) avoids fabricating a redaction where the quoted string has no value at all.
+    (re.compile(r"""(?i)(-H|--header)(=?\s*)(["'])(authorization|proxy-authorization|x-api-key|x-auth-token)(\s*:\s*)[^"']+"""), r"\1\2\3\4\5" + _REDACTED),
+    # --flag=value or --flag value for credential-ish flags (a $var reference is kept).
+    (re.compile(r"(?i)(--?(?:password|passwd|pwd|token|secret|api[-_]?key|apikey|access[-_]?key|auth[-_]?token|credential)[=\s])(\S+)"), _redact_flag),
+    # KEY=VALUE env style for credential-ish names (a *_FILE/_PATH/… name or a $var value
+    # is kept — its value is a path/handle, not an inline secret).
+    (re.compile(r"(?i)\b([A-Za-z0-9_]*(?:PASSWORD|PASSWD|TOKEN|SECRET|APIKEY|API_KEY|ACCESS_KEY|AUTH_TOKEN|CREDENTIAL)[A-Za-z0-9_]*=)(\S+)"), _redact_env),
+    # URL userinfo password (scheme://user:pass@host, or scheme://:pass@host).
+    (re.compile(r"(://[^:/?\s@]*:)([^@/?\s]+)(@)"), r"\1" + _REDACTED + r"\3"),
+)
+
+
+def _scrub_command(command: str) -> str:
+    """Mask obvious credential VALUES in a command (best-effort — see ``_SECRET_SUBS``)."""
+    for pattern, repl in _SECRET_SUBS:
+        command = pattern.sub(repl, command)
+    return command
+
+
+def _normalize_command(command: Any) -> str | None:
+    """The scrubbed, single-line, length-bounded command an EXECUTE tool ran, or ``None``.
+
+    Collapses whitespace to single spaces (a spool line is one line; the Actions summary
+    wants one line too), masks obvious credential values, and bounds the length. It is
+    NOT a promise that no secret survives — share-time redaction is the real safety net —
+    only that a live token in a recognizable shape is not persisted verbatim. Blank ->
+    ``None``."""
+
+    text = str(command or "").strip()
+    if not text or "\x00" in text:
+        return None
+    # Collapse whitespace (keeps words apart), then strip any remaining control/ANSI
+    # bytes so a crafted command cannot inject terminal escapes into the Receipt render.
+    text = _CONTROL_RE.sub("", " ".join(text.split()))
+    # Bound the scrub INPUT before running the credential regexes: a few patterns can
+    # backtrack superlinearly on a pathologically long token run, and only the first
+    # ``_COMMAND_MAX`` chars are stored anyway, so scrubbing a modest lead is enough.
+    return _scrub_command(text[: _COMMAND_MAX * 4])[:_COMMAND_MAX] or None
+
+
 def tool_activity_spool_path(store_dir: Path | str) -> Path:
     return Path(store_dir) / _SPOOL_RELATIVE_PATH
 
@@ -161,19 +280,21 @@ def record_tool_activity_tick(
     category: str,
     name: Any = None,
     path: Any = None,
+    command: Any = None,
     at: float,
 ) -> None:
     """Append ONE tick to the store spool. Best-effort; never raises.
 
     Writes the small scalars ``{c, s, k, t}`` — client, session id, category, and
-    a timestamp — plus ``n``, the tool NAME, when one is given, and ``p``, the
-    repo-relative path a file-EDIT tool wrote, when the caller extracted one (the
-    Actions dimension's "which artifacts were touched" — the caller relativizes it
-    to the session cwd and drops anything outside, so no absolute prefix, home dir,
-    or username is ever stored; arguments, content and output are still never
-    recorded). The line is a single tiny JSON object written with ``O_APPEND`` so
-    concurrent hook processes (many tool calls in flight) never corrupt or
-    interleave lines.
+    a timestamp — plus ``n``, the tool NAME, when one is given; ``p``, the repo-relative
+    path a file-EDIT tool wrote (relativized to cwd, never an absolute prefix); and
+    ``cmd``, the command an EXECUTE tool ran, when the caller extracted one (the Actions
+    dimension's "what did the agent actually run" — single-line, length-bounded, and
+    best-effort scrubbed of obvious credential values by ``_normalize_command``; the raw
+    command is kept for readability per the local-capture model, but a live token in a
+    recognizable shape is not persisted verbatim). Tool OUTPUT and non-command arguments
+    are still never recorded. The line is a single tiny JSON object written with
+    ``O_APPEND`` so concurrent hook processes never corrupt or interleave lines.
     """
 
     try:
@@ -192,6 +313,9 @@ def record_tool_activity_tick(
         touched = _normalize_touched_path(path)
         if touched:
             payload["p"] = touched
+        normalized_command = _normalize_command(command)
+        if normalized_command:
+            payload["cmd"] = normalized_command
         line = json.dumps(
             payload,
             ensure_ascii=False,
@@ -247,6 +371,7 @@ def drain_tool_activity_spool(
     counts: dict[tuple[str, str], dict[str, int]] = {}
     name_counts: dict[tuple[str, str], dict[str, int]] = {}
     touched_paths: dict[tuple[str, str], list[str]] = {}
+    commands: dict[tuple[str, str], list[str]] = {}
     latest: dict[tuple[str, str], float] = {}
     for line in raw.splitlines():
         line = line.strip()
@@ -282,6 +407,13 @@ def drain_tool_activity_spool(
             path_bucket = touched_paths.setdefault(key, [])
             if touched not in path_bucket and len(path_bucket) < _TOUCHED_FILES_PER_BATCH_MAX:
                 path_bucket.append(touched)
+        # Command an execute tool ran (present only on ticks written after command
+        # capture shipped). Deduped, insertion-ordered, hard-capped per batch.
+        command = _normalize_command(row.get("cmd"))
+        if command:
+            cmd_bucket = commands.setdefault(key, [])
+            if command not in cmd_bucket and len(cmd_bucket) < _COMMANDS_PER_BATCH_MAX:
+                cmd_bucket.append(command)
         stamp = row.get("t")
         if isinstance(stamp, (int, float)) and not isinstance(stamp, bool):
             latest[key] = max(latest.get(key, 0.0), float(stamp))
@@ -316,6 +448,12 @@ def drain_tool_activity_spool(
             # rationale as tool_names): a path is never a dict KEY, so the store's
             # secret redaction can never blank it.
             metadata["touched_files"] = list(touched)
+        cmds = commands.get((client, session))
+        if cmds:
+            # Commands ride as a plain list of string VALUES too — the store's secret
+            # redaction is KEY-based, so a command placed under a value never triggers it
+            # (the command was already best-effort scrubbed at ``_normalize_command``).
+            metadata["commands"] = list(cmds)
         events.append(
             {
                 "event_id": f"toolact:{digest}",
@@ -475,10 +613,46 @@ def build_touched_files_by_session(
     return {key: value for key, value in result.items() if value}
 
 
+def build_commands_by_session(
+    events: Iterable[Mapping[str, Any]],
+) -> dict[tuple[str, str], list[str]]:
+    """Collect ``tool_activity_observed`` commands per (client, session).
+
+    Mirrors ``build_touched_files_by_session``: reads each event's ``commands`` list
+    (single-line, best-effort-scrubbed command strings an execute tool ran). Batches are
+    additive and the union is deduped (insertion-ordered) across imports. Each command is
+    re-run through ``_normalize_command`` here (a second scrub + bound), so a command
+    recorded before a scrub rule shipped is re-masked on read. A session recorded before
+    command capture shipped simply has none — an honest gap, never a fabricated entry."""
+
+    result: dict[tuple[str, str], list[str]] = {}
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        if event.get("event_type") != TOOL_ACTIVITY_EVENT_TYPE:
+            continue
+        metadata = event.get("metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        client = str(metadata.get("client") or "").strip()
+        session = str(metadata.get("client_session_id") or "").strip()
+        if not client or not session:
+            continue
+        cmds = metadata.get("commands")
+        if not isinstance(cmds, list):
+            continue
+        bucket = result.setdefault((client, session), [])
+        for candidate in cmds:
+            normalized = _normalize_command(candidate)
+            if normalized and normalized not in bucket:
+                bucket.append(normalized)
+    return {key: value for key, value in result.items() if value}
+
+
 __all__ = [
     "TOOL_ACTIVITY_CAPTURE_BASIS",
     "TOOL_ACTIVITY_EVENT_TYPE",
     "TOOL_CATEGORIES",
+    "build_commands_by_session",
     "build_tool_activity_by_session",
     "build_tool_names_by_session",
     "build_touched_files_by_session",

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1264,8 +1264,10 @@ def _render_receipt_markup(receipt: dict) -> str:
     actions = dims.get("actions") or {}
     counts = actions.get("tool_category_counts") or {}
     category_text = " ".join(f"{k}×{v}" for k, v in sorted(counts.items())) if counts else "not instrumented"
+    _cmd_n = int(actions.get("command_count") or 0)
+    _cmd_txt = f" · ran {_cmd_n} command(s)" if _cmd_n else ""
     lines.append(
-        f"[b]Actions[/]   {_escape(category_text)} · touched {actions.get('touched_file_count', 0)} file(s)"
+        f"[b]Actions[/]   {_escape(category_text)} · touched {actions.get('touched_file_count', 0)} file(s){_cmd_txt}"
         f"   [dim]\\[{_prov('actions')}][/]"
     )
     names_preview = actions.get("tool_names_preview") or []
@@ -1283,6 +1285,12 @@ def _render_receipt_markup(receipt: dict) -> str:
     _elided_files = int(actions.get("touched_files_elided") or 0)
     if _elided_files:
         lines.append(f"           [dim]… +{_elided_files} more[/]")
+    for _cmd in actions.get("commands_preview") or []:
+        # The actual commands the agent ran (single-line, credential-scrubbed).
+        lines.append(f"           [dim]$ {_escape(str(_cmd))}[/]")
+    _elided_commands = int(actions.get("commands_elided") or 0)
+    if _elided_commands:
+        lines.append(f"           [dim]… +{_elided_commands} more[/]")
 
     cost = dims.get("cost") or {}
     lines.append(f"[b]Cost[/]      {_escape(_receipt_summary_cost(cost))}   [dim]\\[{_prov('cost')}][/]")

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -15,6 +15,7 @@ from .confidence import (
 )
 from .session_lifecycle import build_session_end_by_session
 from .tool_activity import (
+    build_commands_by_session,
     build_tool_activity_by_session,
     build_tool_names_by_session,
     build_touched_files_by_session,
@@ -216,7 +217,8 @@ def build_work_ledger(
     tool_activity_by_session = build_tool_activity_by_session(events)
     tool_names_by_session = build_tool_names_by_session(events)
     touched_files_by_session = build_touched_files_by_session(events)
-    if tool_activity_by_session or tool_names_by_session or touched_files_by_session:
+    commands_by_session = build_commands_by_session(events)
+    if tool_activity_by_session or tool_names_by_session or touched_files_by_session or commands_by_session:
         for entry in session_rollup.get("sessions", []):
             entry_key = (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
             counts = tool_activity_by_session.get(entry_key)
@@ -231,6 +233,11 @@ def build_work_ledger(
             touched = touched_files_by_session.get(entry_key)
             if touched:
                 entry["touched_files"] = list(touched)
+            # Commands an execute tool ran (hook-captured, single-line, best-effort
+            # scrubbed of obvious credential values at capture and re-scrubbed on read).
+            commands = commands_by_session.get(entry_key)
+            if commands:
+                entry["commands"] = list(commands)
     # Ambient session-end (SessionEnd hook): stamp each work item with the end
     # time of its OWN session so the outcome reducer can honestly derive the
     # ``ended_open`` disposition — an open step whose session stopped without a

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,262 @@
+"""Hook-captured commands (Actions dimension).
+
+An EXECUTE tool's command is captured by the tool-activity hook, single-lined and
+best-effort scrubbed of obvious credential values (the local-capture model: keep the
+command for readability, mask a live token; share-time redaction is the real safety net),
+spooled, drained onto the tool_activity_observed event, aggregated per session, and
+unioned into the Task's Actions commands for the Receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from agentacct.hooks import _execute_command, capture_tool_activity
+from agentacct.receipt import _actions_dimension, commands_preview
+from agentacct.task_projection import build_task_projection
+from agentacct.tool_activity import (
+    _COMMAND_MAX,
+    _normalize_command,
+    build_commands_by_session,
+    drain_tool_activity_spool,
+)
+
+
+def _store() -> Path:
+    return Path(tempfile.mkdtemp())
+
+
+def _bash_event(command: str, *, session: str = "s1") -> str:
+    return json.dumps(
+        {"tool_name": "Bash", "session_id": session, "cwd": "/r", "tool_input": {"command": command}}
+    )
+
+
+# ---------------------------------------------------------------------------
+# scrub / normalize
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_masks_bearer_and_authorization_header() -> None:
+    out = _normalize_command('curl -H "Authorization: Bearer sk-abcdefghijklmnop" https://x')
+    assert "sk-abcdefghijklmnop" not in out
+    assert "‹redacted›" in out
+    assert "curl" in out and "https://x" in out  # command structure kept
+
+
+def test_scrub_masks_credential_flags() -> None:
+    out = _normalize_command("mysql --password=Secret123 -u root")
+    assert "Secret123" not in out and "--password=" in out  # value masked, flag name kept
+    assert "tok_abcdef123456" not in _normalize_command("deploy --api-key tok_abcdef123456")
+
+
+def test_scrub_masks_env_assignment() -> None:
+    out = _normalize_command("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIexample123 aws s3 ls")
+    assert "wJalrXUtnFEMIexample123" not in out and "AWS_SECRET_ACCESS_KEY=" in out
+
+
+def test_scrub_masks_known_token_shapes() -> None:
+    for token in (
+        "sk-abcdefghijklmnopqrstuv",
+        "ghp_abcdefghijklmnopqrstuvwxyz012345",
+        "AKIAIOSFODNN7EXAMPLE",
+        "xoxb-1234567890-abcdefghij",
+    ):
+        assert token not in _normalize_command(f"echo {token}"), token
+
+
+def test_scrub_masks_url_userinfo() -> None:
+    out = _normalize_command("git clone https://user:ghp_abcdefghijklmnopqrstuvwxyz012345@github.com/x")
+    assert "ghp_abcdefghijklmnopqrstuvwxyz012345" not in out
+    assert "user:" in out and "@github.com" in out
+
+
+def test_normalize_collapses_whitespace_and_bounds_length() -> None:
+    assert _normalize_command("pytest   -q\n\n&&  git   commit") == "pytest -q && git commit"
+    assert len(_normalize_command("echo " + "a" * 1000)) <= _COMMAND_MAX
+
+
+def test_normalize_drops_blank_and_nul() -> None:
+    assert _normalize_command("   ") is None
+    assert _normalize_command("a\x00b") is None
+    assert _normalize_command(None) is None
+
+
+def test_plain_command_unchanged() -> None:
+    assert _normalize_command("pytest -q") == "pytest -q"
+    assert "‹redacted›" not in _normalize_command("git commit -m 'add feature'")
+
+
+def test_scrub_keeps_credential_named_path_and_var_values() -> None:
+    # A *_FILE/_CREDENTIALS name or a $var value is a path/indirection, not an inline
+    # secret — masking it would hide what the agent ran and protect nothing.
+    for cmd, kept in [
+        ("GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp/key.json gcloud auth", "/etc/gcp/key.json"),
+        ("AWS_SHARED_CREDENTIALS_FILE=/home/app/.aws/credentials aws s3 ls", "/home/app/.aws/credentials"),
+        ("FOO_TOKEN=$GITHUB_TOKEN deploy", "$GITHUB_TOKEN"),
+        ("deploy --token $MY_TOKEN", "$MY_TOKEN"),
+    ]:
+        assert kept in _normalize_command(cmd), cmd
+
+
+def test_scrub_does_not_redact_english_or_grep_pattern() -> None:
+    # No standalone bearer/basic scheme sub (it wrecked plain English); an ``authorization:``
+    # header NAME in a grep/echo (quoted OR unquoted) is not a header being SENT — the
+    # header sub anchors on a curl -H/--header flag, so these are kept verbatim.
+    assert (
+        _normalize_command('git commit -m "add basic authentication support"')
+        == 'git commit -m "add basic authentication support"'
+    )
+    assert _normalize_command("grep -i authorization: access.log") == "grep -i authorization: access.log"
+    assert _normalize_command('grep "Authorization:" access.log') == 'grep "Authorization:" access.log'
+    assert _normalize_command('echo "x-api-key: is the header name"') == 'echo "x-api-key: is the header name"'
+
+
+def test_scrub_masks_curl_header_flag_value() -> None:
+    # A real header VALUE sent via curl -H/--header (quoted) is masked; an opaque token
+    # with no known prefix is caught here even though the prefix subs miss it.
+    assert "opaqueTok123456" not in _normalize_command('curl -H "Authorization: Bearer opaqueTok123456" https://x')
+    assert "opaqueKey987" not in _normalize_command('curl --header="X-Api-Key: opaqueKey987" https://x')
+
+
+def test_scrub_env_distinguishes_credential_from_config() -> None:
+    # A credential env (keyword as a whole segment / name suffix) is masked; a config var
+    # that merely CONTAINS the keyword, or a scalar value, or the shell PWD, is kept.
+    for cmd, secret in [
+        ("PGPASSWORD=hunter2 psql", "hunter2"),
+        ("DB_PASSWORD=hunter2 app", "hunter2"),
+        ("GITHUB_TOKEN=ghp_realtoken123456 gh", "ghp_realtoken123456"),
+        ("SECRET_KEY=abc123xyz789 ./app", "abc123xyz789"),
+    ]:
+        assert secret not in _normalize_command(cmd), cmd
+    for cmd, kept in [
+        ("MAX_TOKENS=4096 python run.py", "MAX_TOKENS=4096"),
+        ("TOKENIZERS_PARALLELISM=false python train.py", "TOKENIZERS_PARALLELISM=false"),
+        ("python train.py token_count=5 batch=32", "token_count=5"),
+        ("PWD=/home/user run", "PWD=/home/user"),
+        ("OLDPWD=/tmp run", "OLDPWD=/tmp"),
+    ]:
+        assert kept in _normalize_command(cmd), cmd
+
+
+def test_scrub_masks_json_body_credentials() -> None:
+    assert "hunter2" not in _normalize_command('curl -d {"password":"hunter2"} https://x')
+    assert "supersecret123" not in _normalize_command('curl -d {"api_key":"supersecret123"}')
+
+
+def test_scrub_masks_additional_token_prefixes() -> None:
+    assert "ghr_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345" not in _normalize_command("echo ghr_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")
+    assert "pypi-AgEIcHlwaS5vcmcExampleToken1234" not in _normalize_command("twine upload -p pypi-AgEIcHlwaS5vcmcExampleToken1234")
+
+
+def test_scrub_masks_url_userinfo_without_username() -> None:
+    assert "s3cretpassword" not in _normalize_command("psql redis://:s3cretpassword@localhost:6379/0")
+
+
+def test_normalize_strips_control_and_ansi_bytes() -> None:
+    # A crafted command with a raw ESC/BEL (C0) or CSI/OSC (C1) byte must not carry a
+    # terminal escape into the Receipt render — control bytes are stripped, words stay apart.
+    out = _normalize_command("curl x\x1b[2Kgit status\x07\x9b2K\x9dosc")
+    assert not any(c in out for c in ("\x1b", "\x07", "\x9b", "\x9d"))
+    assert "curl" in out and "git status" in out
+
+
+# ---------------------------------------------------------------------------
+# _execute_command gate
+# ---------------------------------------------------------------------------
+
+
+def test_execute_command_only_for_execute_category() -> None:
+    ev = {"tool_name": "Bash", "tool_input": {"command": "ls"}}
+    assert _execute_command(ev, "execute") == "ls"
+    assert _execute_command(ev, "read") is None  # non-execute category
+    assert _execute_command({"tool_input": {"file_path": "/x"}}, "execute") is None  # no command arg
+    assert _execute_command({"tool_input": {"command": 123}}, "execute") is None  # non-str
+
+
+# ---------------------------------------------------------------------------
+# pipeline: capture -> drain -> commands
+# ---------------------------------------------------------------------------
+
+
+def test_capture_records_commands_deduped_execute_only() -> None:
+    store = _store()
+    capture_tool_activity(_bash_event("pytest -q"), store_dir=store, client="claude-code")
+    capture_tool_activity(_bash_event("pytest -q"), store_dir=store, client="claude-code")  # dup
+    capture_tool_activity(_bash_event("npm run build"), store_dir=store, client="claude-code")
+    # a non-execute tool records no command
+    capture_tool_activity(
+        json.dumps({"tool_name": "Read", "session_id": "s1", "tool_input": {"file_path": "/r/a.py"}}),
+        store_dir=store,
+        client="claude-code",
+    )
+    meta = drain_tool_activity_spool(store)[0]["metadata"]
+    assert meta["commands"] == ["pytest -q", "npm run build"]
+
+
+def test_capture_scrubs_at_the_tick() -> None:
+    store = _store()
+    capture_tool_activity(
+        _bash_event('curl -H "Authorization: Bearer sk-livetokenabcdef123" https://x'),
+        store_dir=store,
+        client="claude-code",
+    )
+    meta = drain_tool_activity_spool(store)[0]["metadata"]
+    assert not any("sk-livetokenabcdef123" in c for c in meta["commands"])
+
+
+def test_build_commands_by_session_unions_and_rescrubs() -> None:
+    def _event(cmds: list[str]) -> dict[str, Any]:
+        return {
+            "event_type": "tool_activity_observed",
+            "metadata": {"client": "opencode", "client_session_id": "ses_x", "commands": cmds},
+        }
+
+    result = build_commands_by_session([_event(["pytest", "ruff"]), _event(["ruff", "mypy"])])
+    assert result[("opencode", "ses_x")] == ["pytest", "ruff", "mypy"]  # additive + deduped
+    # a command that slipped through un-scrubbed is re-masked on read
+    leaky = build_commands_by_session([_event(["deploy --token abcdef1234567890"])])
+    assert not any("abcdef1234567890" in c for c in leaky[("opencode", "ses_x")])
+
+
+# ---------------------------------------------------------------------------
+# projection + receipt
+# ---------------------------------------------------------------------------
+
+
+def _session_with_commands(cmds: list[str]) -> dict[str, Any]:
+    return {
+        "client": "claude-code",
+        "client_session_id": "s1",
+        "identity_scope_state": "unscoped",
+        "namespace_fingerprint": None,
+        "session_kind": "root",
+        "last_activity_at": 1.0,
+        "related": {"parent": None},
+        "usage": {"rows": 1, "priced_rows": 1, "unpriced_rows": 0, "fresh_tokens": 5, "total_tokens": 5, "estimated_cost_usd": 0.01, "model_lanes": [{"model": "claude"}]},
+        "commands": cmds,
+    }
+
+
+def test_projection_unions_session_commands_into_actions() -> None:
+    proj = build_task_projection([_session_with_commands(["pytest -q", "git commit"])], [])
+    actions = proj["tasks"][0]["actions"]
+    assert actions["commands"] == ["pytest -q", "git commit"]
+    assert actions["command_count"] == 2
+
+
+def test_receipt_actions_surfaces_commands_with_preview_cap() -> None:
+    task = {"actions": {"commands": [f"cmd{i}" for i in range(20)], "command_count": 20}}
+    d = _actions_dimension(task)
+    assert len(d["commands_preview"]) == 12
+    assert d["commands_elided"] == 8
+    assert "hook" in d["provenance"]  # commands are a hook-captured signal
+
+
+def test_commands_preview_helper() -> None:
+    shown, elided = commands_preview({"commands": ["a", "b", "c"]}, limit=2)
+    assert shown == ["a", "b"] and elided == 1
+    assert commands_preview({}) == ([], 0)


### PR DESCRIPTION
## What

The Receipt's Actions dimension now records the **commands** an execute-category tool (Bash) ran, not just which tools it invoked. Previously a Receipt showed `Bash ×12` without ever naming the `pytest`, build, or deploy the agent actually executed.

## How

`capture_tool_activity` extracts `tool_input.command` for an execute tool; `_normalize_command` single-lines it, strips control/ANSI bytes, and best-effort masks obvious credential values. The command flows `spool(cmd) → drain → build_commands_by_session → work_ledger entry[commands] → task.actions.commands → receipt commands_preview`, and surfaces as a capped, overflow-disclosed preview in the CLI, TUI, and macOS app — mirroring the touched-files pipeline.

## Scrubbing (best-effort)

The command is kept locally for legibility (redacting a Receipt for **sharing** is a separate concern); this only masks a token in a **recognizable** shape so a live secret is not persisted verbatim:

- **Masked**: a curl `Authorization`/`X-Api-Key` header value (anchored on `-H`/`--header`), a `--password`/`--token`/… credential flag, a credential env assignment (`GITHUB_TOKEN=`, `PGPASSWORD=`, `AWS_SECRET_ACCESS_KEY=`), a known token prefix (`sk-`, `ghp_`, `AKIA`, JWT, `pypi-`, …), a JSON body `"password":"…"`, and URL userinfo.
- **Kept**: config vars that merely contain a keyword (`MAX_TOKENS`, `TOKENIZERS_PARALLELISM`, `token_count`), a scalar/boolean value, a `*_FILE`/`*_CREDENTIALS` path, a `$var` reference, and the shell `PWD`/`OLDPWD`.

Control and C1 (CSI/OSC) bytes are stripped so a crafted command cannot inject terminal escapes into a rendered Receipt. The scrub input is length-bounded so a pathological command cannot cause superlinear backtracking.

The masking is **not** a guarantee — a generic unlabeled high-entropy secret can still pass through; share-time redaction is the real safety net.

## Tests

23 command tests: the scrub (each credential shape masked, each config/false-positive shape kept, control-byte strip, length bound), the `_execute_command` gate, the capture → drain → dedup pipeline, `build_commands_by_session` union + re-scrub, the projection union, and the receipt preview cap + `hook` provenance.

Full suite: 3206 passed, 1 skipped.
