### PR TITLE
release: 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.3] — 2026-08-23
+
+A metadata release: finishes the agentacct rename on the last user-facing
+surfaces the 0.9.1 docs sweep missed. No code or behavior changes.
+
+### Changed
+- Renamed the remaining pre-rename "Agent Chronicle" references to agentacct in
+  the GitHub issue-form templates, the `LICENSE` copyright line, and the
+  `full_demo_task` example. (#121)
+
 ## [0.9.2] — 2026-08-22
 
 A documentation release: the docs now match the surface 0.9.1 actually ships.
@@ -651,7 +661,8 @@ across all of them. Ships alongside the first signed, notarized macOS app.
   `agentacct-claude`, and `agentacct-codex` console scripts. Local-first,
   observe-only, no telemetry, no provider API keys. Python ≥ 3.11 on macOS / Linux.
 
-[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/mikehasa/agentacct/releases/tag/v0.9.3
 [0.9.2]: https://github.com/mikehasa/agentacct/releases/tag/v0.9.2
 [0.9.1]: https://github.com/mikehasa/agentacct/releases/tag/v0.9.1
 [0.9.0]: https://github.com/mikehasa/agentacct/releases/tag/v0.9.0

--- a/apps/agentacct/Scripts/build-app.sh
+++ b/apps/agentacct/Scripts/build-app.sh
@@ -38,7 +38,7 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
     <key>CFBundleIdentifier</key><string>dev.agentacct.app</string>
     <key>CFBundleName</key><string>agentacct</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.9.2</string>
+    <key>CFBundleShortVersionString</key><string>0.9.3</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <key>LSUIElement</key><true/>
     <key>NSHighResolutionCapable</key><true/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentacct"
-version = "0.9.2"
+version = "0.9.3"
 description = "Local-first Agent Work Intelligence for coding agents: usage truth, recorded work, and honest joins"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for 0.9.3 — a metadata release finishing the agentacct rename (#121) on the issue-form templates, the LICENSE copyright line, and the full_demo_task example. No code or behavior changes.

Bumps the version in all three tracked places (pyproject.toml, the app bundle's CFBundleShortVersionString, CHANGELOG.md) so the CI tag/version check passes at release time.