### PR TITLE
fix(receipt): name Actions provenance by capture source, not always hook

### DIFF
--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -66,6 +66,11 @@ RECEIPT_SCHEMA_VERSION = "agentacct.receipt.v1"
 SOURCE_CLIENT_LOG = "client_log"
 SOURCE_MCP = "mcp"
 SOURCE_HOOK = "hook"
+# Derived by agentacct from the client's OWN transcript/DB at import time, for a
+# client whose hook does not fire (Codex from the rollout, OpenCode from the part
+# table). Distinct from ``hook``: no live hook observed it — agentacct read it back
+# from what the client already recorded on disk.
+SOURCE_TRANSCRIPT_SCAN = "transcript_scan"
 SOURCE_CI = "ci"
 SOURCE_GIT = "git"
 SOURCE_HUMAN = "human"
@@ -79,6 +84,7 @@ PROVENANCE_LEGEND: dict[str, str] = {
     SOURCE_CLIENT_LOG: "Observed in the agent's own local session / usage log.",
     SOURCE_MCP: "Recorded by the agent through agentacct's MCP tools (sections, files, checks).",
     SOURCE_HOOK: "Captured by an agentacct client hook (tool categories, mechanical checks).",
+    SOURCE_TRANSCRIPT_SCAN: "Derived by agentacct from the client's own transcript / session store on disk (no live hook).",
     SOURCE_CI: "Reported by external CI or the model provider.",
     SOURCE_GIT: "Derived from the git repository.",
     SOURCE_HUMAN: "Asserted by a person (review, approval, or finding disposition).",
@@ -680,7 +686,21 @@ def _actions_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
     else:
         gaps.append("No touched files were recorded for this Task's steps.")
     if counts or name_counts or commands:
-        provenance.append(SOURCE_HOOK)
+        # Tool categories, names, and commands come from a client hook OR from a
+        # transcript scan of the client's own store (Codex/OpenCode, whose hooks do
+        # not fire) — name the ACTUAL source(s), never an assumed hook. A row
+        # recorded before capture-basis tracking shipped (or a malformed non-list)
+        # has no usable ``capture_bases`` and honestly falls back to hook, its
+        # historical source. Gate on ``isinstance(list)`` like the projection that
+        # writes it, so a corrupted scalar/string can never crash the receipt or be
+        # iterated character-by-character into a silent mislabel.
+        raw_bases = actions.get("capture_bases")
+        capture_bases = [
+            basis
+            for basis in (raw_bases if isinstance(raw_bases, list) else [])
+            if basis in (SOURCE_HOOK, SOURCE_TRANSCRIPT_SCAN)
+        ]
+        provenance.extend(capture_bases or [SOURCE_HOOK])
     else:
         gaps.append(
             "Tool categories were not instrumented for this session; Actions shows touched files only."

--- a/src/agentacct/task_projection.py
+++ b/src/agentacct/task_projection.py
@@ -980,6 +980,10 @@ def build_task_projection(
         # already-recorded data; tool NAMES are captured, arguments never are.
         tool_category_counts: dict[str, int] = {}
         tool_name_counts: dict[str, int] = {}
+        # Which SOURCE(s) captured this Task's Actions — a client hook, a transcript
+        # scan, or both across its sessions — so the Receipt names Actions provenance
+        # honestly instead of assuming a hook.
+        capture_bases: set[str] = set()
         for key in ordered_members:
             counts = sessions[key].get("tool_category_counts")
             if isinstance(counts, Mapping):
@@ -995,6 +999,12 @@ def build_task_projection(
                         label = _text(tool_name)
                         if label:
                             tool_name_counts[label] = tool_name_counts.get(label, 0) + value
+            bases = sessions[key].get("tool_activity_capture_bases")
+            if isinstance(bases, list):
+                for basis in bases:
+                    token = _text(basis)
+                    if token:
+                        capture_bases.add(token)
         touched_files: list[str] = []
         seen_touched_files: set[str] = set()
         # (a) agent-reported section/check files, and (b) the paths a file-edit tool
@@ -1037,6 +1047,7 @@ def build_task_projection(
             "touched_file_count": len(touched_files),
             "commands": commands,
             "command_count": len(commands),
+            "capture_bases": sorted(capture_bases),
         }
         tasks.append(
             {

--- a/src/agentacct/tool_activity.py
+++ b/src/agentacct/tool_activity.py
@@ -499,6 +499,17 @@ def drain_tool_activity_spool(
 # cohort — replaced per (client, session) on each import instead of accumulated.
 DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS = "transcript_scan_tool_activity"
 
+# A tool-activity event's ``capture_basis`` -> the Receipt provenance TOKEN naming
+# where the Actions came from. The tokens are the receipt ``SOURCE_*`` values
+# (``hook`` / ``transcript_scan``); an unknown basis maps to nothing so the Receipt
+# falls back to its own default rather than inventing a source. This is the single
+# place the two capture bases are translated to the user-facing provenance word, so
+# a scan-derived Action is never mislabelled as hook-observed.
+TOOL_ACTIVITY_CAPTURE_SOURCE: dict[str, str] = {
+    TOOL_ACTIVITY_CAPTURE_BASIS: "hook",
+    DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS: "transcript_scan",
+}
+
 
 def is_discovery_tool_activity_event(event: Mapping[str, Any]) -> bool:
     """Whether an event is a discovery-derived (transcript-scan) tool-activity row."""
@@ -788,12 +799,49 @@ def build_commands_by_session(
     return {key: value for key, value in result.items() if value}
 
 
+def build_tool_activity_capture_basis_by_session(
+    events: Iterable[Mapping[str, Any]],
+) -> dict[tuple[str, str], list[str]]:
+    """The SET of tool-activity CAPTURE BASES present per (client, session).
+
+    Which source captured a session's Actions — a client hook, a transcript scan,
+    or (rarely) both — so the Receipt can name Actions provenance HONESTLY instead
+    of assuming a hook. The sibling ``build_*_by_session`` reducers drop the
+    ``capture_basis`` (they only need the counts/paths); this keeps it. Unlike the
+    additive counters it is NOT superseded: it reports every basis that contributed
+    a signal, which is the honest answer for the dimension (a scan supersedes a
+    hook's category counts, but the hook's commands/paths still unioned in). Each
+    basis is translated once, here, to its user-facing provenance token
+    (``hook`` / ``transcript_scan``) via ``TOOL_ACTIVITY_CAPTURE_SOURCE``; an
+    unrecognised basis contributes nothing. Returned as a sorted, deduped list."""
+
+    result: dict[tuple[str, str], set[str]] = {}
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        if event.get("event_type") != TOOL_ACTIVITY_EVENT_TYPE:
+            continue
+        metadata = event.get("metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        client = str(metadata.get("client") or "").strip()
+        session = str(metadata.get("client_session_id") or "").strip()
+        if not client or not session:
+            continue
+        source = TOOL_ACTIVITY_CAPTURE_SOURCE.get(str(metadata.get("capture_basis") or ""))
+        if source is None:
+            continue
+        result.setdefault((client, session), set()).add(source)
+    return {key: sorted(value) for key, value in result.items() if value}
+
+
 __all__ = [
     "TOOL_ACTIVITY_CAPTURE_BASIS",
+    "TOOL_ACTIVITY_CAPTURE_SOURCE",
     "TOOL_ACTIVITY_EVENT_TYPE",
     "TOOL_CATEGORIES",
     "build_commands_by_session",
     "build_tool_activity_by_session",
+    "build_tool_activity_capture_basis_by_session",
     "build_tool_names_by_session",
     "build_touched_files_by_session",
     "drain_tool_activity_spool",

--- a/src/agentacct/work_ledger.py
+++ b/src/agentacct/work_ledger.py
@@ -17,6 +17,7 @@ from .session_lifecycle import build_session_end_by_session
 from .tool_activity import (
     build_commands_by_session,
     build_tool_activity_by_session,
+    build_tool_activity_capture_basis_by_session,
     build_tool_names_by_session,
     build_touched_files_by_session,
 )
@@ -218,6 +219,10 @@ def build_work_ledger(
     tool_names_by_session = build_tool_names_by_session(events)
     touched_files_by_session = build_touched_files_by_session(events)
     commands_by_session = build_commands_by_session(events)
+    # Which SOURCE captured each session's Actions (a client hook vs a transcript
+    # scan). Carried so the Receipt names Actions provenance honestly instead of
+    # assuming a hook — Codex/OpenCode Actions are transcript-scan-derived.
+    capture_basis_by_session = build_tool_activity_capture_basis_by_session(events)
     if tool_activity_by_session or tool_names_by_session or touched_files_by_session or commands_by_session:
         for entry in session_rollup.get("sessions", []):
             entry_key = (str(entry.get("client") or ""), str(entry.get("client_session_id") or ""))
@@ -227,6 +232,9 @@ def build_work_ledger(
             names = tool_names_by_session.get(entry_key)
             if names:
                 entry["tool_name_counts"] = dict(names)
+            bases = capture_basis_by_session.get(entry_key)
+            if bases:
+                entry["tool_activity_capture_bases"] = list(bases)
             # Paths a file-edit tool wrote (hook-captured), cwd-relative — an out-of-tree
             # edit rides as ``../`` and a home-file edit as ``~/…`` (no username). Each was
             # gated by _normalize_touched_path at the tick, the drain, and

--- a/tests/test_actions_provenance.py
+++ b/tests/test_actions_provenance.py
@@ -1,0 +1,211 @@
+"""Honest Actions provenance: distinguish a transcript scan from a client hook.
+
+The Receipt Actions dimension used to declare ``hook`` provenance for any tool
+categories/names/commands. But Codex and OpenCode Actions are derived from the
+client's own store on disk at import time (their hooks do not fire), not observed
+by a live hook — so they now carry a distinct ``transcript_scan`` provenance.
+"""
+
+from __future__ import annotations
+
+from agentacct.receipt import (
+    SOURCE_HOOK,
+    SOURCE_MCP,
+    SOURCE_TRANSCRIPT_SCAN,
+    _actions_dimension,
+)
+from agentacct.tool_activity import (
+    DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS,
+    TOOL_ACTIVITY_CAPTURE_BASIS,
+    TOOL_ACTIVITY_EVENT_TYPE,
+    build_tool_activity_capture_basis_by_session,
+)
+
+
+def _activity_event(client: str, session: str, basis: str) -> dict:
+    return {
+        "event_type": TOOL_ACTIVITY_EVENT_TYPE,
+        "metadata": {
+            "client": client,
+            "client_session_id": session,
+            "capture_basis": basis,
+            "tool_category_counts": {"execute": 1},
+        },
+    }
+
+
+# --- the capture-basis builder ----------------------------------------------
+
+
+def test_capture_basis_builder_maps_hook_and_scan():
+    bases = build_tool_activity_capture_basis_by_session(
+        [
+            _activity_event("opencode", "s1", DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS),
+            _activity_event("claude-code", "s2", TOOL_ACTIVITY_CAPTURE_BASIS),
+            _activity_event("codex", "s3", DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS),
+        ]
+    )
+    assert bases[("opencode", "s1")] == ["transcript_scan"]
+    assert bases[("claude-code", "s2")] == ["hook"]
+    assert bases[("codex", "s3")] == ["transcript_scan"]
+
+
+def test_capture_basis_builder_reports_both_when_mixed_and_dedupes():
+    bases = build_tool_activity_capture_basis_by_session(
+        [
+            _activity_event("x", "s", TOOL_ACTIVITY_CAPTURE_BASIS),
+            _activity_event("x", "s", DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS),
+            _activity_event("x", "s", DISCOVERY_TOOL_ACTIVITY_CAPTURE_BASIS),
+        ]
+    )
+    assert bases[("x", "s")] == ["hook", "transcript_scan"]
+
+
+def test_capture_basis_builder_ignores_unknown_basis_and_blank_identity():
+    bases = build_tool_activity_capture_basis_by_session(
+        [
+            _activity_event("x", "s", "some_future_basis"),  # unknown -> nothing
+            _activity_event("", "s", TOOL_ACTIVITY_CAPTURE_BASIS),  # blank client
+            _activity_event("x", "", TOOL_ACTIVITY_CAPTURE_BASIS),  # blank session
+            {"event_type": "other", "metadata": {}},  # not a tool-activity event
+        ]
+    )
+    assert bases == {}
+
+
+# --- the Actions dimension provenance ---------------------------------------
+
+
+def test_actions_scan_declares_transcript_scan_not_hook():
+    d = _actions_dimension(
+        {
+            "actions": {
+                "tool_category_counts": {"execute": 3},
+                "commands": ["npm test"],
+                "capture_bases": [SOURCE_TRANSCRIPT_SCAN],
+            }
+        }
+    )
+    assert d["provenance"] == [SOURCE_TRANSCRIPT_SCAN]
+    assert SOURCE_HOOK not in d["provenance"]
+
+
+def test_actions_hook_declares_hook():
+    d = _actions_dimension(
+        {"actions": {"tool_category_counts": {"read": 3}, "capture_bases": [SOURCE_HOOK]}}
+    )
+    assert d["provenance"] == [SOURCE_HOOK]
+
+
+def test_actions_mixed_declares_both():
+    d = _actions_dimension(
+        {
+            "actions": {
+                "tool_name_counts": {"bash": 2},
+                "capture_bases": [SOURCE_HOOK, SOURCE_TRANSCRIPT_SCAN],
+            }
+        }
+    )
+    assert SOURCE_HOOK in d["provenance"]
+    assert SOURCE_TRANSCRIPT_SCAN in d["provenance"]
+
+
+def test_actions_without_capture_bases_falls_back_to_hook():
+    # A row recorded before capture-basis tracking shipped has no capture_bases and
+    # honestly falls back to hook (its historical source) — never invents a scan.
+    d = _actions_dimension({"actions": {"tool_category_counts": {"read": 3}}})
+    assert d["provenance"] == [SOURCE_HOOK]
+
+
+def test_actions_malformed_capture_bases_never_crashes_or_mislabels():
+    # A corrupted non-list capture_bases (a truthy scalar, or a bare string that is
+    # iterable char-by-char) must not crash the receipt or be silently mislabeled —
+    # it coerces to the honest historical hook fallback.
+    for bad in (True, 5, 1.5, "transcript_scan", {"transcript_scan": 1}):
+        d = _actions_dimension(
+            {"actions": {"tool_category_counts": {"read": 3}, "capture_bases": bad}}
+        )
+        assert d["provenance"] == [SOURCE_HOOK]
+    # A list with junk entries keeps only the valid tokens.
+    d = _actions_dimension(
+        {
+            "actions": {
+                "tool_category_counts": {"read": 3},
+                "capture_bases": [SOURCE_TRANSCRIPT_SCAN, "bogus", 7, None],
+            }
+        }
+    )
+    assert d["provenance"] == [SOURCE_TRANSCRIPT_SCAN]
+
+
+def test_actions_scan_with_section_touched_files_reports_both_sources():
+    # touched files recorded via MCP sections stay MCP; the scan-captured categories
+    # add transcript_scan — both are honestly present.
+    d = _actions_dimension(
+        {
+            "work_items": [{"files": ["src/a.py"]}],
+            "actions": {
+                "tool_category_counts": {"edit": 1},
+                "touched_files": ["src/a.py"],
+                "capture_bases": [SOURCE_TRANSCRIPT_SCAN],
+            },
+        }
+    )
+    assert SOURCE_MCP in d["provenance"]
+    assert SOURCE_TRANSCRIPT_SCAN in d["provenance"]
+
+
+# --- end to end: real store -> receipt --------------------------------------
+
+
+def test_opencode_receipt_actions_declare_transcript_scan(tmp_path):
+    from typer.testing import CliRunner
+
+    from agentacct.api import _task_title, build_store_task_projection
+    from agentacct.cli import app
+    from agentacct.receipt import build_receipt, latest_store_activity
+    from tests.test_opencode_actions import (
+        _add_opencode_tool_parts,
+        _make_opencode_db_home,
+        _session_row,
+        _tool_part,
+    )
+
+    home = _make_opencode_db_home(tmp_path, rows=[_session_row("ses_a", "/w/proj")])
+    _add_opencode_tool_parts(
+        home,
+        [
+            _tool_part("ses_a", "bash", command="npm test", exit_code=0, time_end=5),
+            _tool_part("ses_a", "read", file_path="/w/proj/README.md"),
+        ],
+    )
+    store = tmp_path / "state"
+    result = CliRunner().invoke(
+        app,
+        [
+            "usage", "import-local", "--client", "opencode",
+            "--store-dir", str(store), "--opencode-home", str(home), "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    projection = build_store_task_projection(store)
+    tasks = [t for t in projection.get("tasks", []) if isinstance(t, dict)]
+    task = next(t for t in tasks if "ses_a" in str(t.get("session_keys")))
+    # The projection carried the transcript-scan capture basis onto the Task.
+    assert task["actions"]["capture_bases"] == [SOURCE_TRANSCRIPT_SCAN]
+
+    receipt = build_receipt(
+        task,
+        public_task_id=str(task.get("task_id")),
+        title=_task_title(task),
+        latest_store_activity_at=latest_store_activity(tasks),
+    )
+    actions_dim = next(
+        d for d in receipt["dimensions"] if isinstance(d, dict) and d.get("key") == "actions"
+    ) if isinstance(receipt.get("dimensions"), list) else receipt["dimensions"]["actions"]
+    assert SOURCE_TRANSCRIPT_SCAN in actions_dim["provenance"]
+    assert SOURCE_HOOK not in actions_dim["provenance"]
+    # The provenance roll-up legend explains the new source.
+    legend = receipt["dimensions"]["provenance"]["legend"]
+    assert SOURCE_TRANSCRIPT_SCAN in legend


### PR DESCRIPTION
The Receipt Actions dimension declared `hook` provenance for any tool categories, names, or commands. But Codex (#106) and OpenCode (#107) Actions are derived from the client's own transcript / session store on disk at import time — their hooks do not fire — so no live hook ever observed them. This names the actual capture source instead, closing the follow-up flagged in #107.

## Change
- **`tool_activity.py`** — `TOOL_ACTIVITY_CAPTURE_SOURCE` maps a tool-activity event's `capture_basis` to its user-facing provenance token (`hook` / `transcript_scan`); `build_tool_activity_capture_basis_by_session` keeps the capture basis the sibling reducers drop, returning the sorted SET of tokens present per `(client, session)` — not superseded, so a session captured by both sources reports both.
- **`work_ledger.py`** — stamps `tool_activity_capture_bases` onto each session rollup entry.
- **`task_projection.py`** — unions the member sessions' bases into `task["actions"]["capture_bases"]`.
- **`receipt.py`** — adds the `transcript_scan` provenance source + legend; `_actions_dimension` names Actions by the actual capture basis. A row recorded before this shipped (or a malformed non-list) has no usable `capture_bases` and falls back to `hook`, its historical source, without crashing.

## Result
A Codex/OpenCode Task's Actions now read `transcript_scan`; a Claude Code / Hermes Task's read `hook`; a session captured by both reads both.

## Verification
- Full suite: 3268 passed, 1 skipped (plain pytest); new `test_actions_provenance.py`.
- Live (new-code projection on a copy of the real store): 19 Codex tasks + 5 OpenCode tasks now read `transcript_scan`; 10 Claude Code + 1 Hermes read `hook`; one mixed Codex task reads both. Before this change every one read `hook`.
- Adversarial find→verify review (4 agents): one confirmed medium bug — `_actions_dimension` iterated `capture_bases` without an `isinstance(list)` guard (crash on a truthy scalar, silent `hook`-mislabel on a bare string) — fixed to mirror the projection's guard, with a malformed-input test. Backward-compat and honesty finders returned clean.

## Scope
Only the tool-activity-derived Actions provenance (categories / names / commands) changes. The touched-files `mcp` provenance and the evidence/check dimension provenance are unchanged; existing fixtures without `capture_bases` keep their `hook` label via the fallback.
