### PR TITLE
fix(evidence): don't conflict on equal-watermark evidence-link drift

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -8812,10 +8812,15 @@ def _print_evidence_refreshable_usage_warning(
             else int(bool(errors))
         )
         conflict_count = int(outcome_map.get("conflicts") or 0)
+        # existing_conflicts (prior unresolved conflicts re-detected this pass)
+        # can be the sole reason the reconcile is unhealthy, so surface it too —
+        # a bare "conflicts=0" otherwise hides the actual cause.
+        existing_conflict_count = int(outcome_map.get("existing_conflicts") or 0)
         print(
             f"{prefix}WARNING: the local usage ledger was saved, but Evidence v2 "
             "current-usage reconciliation is not healthy "
-            f"(errors={error_count} conflicts={conflict_count}). "
+            f"(errors={error_count} conflicts={conflict_count} "
+            f"existing_conflicts={existing_conflict_count}). "
             "Retry usage refresh and inspect "
             "ingestion health before any Evidence rebuild or cleanup.",
             file=sys.stderr,

--- a/src/agentacct/evidence_runtime.py
+++ b/src/agentacct/evidence_runtime.py
@@ -27,6 +27,7 @@ from .refreshable_usage import (
     refreshable_usage_source_order,
     refreshable_usage_truth_digest,
     refreshable_usage_truth_material,
+    refreshable_usage_usage_material_digest_from_material,
 )
 from .usage_truth import (
     LOCAL_USAGE_PROVENANCE,
@@ -301,6 +302,10 @@ class EvidenceRuntime:
                 source_order=source_order,
                 revision_id=revision_id,
                 envelope=envelope,
+                # Tokens-only digest (evidence links excluded): lets the store
+                # tell a real usage change from mere provenance drift at an equal
+                # source-order watermark.
+                usage_material_hash=refreshable_usage_usage_material_digest_from_material(truth),
             ),
             revision_id,
         )

--- a/src/agentacct/evidence_store.py
+++ b/src/agentacct/evidence_store.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, Iterator, Mapping, Sequence
 
 from .evidence import ClaimedLink, EvidenceEnvelope, canonical_digest, canonical_json_bytes, normalize_timestamp
+from .refreshable_usage import refreshable_usage_usage_material_digest_from_material
 
 
 EVIDENCE_STORE_SCHEMA_VERSION = "agent-chronicle.evidence-store.v1"
@@ -174,6 +175,10 @@ class RefreshableUsageItem:
     usage adapter.  The store deliberately does not derive them from the full
     envelope because refresh observations may legitimately remint transport
     timestamps and evidence ids while describing the same current fact.
