### PR TITLE
feat(opencode): derive Receipt Actions and checks from the part table

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8142,12 +8142,14 @@ def _local_usage_import_payload(
             except Exception:  # noqa: BLE001 - draining the spool must never fail the import.
                 pass
             # Emit transcript-scan-derived tool activity (Receipt Actions) for a
-            # client whose hook does not capture it — currently Codex, from its
-            # rollout tool calls collected during discovery. Scoped-replace per
-            # (client, session): a re-import REFRESHES a scanned session's Actions
-            # (so a still-growing session is never frozen and never double-counts)
-            # and never touches a session this scan did not cover. Best-effort,
-            # like the spool drains above.
+            # client whose hook does not capture it. The carrier rides on whichever
+            # discovery lane the client produces: Codex on its session OBSERVATION
+            # (from the rollout), OpenCode on its usage EVENT (from the part table).
+            # Scoped-replace per (client, session): a re-import REFRESHES a scanned
+            # session's Actions (so a still-growing session is never frozen and never
+            # double-counts) and never touches a session this scan did not cover. The
+            # event_id is stable per (client, session), so the two lanes can never
+            # double-emit one session. Best-effort, like the spool drains above.
             try:
                 from .tool_activity import (
                     build_discovery_tool_activity_event,
@@ -8155,16 +8157,28 @@ def _local_usage_import_payload(
                 )
 
                 scan_captured_at = time.time()
-                discovery_activity_events: list[dict[str, Any]] = []
-                for observation in discovery.session_observations:
+                activity_carriers = [
+                    (
+                        carrier.client,
+                        carrier.client_session_id,
+                        getattr(carrier, "rollout_tool_activity", None),
+                    )
+                    for carrier in (
+                        *discovery.session_observations,
+                        *discovery.events,
+                    )
+                ]
+                discovery_activity_by_id: dict[str, dict[str, Any]] = {}
+                for client_name, session_id, activity in activity_carriers:
                     built = build_discovery_tool_activity_event(
-                        client=observation.client,
-                        session_id=observation.client_session_id,
-                        activity=getattr(observation, "rollout_tool_activity", None),
+                        client=client_name,
+                        session_id=session_id,
+                        activity=activity,
                         captured_at=scan_captured_at,
                     )
                     if built is not None:
-                        discovery_activity_events.append(built)
+                        discovery_activity_by_id[built["event_id"]] = built
+                discovery_activity_events = list(discovery_activity_by_id.values())
                 if discovery_activity_events:
                     scanned_activity_keys = {
                         (
@@ -8190,6 +8204,32 @@ def _local_usage_import_payload(
                         discovery_activity_events,
                     )
             except Exception:  # noqa: BLE001 - deriving Actions must never fail the import.
+                pass
+            # Emit transcript-scan-derived mechanical checks — the independent
+            # (harness-observed) exit codes that lift a step to
+            # ``independently_checked`` — for a client whose hook does not fire.
+            # Currently OpenCode, from a bash tool's DB-recorded exit code. Each
+            # envelope's idempotency key is content+event_timestamp derived and the
+            # tick carries a STABLE DB timestamp, so a re-import dedupes in the
+            # Evidence store rather than double-recording. Best-effort, like the
+            # mechanical-check spool drain above.
+            try:
+                from .mechanical_capture import (
+                    build_discovery_mechanical_check_envelopes,
+                )
+
+                discovery_check_ticks: list[Any] = []
+                for carrier in discovery.events:
+                    ticks = getattr(carrier, "rollout_mechanical_checks", ()) or ()
+                    discovery_check_ticks.extend(ticks)
+                for envelope in build_discovery_mechanical_check_envelopes(
+                    discovery_check_ticks
+                ):
+                    try:
+                        service.evidence.append(envelope)
+                    except Exception:  # noqa: BLE001 - one bad append must not abort the rest.
+                        continue
+            except Exception:  # noqa: BLE001 - deriving checks must never fail the import.
                 pass
         if dry_run:
             projectable_observation_identities: set[tuple[str, str, str]] = set()

--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -61,6 +61,7 @@ from .tool_activity import (
     normalize_tool_name,
     tool_category,
 )
+from .mechanical_capture import classify_command, command_digest
 
 UsageClientName = Literal["codex", "claude-code", "opencode", "hermes", "openclaw"]
 ObservedClientName = Literal[
@@ -360,6 +361,22 @@ class ClientUsageEvent:
     # byte-identical to the pre-split behavior.
     token_lineage_session_kind: str | None = None
     token_lineage_parent_client_session_id: str | None = None
+    # Discovery-side Actions signals derived from the client's own transcript/DB
+    # when its hook does not capture them — currently OpenCode, from the ``part``
+    # table's tool calls (Codex rides the analogous carrier on its
+    # ClientSessionObservation). ``rollout_tool_activity`` holds the same
+    # {tool_category_counts / tool_names / touched_files / commands} shape the hook
+    # drain emits; ``rollout_mechanical_checks`` holds spool-shaped check ticks (a
+    # bash exit code the harness observed, which lifts a step to
+    # ``independently_checked``). INTERNAL carriers: the import orchestrator emits
+    # them as separate tool_activity_observed / machine_check_observed events;
+    # ``to_sentinel_event`` never reads them, and ``compare=False`` keeps them out
+    # of the frozen dataclass's identity/hash and every stored-row equality (a usage
+    # row differing only in what tools it ran is the same row).
+    rollout_tool_activity: Mapping[str, Any] | None = field(default=None, compare=False)
+    rollout_mechanical_checks: tuple[Mapping[str, Any], ...] = field(
+        default=(), compare=False
+    )
 
     def __post_init__(self) -> None:
         if self.client not in USAGE_EVENT_CLIENTS:
@@ -3345,22 +3362,269 @@ def _scan_opencode_part_evidence(
     return evidence
 
 
+# --- OpenCode Actions + verification extraction (discovery-side) -------------
+# OpenCode's observe-only plugin barely fires for its built-in tools (real store
+# evidence: ~0 hook ticks), but every tool call it made is on disk in the
+# ``part`` table. These pure helpers derive the SAME Actions signals the hook
+# path produces (tool categories + names, cwd-relative touched files, best-effort-
+# scrubbed commands) AND the one signal OpenCode uniquely affords at discovery
+# time: a bash tool's harness ``exit`` code, turned into a mechanical-check tick
+# that lifts a step to ``independently_checked`` (Codex's rollout has no clean
+# exit code, so its discovery-side verification is deferred). Only tool NAMES,
+# cwd-relative touched PATHS, best-effort-scrubbed COMMANDS, and a coarse check
+# kind/runner/sha256 digest/exit are derived; never tool output, never a preview,
+# never an absolute path prefix.
+
+_OPENCODE_TOOL_PARTS_SCAN_MAX = 5000  # bound accumulation per pathological session
+_OPENCODE_CHECK_TICKS_MAX = 200  # bound checks carried per session
+
+
+def _opencode_edit_paths(part: Mapping[str, Any]) -> list[str]:
+    """Every edit-target path one OpenCode edit-family tool part names, as written
+    (absolute or relative). Reads three shapes: the direct ``filePath`` (native
+    edit/write), the structured ``apply_patch`` metadata ``files[].filePath``, and
+    the raw ``apply_patch`` body (same ``*** Add/Update/Delete File:`` grammar the
+    Codex reader parses). Relativization and normalization are the caller's final
+    gate; a ``read`` (which touches nothing) is never routed here."""
+
+    paths: list[str] = []
+    file_path = part.get("file_path")
+    if isinstance(file_path, str) and file_path.strip():
+        paths.append(file_path)
+    files_json = part.get("files_json")
+    if isinstance(files_json, str) and files_json.strip():
+        try:
+            files = json.loads(files_json)
+        except (json.JSONDecodeError, ValueError):
+            files = None
+        if isinstance(files, list):
+            for entry in files:
+                if not isinstance(entry, Mapping):
+                    continue
+                candidate = entry.get("filePath") or entry.get("path")
+                if isinstance(candidate, str) and candidate.strip():
+                    paths.append(candidate)
+    paths.extend(_codex_apply_patch_paths(part.get("patch_text")))
+    return paths
+
+
+def _opencode_check_tick(
+    part: Mapping[str, Any],
+    *,
+    session_id: str,
+) -> dict[str, Any] | None:
+    """A spool-shaped mechanical-check tick from ONE completed OpenCode execute
+    part, or ``None`` when the part is not an unambiguous check whose harness exit
+    code is trustworthy. Recognizes a check runner with the SAME ``classify_command``
+    the hook path uses, and reads the harness ``exit`` code plus a STABLE end
+    timestamp from the DB (so the content-derived idempotency key dedupes a
+    re-imported check instead of double-recording it). Stores only the coarse check
+    kind, runner, and a sha256 digest of the command — never the command text."""
+
+    raw_command = part.get("command")
+    if not isinstance(raw_command, str) or not raw_command.strip():
+        return None
+    if str(part.get("status") or "").strip().lower() != "completed":
+        return None
+    exit_code = part.get("exit_code")
+    if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+        return None
+    classified = classify_command(raw_command)
+    if classified is None:
+        return None
+    check_kind, runner = classified
+    # OpenCode stamps tool times in MILLISECONDS; the tick timestamp is epoch
+    # SECONDS (matching the hook's ``time.time()``), so the check attaches to the
+    # step active when it ran and normalize_timestamp does not read year ~58500.
+    at_ms = part.get("time_end")
+    if isinstance(at_ms, bool) or not isinstance(at_ms, (int, float)):
+        at_ms = part.get("row_time")
+    if isinstance(at_ms, bool) or not isinstance(at_ms, (int, float)) or float(at_ms) <= 0:
+        return None
+    return {
+        "c": "opencode",
+        "s": session_id,
+        "k": check_kind,
+        "r": runner,
+        "d": command_digest(raw_command),
+        "x": int(exit_code),
+        "t": float(at_ms) / 1000.0,
+    }
+
+
+def _opencode_actions_from_parts(
+    parts: list[Mapping[str, Any]],
+    *,
+    cwd: str | None,
+    session_id: str,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Derive ``(activity, check_ticks)`` for ONE OpenCode session from its tool
+    parts. ``activity`` is the exact metadata shape the hook drain emits (values,
+    not keys, so the store's key-based secret redaction can't blank a
+    credential-shaped name/path). ``parts`` are ``{tool, status, command,
+    exit_code, file_path, patch_text, files_json, time_end, row_time}`` dicts
+    already json-extracted from the ``part`` table (never the output/preview blob).
+    Pure — no DB, no filesystem."""
+
+    name_counts: dict[str, int] = {}
+    category_counts: dict[str, int] = {}
+    commands: list[str] = []
+    touched: list[str] = []
+    check_ticks: list[dict[str, Any]] = []
+    for part in parts:
+        name = normalize_tool_name(part.get("tool"))
+        category: str | None = None
+        if name:
+            name_counts[name] = name_counts.get(name, 0) + 1
+            category = tool_category(name)
+            category_counts[category] = category_counts.get(category, 0) + 1
+        # Commands + verification checks ride on an execute part's ``command``
+        # (OpenCode's ``bash``); a non-execute tool never carries one.
+        if isinstance(part.get("command"), str) and part.get("command").strip():
+            command = _normalize_command(part.get("command"))
+            if (
+                command
+                and command not in commands
+                and len(commands) < _COMMANDS_PER_BATCH_MAX
+            ):
+                commands.append(command)
+            tick = _opencode_check_tick(part, session_id=session_id)
+            if tick is not None and len(check_ticks) < _OPENCODE_CHECK_TICKS_MAX:
+                check_ticks.append(tick)
+        if category == "edit":
+            for raw_path in _opencode_edit_paths(part):
+                touched_path = _normalize_touched_path(
+                    _codex_relativize_touched_path(raw_path, cwd)
+                )
+                if (
+                    touched_path
+                    and touched_path not in touched
+                    and len(touched) < _TOUCHED_FILES_PER_BATCH_MAX
+                ):
+                    touched.append(touched_path)
+    activity: dict[str, Any] = {}
+    if category_counts:
+        activity["tool_category_counts"] = dict(sorted(category_counts.items()))
+    if name_counts:
+        activity["tool_names"] = [
+            {"name": name, "count": count}
+            for name, count in sorted(name_counts.items())
+        ]
+    if touched:
+        activity["touched_files"] = touched
+    if commands:
+        activity["commands"] = commands
+    return activity, check_ticks
+
+
+def _scan_opencode_part_actions(
+    con: sqlite3.Connection,
+    session_ids: list[str],
+    cwd_by_session: Mapping[str, str | None],
+) -> dict[str, dict[str, Any]]:
+    """Derive per-session discovery-side Actions + mechanical checks from the
+    ``part`` table for the sessions being imported.
+
+    Privacy + cost boundary: the row's ``data`` blob also holds tool OUTPUT and
+    file previews, which are NEVER SELECTed. SQL ``json_extract`` pulls ONLY the
+    whitelisted scalar fields — tool name, status, the bash command + its exit, the
+    edit target path / patch body / structured file list, and the call end time —
+    so output, previews, message bodies, and every other tool's payload never enter
+    the process. Rows are streamed (no ``fetchall`` of the part table) and bounded
+    per session (``_OPENCODE_TOOL_PARTS_SCAN_MAX``).
+
+    Malformed-JSON tolerance: the OpenCode store is read while OpenCode may be
+    mid-write, so a ``data`` cell can be a truncated/partial write. A bare
+    ``json_extract`` in the WHERE would RAISE ``OperationalError`` (a
+    ``sqlite3.DatabaseError``) on such a row and abort the whole scan — which, being
+    uncaught in this path, would zero the client's already-read token/cost/evidence
+    rows. So the ``type`` filter is guarded by ``json_valid`` inside a CASE
+    (whose evaluation order SQL guarantees, unlike a WHERE AND-term): a malformed or
+    NULL ``data`` row yields NULL, fails ``= 'tool'``, and is skipped — matching the
+    deliberately-tolerant sibling ``_scan_opencode_part_evidence``. Every surviving
+    row is valid JSON, so the SELECT ``json_extract`` fields cannot raise. Returns
+    ``{session_id: {"activity": {...}, "checks": [...]}}`` for sessions with a signal.
+    """
+
+    result: dict[str, dict[str, Any]] = {}
+    if not session_ids:
+        return result
+    if not {"session_id", "data"} <= _sqlite_table_columns(con, "part"):
+        return result
+    placeholders = ", ".join("?" for _ in session_ids)
+    cursor = con.execute(
+        f"""
+        select
+            session_id                                   as session_id,
+            json_extract(data, '$.tool')                 as tool,
+            json_extract(data, '$.state.status')         as status,
+            json_extract(data, '$.state.input.command')  as command,
+            json_extract(data, '$.state.metadata.exit')  as exit_code,
+            json_extract(data, '$.state.input.filePath') as file_path,
+            json_extract(data, '$.state.input.patchText') as patch_text,
+            json_extract(data, '$.state.metadata.files') as files_json,
+            json_extract(data, '$.state.time.end')       as time_end,
+            time_updated                                 as row_time
+        from part
+        where session_id in ({placeholders})
+          and (
+              case when json_valid(data) then json_extract(data, '$.type') end
+          ) = 'tool'
+        """,
+        session_ids,
+    )
+    parts_by_session: dict[str, list[Mapping[str, Any]]] = {}
+    for row in cursor:
+        sid = str(row["session_id"] or "").strip()
+        if not sid:
+            continue
+        bucket = parts_by_session.setdefault(sid, [])
+        if len(bucket) >= _OPENCODE_TOOL_PARTS_SCAN_MAX:
+            continue
+        bucket.append(
+            {
+                "tool": row["tool"],
+                "status": row["status"],
+                "command": row["command"],
+                "exit_code": row["exit_code"],
+                "file_path": row["file_path"],
+                "patch_text": row["patch_text"],
+                "files_json": row["files_json"],
+                "time_end": row["time_end"],
+                "row_time": row["row_time"],
+            }
+        )
+    for sid, parts in parts_by_session.items():
+        activity, checks = _opencode_actions_from_parts(
+            parts, cwd=cwd_by_session.get(sid), session_id=sid
+        )
+        if activity or checks:
+            result[sid] = {"activity": activity, "checks": checks}
+    return result
+
+
 def _read_opencode_session_db_usage(
     db_source: _RegularSourceFile,
     *,
     limit_sessions: int,
-) -> tuple[int, list[dict[str, Any]], dict[str, LogEvidenceAccumulator]]:
+) -> tuple[
+    int,
+    list[dict[str, Any]],
+    dict[str, LogEvidenceAccumulator],
+    dict[str, dict[str, Any]],
+]:
     """Read the authoritative ``session`` rollup from one ``opencode*.db``.
 
-    Returns ``(discovered_rows, selected_rows, evidence_by_session)``. Only the
-    per-session token, cost, model, lineage, directory, and timestamp columns of
-    the ``session`` table are read for usage; the ``part`` table is read
-    SEPARATELY and, via a server-name SQL prefilter, ONLY for rows that name the
-    agentacct MCP server — to pair the session's own agentacct creation-tool
-    event ids (see ``_scan_opencode_part_evidence`` for the boundary). Other
-    tools' payloads, prompts, and message bodies are never SELECTed or parsed.
-    Raises on a corrupt or unreadable database so discovery fails closed rather
-    than reporting the store as silently absent.
+    Returns ``(discovered_rows, selected_rows, evidence_by_session,
+    actions_by_session)``. The per-session token, cost, model, lineage, directory,
+    and timestamp columns of the ``session`` table are read for usage; the ``part``
+    table is read SEPARATELY, twice, each with its own whitelist: once via a
+    server-name SQL prefilter for the agentacct creation-tool event ids only (see
+    ``_scan_opencode_part_evidence``), and once via ``json_extract`` for the
+    discovery-side Actions + check fields only (see ``_scan_opencode_part_actions``).
+    Neither scan SELECTs tool output, previews, prompts, or message bodies. Raises
+    on a corrupt or unreadable database so discovery fails closed rather than
+    reporting the store as silently absent.
     """
 
     con = _connect_regular_source_sqlite_read_only(db_source)
@@ -3410,6 +3674,19 @@ def _read_opencode_session_db_usage(
             sid for sid in (str(row["id"] or "").strip() for row in rows) if sid
         ]
         evidence_by_session = _scan_opencode_part_evidence(con, session_ids)
+        # The session ``directory`` is the cwd an edit target is relativized
+        # against; absent (older/degraded schema) it is None and an absolute path
+        # is dropped rather than leaked.
+        cwd_by_session: dict[str, str | None] = {
+            str(row["id"] or "").strip(): (
+                row["directory"] if "directory" in columns else None
+            )
+            for row in rows
+            if str(row["id"] or "").strip()
+        }
+        actions_by_session = _scan_opencode_part_actions(
+            con, session_ids, cwd_by_session
+        )
     finally:
         con.close()
     selected: list[dict[str, Any]] = []
@@ -3424,7 +3701,7 @@ def _read_opencode_session_db_usage(
         usage["cache_read_tokens_reported"] = "tokens_cache_read" in columns
         usage["cache_write_tokens_reported"] = "tokens_cache_write" in columns
         selected.append(usage)
-    return max(0, discovered_rows), selected, evidence_by_session
+    return max(0, discovered_rows), selected, evidence_by_session, actions_by_session
 
 
 def discover_opencode_usage_from_db(
@@ -3446,7 +3723,12 @@ def discover_opencode_usage_from_db(
     seen_sessions: set[tuple[str, str]] = set()
     for db_source in db_sources:
         namespace = _source_home_namespace(db_source.root)
-        _discovered, selected_rows, evidence_by_session = _read_opencode_session_db_usage(
+        (
+            _discovered,
+            selected_rows,
+            evidence_by_session,
+            actions_by_session,
+        ) = _read_opencode_session_db_usage(
             db_source,
             limit_sessions=limit_sessions,
         )
@@ -3479,6 +3761,7 @@ def discover_opencode_usage_from_db(
             parent_id = _limited_optional_text(usage.get("parent_id"), 512)
             if parent_id == session_id:
                 parent_id = None
+            session_actions = actions_by_session.get(session_id)
             event = ClientUsageEvent(
                 client="opencode",
                 client_session_id=session_id,
@@ -3515,6 +3798,20 @@ def discover_opencode_usage_from_db(
                 evidenced_event_ids=tuple(evidence_fields.get("evidenced_event_ids", ())),
                 evidenced_event_id_total=int(evidence_fields.get("evidenced_event_id_total", 0)),
                 evidenced_outputs_skipped=int(evidence_fields.get("evidenced_outputs_skipped", 0)),
+                # Discovery-side Actions + verification carriers (part-table scan).
+                # INTERNAL: the import orchestrator emits them as separate
+                # tool_activity_observed / machine_check_observed events; they never
+                # enter this event's own sentinel serialization.
+                rollout_tool_activity=(
+                    (session_actions.get("activity") or None)
+                    if session_actions
+                    else None
+                ),
+                rollout_mechanical_checks=(
+                    tuple(session_actions.get("checks") or ())
+                    if session_actions
+                    else ()
+                ),
             )
             # A session that recorded agentacct work is worth emitting even if the
             # session table carries no token/cost yet (the recorded work IS the

--- a/src/agentacct/mechanical_capture.py
+++ b/src/agentacct/mechanical_capture.py
@@ -417,6 +417,34 @@ def drain_mechanical_check_spool(
     return envelopes
 
 
+def build_discovery_mechanical_check_envelopes(
+    ticks: Iterable[Mapping[str, Any]],
+) -> list[Any]:
+    """Build ``machine_check_observed`` envelopes from discovery-derived ticks.
+
+    A client whose observe-only hook does not fire (OpenCode, whose plugin barely
+    records) can still have its checks recovered from its own transcript/DB at
+    import time. Each tick has the SAME ``{c, s, k, r, d, x, t}`` shape the spool
+    holds, so this reuses ``_build_envelope`` — the per-client adapter/schema and
+    EVERY validator (safe runner, sha256 digest, exit-code bounds) are byte-
+    identical to the hook path, and there is no second wire format to keep in sync.
+
+    The caller MUST stamp each tick's ``t`` with a STABLE source time (e.g. the
+    DB's recorded call-end time in epoch seconds), never a fresh clock: the
+    envelope's idempotency key is content+``event_timestamp`` derived, so a stable
+    timestamp dedupes a re-imported check in the Evidence store instead of double-
+    recording it. Returns the built envelopes (invalid ticks are dropped)."""
+
+    envelopes: list[Any] = []
+    for tick in ticks:
+        if not isinstance(tick, Mapping):
+            continue
+        envelope = _build_envelope(tick)
+        if envelope is not None:
+            envelopes.append(envelope)
+    return envelopes
+
+
 def ingest_mechanical_check_spool(
     store_dir: Path | str,
     *,
@@ -450,4 +478,5 @@ __all__ = [
     "record_mechanical_check_tick",
     "drain_mechanical_check_spool",
     "ingest_mechanical_check_spool",
+    "build_discovery_mechanical_check_envelopes",
 ]

--- a/tests/test_opencode_actions.py
+++ b/tests/test_opencode_actions.py
@@ -1,0 +1,529 @@
+"""Discovery-side OpenCode Actions + verification extraction.
+
+OpenCode's observe-only plugin barely fires for its built-in tools, so these
+signals are derived from the ``part`` table (its on-disk tool-call log) at
+discovery time instead — the same store the token importer already reads. Unlike
+Codex, OpenCode records a bash tool's harness ``exit`` code, so its checks lift a
+step to ``independently_checked`` (not just self_checked).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from agentacct import client_usage as cu
+from agentacct.client_usage import discover_opencode_usage
+from agentacct.mechanical_capture import build_discovery_mechanical_check_envelopes
+from agentacct.mechanical_checks import build_mechanical_check_events
+from agentacct.task_outcome import step_evidence_grade
+from agentacct.tool_activity import (
+    build_commands_by_session,
+    build_tool_activity_by_session,
+    build_tool_names_by_session,
+    build_touched_files_by_session,
+    is_discovery_tool_activity_event,
+)
+
+from tests.test_client_usage import _make_opencode_db_home
+
+
+# --- part-row fixtures ------------------------------------------------------
+
+
+def _tool_part(
+    session_id: str,
+    tool: str,
+    *,
+    status: str = "completed",
+    command: str | None = None,
+    exit_code: object = None,
+    file_path: str | None = None,
+    patch_text: str | None = None,
+    files: list[dict[str, object]] | None = None,
+    time_end: int | None = None,
+) -> dict[str, object]:
+    """One OpenCode ``part`` row in its real ``{"type":"tool","state":{...}}`` shape."""
+
+    state_input: dict[str, object] = {}
+    if command is not None:
+        state_input["command"] = command
+    if file_path is not None:
+        state_input["filePath"] = file_path
+    if patch_text is not None:
+        state_input["patchText"] = patch_text
+    metadata: dict[str, object] = {}
+    if exit_code is not None:
+        metadata["exit"] = exit_code
+    if files is not None:
+        metadata["files"] = files
+    state: dict[str, object] = {"status": status, "input": state_input}
+    if metadata:
+        state["metadata"] = metadata
+    if time_end is not None:
+        state["time"] = {"start": time_end - 1, "end": time_end}
+    return {
+        "session_id": session_id,
+        "data": json.dumps({"type": "tool", "tool": tool, "state": state}),
+    }
+
+
+def _add_opencode_tool_parts(
+    opencode_home: Path,
+    parts: list[dict[str, object]],
+    *,
+    db_name: str = "opencode.db",
+) -> None:
+    """Create the ``part`` table and insert pre-assembled tool rows (from ``_tool_part``)."""
+
+    con = sqlite3.connect(opencode_home / db_name)
+    try:
+        con.execute(
+            "create table part (id text primary key, message_id text, session_id text, "
+            "time_created integer, time_updated integer, data text)"
+        )
+        for index, part in enumerate(parts):
+            con.execute(
+                "insert into part (id, message_id, session_id, time_created, time_updated, data) "
+                "values (?, ?, ?, ?, ?, ?)",
+                (
+                    f"prt_{index}",
+                    f"msg_{index}",
+                    part.get("session_id"),
+                    index,
+                    index,
+                    part.get("data"),
+                ),
+            )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _session_row(session_id: str, directory: str) -> dict[str, object]:
+    return {
+        "id": session_id,
+        "project_id": "global",
+        "parent_id": None,
+        "directory": directory,
+        "title": "s",
+        "cost": 0.0,
+        "tokens_input": 100,
+        "tokens_output": 20,
+        "tokens_reasoning": 0,
+        "tokens_cache_read": 0,
+        "tokens_cache_write": 0,
+        "model": json.dumps({"id": "gpt-5", "providerID": "openai"}),
+        "time_created": 1_785_248_000_000,
+        "time_updated": 1_785_249_000_000,
+    }
+
+
+# --- pure extraction: edit paths --------------------------------------------
+
+
+def test_edit_paths_from_filepath_files_and_patch_body():
+    part = {
+        "file_path": "/w/proj/src/edit.py",
+        "files_json": json.dumps(
+            [{"filePath": "/w/proj/src/patched.py", "type": "update"}]
+        ),
+        "patch_text": "*** Begin Patch\n*** Add File: notes.txt\n+hi\n*** End Patch",
+    }
+    assert cu._opencode_edit_paths(part) == [
+        "/w/proj/src/edit.py",
+        "/w/proj/src/patched.py",
+        "notes.txt",
+    ]
+
+
+def test_edit_paths_ignore_missing_and_malformed():
+    assert cu._opencode_edit_paths({}) == []
+    assert cu._opencode_edit_paths(
+        {"file_path": "  ", "files_json": "not json", "patch_text": None}
+    ) == []
+    # A files list whose entries are not path-bearing yields nothing.
+    assert cu._opencode_edit_paths({"files_json": json.dumps([{"type": "x"}, 5])}) == []
+
+
+# --- pure extraction: check tick --------------------------------------------
+
+
+def _bash(**over) -> dict[str, object]:
+    base: dict[str, object] = {
+        "tool": "bash",
+        "status": "completed",
+        "command": "npm test",
+        "exit_code": 0,
+        "time_end": 1_785_248_957_928,
+        "row_time": 1_785_248_957_928,
+    }
+    base.update(over)
+    return base
+
+
+def test_check_tick_recognizes_check_and_converts_ms_to_seconds():
+    tick = cu._opencode_check_tick(_bash(), session_id="ses_1")
+    assert tick is not None
+    assert tick["c"] == "opencode" and tick["s"] == "ses_1"
+    assert tick["k"] == "test" and tick["r"] == "npm" and tick["x"] == 0
+    # OpenCode stamps MILLISECONDS; the tick is epoch SECONDS (matching time.time()).
+    assert tick["t"] == 1_785_248_957_928 / 1000.0
+    assert tick["d"].startswith("sha256:")
+
+
+def test_check_tick_failing_exit_is_kept():
+    tick = cu._opencode_check_tick(_bash(command="npm run build", exit_code=2), session_id="s")
+    assert tick["k"] == "build" and tick["x"] == 2
+
+
+def test_check_tick_rejects_non_check_and_masked_and_bad_exit():
+    assert cu._opencode_check_tick(_bash(command="git status"), session_id="s") is None
+    # A masked runner (``|| true``) can exit 0 while the check failed → not captured.
+    assert cu._opencode_check_tick(_bash(command="npm test || true"), session_id="s") is None
+    assert cu._opencode_check_tick(_bash(status="error"), session_id="s") is None
+    assert cu._opencode_check_tick(_bash(exit_code=True), session_id="s") is None  # bool
+    assert cu._opencode_check_tick(_bash(exit_code="0"), session_id="s") is None  # str
+    assert cu._opencode_check_tick(_bash(command=None), session_id="s") is None
+
+
+def test_check_tick_falls_back_to_row_time_then_drops_when_no_timestamp():
+    tick = cu._opencode_check_tick(
+        _bash(time_end=None, row_time=1_785_000_000_000), session_id="s"
+    )
+    assert tick["t"] == 1_785_000_000_000 / 1000.0
+    assert cu._opencode_check_tick(_bash(time_end=None, row_time=None), session_id="s") is None
+    assert cu._opencode_check_tick(_bash(time_end=0, row_time=0), session_id="s") is None
+
+
+# --- pure extraction: per-session aggregation -------------------------------
+
+
+def test_actions_from_parts_aggregates_all_signals_and_excludes_read_from_touched():
+    parts = [
+        {"tool": "bash", "status": "completed", "command": "npm test", "exit_code": 0,
+         "time_end": 1_785_248_957_928, "row_time": 1_785_248_957_928},
+        {"tool": "bash", "status": "completed", "command": "git status", "exit_code": 0,
+         "time_end": 1_785_248_958_000, "row_time": 1_785_248_958_000},
+        {"tool": "read", "status": "completed", "file_path": "/w/proj/README.md"},
+        {"tool": "apply_patch", "status": "completed",
+         "patch_text": "*** Add File: notes.txt\n",
+         "files_json": json.dumps([{"filePath": "/w/proj/src/a.py", "type": "update"}])},
+        {"tool": "glob", "status": "completed"},
+    ]
+    activity, checks = cu._opencode_actions_from_parts(
+        parts, cwd="/w/proj", session_id="ses_1"
+    )
+    assert activity["tool_category_counts"] == {
+        "edit": 1,
+        "execute": 2,
+        "read": 1,
+        "search": 1,
+    }
+    names = {entry["name"]: entry["count"] for entry in activity["tool_names"]}
+    assert names == {"bash": 2, "read": 1, "apply_patch": 1, "glob": 1}
+    # Both bash commands captured; only the check runner (npm test) is a check.
+    assert activity["commands"] == ["npm test", "git status"]
+    # read's filePath is NEVER a touched file; the edit paths are relativized
+    # (structured metadata files before the raw patch body, insertion-ordered).
+    assert activity["touched_files"] == ["src/a.py", "notes.txt"]
+    assert [(c["k"], c["r"], c["x"]) for c in checks] == [("test", "npm", 0)]
+
+
+def test_actions_from_parts_dedupes_commands_and_paths():
+    parts = [
+        {"tool": "bash", "status": "completed", "command": "ls", "exit_code": 0,
+         "time_end": 1, "row_time": 1},
+        {"tool": "bash", "status": "completed", "command": "ls", "exit_code": 0,
+         "time_end": 2, "row_time": 2},
+        {"tool": "edit", "status": "completed", "file_path": "a.py"},
+        {"tool": "edit", "status": "completed", "file_path": "a.py"},
+    ]
+    activity, _ = cu._opencode_actions_from_parts(parts, cwd=None, session_id="s")
+    assert activity["commands"] == ["ls"]
+    assert activity["touched_files"] == ["a.py"]
+
+
+def test_actions_from_parts_empty_is_empty():
+    activity, checks = cu._opencode_actions_from_parts([], cwd=None, session_id="s")
+    assert activity == {}
+    assert checks == []
+
+
+# --- integration: discovery populates the carriers --------------------------
+
+
+def test_discover_opencode_populates_rollout_carriers(tmp_path):
+    home = _make_opencode_db_home(
+        tmp_path, rows=[_session_row("ses_a", "/w/proj")]
+    )
+    _add_opencode_tool_parts(
+        home,
+        [
+            _tool_part("ses_a", "bash", command="npm test", exit_code=0,
+                       time_end=1_785_248_957_928),
+            _tool_part("ses_a", "apply_patch",
+                       patch_text="*** Begin Patch\n*** Update File: src/w.py\n+x\n*** End Patch\n",
+                       files=[{"filePath": "/w/proj/src/w.py", "type": "update"}]),
+            _tool_part("ses_a", "read", file_path="/w/proj/README.md"),
+        ],
+    )
+    events = discover_opencode_usage(opencode_home=home, limit_sessions=10)
+    event = next(e for e in events if e.client_session_id == "ses_a")
+    activity = event.rollout_tool_activity
+    assert activity["commands"] == ["npm test"]
+    assert activity["touched_files"] == ["src/w.py"]
+    assert activity["tool_category_counts"] == {"edit": 1, "execute": 1, "read": 1}
+    checks = event.rollout_mechanical_checks
+    assert [(c["k"], c["r"], c["x"]) for c in checks] == [("test", "npm", 0)]
+
+    # The carriers are INTERNAL: they never leak into the usage sentinel event.
+    metadata = event.to_sentinel_event()["metadata"]
+    assert "rollout_tool_activity" not in metadata
+    assert "rollout_mechanical_checks" not in metadata
+
+
+def test_discover_tolerates_malformed_and_null_part_data(tmp_path):
+    # The OpenCode db is read while OpenCode may be mid-write, so a part.data cell
+    # can be a truncated/partial write. A malformed or NULL row must be SKIPPED,
+    # never abort the scan (a bare json_extract in SQL raises OperationalError,
+    # which would zero the client's already-read usage). One clean bash row still
+    # yields its command + check.
+    home = _make_opencode_db_home(tmp_path, rows=[_session_row("ses_a", "/w/proj")])
+    con = sqlite3.connect(home / "opencode.db")
+    con.execute(
+        "create table part (id text primary key, message_id text, session_id text, "
+        "time_created integer, time_updated integer, data text)"
+    )
+    good = _tool_part("ses_a", "bash", command="npm test", exit_code=0, time_end=5)["data"]
+    con.executemany(
+        "insert into part (id, message_id, session_id, time_created, time_updated, data) "
+        "values (?, ?, ?, ?, ?, ?)",
+        [
+            ("p0", "m0", "ses_a", 1, 1, "plain text, a torn write"),  # malformed JSON
+            ("p1", "m1", "ses_a", 2, 2, None),  # NULL data
+            ("p2", "m2", "ses_a", 3, 5, good),  # a clean tool row
+            ("p3", "m3", "ses_a", 4, 4, '{"type":"reasoning"}'),  # valid non-tool
+        ],
+    )
+    con.commit()
+    con.close()
+    events = discover_opencode_usage(opencode_home=home, limit_sessions=10)
+    event = next(e for e in events if e.client_session_id == "ses_a")
+    assert event.rollout_tool_activity["commands"] == ["npm test"]
+    assert [(c["k"], c["r"]) for c in event.rollout_mechanical_checks] == [("test", "npm")]
+
+
+def _import_args(store: Path, home: Path) -> list[str]:
+    return [
+        "usage", "import-local", "--client", "opencode",
+        "--store-dir", str(store), "--opencode-home", str(home), "--json",
+    ]
+
+
+def test_import_local_emits_and_refreshes_opencode_actions(tmp_path):
+    from typer.testing import CliRunner
+
+    from agentacct.cli import app
+    from agentacct.service import SentinelService
+
+    home = _make_opencode_db_home(tmp_path, rows=[_session_row("ses_a", "/w/proj")])
+    _add_opencode_tool_parts(
+        home,
+        [
+            _tool_part("ses_a", "bash", command="npm test", exit_code=0,
+                       time_end=1_785_248_957_928),
+            _tool_part("ses_a", "apply_patch",
+                       files=[{"filePath": "/w/proj/src/w.py", "type": "update"}]),
+        ],
+    )
+    store = tmp_path / "state"
+    first = CliRunner().invoke(app, _import_args(store, home))
+    assert first.exit_code == 0, first.output
+
+    def _activity_events():
+        return [
+            event
+            for event in SentinelService(store).list_all_events()
+            if is_discovery_tool_activity_event(event)
+            and event["metadata"].get("client") == "opencode"
+            and event["metadata"].get("client_session_id") == "ses_a"
+        ]
+
+    events = _activity_events()
+    assert len(events) == 1
+    md = events[0]["metadata"]
+    assert md["commands"] == ["npm test"]
+    assert md["touched_files"] == ["src/w.py"]
+    assert md["tool_category_counts"] == {"edit": 1, "execute": 1}
+
+    # The session grows; a re-import REFRESHES its Actions in place (one event,
+    # never doubled), now reflecting the new command.
+    con = sqlite3.connect(home / "opencode.db")
+    con.execute(
+        "insert into part (id, message_id, session_id, time_created, time_updated, data) "
+        "values (?, ?, ?, ?, ?, ?)",
+        ("prt_new", "msg_new", "ses_a", 9, 9,
+         _tool_part("ses_a", "bash", command="ruff check", exit_code=0, time_end=2)["data"]),
+    )
+    con.commit()
+    con.close()
+    second = CliRunner().invoke(app, _import_args(store, home))
+    assert second.exit_code == 0, second.output
+    refreshed = _activity_events()
+    assert len(refreshed) == 1
+    assert refreshed[0]["metadata"]["commands"] == ["npm test", "ruff check"]
+
+
+def test_import_local_emits_opencode_mechanical_check_idempotently(tmp_path):
+    from typer.testing import CliRunner
+
+    from agentacct.cli import app
+    from agentacct.service import SentinelService
+
+    home = _make_opencode_db_home(tmp_path, rows=[_session_row("ses_a", "/w/proj")])
+    _add_opencode_tool_parts(
+        home,
+        [
+            _tool_part("ses_a", "bash", command="npm test", exit_code=0,
+                       time_end=1_785_248_957_928),
+            _tool_part("ses_a", "bash", command="echo hi", exit_code=0, time_end=2),
+        ],
+    )
+    store = tmp_path / "state"
+    assert CliRunner().invoke(app, _import_args(store, home)).exit_code == 0
+
+    def _checks():
+        return SentinelService(store).evidence.envelopes(
+            event_type="machine_check_observed"
+        )
+
+    checks = _checks()
+    assert len(checks) == 1  # only the recognized check runner (echo hi is not one)
+    env = checks[0]
+    assert env.source_type == "client_hook"
+    assert env.source_system == "opencode"
+    assert env.source_schema == "opencode_tool_execute_after.v1"
+    assert env.subjects.to_dict()["client_session_id"] == "ses_a"
+    attrs = env.payload["attributes"]
+    assert attrs["check_kind"] == "test" and attrs["runner"] == "npm"
+    assert attrs["exit_code"] == 0 and attrs["passed"] is True
+
+    # A re-import re-derives a byte-identical check (stable DB timestamp) → the
+    # content idempotency key dedupes; still exactly one, never double-recorded.
+    assert CliRunner().invoke(app, _import_args(store, home)).exit_code == 0
+    assert len(_checks()) == 1
+
+
+def test_produced_opencode_check_lifts_step_to_independently_checked():
+    # The produced envelope is the right shape to flow through the existing
+    # mechanical-check projection and lift a completed step past self_checked.
+    ticks = [
+        {"c": "opencode", "s": "ses_a", "k": "test", "r": "npm",
+         "d": "sha256:" + "a" * 64, "x": 0, "t": 1_785_248_957.928}
+    ]
+    envelopes = build_discovery_mechanical_check_envelopes(ticks)
+    checks = build_mechanical_check_events(envelopes)
+    assert len(checks) == 1
+    assert checks[0]["source_type"] == "client_hook"
+    grade = step_evidence_grade(
+        {"latest_status": "completed", "current_check_events": checks}
+    )["grade"]
+    assert grade == "independently_checked"
+
+
+def test_produced_check_attaches_to_check_relevant_step_via_session_time():
+    # End to end through the REAL session-time attribution path: a produced
+    # opencode check attaches to a check-relevant step begun in its session at or
+    # before its time, and is honestly declined for a research-kind step.
+    from agentacct.api import _link_mechanical_checks_by_session_time
+
+    check = build_mechanical_check_events(
+        build_discovery_mechanical_check_envelopes(
+            [{"c": "opencode", "s": "ses_a", "k": "test", "r": "npm",
+              "d": "sha256:" + "a" * 64, "x": 0, "t": 1_785_248_957.928}]
+        )
+    )[0]
+
+    def _projection(kind: str) -> dict:
+        return {
+            "tasks": [
+                {
+                    "task_id": "t1",
+                    "work_items": [
+                        {
+                            "client_session_id": "ses_a",
+                            "kind": kind,
+                            "latest_status": "completed",
+                            "started_at": 1_785_248_957.0,  # begun before the check
+                        }
+                    ],
+                    "current_check_events": [check],
+                }
+            ]
+        }
+
+    # A check-relevant (implementation) step gets the check → independently_checked.
+    impl = _link_mechanical_checks_by_session_time(_projection("implementation"))
+    step = impl["tasks"][0]["work_items"][0]
+    assert len(step.get("current_check_events") or []) == 1
+    assert step_evidence_grade(step)["grade"] == "independently_checked"
+
+    # A research step never gets a test/build check placed on it (honesty guard),
+    # matching the live receipt where a repo-overview step left the check
+    # unattributed rather than crediting research work.
+    research = _link_mechanical_checks_by_session_time(_projection("research"))
+    assert not (research["tasks"][0]["work_items"][0].get("current_check_events") or [])
+
+
+# --- privacy + supersession -------------------------------------------------
+
+
+def test_discovery_activity_supersedes_opencode_hook_events_no_double_count():
+    # If an OpenCode hook event and the discovery scan both cover a session, the
+    # additive counters must not sum both (the scan is a superset). The existing
+    # client-agnostic supersession handles OpenCode with no per-client code.
+    hook_event = {
+        "event_id": "toolact:hook",
+        "event_type": "tool_activity_observed",
+        "source": "opencode",
+        "metadata": {
+            "client": "opencode",
+            "client_session_id": "ses_dup",
+            "capture_basis": "client_hook_tool_category",
+            "tool_category_counts": {"execute": 2},
+        },
+    }
+    from agentacct.tool_activity import build_discovery_tool_activity_event
+
+    scan_event = build_discovery_tool_activity_event(
+        client="opencode",
+        session_id="ses_dup",
+        activity={"tool_category_counts": {"execute": 5, "edit": 1}},
+        captured_at=1.0,
+    )
+    for events in ([hook_event, scan_event], [scan_event, hook_event]):
+        assert build_tool_activity_by_session(events)[("opencode", "ses_dup")] == {
+            "execute": 5,
+            "edit": 1,
+        }
+
+
+def test_discovery_activity_flows_through_actions_builders():
+    from agentacct.tool_activity import build_discovery_tool_activity_event
+
+    event = build_discovery_tool_activity_event(
+        client="opencode",
+        session_id="ses_b",
+        activity={
+            "tool_category_counts": {"execute": 3, "edit": 1},
+            "commands": ["npm test"],
+            "touched_files": ["src/a.py"],
+        },
+        captured_at=1.0,
+    )
+    events = [event]
+    assert build_commands_by_session(events)[("opencode", "ses_b")] == ["npm test"]
+    assert build_touched_files_by_session(events)[("opencode", "ses_b")] == ["src/a.py"]
+    assert build_tool_names_by_session(events) == {}


### PR DESCRIPTION
OpenCode's observe-only plugin does not reliably fire for its built-in tools, so the Receipt Actions dimension (commands, touched files, tool categories + names) was blank for OpenCode sessions and no step could reach `independently_checked`. The OpenCode store on disk — already scanned for tokens — records every tool call in the `part` table, so these signals are derived from it at discovery time instead, with no hook dependency and backfilling existing sessions. This mirrors the Codex discovery-side extraction (#106) and adds the verification signal OpenCode uniquely affords.

## What it derives (per session, from the `part` table)
- **Commands** — from a bash tool's `state.input.command`, best-effort credential-scrubbed and length-bounded.
- **Touched files** — from an edit-family tool's `state.input.filePath`, the `apply_patch` structured metadata files, and the `apply_patch` body, cwd-relativized; an absolute path outside cwd is dropped, never leaked. A `read` is never counted as a touched file.
- **Tool categories + names** — from every tool part, over the shared taxonomy (OpenCode's core tools are already covered).
- **Verification** — a bash tool's harness exit code (`state.metadata.exit`) becomes a `machine_check_observed` envelope (`source_type=client_hook`, opencode adapter) whose stable DB timestamp lifts a check-relevant step to `independently_checked`. Codex's rollout has no clean exit code, so this signal is OpenCode-only.

## How it flows
The signals ride on the session's `ClientUsageEvent` as two internal `compare=False` carriers, and the import emits them as `tool_activity_observed` and `machine_check_observed` events through the same client-agnostic Actions builders and Evidence projection the hook path uses (zero changes to work_ledger/receipt, and no OpenCode observation-lane / reconciliation side effects). Re-import refreshes a scanned session's Actions in place via a scoped replace; each check's content+timestamp idempotency key dedupes a re-imported check. `_build_envelope` is reused via a new public wrapper, so the per-client adapter/schema and every validator are identical to the hook path.

## Robustness / privacy
- The `part` scan tolerates a torn/partial write (the DB is read while OpenCode may be mid-write): a malformed or NULL `data` row is skipped via a `json_valid`-guarded `CASE` type filter rather than aborting the whole scan, matching the sibling `_scan_opencode_part_evidence`.
- SQL `json_extract` pulls only whitelisted scalar fields; tool output, file previews, and message bodies never enter the process. Only tool names, cwd-relative paths, scrubbed commands, and a coarse check kind/runner/sha256 digest/exit are derived.

## Verification
- Full suite: 3257 passed, 1 skipped (plain pytest); 17 new tests in `test_opencode_actions.py` covering extraction, ms→s timestamps, dedup/caps, idempotent re-import, malformed-row tolerance, and the check lifting a check-relevant step to `independently_checked` through the real session-time attribution path.
- Adversarial find→verify review (8 agents): one confirmed finding (a malformed `part.data` row aborting the scan) fixed with the `json_valid`-guarded filter; three false positives.
- Live: run against the real `~/.local/share/opencode/opencode.db` — commands, touched files, tool categories/names, and bash exit codes are extracted from actual sessions; the emitted checks land in the Evidence store with real timestamps.

## Known follow-up (out of scope)
The Receipt Actions `provenance` label is hardcoded to `hook` in `_actions_dimension`, so discovery-scan-derived Actions (both OpenCode here and Codex from #106) are labeled `hook` rather than `transcript scan`. Threading `capture_basis` through to the provenance label is a separate honesty fix spanning both clients.
