### PR TITLE
feat(codex): derive Receipt Actions from the rollout transcript

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8141,6 +8141,56 @@ def _local_usage_import_payload(
                 )
             except Exception:  # noqa: BLE001 - draining the spool must never fail the import.
                 pass
+            # Emit transcript-scan-derived tool activity (Receipt Actions) for a
+            # client whose hook does not capture it — currently Codex, from its
+            # rollout tool calls collected during discovery. Scoped-replace per
+            # (client, session): a re-import REFRESHES a scanned session's Actions
+            # (so a still-growing session is never frozen and never double-counts)
+            # and never touches a session this scan did not cover. Best-effort,
+            # like the spool drains above.
+            try:
+                from .tool_activity import (
+                    build_discovery_tool_activity_event,
+                    is_discovery_tool_activity_event,
+                )
+
+                scan_captured_at = time.time()
+                discovery_activity_events: list[dict[str, Any]] = []
+                for observation in discovery.session_observations:
+                    built = build_discovery_tool_activity_event(
+                        client=observation.client,
+                        session_id=observation.client_session_id,
+                        activity=getattr(observation, "rollout_tool_activity", None),
+                        captured_at=scan_captured_at,
+                    )
+                    if built is not None:
+                        discovery_activity_events.append(built)
+                if discovery_activity_events:
+                    scanned_activity_keys = {
+                        (
+                            event["metadata"]["client"],
+                            event["metadata"]["client_session_id"],
+                        )
+                        for event in discovery_activity_events
+                    }
+
+                    def _should_replace_discovery_activity(
+                        existing_event: dict[str, Any],
+                    ) -> bool:
+                        if not is_discovery_tool_activity_event(existing_event):
+                            return False
+                        metadata = existing_event.get("metadata") or {}
+                        return (
+                            metadata.get("client"),
+                            metadata.get("client_session_id"),
+                        ) in scanned_activity_keys
+
+                    service.replace_events(
+                        _should_replace_discovery_activity,
+                        discovery_activity_events,
+                    )
+            except Exception:  # noqa: BLE001 - deriving Actions must never fail the import.
+                pass
         if dry_run:
             projectable_observation_identities: set[tuple[str, str, str]] = set()
             observation_conflict_identities = 0

--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -8,6 +8,7 @@ import json
 import math
 import os
 import pickle
+import re
 import sqlite3
 import stat
 import time
@@ -51,6 +52,14 @@ from .usage_truth import (
     normalized_local_usage_session_id,
     recognized_local_usage_row_identity,
     sanitize_session_key_component,
+)
+from .tool_activity import (
+    _COMMANDS_PER_BATCH_MAX,
+    _TOUCHED_FILES_PER_BATCH_MAX,
+    _normalize_command,
+    _normalize_touched_path,
+    normalize_tool_name,
+    tool_category,
 )
 
 UsageClientName = Literal["codex", "claude-code", "opencode", "hermes", "openclaw"]
@@ -630,6 +639,13 @@ class ClientSessionObservation:
     source_parse_complete: bool = True
     # Same read-time refusal diagnostic as ClientUsageEvent; never persisted.
     refused_recording_attempts: tuple[Mapping[str, Any], ...] = ()
+    # Discovery-side Actions signals (tool_category_counts / tool_names /
+    # touched_files / commands) derived from the client's own transcript when its
+    # hook does not capture them — currently Codex, from the rollout's tool calls.
+    # An INTERNAL carrier: it rides to the import orchestrator, which emits it as a
+    # separate ``tool_activity_observed`` event; it is NOT part of the session
+    # observation's own sentinel event (to_sentinel_event never reads it).
+    rollout_tool_activity: Mapping[str, Any] | None = None
 
     @property
     def session_identity(self) -> tuple[str, str]:
@@ -1286,6 +1302,9 @@ def _discover_codex_usage_from_home(
                     source_parse_complete=parse_complete_by_session.get(
                         row_id,
                         False,
+                    ),
+                    rollout_tool_activity=(
+                        observation_metadata.get("tool_activity") or None
                     ),
                 )
             )
@@ -7188,6 +7207,148 @@ def _emit_scan_phase(label: str) -> None:
         pass
 
 