+
+    ``usage_material_hash`` is the tokens-only digest (client-log evidence links
+    excluded).  When two revisions share it but differ on ``content_hash``, only
+    provenance drifted and the reconcile must not treat that as usage divergence.
     """
 
     slot_key: str
@@ -182,6 +187,7 @@ class RefreshableUsageItem:
     revision_id: str
     source_order: int | None
     envelope: EvidenceEnvelope
+    usage_material_hash: str | None = None
 
 
 @dataclass(frozen=True)
@@ -789,6 +795,53 @@ class EvidenceStore:
             validated.append((item, identity_json))
         return tuple(validated)
 
+    def _head_usage_material_hash(
+        self, connection: sqlite3.Connection, head: sqlite3.Row
+    ) -> str | None:
+        """Tokens-only digest of the stored head's usage, or ``None`` if it
+        cannot be recomputed.  Fetched lazily (only when a conflict would
+        otherwise be recorded), so the reconcile hot path pays nothing."""
+
+        try:
+            evidence_id = head["evidence_id"]
+        except (IndexError, KeyError):
+            return None
+        if not evidence_id:
+            return None
+        row = connection.execute(
+            "SELECT envelope_json FROM evidence_versions WHERE evidence_id = ?",
+            (str(evidence_id),),
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            envelope = json.loads(row["envelope_json"])
+            truth = envelope["payload"]["refreshable_usage"]["truth"]
+        except (KeyError, TypeError, ValueError):
+            return None
+        if not isinstance(truth, Mapping):
+            return None
+        try:
+            return refreshable_usage_usage_material_digest_from_material(truth)
+        except Exception:  # noqa: BLE001 - a bad stored truth simply falls back to conflict.
+            return None
+
+    def _refreshable_usage_provenance_only_drift(
+        self,
+        connection: sqlite3.Connection,
+        head: sqlite3.Row,
+        item: "RefreshableUsageItem",
+    ) -> bool:
+        """True when the incoming item and the stored head carry the SAME usage
+        material and differ only in client-log evidence links.  Callers gate
+        this behind an already-established content-hash mismatch and the absence
+        of a reliable source-order ordering."""
+
+        if item.usage_material_hash is None:
+            return False
+        head_material = self._head_usage_material_hash(connection, head)
+        return head_material is not None and head_material == item.usage_material_hash
+
     @staticmethod
     def _refreshable_usage_conflict_key(
         *,
@@ -1025,6 +1078,17 @@ class EvidenceStore:
                         counts["updated"] += 1
                     elif reliable_older:
                         counts["stale"] += 1
+                    elif self._refreshable_usage_provenance_only_drift(
+                        connection, head, item
+                    ):
+                        # Same usage material; only the client-log evidence links
+                        # drifted (e.g. an older import cited no source events).
+                        # Equal-source-order evidence-link drift is not usage
+                        # divergence, so refresh it as unchanged rather than
+                        # parking a permanent conflict. Scoped to the live head;
+                        # a tombstoned head keeps the stricter conflict path,
+                        # where resurrection semantics are the concern.
+                        counts["unchanged"] += 1
                     else:
                         conflict_key = self._refreshable_usage_conflict_key(
                             head=head,

--- a/tests/test_client_usage.py
+++ b/tests/test_client_usage.py
@@ -6231,6 +6231,29 @@ def test_usage_reconcile_failure_is_fail_open_degraded_then_noop_self_heals(
     assert "Evidence v2 current-usage reconciliation is not healthy" in watch.output
 
 
+def test_evidence_refreshable_usage_warning_surfaces_existing_conflicts(capsys):
+    # existing_conflicts alone can make the reconcile unhealthy; the warning must
+    # print that count, not just conflicts (which is 0 here), so the degraded
+    # cause is not hidden.
+    from agentacct.cli import _print_evidence_refreshable_usage_warning
+
+    _print_evidence_refreshable_usage_warning(
+        {
+            "evidence_refreshable_usage": {
+                "complete_requested": True,
+                "complete_applied": True,
+                "errors": [],
+                "conflicts": 0,
+                "existing_conflicts": 2,
+            }
+        }
+    )
+    err = capsys.readouterr().err
+    assert "current-usage reconciliation is not healthy" in err
+    assert "conflicts=0" in err
+    assert "existing_conflicts=2" in err
+
+
 def test_usage_import_refresh_preserves_prior_estimate_on_unchanged_session(tmp_path):
     # D1: a prior --estimate-costs run leaves an estimated_from_tokens cost; a
     # later --refresh WITHOUT --estimate-costs over the unchanged session must

--- a/tests/test_refreshable_usage_runtime.py
+++ b/tests/test_refreshable_usage_runtime.py
@@ -701,6 +701,51 @@ def test_equal_source_order_divergence_records_one_stable_conflict(tmp_path: Pat
     assert (_stats(runtime), _spool_size(runtime)) == after_first_conflict
 
 
+def test_equal_source_order_evidence_link_drift_refreshes_without_conflict(tmp_path: Path) -> None:
+    """Provenance-only drift — identical usage material, different client-log
+    evidence links, equal source-order watermark — refreshes as a no-op instead
+    of parking a permanent conflict. Regression for opencode session_total slots
+    stuck when an older import recorded no source-event ids and the current
+    importer populates them at the same watermark."""
+
+    runtime = EvidenceRuntime(tmp_path, enabled=True)
+    incumbent = _usage_event(
+        event_id="evt_incumbent",
+        source_order=100.0,
+        input_tokens=100,
+        evidenced_event_ids=(),  # an older import cited no source events
+    )
+    _assert_counts(
+        runtime.reconcile_refreshable_usage_snapshot([incumbent], complete=True),
+        inserted=1,
+        spool_written=1,
+    )
+
+    enriched = _usage_event(
+        event_id="evt_enriched",
+        created_at=2_000.0,
+        source_order=100.0,
+        input_tokens=100,  # identical usage material
+        evidenced_event_ids=("evt_evidence_a", "evt_evidence_b"),  # now populated
+    )
+    outcome = _assert_counts(
+        runtime.reconcile_refreshable_usage_snapshot([enriched], complete=True),
+        noop=1,
+    )
+    assert _error_count(outcome) == 0
+    stats = _stats(runtime)
+    assert stats["conflict_groups"] == 0
+    assert stats["conflict_versions"] == 0
+
+    # Deterministic: re-issuing the enriched snapshot stays a no-op, never a
+    # conflict, so a watcher never re-flags it as unhealthy.
+    _assert_counts(
+        runtime.reconcile_refreshable_usage_snapshot([enriched], complete=True),
+        noop=1,
+    )
+    assert _stats(runtime)["conflict_groups"] == 0
+
+
 def test_identical_concurrent_snapshots_commit_one_physical_revision(tmp_path: Path) -> None:
     runtime_a = EvidenceRuntime(tmp_path, enabled=True)
     runtime_b = EvidenceRuntime(tmp_path, enabled=True)


### PR DESCRIPTION
## The bug

`continuous sync` reported `degraded` because Evidence-v2 current-usage reconciliation never reached a clean state. Root cause: a refreshable-usage revision's `content_hash` folds in its client-log **evidence links** (`event_ids`), which legitimately drift while the usage stays frozen — e.g. an older import recorded no source-event ids and the current importer populates them. When two revisions share the same usage but carry different evidence links at an **equal `source_order` watermark**, the reconcile couldn't order them, recorded a conflict, and re-counted it as an `existing_conflict` on **every** pass — so the degraded flag latched permanently (observed: two `opencode` `session_total` slots with byte-identical tokens differing only in `event_ids`).

The health warning also printed only `conflicts` — so it read `conflicts=0` while `existing_conflicts` was the real cause, hiding it.

## The fix

The codebase already defines a tokens-only **`usage_material`** digest (evidence links excluded); its docstring states that equal-source-order evidence-link drift "must not be treated as usage divergence." This wires that dormant digest into the reconcile:

- `RefreshableUsageItem` carries a `usage_material_hash`; `evidence_runtime` computes it from the truth it already builds.
- In the live (non-tombstoned) conflict branch, when the incoming item's usage material matches the stored head (recomputed lazily from the head's stored envelope — only on the otherwise-conflicting path, no hot-path cost) and only the evidence links differ, it routes to `unchanged` instead of recording a conflict.
- A genuine token/model/cost change still produces a different `usage_material` digest and still conflicts. The tombstoned branch is unchanged (resurrection semantics).
- The health warning now prints `existing_conflicts` alongside `conflicts`.

## Tests

Two regression tests: provenance-only drift at an equal watermark refreshes as a no-op (never a conflict, deterministic across repeats); the warning surfaces `existing_conflicts` when it is the sole cause. Full suite green (3270 passed, 1 skipped).

Reviewed with a multi-agent adversarial pass (correctness / regression-masking / edge-robustness / design).

## Known residue (out of scope)

On an **already-degraded** store, the historical conflict was persisted before this fix (a `refreshable_usage_conflicts` row + an `is_conflict=1` version). Once deployed, the next reconcile routes those slots to `unchanged`, so the **health signal clears**. But the store is append-only forensic, so the pre-existing conflict *records* remain in the `evidence conflicts` listing / `conflict_*` stats (a rebuild would replay them from the spool). Clearing that residue is a separate one-time concern, not a change to this fix's forward behavior.
