### PR TITLE
fix(rename): finish agentacct rename in issue templates, LICENSE, and demo example

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report something broken in Agent Chronicle
+description: Report something broken in agentacct
 title: "bug: "
 labels: ["bug"]
 body:
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Summary
       description: What went wrong?
-      placeholder: Agent Chronicle did...
+      placeholder: agentacct did...
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an improvement to the Agent Chronicle CLI
+description: Suggest an improvement to the agentacct CLI
 title: "feat: "
 labels: ["enhancement"]
 body:
@@ -15,7 +15,7 @@ body:
     id: proposal
     attributes:
       label: Proposed solution
-      description: What should Agent Chronicle do?
+      description: What should agentacct do?
     validations:
       required: true
   - type: textarea
@@ -29,4 +29,4 @@ body:
       options:
         - label: This should preserve local-first behavior.
         - label: This should not require provider API keys by default.
-        - label: This should not control processes Agent Chronicle did not start.
+        - label: This should not control processes agentacct did not start.

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -28,8 +28,8 @@ body:
   - type: textarea
     id: desired
     attributes:
-      label: Desired Chronicle behavior
-      description: What should Agent Chronicle track, block, report, or display?
+      label: Desired agentacct behavior
+      description: What should agentacct track, block, report, or display?
     validations:
       required: true
   - type: textarea

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Agent Chronicle contributors
+Copyright (c) 2026 agentacct contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/full_demo_task.py
+++ b/examples/full_demo_task.py
@@ -1,7 +1,7 @@
-"""A deterministic task for Agent Chronicle end-to-end demos.
+"""A deterministic task for agentacct end-to-end demos.
 
 This script is intentionally boring: it sleeps, prints progress, and exits 0.
-Use it to validate Chronicle's run/report/API/MCP/outcome/value pipeline without
+Use it to validate agentacct's run/report/API/MCP/outcome/value pipeline without
 calling a real agent or touching real user processes.
 """
 
@@ -15,12 +15,12 @@ import time
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run a safe deterministic Agent Chronicle demo task.")
+    parser = argparse.ArgumentParser(description="Run a safe deterministic agentacct demo task.")
     parser.add_argument("--steps", type=int, default=6, help="Number of visible task steps to print.")
     parser.add_argument("--sleep-seconds", type=float, default=1.0, help="Seconds to sleep per step.")
     parser.add_argument(
         "--label",
-        default="agent-chronicle-full-demo",
+        default="agentacct-full-demo",
         help="Human-readable label included in the final JSON summary.",
     )
     return parser.parse_args()


### PR DESCRIPTION
## Summary

The docs rename (#115) missed a few user-facing surfaces that still show the pre-rename **Agent Chronicle** product name. This finishes the rename for them:

- **`.github/ISSUE_TEMPLATE/` bug/feature/integration forms** — the "New issue" forms on GitHub still read "Report something broken in Agent Chronicle", "Suggest an improvement to the Agent Chronicle CLI", "Desired Chronicle behavior", and the bug-summary placeholder "Agent Chronicle did…". (`pull_request_template.md` was already fixed in #115.)
- **`LICENSE`** — copyright line renamed to `agentacct contributors`.
- **`examples/full_demo_task.py`** — docstring, argparse description, and the demo `--label` default.

## Deliberately left verbatim (frozen backward-compat vocabulary)

Per the `test_rename_compat.py` tripwires, these are stored/wire format on real machines, not branding, and stay as-is: the legacy heading/marker recognizers in `cli.py`, the rename-history note in `env_compat.py`, the `AGENT_CHRONICLE_*` / `AGENT_SENTINEL_*` run-id env reads in the demo, and internal test comments/fixtures.

## Out of scope (flagged separately)

`examples/agent_like_openrouter_loop.py` still names the old brand **and** documents `… cost proxy`, whose backing `proxy.py` was removed in #113. It needs a real decision (update to the current mechanism, or delete) rather than a cosmetic rename, so it is not touched here.

## Test plan

- [x] The 3 issue templates parse as valid GitHub form YAML
- [x] `examples/full_demo_task.py` compiles; frozen `AGENT_*_RUN_ID` env reads untouched
- [x] `tests/test_rename_compat.py` + `tests/test_install_guide.py` pass (68) — no frozen vocab touched, no bare "Sentinel" introduced
- [x] No residual "Agent Chronicle" / bare "Chronicle" in the edited files