+# --- Codex Actions extraction (discovery-side) ------------------------------
+# Codex's PreToolUse hook barely fires for its built-in tools, but the rollout
+# on disk already records every tool call. These pure helpers derive the same
+# Actions signals the claude-code hook path produces (tool categories + names,
+# touched files, commands), so a Codex Task's Receipt shows WHAT it did —
+# retroactively, from data already scanned for tokens, with no hook dependency.
+# Only tool NAMES, cwd-relative touched PATHS, and best-effort-scrubbed COMMANDS
+# are derived; never tool output, never an absolute path prefix.
+
+_CODEX_TOOL_CALLS_SCAN_MAX = 5000  # bound accumulation on a pathological rollout
+_CODEX_APPLY_PATCH_FILE_RE = re.compile(
+    r"^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+?)\s*$", re.MULTILINE
+)
+_CODEX_APPLY_PATCH_MOVE_RE = re.compile(
+    r"^\*\*\*\s+Move\s+to:\s*(.+?)\s*$", re.MULTILINE
+)
+# Best-effort ``cmd`` extraction from Codex's JS ``exec`` runtime call, e.g.
+# ``tools.exec_command({cmd:"pytest -q", workdir:"…"})``. Matches the FIRST single-
+# or double-quoted ``cmd`` literal, honoring backslash escapes (so an embedded
+# ``\"`` does not truncate the command mid-string). A template-literal (backtick)
+# or otherwise unquoted cmd is SKIPPED — an honest undercount, never a half-parsed
+# capture. The clean ``exec_command`` function_call channel (exact JSON ``cmd``)
+# is read precisely instead.
+_CODEX_EXEC_JS_CMD_RE = re.compile(
+    r"""cmd\s*:\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)')"""
+)
+
+
+def _codex_apply_patch_paths(patch_text: Any) -> list[str]:
+    """The file paths an ``apply_patch`` touched, parsed from its patch body."""
+
+    if not isinstance(patch_text, str) or "*** " not in patch_text:
+        return []
+    paths = [m.group(1) for m in _CODEX_APPLY_PATCH_FILE_RE.finditer(patch_text)]
+    paths.extend(m.group(1) for m in _CODEX_APPLY_PATCH_MOVE_RE.finditer(patch_text))
+    return paths
+
+
+def _codex_command_text(name: str, raw_arg: Any) -> str | None:
+    """The shell command a Codex exec tool ran — exact for ``exec_command`` (JSON
+    ``cmd``), best-effort for the JS ``exec`` runtime. Never returns tool output."""
+
+    if not isinstance(raw_arg, str) or not raw_arg:
+        return None
+    if name == "exec_command":
+        try:
+            parsed = json.loads(raw_arg)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if isinstance(parsed, dict):
+            cmd = parsed.get("cmd") or parsed.get("command")
+            return cmd if isinstance(cmd, str) and cmd.strip() else None
+        return None
+    if name == "exec":
+        match = _CODEX_EXEC_JS_CMD_RE.search(raw_arg)
+        if match:
+            return match.group(1) if match.group(1) is not None else match.group(2)
+    return None
+
+
+def _codex_relativize_touched_path(raw_path: str, cwd: str | None) -> str | None:
+    """A cwd-relative form of an apply_patch path, or ``None`` if it would carry an
+    absolute prefix. Codex writes cwd-relative paths in practice; an absolute path
+    is relativized when under cwd and otherwise DROPPED (missing beats a leaked home
+    dir / username). Pure string math — never touches the filesystem."""
+
+    text = str(raw_path or "").strip()
+    if not text:
+        return None
+    if not os.path.isabs(text):
+        return text  # already relative — _normalize_touched_path is the final gate
+    cwd_abs = (
+        os.path.normpath(cwd)
+        if isinstance(cwd, str) and os.path.isabs(cwd)
+        else None
+    )
+    if cwd_abs is None:
+        return None
+    try:
+        target_abs = os.path.normpath(text)
+        if target_abs == cwd_abs or target_abs.startswith(cwd_abs + os.sep):
+            rel = os.path.relpath(target_abs, cwd_abs)
+            return rel if rel and not rel.startswith("..") else None
+    except (ValueError, OSError):
+        return None
+    return None
+
+
+def _codex_tool_activity_from_calls(
+    tool_calls: list[tuple[str, Any]],
+    *,
+    cwd: str | None,
+) -> dict[str, Any]:
+    """Derive Actions signals from a rollout's collected ``(name, raw_arg)`` tool
+    calls, in the SAME metadata shape the hook drain emits (values, not keys, so the
+    store's key-based secret redaction can't blank a credential-shaped name/path)."""
+
+    name_counts: dict[str, int] = {}
+    category_counts: dict[str, int] = {}
+    commands: list[str] = []
+    touched: list[str] = []
+    for raw_name, raw_arg in tool_calls:
+        name = normalize_tool_name(raw_name)
+        if name:
+            name_counts[name] = name_counts.get(name, 0) + 1
+            category = tool_category(name)
+            category_counts[category] = category_counts.get(category, 0) + 1
+        lowered = str(raw_name or "").strip().lower()
+        if lowered in ("exec", "exec_command"):
+            command = _normalize_command(_codex_command_text(lowered, raw_arg))
+            if (
+                command
+                and command not in commands
+                and len(commands) < _COMMANDS_PER_BATCH_MAX
+            ):
+                commands.append(command)
+        elif lowered == "apply_patch":
+            for raw_path in _codex_apply_patch_paths(raw_arg):
+                touched_path = _normalize_touched_path(
+                    _codex_relativize_touched_path(raw_path, cwd)
+                )
+                if (
+                    touched_path
+                    and touched_path not in touched
+                    and len(touched) < _TOUCHED_FILES_PER_BATCH_MAX
+                ):
+                    touched.append(touched_path)
+    activity: dict[str, Any] = {}
+    if category_counts:
+        activity["tool_category_counts"] = dict(sorted(category_counts.items()))
+    if name_counts:
+        activity["tool_names"] = [
+            {"name": name, "count": count}
+            for name, count in sorted(name_counts.items())
+        ]
+    if touched:
+        activity["touched_files"] = touched
+    if commands:
+        activity["commands"] = commands
+    return activity
+
+
 def _read_codex_rollout_usage(
     source: _RegularSourceFile | Path,
     *,
@@ -7284,6 +7445,10 @@ def _read_codex_rollout_usage_uncached(
     replayed_parent_session_meta = False
     first_activity_at: int | None = None
     last_activity_at: int | None = None
+    # Tool calls (name, raw_arg) for the discovery-side Actions extraction. The
+    # raw arg is read ONLY by _codex_tool_activity_from_calls (command text /
+    # apply_patch paths); tool output is never collected here.
+    tool_calls: list[tuple[str, Any]] = []
     token_usage_events: list[tuple[Any, ...]] = []
     raw_token_event_count = 0
     replay_prefix_token_events = 0
@@ -7424,6 +7589,22 @@ def _read_codex_rollout_usage_uncached(
             if not isinstance(payload, dict):
                 continue
             payload_type = payload.get("type")
+            # Collect tool calls for the discovery-side Actions extraction. A
+            # function_call carries its args as a JSON string under ``arguments``;
+            # a custom_tool_call (Codex's ``exec`` runtime and ``apply_patch``)
+            # carries them as a string under ``input``.
+            if (
+                payload_type in ("function_call", "custom_tool_call")
+                and len(tool_calls) < _CODEX_TOOL_CALLS_SCAN_MAX
+            ):
+                call_name = payload.get("name")
+                if isinstance(call_name, str) and call_name:
+                    call_arg = (
+                        payload.get("arguments")
+                        if payload_type == "function_call"
+                        else payload.get("input")
+                    )
+                    tool_calls.append((call_name, call_arg))
             if payload_type == "function_call":
                 # Pairing is strictly by call_id (never the response-item id).
                 call_id = payload.get("call_id")
@@ -7602,6 +7783,9 @@ def _read_codex_rollout_usage_uncached(
         _parse_stats["schema_drift_rollouts"] = _safe_nonnegative_int(
             _parse_stats.get("schema_drift_rollouts")
         ) + 1
+    rollout_tool_activity = _codex_tool_activity_from_calls(
+        tool_calls, cwd=session_meta_cwd
+    )
     if _observation_metadata is not None:
         _observation_metadata.update(
             {
@@ -7612,6 +7796,7 @@ def _read_codex_rollout_usage_uncached(
                 "last_activity_at": last_activity_at,
                 "observed_models": [model] if model else [],
                 "valid_object_count": int(saw_valid_object),
+                "tool_activity": rollout_tool_activity,
                 **evidence.as_usage_fields(),
             }
         )

--- a/src/agentacct/tool_activity.py
+++ b/src/agentacct/tool_activity.py
@@ -74,6 +74,26 @@ _CATEGORY_BY_TOOL_NAME: dict[str, str] = {
     "todowrite": "plan",
     "exitplanmode": "plan",
     "enterplanmode": "plan",
+    # Codex tool names (verified from real ~/.codex rollouts). Codex runs shell
+    # through a JS ``exec`` runtime and a plain ``exec_command``, edits through
+    # ``apply_patch`` (a patch body, not a file_path arg), and coordinates work
+    # through the agent tools. Without these, every core Codex tool collapsed to
+    # ``other``, so its Actions category breakdown was uninformative.
+    "exec": "execute",
+    "exec_command": "execute",
+    "local_shell": "execute",
+    "shell": "execute",
+    "js": "execute",
+    "apply_patch": "edit",
+    "spawn_agent": "agent",
+    "wait_agent": "agent",
+    "list_agents": "agent",
+    "interrupt_agent": "agent",
+    "followup_task": "agent",
+    "send_message": "agent",
+    "update_plan": "plan",
+    # Generic shell aliases other agents use (e.g. Hermes' ``terminal``).
+    "terminal": "execute",
 }
 
 
@@ -472,6 +492,87 @@ def drain_tool_activity_spool(
     return events
 
 
+# A client whose hook does not capture tool activity can still have it derived
+# from its own transcript at discovery time (currently Codex, from the rollout).
+# These events carry a DISTINCT capture_basis so they are honestly labelled as
+# transcript-scan-derived (not hook-observed) and can be refreshed as a scoped
+# cohort — replaced per (client, session) on each import instead of accumulated.
+DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS = "transcript_scan_tool_activity"
+
+
+def is_discovery_tool_activity_event(event: Mapping[str, Any]) -> bool:
+    """Whether an event is a discovery-derived (transcript-scan) tool-activity row."""
+
+    if event.get("event_type") != TOOL_ACTIVITY_EVENT_TYPE:
+        return False
+    metadata = event.get("metadata")
+    return (
+        isinstance(metadata, Mapping)
+        and metadata.get("capture_basis") == DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS
+    )
+
+
+def build_discovery_tool_activity_event(
+    *,
+    client: str,
+    session_id: str,
+    activity: Mapping[str, Any] | None,
+    captured_at: float,
+) -> dict[str, Any] | None:
+    """Build ONE ``tool_activity_observed`` event from transcript-scan-derived
+    Actions signals, in the exact shape the hook drain emits so it flows through
+    the same client-agnostic Actions build. Returns ``None`` when there is no real
+    signal. The event_id is stable per (client, session): a scoped ``replace_events``
+    refreshes it on each import, so a still-growing session is never frozen and a
+    re-import never double-counts."""
+
+    if not activity:
+        return None
+    metadata: dict[str, Any] = {
+        "client": client,
+        "client_session_id": session_id,
+        "capture_basis": DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS,
+        "captured_at": captured_at,
+        "sentinel_semantic_kind": "tool_activity",
+    }
+    category_counts = activity.get("tool_category_counts")
+    if isinstance(category_counts, Mapping) and category_counts:
+        metadata["tool_category_counts"] = {
+            str(key): int(value)
+            for key, value in sorted(category_counts.items())
+            if isinstance(value, int) and not isinstance(value, bool)
+        }
+    names = activity.get("tool_names")
+    if isinstance(names, list) and names:
+        # Same redaction-safe shape as the drain: names ride as list VALUES.
+        metadata["tool_names"] = [
+            {"name": str(entry.get("name")), "count": int(entry.get("count") or 0)}
+            for entry in names
+            if isinstance(entry, Mapping) and entry.get("name")
+        ]
+    touched = activity.get("touched_files")
+    if isinstance(touched, list) and touched:
+        metadata["touched_files"] = [str(path) for path in touched if str(path).strip()]
+    commands = activity.get("commands")
+    if isinstance(commands, list) and commands:
+        metadata["commands"] = [str(cmd) for cmd in commands if str(cmd).strip()]
+    # Only the five base keys means nothing survived normalization → no event.
+    if len(metadata) <= 5:
+        return None
+    digest = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"{DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS}\0{client}\0{session_id}",
+    ).hex
+    return {
+        "event_id": f"toolact:{digest}",
+        "created_at": captured_at,
+        "source": client,
+        "event_type": TOOL_ACTIVITY_EVENT_TYPE,
+        "run_id": None,
+        "metadata": metadata,
+    }
+
+
 def ingest_tool_activity_spool(
     store_dir: Path | str,
     *,
@@ -500,17 +601,25 @@ def ingest_tool_activity_spool(
     return written
 
 
-def build_tool_activity_by_session(
+def _sum_additive_tool_activity(
     events: Iterable[Mapping[str, Any]],
+    *,
+    extract: Callable[[Mapping[str, Any]], Iterable[tuple[str, int]]],
 ) -> dict[tuple[str, str], dict[str, int]]:
-    """Sum ``tool_activity_observed`` batch counts per (client, session).
+    """Sum a per-(client, session) additive tool-activity field across events.
 
-    Batches are additive: reducing the whole event log sums every recorded
-    batch, so the per-session total is stable no matter how many import runs
-    produced it. Only known categories and positive integer counts are kept.
+    Batches are additive, so the per-session total is stable across import runs.
+    ONE exception keeps the sum honest: a transcript-scan-derived event (a
+    client whose hook does not capture tool activity, so it is scanned from the
+    transcript — currently Codex) is the FULL-transcript SUPERSET of whatever the
+    same session's PreToolUse hook also observed, so summing both would
+    double-count the overlapping calls. For a session that has any transcript-scan
+    event, only its transcript-scan events contribute; the hook events for that
+    session are dropped (regardless of event order in the log).
     """
 
     result: dict[tuple[str, str], dict[str, int]] = {}
+    scan_superseded: set[tuple[str, str]] = set()
     for event in events:
         if not isinstance(event, Mapping):
             continue
@@ -522,17 +631,65 @@ def build_tool_activity_by_session(
         session = str(metadata.get("client_session_id") or "").strip()
         if not client or not session:
             continue
-        counts = metadata.get("tool_category_counts")
-        if not isinstance(counts, Mapping):
+        key = (client, session)
+        is_scan = (
+            metadata.get("capture_basis") == DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS
+        )
+        if key in scan_superseded and not is_scan:
+            # A transcript scan already covers this session's full tool activity;
+            # its hook events would double-count the overlap.
             continue
-        bucket = result.setdefault((client, session), {})
-        for category, value in counts.items():
-            if category not in TOOL_CATEGORIES:
-                continue
-            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-                continue
-            bucket[category] = bucket.get(category, 0) + value
+        if is_scan and key not in scan_superseded:
+            # Drop any hook contributions accumulated before the scan was seen.
+            result.pop(key, None)
+            scan_superseded.add(key)
+        bucket = result.setdefault(key, {})
+        for name, value in extract(metadata):
+            bucket[name] = bucket.get(name, 0) + value
     return {key: value for key, value in result.items() if value}
+
+
+def _category_count_pairs(metadata: Mapping[str, Any]) -> Iterable[tuple[str, int]]:
+    counts = metadata.get("tool_category_counts")
+    if not isinstance(counts, Mapping):
+        return
+    for category, value in counts.items():
+        if category not in TOOL_CATEGORIES:
+            continue
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            continue
+        yield str(category), value
+
+
+def _tool_name_count_pairs(metadata: Mapping[str, Any]) -> Iterable[tuple[str, int]]:
+    names = metadata.get("tool_names")
+    if not isinstance(names, list):
+        return
+    for entry in names:
+        if not isinstance(entry, Mapping):
+            continue
+        name = normalize_tool_name(entry.get("name"))
+        if not name:
+            continue
+        value = entry.get("count")
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            continue
+        yield name, value
+
+
+def build_tool_activity_by_session(
+    events: Iterable[Mapping[str, Any]],
+) -> dict[tuple[str, str], dict[str, int]]:
+    """Sum ``tool_activity_observed`` batch counts per (client, session).
+
+    Batches are additive: reducing the whole event log sums every recorded
+    batch, so the per-session total is stable no matter how many import runs
+    produced it. Only known categories and positive integer counts are kept. A
+    transcript-scan event supersedes the same session's hook events (see
+    ``_sum_additive_tool_activity``) so the two sources never double-count.
+    """
+
+    return _sum_additive_tool_activity(events, extract=_category_count_pairs)
 
 
 def build_tool_names_by_session(
@@ -545,40 +702,15 @@ def build_tool_names_by_session(
     ``tool_names`` list of ``{"name": …, "count": …}`` objects — the name is a
     VALUE, not a dict key, so a credential-shaped connector name is never
     redacted out by the store's secret redaction. Batches are additive, so the
-    per-session total is stable across imports. Names are an OPEN set, so unlike
-    categories they are not filtered against a fixed vocabulary — but they are
-    normalized (trimmed, length-bounded) and only positive integer counts are
-    kept. A session recorded before name capture shipped simply has no names — an
-    honest gap, never a fabricated zero.
+    per-session total is stable across imports (a transcript scan supersedes the
+    session's hook events, as above). Names are an OPEN set, so unlike categories
+    they are not filtered against a fixed vocabulary — but they are normalized
+    (trimmed, length-bounded) and only positive integer counts are kept. A
+    session recorded before name capture shipped simply has no names — an honest
+    gap, never a fabricated zero.
     """
 
-    result: dict[tuple[str, str], dict[str, int]] = {}
-    for event in events:
-        if not isinstance(event, Mapping):
-            continue
-        if event.get("event_type") != TOOL_ACTIVITY_EVENT_TYPE:
-            continue
-        metadata = event.get("metadata")
-        metadata = metadata if isinstance(metadata, Mapping) else {}
-        client = str(metadata.get("client") or "").strip()
-        session = str(metadata.get("client_session_id") or "").strip()
-        if not client or not session:
-            continue
-        names = metadata.get("tool_names")
-        if not isinstance(names, list):
-            continue
-        bucket = result.setdefault((client, session), {})
-        for entry in names:
-            if not isinstance(entry, Mapping):
-                continue
-            name = normalize_tool_name(entry.get("name"))
-            if not name:
-                continue
-            value = entry.get("count")
-            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-                continue
-            bucket[name] = bucket.get(name, 0) + value
-    return {key: value for key, value in result.items() if value}
+    return _sum_additive_tool_activity(events, extract=_tool_name_count_pairs)
 
 
 def build_touched_files_by_session(

--- a/tests/test_codex_actions.py
+++ b/tests/test_codex_actions.py
@@ -1,0 +1,421 @@
+"""Discovery-side Codex Actions extraction (commands / touched files / tools).
+
+Codex's PreToolUse hook barely fires for its built-in tools, so these signals
+are derived from the rollout on disk at discovery time instead. The rollout is
+the same file the token importer already reads.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from agentacct import client_usage as cu
+from agentacct.client_usage import discover_codex_usage
+from agentacct.tool_activity import (
+    DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS,
+    TOOL_ACTIVITY_EVENT_TYPE,
+    build_commands_by_session,
+    build_discovery_tool_activity_event,
+    build_tool_activity_by_session,
+    build_tool_names_by_session,
+    build_touched_files_by_session,
+    is_discovery_tool_activity_event,
+)
+
+from tests.test_client_usage import _make_codex_home, _add_codex_thread
+
+
+# --- pure extraction helpers ------------------------------------------------
+
+
+def test_apply_patch_paths_parses_add_update_delete_move():
+    patch = (
+        "*** Begin Patch\n"
+        "*** Add File: src/new.py\n+print('x')\n"
+        "*** Update File: src/old.py\n@@\n-a\n+b\n"
+        "*** Delete File: docs/gone.md\n"
+        "*** Move to: src/renamed.py\n"
+        "*** End Patch\n"
+    )
+    assert cu._codex_apply_patch_paths(patch) == [
+        "src/new.py",
+        "src/old.py",
+        "docs/gone.md",
+        "src/renamed.py",
+    ]
+
+
+def test_apply_patch_paths_ignores_non_patch_text():
+    assert cu._codex_apply_patch_paths("just some output, no patch") == []
+    assert cu._codex_apply_patch_paths(None) == []
+
+
+def test_command_text_from_exec_command_json():
+    raw = json.dumps({"cmd": "pytest -q", "workdir": "/repo", "yield_time_ms": 10})
+    assert cu._codex_command_text("exec_command", raw) == "pytest -q"
+
+
+def test_command_text_from_js_exec_handles_escaped_quotes():
+    js = 'const r = await tools.exec_command({cmd:"echo \\"hi there\\"",workdir:"/r"});text(r.output);'
+    # The embedded escaped quote must NOT truncate the command mid-string.
+    assert cu._codex_command_text("exec", js) == 'echo \\"hi there\\"'
+
+
+def test_command_text_from_js_exec_single_quoted():
+    js = "await tools.exec_command({cmd:'ls -la', workdir:'/r'});"
+    assert cu._codex_command_text("exec", js) == "ls -la"
+
+
+def test_command_text_skips_template_literal_and_garbage():
+    # A backtick/template cmd is deliberately skipped (honest undercount) rather
+    # than captured half-parsed.
+    assert cu._codex_command_text("exec", "tools.exec_command({cmd:`git ${x}`})") is None
+    assert cu._codex_command_text("exec_command", "not json at all") is None
+    assert cu._codex_command_text("exec_command", "") is None
+
+
+def test_relativize_touched_path_keeps_relative_relativizes_under_cwd_drops_outside():
+    assert cu._codex_relativize_touched_path("src/a.py", "/work/project") == "src/a.py"
+    assert (
+        cu._codex_relativize_touched_path("/work/project/src/a.py", "/work/project")
+        == "src/a.py"
+    )
+    # Absolute path outside cwd carries a home/username-leaking prefix -> dropped.
+    assert cu._codex_relativize_touched_path("/etc/passwd", "/work/project") is None
+    # Absolute path with no absolute cwd to relativize against -> dropped.
+    assert cu._codex_relativize_touched_path("/abs/x", None) is None
+
+
+def test_tool_activity_from_calls_aggregates_all_signals():
+    calls = [
+        ("exec", 'tools.exec_command({cmd:"git status"})'),
+        ("exec_command", json.dumps({"cmd": "pytest -q"})),
+        ("apply_patch", "*** Begin Patch\n*** Add File: src/a.py\n+x\n*** End Patch\n"),
+        ("spawn_agent", "{}"),
+        ("read_file", "{}"),  # unknown -> category "other", name kept
+    ]
+    activity = cu._codex_tool_activity_from_calls(calls, cwd="/work/project")
+    assert activity["tool_category_counts"] == {
+        "agent": 1,
+        "edit": 1,
+        "execute": 2,
+        "other": 1,
+    }
+    names = {entry["name"]: entry["count"] for entry in activity["tool_names"]}
+    assert names == {
+        "exec": 1,
+        "exec_command": 1,
+        "apply_patch": 1,
+        "spawn_agent": 1,
+        "read_file": 1,
+    }
+    assert activity["commands"] == ["git status", "pytest -q"]
+    assert activity["touched_files"] == ["src/a.py"]
+
+
+def test_tool_activity_from_calls_dedupes_commands_and_paths():
+    calls = [
+        ("exec_command", json.dumps({"cmd": "ls"})),
+        ("exec_command", json.dumps({"cmd": "ls"})),
+        ("apply_patch", "*** Add File: a.py\n"),
+        ("apply_patch", "*** Update File: a.py\n"),
+    ]
+    activity = cu._codex_tool_activity_from_calls(calls, cwd=None)
+    assert activity["commands"] == ["ls"]
+    assert activity["touched_files"] == ["a.py"]
+
+
+def test_tool_activity_empty_calls_is_empty():
+    assert cu._codex_tool_activity_from_calls([], cwd=None) == {}
+
+
+# --- event build ------------------------------------------------------------
+
+
+def test_build_discovery_event_shape_and_stable_id():
+    activity = {
+        "tool_category_counts": {"execute": 2},
+        "tool_names": [{"name": "exec", "count": 2}],
+        "commands": ["ls", "pwd"],
+        "touched_files": ["a.py"],
+    }
+    event = build_discovery_tool_activity_event(
+        client="codex", session_id="sess-1", activity=activity, captured_at=123.0
+    )
+    assert event["event_type"] == TOOL_ACTIVITY_EVENT_TYPE
+    assert event["source"] == "codex"
+    assert is_discovery_tool_activity_event(event)
+    md = event["metadata"]
+    assert md["client"] == "codex"
+    assert md["client_session_id"] == "sess-1"
+    assert md["capture_basis"] == DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS
+    assert md["commands"] == ["ls", "pwd"]
+    assert md["touched_files"] == ["a.py"]
+    # Stable per (client, session): a re-scan yields the SAME id so a scoped
+    # replace refreshes rather than duplicates.
+    again = build_discovery_tool_activity_event(
+        client="codex", session_id="sess-1", activity=activity, captured_at=999.0
+    )
+    assert again["event_id"] == event["event_id"]
+
+
+def test_build_discovery_event_none_when_no_signal():
+    assert build_discovery_tool_activity_event(
+        client="codex", session_id="s", activity=None, captured_at=1.0
+    ) is None
+    assert build_discovery_tool_activity_event(
+        client="codex", session_id="s", activity={}, captured_at=1.0
+    ) is None
+
+
+def test_transcript_scan_supersedes_hook_events_no_double_count():
+    # A codex session's PreToolUse hook may fire for SOME tools, producing a
+    # hook tool_activity event; the discovery scan then emits a FULL-transcript
+    # event for the same session. The additive counters must NOT sum both (the
+    # scan is a superset) — the scan supersedes the hook for that session.
+    hook_event = {
+        "event_id": "toolact:hook",
+        "event_type": TOOL_ACTIVITY_EVENT_TYPE,
+        "source": "codex",
+        "metadata": {
+            "client": "codex",
+            "client_session_id": "sess-dup",
+            "capture_basis": "client_hook_tool_category",
+            "tool_category_counts": {"execute": 2},
+            "tool_names": [{"name": "exec", "count": 2}],
+        },
+    }
+    scan_event = build_discovery_tool_activity_event(
+        client="codex",
+        session_id="sess-dup",
+        activity={
+            "tool_category_counts": {"execute": 5, "edit": 3},
+            "tool_names": [{"name": "exec", "count": 5}, {"name": "apply_patch", "count": 3}],
+        },
+        captured_at=1.0,
+    )
+    # Try BOTH event orders — the supersede must hold regardless of log order.
+    for events in ([hook_event, scan_event], [scan_event, hook_event]):
+        categories = build_tool_activity_by_session(events)[("codex", "sess-dup")]
+        names = build_tool_names_by_session(events)[("codex", "sess-dup")]
+        assert categories == {"execute": 5, "edit": 3}  # not execute=7
+        assert names == {"exec": 5, "apply_patch": 3}  # not exec=7
+
+    # A DIFFERENT codex session with only a hook event is unaffected.
+    other_hook = {
+        "event_id": "toolact:hook2",
+        "event_type": TOOL_ACTIVITY_EVENT_TYPE,
+        "source": "codex",
+        "metadata": {
+            "client": "codex",
+            "client_session_id": "sess-hook-only",
+            "capture_basis": "client_hook_tool_category",
+            "tool_category_counts": {"execute": 4},
+        },
+    }
+    both = build_tool_activity_by_session([hook_event, scan_event, other_hook])
+    assert both[("codex", "sess-hook-only")] == {"execute": 4}
+
+
+def test_discovery_event_flows_through_actions_builders():
+    # The whole point: a discovery event feeds the SAME client-agnostic Actions
+    # builders the hook path uses, with zero changes to them.
+    event = build_discovery_tool_activity_event(
+        client="codex",
+        session_id="sess-9",
+        activity={
+            "tool_category_counts": {"execute": 3, "edit": 1},
+            "commands": ["git status"],
+            "touched_files": ["src/a.py"],
+        },
+        captured_at=1.0,
+    )
+    events = [event]
+    assert build_commands_by_session(events)[("codex", "sess-9")] == ["git status"]
+    assert build_touched_files_by_session(events)[("codex", "sess-9")] == ["src/a.py"]
+    assert build_tool_activity_by_session(events)[("codex", "sess-9")] == {
+        "execute": 3,
+        "edit": 1,
+    }
+
+
+# --- integration: discovery populates the observation carrier ---------------
+
+
+def _rewrite_rollout_with_tool_calls(codex_home, session_id, cwd, lines):
+    rollout = next((codex_home / "sessions").rglob(f"*{session_id}.jsonl"))
+    body = [
+        json.dumps(
+            {"type": "session_meta", "payload": {"id": session_id, "cwd": cwd}}
+        ),
+        json.dumps(
+            {
+                "type": "event_msg",
+                "payload": {
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 100,
+                            "cached_input_tokens": 0,
+                            "output_tokens": 20,
+                            "reasoning_output_tokens": 0,
+                            "total_tokens": 120,
+                        }
+                    },
+                    "model": "gpt-5.5",
+                },
+            }
+        ),
+        *[json.dumps(line) for line in lines],
+    ]
+    rollout.write_text("\n".join(body) + "\n", encoding="utf-8")
+
+
+def test_discover_codex_populates_rollout_tool_activity(tmp_path):
+    codex_home = _make_codex_home(tmp_path)
+    _add_codex_thread(
+        codex_home, session_id="worker", updated_at=300, model="gpt-5.5"
+    )
+    _rewrite_rollout_with_tool_calls(
+        codex_home,
+        "worker",
+        "/work/project",
+        [
+            {
+                "type": "custom_tool_call",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "exec",
+                    "call_id": "c1",
+                    "input": 'tools.exec_command({cmd:"pytest -q", workdir:"/work/project"});',
+                },
+            },
+            {
+                "type": "custom_tool_call",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "apply_patch",
+                    "call_id": "c2",
+                    "input": "*** Begin Patch\n*** Update File: src/worker.py\n+x\n*** End Patch\n",
+                },
+            },
+        ],
+    )
+
+    observations: list = []
+    discover_codex_usage(
+        codex_home=codex_home, limit_sessions=10, _session_observations=observations
+    )
+    by_id = {o.client_session_id: o for o in observations}
+    worker = by_id["worker"]
+    activity = worker.rollout_tool_activity
+    assert activity["commands"] == ["pytest -q"]
+    assert activity["touched_files"] == ["src/worker.py"]
+    assert activity["tool_category_counts"] == {"edit": 1, "execute": 1}
+
+    # The carrier is INTERNAL: it never leaks into the session observation event.
+    assert "rollout_tool_activity" not in worker.to_sentinel_event()["metadata"]
+    assert "tool_activity" not in worker.to_sentinel_event()["metadata"]
+
+
+def test_import_local_emits_and_refreshes_codex_actions(tmp_path):
+    from typer.testing import CliRunner
+
+    from agentacct.cli import app
+    from agentacct.service import SentinelService
+
+    codex_home = _make_codex_home(tmp_path)
+    _add_codex_thread(
+        codex_home, session_id="worker", updated_at=300, model="gpt-5.5"
+    )
+    _rewrite_rollout_with_tool_calls(
+        codex_home,
+        "worker",
+        "/work/project",
+        [
+            {
+                "type": "custom_tool_call",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "exec",
+                    "call_id": "c1",
+                    "input": 'tools.exec_command({cmd:"pytest -q"});',
+                },
+            },
+            {
+                "type": "custom_tool_call",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "apply_patch",
+                    "call_id": "c2",
+                    "input": "*** Begin Patch\n*** Update File: src/worker.py\n+x\n*** End Patch\n",
+                },
+            },
+        ],
+    )
+    store = tmp_path / "state"
+    args = [
+        "usage",
+        "import-local",
+        "--client",
+        "codex",
+        "--store-dir",
+        str(store),
+        "--codex-home",
+        str(codex_home),
+        "--json",
+    ]
+
+    first = CliRunner().invoke(app, args)
+    assert first.exit_code == 0, first.output
+
+    def _codex_activity_events(store_dir):
+        return [
+            event
+            for event in SentinelService(store_dir).list_all_events()
+            if is_discovery_tool_activity_event(event)
+            and event["metadata"].get("client") == "codex"
+            and event["metadata"].get("client_session_id") == "worker"
+        ]
+
+    events = _codex_activity_events(store)
+    assert len(events) == 1
+    metadata = events[0]["metadata"]
+    assert metadata["commands"] == ["pytest -q"]
+    assert metadata["touched_files"] == ["src/worker.py"]
+    assert metadata["tool_category_counts"] == {"edit": 1, "execute": 1}
+
+    # The session grows (a second command runs), then re-import. The scoped
+    # replace REFRESHES the session's Actions in place: still exactly ONE event
+    # (never doubled/accumulated), and now reflecting the NEW command — a
+    # still-growing session is never frozen at its first-seen state.
+    _rewrite_rollout_with_tool_calls(
+        codex_home,
+        "worker",
+        "/work/project",
+        [
+            {
+                "type": "custom_tool_call",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "exec",
+                    "call_id": "c1",
+                    "input": 'tools.exec_command({cmd:"pytest -q"});',
+                },
+            },
+            {
+                "type": "custom_tool_call",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "exec",
+                    "call_id": "c3",
+                    "input": 'tools.exec_command({cmd:"ruff check"});',
+                },
+            },
+        ],
+    )
+    second = CliRunner().invoke(app, args)
+    assert second.exit_code == 0, second.output
+    refreshed = _codex_activity_events(store)
+    assert len(refreshed) == 1
+    assert refreshed[0]["metadata"]["commands"] == ["pytest -q", "ruff check"]


### PR DESCRIPTION
## What

Codex's PreToolUse hook does not reliably fire for its built-in tools (`exec`, `apply_patch`, …), so the Receipt **Actions** dimension — commands, touched files, tool categories + names — was blank for Codex sessions. The Codex rollout on disk, already scanned for tokens, records every tool call. This derives the Actions signals from it at discovery time instead: **no hook dependency, and it backfills every existing session.**

## Signals

- **Commands** — from `exec_command` (exact JSON `cmd`) and the JS `exec` runtime (best-effort on a quoted `cmd:` literal, honoring escapes; a template-literal / complex form is skipped rather than half-parsed). Best-effort credential-scrubbed and length-bounded via the existing `_normalize_command`.
- **Touched files** — from `apply_patch` patch bodies (`*** Add/Update/Delete File`, `*** Move to`), cwd-relativized; an absolute path outside cwd is dropped, never leaked (final gate: the existing `_normalize_touched_path`).
- **Tool categories + names** — from every `function_call` / `custom_tool_call`, with the Codex tool names added to the shared category taxonomy (`exec`/`exec_command`→execute, `apply_patch`→edit, the agent tools→agent, …).

## Plumbing

The signals ride on the session observation as an internal carrier (never part of the session-observation event) and are emitted as `tool_activity_observed` events, so they flow through the **same client-agnostic Actions builders** the hook path uses — zero changes to `work_ledger` / `receipt`.

- **Refreshable:** re-import replaces a scanned session's Actions in place via a scoped `replace_events` (a still-growing session is never frozen and never double-counts), and never touches a session this scan did not cover.
- **No double-count with the hook:** a transcript-scan event is the full-transcript superset of whatever the same session's hook also observed, so it **supersedes** the hook events for that session in the additive category/name builders — each call is counted once.

## Verified on real data

Run against the local `~/.codex` (read-only): **692 of 1184 sessions** now carry Actions, **19,845 commands** and correct tool categories/names extracted from data already on disk.

## Testing

- Full suite: `3241 passed, 1 skipped`.
- 16 new tests: apply_patch path parsing; exec/exec_command command extraction (incl. escaped quotes, template-literal skip); path relativization (relative kept / absolute-under-cwd relativized / outside dropped); aggregation + dedup + caps; event shape + stable id; flow through the Actions builders; the transcript-scan-supersedes-hook rule (both event orders); the internal carrier never leaking into the session event; and a CLI `import-local` integration test proving emission + idempotent refresh.
- One adversarial-review finding (transcript-scan/hook double-count of the additive counters) fixed before this PR, with the supersede test locking it.
