### PR TITLE
fix(codex): restore gradeable evidence from paginated MCP rollouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Read Codex's paginated `item_completed` / `McpToolCall` rollout records
+  when linking agentacct MCP receipts and deriving Actions, while retaining
+  compatibility with legacy Codex rollout carriers. Duplicate carrier
+  representations are reconciled by logical call id; malformed results and
+  conflicting successful event ids fail closed without letting a failed
+  duplicate suppress a valid receipt.
+
 ## [0.9.3] — 2026-08-23
 
 A metadata release: finishes the agentacct rename on the last user-facing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Read Codex's paginated `item_completed` / `McpToolCall` rollout records
   when linking agentacct MCP receipts and deriving Actions, while retaining
   compatibility with legacy Codex rollout carriers. Duplicate carrier
-  representations are reconciled by logical call id; malformed results and
-  conflicting successful event ids fail closed without letting a failed
-  duplicate suppress a valid receipt.
+  representations are reconciled by logical call id. A clean failed or unknown
+  duplicate does not suppress a valid receipt; malformed carriers, identity
+  conflicts, and conflicting successful event ids invalidate that logical call
+  and report evidence schema drift.
 
 ## [0.9.3] — 2026-08-23
 

--- a/docs/coding-agent-integrations.md
+++ b/docs/coding-agent-integrations.md
@@ -128,6 +128,18 @@ agentacct mcp doctor
 
 The `--write` path updates project `.codex/config.toml` with a portable store path. Some Codex versions may not load project-local `.codex/config.toml`; in that case use the previewed `codex mcp add ...` command or per-command config flags.
 
+Local usage import recognizes both Codex's current paginated
+`item_completed` / `McpToolCall` rollout records and the older
+`function_call`, `function_call_output`, and `mcp_tool_call_end` carriers.
+When Codex writes the same logical MCP call in more than one representation,
+agentacct reconciles them by call id so the receipt and Action are counted
+once. Malformed recording results and conflicting successful event ids do not
+donate evidence; a valid receipt still survives a failed duplicate carrier.
+
+No migration or backfill runs automatically; rows not revisited by an explicit
+refresh remain unchanged. Restart a long-running watcher after upgrading so
+subsequent scans use the new parser.
+
 ### Hermes
 
 ```bash

--- a/docs/coding-agent-integrations.md
+++ b/docs/coding-agent-integrations.md
@@ -133,8 +133,9 @@ Local usage import recognizes both Codex's current paginated
 `function_call`, `function_call_output`, and `mcp_tool_call_end` carriers.
 When Codex writes the same logical MCP call in more than one representation,
 agentacct reconciles them by call id so the receipt and Action are counted
-once. Malformed recording results and conflicting successful event ids do not
-donate evidence; a valid receipt still survives a failed duplicate carrier.
+once. A clean failed or unknown duplicate does not suppress a valid receipt.
+Malformed carriers, identity conflicts, and conflicting successful event ids
+invalidate that logical call and report evidence schema drift.
 
 No migration or backfill runs automatically; rows not revisited by an explicit
 refresh remain unchanged. Restart a long-running watcher after upgrading so

--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -17,8 +17,18 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, TextIO
 
+from .codex_rollout_adapter import (
+    CodexEvidenceFragment,
+    codex_function_action_name,
+    codex_mcp_action_name,
+    codex_model_from_record,
+    codex_record_may_contain_evidence,
+    decode_codex_evidence_fragment,
+    reconcile_codex_evidence_fragments,
+    validated_codex_identifier,
+)
 from .confidence import COST_BASIS_CLIENT_SESSION, COST_BASIS_PRICING_TABLE, COST_CLIENT_REPORTED, COST_ESTIMATED_FROM_TOKENS, COST_UNKNOWN, USAGE_CLIENT_REPORTED
 from .env_compat import read_env_alias
 from .cost import estimate_model_cost_breakdown_usd, has_model_price, model_pricing_entry
@@ -26,15 +36,9 @@ from .log_evidence import (
     ACCEPTED_SERVER_KEYS,
     LogEvidenceAccumulator,
     classify_claude_tool_use,
-    classify_codex_function_call,
-    classify_codex_mcp_invocation,
     claude_tool_use_creation_tool,
-    extract_created_event_id,
     opencode_tool_creation_tool,
     refused_recording_rows,
-    unwrap_codex_mcp_error,
-    unwrap_codex_mcp_result,
-    unwrap_codex_output_text,
 )
 from .source_paths import resolve_core_usage_source_plans, resolve_usage_source_paths
 from .store_resolution import claude_worktree_owner_path_text
@@ -1084,6 +1088,7 @@ def _discover_codex_usage_from_home(
     rollout_parse_stats: dict[str, int] = {
         "unparseable_rollouts": 0,
         "schema_drift_rollouts": 0,
+        "evidence_schema_drift_rollouts": 0,
     }
     _codex_total_rows = len(rows)
     for _codex_index, row in enumerate(rows):
@@ -1091,6 +1096,7 @@ def _discover_codex_usage_from_home(
         row_parse_stats: dict[str, int] = {
             "unparseable_rollouts": 0,
             "schema_drift_rollouts": 0,
+            "evidence_schema_drift_rollouts": 0,
         }
         observation_metadata: dict[str, Any] = {}
         rollout_source = rollout_source_by_session.get(row_id)
@@ -1135,6 +1141,9 @@ def _discover_codex_usage_from_home(
         if rollout_parse_stats["schema_drift_rollouts"]:
             if "codex_rollout_schema_drift" not in error_codes:
                 error_codes.append("codex_rollout_schema_drift")
+        if rollout_parse_stats["evidence_schema_drift_rollouts"]:
+            if "codex_rollout_evidence_schema_drift" not in error_codes:
+                error_codes.append("codex_rollout_evidence_schema_drift")
         _discovery_stats["error_codes"] = error_codes
     index_source = _regular_source_file(root / "session_index.jsonl", root=root)
     titles_by_session = (
@@ -7256,18 +7265,6 @@ def _read_codex_rollout_parent_thread_id(
     return None
 
 
-# Tool-call channel payloads carry agent/tool-controlled data (invocation
-# arguments, tool results). A "model" string inside them is a tool ARGUMENT
-# or an echoed result field — never the session's model label — so the model
-# scan skips these payload types entirely (an agent passing
-# {"model": "gpt-x"} to a tool must not relabel, and thus reprice, the
-# session). The legitimate carriers (session_meta / turn_context / the
-# token-usage event_msg payloads) are unaffected.
-_CODEX_MODEL_SCAN_EXCLUDED_PAYLOAD_TYPES = frozenset(
-    {"function_call", "function_call_output", "mcp_tool_call_begin", "mcp_tool_call_end"}
-)
-
-
 # ---------------------------------------------------------------------------
 # Codex rollout parse memoization.
 #
@@ -7297,7 +7294,8 @@ _CODEX_PARSER_CODE_VERSION: str | None = None
 def _codex_parser_code_version() -> str | None:
     """A version tag that changes whenever the parsing code changes, so a stale
     cache from an older parser is never trusted. Hashes the installed package
-    version, a manual format counter, and this module + its evidence dependency.
+    version, a manual format counter, and this module plus its rollout-adapter
+    and evidence dependencies.
     Returns None when the source cannot be read (frozen bundle / .pyc-only): in
     that case the version cannot be proven, so the cache is disabled rather than
     keyed on a constant 'missing' tag that would survive an upgrade."""
@@ -7319,7 +7317,12 @@ def _codex_parser_code_version() -> str | None:
         except Exception:  # noqa: BLE001 - metadata is best-effort.
             hasher.update(b"\0nopkgver\0")
         readable = True
-        for module_path in (Path(__file__), Path(__file__).with_name("log_evidence.py")):
+        for module_path in (
+            Path(__file__),
+            Path(__file__).with_name("codex_rollout_adapter.py"),
+            Path(__file__).with_name("log_evidence.py"),
+            Path(__file__).with_name("tool_activity.py"),
+        ):
             try:
                 hasher.update(module_path.read_bytes())
             except OSError:
@@ -7513,7 +7516,9 @@ def _emit_scan_phase(label: str) -> None:
 # Only tool NAMES, cwd-relative touched PATHS, and best-effort-scrubbed COMMANDS
 # are derived; never tool output, never an absolute path prefix.
 
-_CODEX_TOOL_CALLS_SCAN_MAX = 5000  # bound accumulation on a pathological rollout
+_CODEX_TOOL_ACTIVITY_CARRIER_CAP = 5000
+_CODEX_EVIDENCE_FRAGMENT_CAP = 5000
+_CODEX_TOOL_ARGUMENT_TEXT_MAX = 1_000_000
 _CODEX_APPLY_PATCH_FILE_RE = re.compile(
     r"^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+?)\s*$", re.MULTILINE
 )
@@ -7532,33 +7537,41 @@ _CODEX_EXEC_JS_CMD_RE = re.compile(
 )
 
 
+def _iter_codex_apply_patch_paths(patch_text: Any) -> Iterator[str]:
+    if not isinstance(patch_text, str) or "*** " not in patch_text:
+        return
+    for pattern in (_CODEX_APPLY_PATCH_FILE_RE, _CODEX_APPLY_PATCH_MOVE_RE):
+        for match in pattern.finditer(patch_text):
+            yield match.group(1)
+
+
 def _codex_apply_patch_paths(patch_text: Any) -> list[str]:
     """The file paths an ``apply_patch`` touched, parsed from its patch body."""
 
-    if not isinstance(patch_text, str) or "*** " not in patch_text:
-        return []
-    paths = [m.group(1) for m in _CODEX_APPLY_PATCH_FILE_RE.finditer(patch_text)]
-    paths.extend(m.group(1) for m in _CODEX_APPLY_PATCH_MOVE_RE.finditer(patch_text))
-    return paths
+    return list(_iter_codex_apply_patch_paths(patch_text))
 
 
-def _codex_command_text(name: str, raw_arg: Any) -> str | None:
+def _codex_command_text(tool_name: str, raw_arguments: Any) -> str | None:
     """The shell command a Codex exec tool ran — exact for ``exec_command`` (JSON
     ``cmd``), best-effort for the JS ``exec`` runtime. Never returns tool output."""
 
-    if not isinstance(raw_arg, str) or not raw_arg:
+    if (
+        not isinstance(raw_arguments, str)
+        or not raw_arguments
+        or len(raw_arguments) > _CODEX_TOOL_ARGUMENT_TEXT_MAX
+    ):
         return None
-    if name == "exec_command":
+    if tool_name == "exec_command":
         try:
-            parsed = json.loads(raw_arg)
-        except (json.JSONDecodeError, ValueError):
+            parsed = json.loads(raw_arguments)
+        except (json.JSONDecodeError, ValueError, RecursionError):
             return None
         if isinstance(parsed, dict):
             cmd = parsed.get("cmd") or parsed.get("command")
             return cmd if isinstance(cmd, str) and cmd.strip() else None
         return None
-    if name == "exec":
-        match = _CODEX_EXEC_JS_CMD_RE.search(raw_arg)
+    if tool_name == "exec":
+        match = _CODEX_EXEC_JS_CMD_RE.search(raw_arguments)
         if match:
             return match.group(1) if match.group(1) is not None else match.group(2)
     return None
@@ -7592,58 +7605,459 @@ def _codex_relativize_touched_path(raw_path: str, cwd: str | None) -> str | None
     return None
 
 
-def _codex_tool_activity_from_calls(
-    tool_calls: list[tuple[str, Any]],
-    *,
-    cwd: str | None,
-) -> dict[str, Any]:
-    """Derive Actions signals from a rollout's collected ``(name, raw_arg)`` tool
-    calls, in the SAME metadata shape the hook drain emits (values, not keys, so the
-    store's key-based secret redaction can't blank a credential-shaped name/path)."""
+@dataclass(frozen=True)
+class _CodexToolActivityFact:
+    """One bounded Actions fact after raw arguments have been discarded."""
 
-    name_counts: dict[str, int] = {}
-    category_counts: dict[str, int] = {}
-    commands: list[str] = []
-    touched: list[str] = []
-    for raw_name, raw_arg in tool_calls:
-        name = normalize_tool_name(raw_name)
-        if name:
-            name_counts[name] = name_counts.get(name, 0) + 1
-            category = tool_category(name)
-            category_counts[category] = category_counts.get(category, 0) + 1
-        lowered = str(raw_name or "").strip().lower()
-        if lowered in ("exec", "exec_command"):
-            command = _normalize_command(_codex_command_text(lowered, raw_arg))
-            if (
-                command
-                and command not in commands
-                and len(commands) < _COMMANDS_PER_BATCH_MAX
-            ):
-                commands.append(command)
-        elif lowered == "apply_patch":
-            for raw_path in _codex_apply_patch_paths(raw_arg):
-                touched_path = _normalize_touched_path(
-                    _codex_relativize_touched_path(raw_path, cwd)
+    action_name: str
+    command: str | None = None
+    has_command_conflict: bool = False
+
+
+@dataclass(frozen=True)
+class _CodexActionCarrier:
+    """One ephemeral tool-call carrier decoded from a rollout line."""
+
+    call_id: Any
+    action_name: Any
+    raw_arguments: Any
+
+
+@dataclass(frozen=True)
+class _CodexToolActivityCarrierIdentity:
+    """The bounded identity retained between the two Actions scan phases."""
+
+    call_id: str | None
+    action_name: str | None
+
+
+def _codex_action_carrier(payload: Mapping[str, Any]) -> _CodexActionCarrier | None:
+    """Decode a supported Actions carrier without retaining its raw arguments."""
+
+    payload_type = payload.get("type")
+    if payload_type in {"function_call", "custom_tool_call"}:
+        call_name = payload.get("name")
+        action_name = call_name
+        raw_arguments = (
+            payload.get("arguments")
+            if payload_type == "function_call"
+            else payload.get("input")
+        )
+        if payload_type == "function_call":
+            action_name = codex_function_action_name(
+                payload.get("namespace"),
+                call_name,
+            )
+        return _CodexActionCarrier(
+            call_id=payload.get("call_id"),
+            action_name=action_name,
+            raw_arguments=raw_arguments,
+        )
+    if payload_type == "mcp_tool_call_end":
+        invocation = payload.get("invocation")
+        if isinstance(invocation, Mapping):
+            return _CodexActionCarrier(
+                call_id=payload.get("call_id"),
+                action_name=codex_mcp_action_name(
+                    invocation.get("server"),
+                    invocation.get("tool"),
+                ),
+                raw_arguments=invocation.get("arguments"),
+            )
+        return None
+    if payload_type == "item_completed":
+        item = payload.get("item")
+        if isinstance(item, Mapping) and item.get("type") == "McpToolCall":
+            return _CodexActionCarrier(
+                call_id=item.get("id"),
+                action_name=codex_mcp_action_name(
+                    item.get("server"),
+                    item.get("tool"),
+                ),
+                raw_arguments=item.get("arguments"),
+            )
+    return None
+
+
+def _normalized_codex_action_name(raw_action_name: Any) -> str | None:
+    """Return one exact, bounded Actions name without truncating identities."""
+
+    validated_action_name = validated_codex_identifier(
+        raw_action_name,
+        max_length=120,
+    )
+    if validated_action_name is None:
+        return None
+    return validated_action_name
+
+
+def _merge_codex_action_names(first_name: str, second_name: str) -> str | None:
+    """Choose a canonical MCP name over its matching bare legacy name."""
+
+    if first_name == second_name:
+        return first_name
+    if (
+        first_name.startswith("mcp__")
+        and first_name.rsplit("__", 1)[-1] == second_name
+    ):
+        return first_name
+    if (
+        second_name.startswith("mcp__")
+        and second_name.rsplit("__", 1)[-1] == first_name
+    ):
+        return second_name
+    return None
+
+
+def _merge_codex_tool_activity_facts(
+    first_fact: _CodexToolActivityFact,
+    second_fact: _CodexToolActivityFact,
+) -> _CodexToolActivityFact | None:
+    """Merge duplicate representations, or reject an ambiguous call identity."""
+
+    merged_action_name = _merge_codex_action_names(
+        first_fact.action_name,
+        second_fact.action_name,
+    )
+    if merged_action_name is None:
+        return None
+    has_command_conflict = (
+        first_fact.has_command_conflict or second_fact.has_command_conflict
+    )
+    if (
+        first_fact.command
+        and second_fact.command
+        and first_fact.command != second_fact.command
+    ):
+        has_command_conflict = True
+    merged_command = (
+        None
+        if has_command_conflict
+        else first_fact.command or second_fact.command
+    )
+    return _CodexToolActivityFact(
+        action_name=merged_action_name,
+        command=merged_command,
+        has_command_conflict=has_command_conflict,
+    )
+
+
+class _CodexToolActivityAccumulator:
+    """Bounded two-phase Actions projection.
+
+    Phase one reconciles logical call identities and scrubbed commands. Phase two
+    revisits only those same source lines and collects paths from calls that are
+    still valid. Deferring path selection makes the output independent of whether
+    a conflicting duplicate appears before or after another valid call, without
+    retaining raw arguments or a carrier-by-path product in memory.
+    """
+
+    def __init__(
+        self,
+        *,
+        carrier_cap: int = _CODEX_TOOL_ACTIVITY_CARRIER_CAP,
+        touched_path_cap: int = _TOUCHED_FILES_PER_BATCH_MAX,
+    ) -> None:
+        self._carrier_cap = max(0, carrier_cap)
+        self._retained_touched_path_cap = max(0, touched_path_cap)
+        self._carrier_identities_by_source_line: dict[
+            int,
+            _CodexToolActivityCarrierIdentity,
+        ] = {}
+        self._facts_by_call_id: dict[str, _CodexToolActivityFact | None] = {}
+        self._anonymous_call_facts_by_source_line: dict[
+            int,
+            _CodexToolActivityFact,
+        ] = {}
+        self._touched_path_scan_count = 0
+        self._touched_path_scan_valid = True
+        self._touched_paths: list[str] = []
+        self._touched_path_set: set[str] = set()
+
+    @staticmethod
+    def _decode_call_activity_fact(
+        raw_action_name: Any,
+        raw_arguments: Any,
+    ) -> _CodexToolActivityFact | None:
+        normalized_action_name = _normalized_codex_action_name(raw_action_name)
+        if normalized_action_name is None:
+            return None
+        lowered_action_name = normalized_action_name.lower()
+        command = None
+        if lowered_action_name in {"exec", "exec_command"}:
+            command = _normalize_command(
+                _codex_command_text(lowered_action_name, raw_arguments)
+            )
+        return _CodexToolActivityFact(
+            action_name=normalized_action_name,
+            command=command,
+        )
+
+    def record_call(
+        self,
+        call_id: Any,
+        raw_action_name: Any,
+        raw_arguments: Any,
+        *,
+        source_line_number: int,
+    ) -> None:
+        if len(self._carrier_identities_by_source_line) >= self._carrier_cap:
+            return
+        validated_call_id = validated_codex_identifier(call_id)
+        normalized_action_name = _normalized_codex_action_name(raw_action_name)
+        self._carrier_identities_by_source_line[source_line_number] = (
+            _CodexToolActivityCarrierIdentity(
+                call_id=validated_call_id,
+                action_name=normalized_action_name,
+            )
+        )
+        candidate_fact = self._decode_call_activity_fact(
+            normalized_action_name,
+            raw_arguments,
+        )
+        if candidate_fact is None:
+            return
+        if (
+            validated_call_id is not None
+            and validated_call_id in self._facts_by_call_id
+        ):
+            existing_fact = self._facts_by_call_id[validated_call_id]
+            if existing_fact is None:
+                return
+            self._facts_by_call_id[validated_call_id] = (
+                _merge_codex_tool_activity_facts(
+                    existing_fact,
+                    candidate_fact,
                 )
-                if (
-                    touched_path
-                    and touched_path not in touched
-                    and len(touched) < _TOUCHED_FILES_PER_BATCH_MAX
-                ):
-                    touched.append(touched_path)
-    activity: dict[str, Any] = {}
-    if category_counts:
-        activity["tool_category_counts"] = dict(sorted(category_counts.items()))
-    if name_counts:
-        activity["tool_names"] = [
-            {"name": name, "count": count}
-            for name, count in sorted(name_counts.items())
-        ]
-    if touched:
-        activity["touched_files"] = touched
-    if commands:
-        activity["commands"] = commands
-    return activity
+            )
+            return
+        if validated_call_id is not None:
+            self._facts_by_call_id[validated_call_id] = candidate_fact
+        else:
+            self._anonymous_call_facts_by_source_line[source_line_number] = (
+                candidate_fact
+            )
+
+    def expects_carrier_on_source_line(self, source_line_number: int) -> bool:
+        return source_line_number in self._carrier_identities_by_source_line
+
+    def _final_fact_for_carrier(
+        self,
+        source_line_number: int,
+        identity: _CodexToolActivityCarrierIdentity,
+    ) -> _CodexToolActivityFact | None:
+        if identity.call_id is None:
+            final_fact = self._anonymous_call_facts_by_source_line.get(
+                source_line_number
+            )
+        else:
+            final_fact = self._facts_by_call_id.get(identity.call_id)
+        if (
+            final_fact is None
+            or identity.action_name is None
+            or _merge_codex_action_names(
+                final_fact.action_name,
+                identity.action_name,
+            )
+            is None
+        ):
+            return None
+        return final_fact
+
+    def needs_touched_path_scan(self) -> bool:
+        if self._retained_touched_path_cap <= 0:
+            return False
+        for source_line_number, identity in (
+            self._carrier_identities_by_source_line.items()
+        ):
+            if (
+                identity.action_name is not None
+                and identity.action_name.lower() == "apply_patch"
+                and self._final_fact_for_carrier(source_line_number, identity)
+                is not None
+            ):
+                return True
+        return False
+
+    def record_touched_paths(
+        self,
+        source_line_number: int,
+        carrier: _CodexActionCarrier | None,
+        *,
+        cwd: str | None,
+    ) -> None:
+        """Collect paths from one phase-two carrier after final reconciliation."""
+
+        expected_identity = self._carrier_identities_by_source_line.get(
+            source_line_number
+        )
+        if expected_identity is None:
+            self._touched_path_scan_valid = False
+            return
+        self._touched_path_scan_count += 1
+        if carrier is None:
+            self._touched_path_scan_valid = False
+            return
+        actual_identity = _CodexToolActivityCarrierIdentity(
+            call_id=validated_codex_identifier(carrier.call_id),
+            action_name=_normalized_codex_action_name(carrier.action_name),
+        )
+        if actual_identity != expected_identity:
+            self._touched_path_scan_valid = False
+            return
+
+        final_fact = self._final_fact_for_carrier(
+            source_line_number,
+            expected_identity,
+        )
+        if (
+            final_fact is None
+            or expected_identity.action_name is None
+            or expected_identity.action_name.lower() != "apply_patch"
+            or len(self._touched_paths) >= self._retained_touched_path_cap
+            or not isinstance(carrier.raw_arguments, str)
+            or len(carrier.raw_arguments) > _CODEX_TOOL_ARGUMENT_TEXT_MAX
+        ):
+            return
+
+        for raw_path in _iter_codex_apply_patch_paths(carrier.raw_arguments):
+            normalized_path = _normalize_touched_path(
+                _codex_relativize_touched_path(raw_path, cwd)
+            )
+            if normalized_path is None or normalized_path in self._touched_path_set:
+                continue
+            self._touched_paths.append(normalized_path)
+            self._touched_path_set.add(normalized_path)
+            if len(self._touched_paths) >= self._retained_touched_path_cap:
+                break
+
+    def finish_touched_path_scan(self, *, source_unchanged: bool) -> None:
+        """Keep phase-two paths only when every retained carrier was re-read."""
+
+        if (
+            not source_unchanged
+            or not self._touched_path_scan_valid
+            or self._touched_path_scan_count
+            != len(self._carrier_identities_by_source_line)
+        ):
+            self._touched_paths.clear()
+            self._touched_path_set.clear()
+
+    def _retained_facts_in_carrier_order(self) -> Iterator[_CodexToolActivityFact]:
+        seen_call_ids: set[str] = set()
+        for source_line_number, identity in (
+            self._carrier_identities_by_source_line.items()
+        ):
+            if (
+                identity.call_id is not None
+                and identity.call_id in seen_call_ids
+            ):
+                continue
+            fact = self._final_fact_for_carrier(source_line_number, identity)
+            if fact is None:
+                continue
+            if identity.call_id is not None:
+                seen_call_ids.add(identity.call_id)
+            yield fact
+
+    def as_activity(self) -> dict[str, Any]:
+        action_name_counts: dict[str, int] = {}
+        category_counts: dict[str, int] = {}
+        commands: list[str] = []
+        command_set: set[str] = set()
+        for fact in self._retained_facts_in_carrier_order():
+            action_name_counts[fact.action_name] = (
+                action_name_counts.get(fact.action_name, 0) + 1
+            )
+            category = tool_category(fact.action_name)
+            category_counts[category] = category_counts.get(category, 0) + 1
+            if (
+                fact.command
+                and len(commands) < _COMMANDS_PER_BATCH_MAX
+                and fact.command not in command_set
+            ):
+                commands.append(fact.command)
+                command_set.add(fact.command)
+
+        activity: dict[str, Any] = {}
+        if category_counts:
+            activity["tool_category_counts"] = dict(
+                sorted(category_counts.items())
+            )
+        if action_name_counts:
+            activity["tool_names"] = [
+                {"name": action_name, "count": count}
+                for action_name, count in sorted(action_name_counts.items())
+            ]
+        if self._touched_paths:
+            activity["touched_files"] = list(self._touched_paths)
+        if commands:
+            activity["commands"] = commands
+        return activity
+
+
+def _codex_open_file_snapshot(handle: TextIO) -> tuple[int, int, int, int, int]:
+    """Identity and mutation fields for one already-open regular rollout."""
+
+    file_stat = os.fstat(handle.fileno())
+    return (
+        int(file_stat.st_dev),
+        int(file_stat.st_ino),
+        int(file_stat.st_size),
+        int(file_stat.st_mtime_ns),
+        int(file_stat.st_ctime_ns),
+    )
+
+
+def _collect_codex_rollout_touched_paths(
+    handle: TextIO,
+    *,
+    source_snapshot: tuple[int, int, int, int, int] | None,
+    source_line_count: int,
+    tool_activity: _CodexToolActivityAccumulator,
+    cwd: str | None,
+) -> None:
+    """Re-read retained carrier lines and fail closed if the source changes."""
+
+    if not tool_activity.needs_touched_path_scan():
+        return
+    source_unchanged = False
+    try:
+        if (
+            source_snapshot is None
+            or source_snapshot != _codex_open_file_snapshot(handle)
+        ):
+            raise OSError("rollout changed during its primary scan")
+        handle.seek(0)
+        for source_line_number in range(1, source_line_count + 1):
+            line = handle.readline()
+            if line == "":
+                break
+            if not tool_activity.expects_carrier_on_source_line(
+                source_line_number
+            ):
+                continue
+            carrier = None
+            try:
+                obj = json.loads(line)
+            except (json.JSONDecodeError, RecursionError):
+                obj = None
+            if isinstance(obj, Mapping):
+                payload = obj.get("payload")
+                if isinstance(payload, Mapping):
+                    carrier = _codex_action_carrier(payload)
+            tool_activity.record_touched_paths(
+                source_line_number,
+                carrier,
+                cwd=cwd,
+            )
+        else:
+            source_unchanged = source_snapshot == _codex_open_file_snapshot(handle)
+    except (OSError, ValueError):
+        # Touched files are optional Actions metadata. If the live rollout moves
+        # while it is being scanned, omit paths instead of mixing two snapshots.
+        source_unchanged = False
+    tool_activity.finish_touched_path_scan(source_unchanged=source_unchanged)
 
 
 def _read_codex_rollout_usage(
@@ -7719,12 +8133,13 @@ def _read_codex_rollout_usage_uncached(
     _parse_stats: dict[str, int] | None = None,
     _observation_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
-    """Read token totals + session_meta parent + client-log evidence in ONE pass.
+    """Read token totals, session lineage, Actions, and client-log evidence.
 
     Returns None only when the rollout holds neither a total_token_usage line
     nor any client-log evidence; an evidence-only rollout returns a dict
     WITHOUT ``input_tokens`` so the caller's sqlite tokens_used fallback still
-    fires while the evidence rides along.
+    fires while the evidence rides along. The primary scan reconciles call
+    identities; a bounded second scan extracts paths only from final valid calls.
     """
 
     source_file = _coerce_private_regular_source(source)
@@ -7742,10 +8157,11 @@ def _read_codex_rollout_usage_uncached(
     replayed_parent_session_meta = False
     first_activity_at: int | None = None
     last_activity_at: int | None = None
-    # Tool calls (name, raw_arg) for the discovery-side Actions extraction. The
-    # raw arg is read ONLY by _codex_tool_activity_from_calls (command text /
-    # apply_patch paths); tool output is never collected here.
-    tool_calls: list[tuple[str, Any]] = []
+    # Discovery-side Actions retain only bounded identities and scrubbed commands.
+    # Patch bodies are revisited, never retained, after all duplicate call
+    # representations have been reconciled.
+    tool_activity = _CodexToolActivityAccumulator()
+    source_line_count = 0
     token_usage_events: list[tuple[Any, ...]] = []
     raw_token_event_count = 0
     replay_prefix_token_events = 0
@@ -7754,31 +8170,13 @@ def _read_codex_rollout_usage_uncached(
     replay_probe_event: tuple[Any, ...] | None = None
     replay_second: str | None = None
     replay_probe_complete = False
-    # Client-log evidence extraction (log_evidence.py): remember creation-tool
-    # function_calls by call_id (allowlist by BARE tool name + namespace
-    # check), then run the strict single-created-event shape check on their
-    # paired outputs only. Read-tool outputs echo OTHER sessions' event ids
-    # and are structurally invisible here. Namespace-rejected creation-name
-    # calls are remembered too so their outputs are skipped-but-counted
-    # (custom server registration names surface in the counters).
-    #
-    # Codex 0.144.0-alpha.4 dropped the duplicate function_call records for
-    # MCP tools: mcp_tool_call_end event_msg lines are now the ONLY channel
-    # carrying creation-tool outputs, so BOTH channels are read. Pre-0.144
-    # rollouts carry the same call under both shapes with an identical
-    # call_id (verified 10/10 overlap), so the two sets below dedup across
-    # the channels, regardless of file order:
-    # - a call_id is CONSUMED only by a DONATING channel (its output
-    #   unwrapped to a well-formed created-event payload) — each call donates
-    #   at most once;
-    # - a rejected / unwrap-failed representation is skip-counted (at most
-    #   once per call_id) but never consumes the id, so if the two
-    #   representations of one call ever diverge (codex bug, torn file) the
-    #   other channel's valid output still donates instead of being blocked.
-    accepted_calls: dict[str, str] = {}
-    rejected_calls: set[str] = set()
-    donated_call_ids: set[str] = set()
-    skip_counted_call_ids: set[str] = set()
+    # Client-log evidence is decoded into carrier-independent fragments during
+    # the scan and reconciled by logical call id after it. This supports legacy
+    # function/output pairs, legacy mcp_tool_call_end records, and current
+    # paginated item_completed/McpToolCall records without making file order or
+    # one Codex persistence representation part of the evidence model.
+    evidence_fragments: list[CodexEvidenceFragment] = []
+    evidence_fragment_cap_exceeded = False
     evidence = LogEvidenceAccumulator()
     saw_nonempty_line = False
     saw_valid_object = False
@@ -7786,47 +8184,27 @@ def _read_codex_rollout_usage_uncached(
     saw_token_usage_schema_drift = False
     cache_write_tokens_applicable = False
 
-    def _skip_once(
-        call_key: str | None,
-        text: str | None = None,
-        *,
-        tool: str | None = None,
+    def _record_tool_activity(
+        source_line_number: int,
+        carrier: _CodexActionCarrier,
     ) -> None:
-        # ``text``/``tool``, when the channel has them, let the accumulator
-        # classify an agentacct refusal into its bounded reason vocabulary.
-        # The dedup below still applies, so one refused call is counted once
-        # even when both codex channels carry it.
-        if call_key is None:
-            evidence.record_skip(text, tool=tool)
-            return
-        if call_key in donated_call_ids or call_key in skip_counted_call_ids:
-            return
-        skip_counted_call_ids.add(call_key)
-        evidence.record_skip(text, tool=tool)
-
-    def _donate_once(
-        call_key: str,
-        text: str | None,
-        *,
-        refusal_text: str | None = None,
-        tool: str | None = None,
-    ) -> None:
-        if not isinstance(text, str) or extract_created_event_id(text) is None:
-            # Unwrap/shape failure: counted, but the call_id stays available
-            # for the other channel's (possibly valid) representation.
-            _skip_once(call_key, refusal_text if refusal_text is not None else text, tool=tool)
-            return
-        if call_key in donated_call_ids:
-            return
-        donated_call_ids.add(call_key)
-        evidence.add_output_text(text)
+        tool_activity.record_call(
+            carrier.call_id,
+            carrier.action_name,
+            carrier.raw_arguments,
+            source_line_number=source_line_number,
+        )
     with _open_regular_source_text(source_file) as handle:
-        for line in handle:
+        try:
+            source_snapshot = _codex_open_file_snapshot(handle)
+        except OSError:
+            source_snapshot = None
+        for source_line_count, line in enumerate(handle, start=1):
             if line.strip():
                 saw_nonempty_line = True
             try:
                 obj = json.loads(line)
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, RecursionError):
                 if line.strip():
                     saw_malformed_line = True
                 continue
@@ -7886,88 +8264,27 @@ def _read_codex_rollout_usage_uncached(
             if not isinstance(payload, dict):
                 continue
             payload_type = payload.get("type")
-            # Collect tool calls for the discovery-side Actions extraction. A
-            # function_call carries its args as a JSON string under ``arguments``;
-            # a custom_tool_call (Codex's ``exec`` runtime and ``apply_patch``)
-            # carries them as a string under ``input``.
-            if (
-                payload_type in ("function_call", "custom_tool_call")
-                and len(tool_calls) < _CODEX_TOOL_CALLS_SCAN_MAX
+            action_carrier = _codex_action_carrier(payload)
+            if action_carrier is not None:
+                _record_tool_activity(source_line_count, action_carrier)
+
+            if len(evidence_fragments) < _CODEX_EVIDENCE_FRAGMENT_CAP:
+                fragment = decode_codex_evidence_fragment(obj)
+                if fragment is not None:
+                    evidence_fragments.append(fragment)
+            elif (
+                not evidence_fragment_cap_exceeded
+                and codex_record_may_contain_evidence(obj)
             ):
-                call_name = payload.get("name")
-                if isinstance(call_name, str) and call_name:
-                    call_arg = (
-                        payload.get("arguments")
-                        if payload_type == "function_call"
-                        else payload.get("input")
-                    )
-                    tool_calls.append((call_name, call_arg))
-            if payload_type == "function_call":
-                # Pairing is strictly by call_id (never the response-item id).
-                call_id = payload.get("call_id")
-                if isinstance(call_id, str) and call_id:
-                    verdict = classify_codex_function_call(payload.get("name"), payload.get("namespace"))
-                    if verdict == "accepted":
-                        accepted_calls[call_id] = str(payload.get("name"))
-                    elif verdict == "rejected":
-                        rejected_calls.add(call_id)
-            elif payload_type == "function_call_output":
-                call_id = payload.get("call_id")
-                if isinstance(call_id, str) and call_id in accepted_calls:
-                    # No refusal text is passed on this legacy channel: a
-                    # failed call's ``output`` is codex's own plain-text error,
-                    # which unwrap_codex_output_text (JSON/content-block only)
-                    # returns None for. Such a call stays a plain skip and is
-                    # reported in the unclassified remainder rather than
-                    # guessed at from an unverified wire shape — an
-                    # UNDER-count, which is the honest direction for a figure
-                    # that claims "agentacct refused this".
-                    _donate_once(
-                        call_id,
-                        unwrap_codex_output_text(payload.get("output")),
-                        tool=accepted_calls[call_id],
-                    )
-                elif isinstance(call_id, str) and call_id in rejected_calls:
-                    _skip_once(call_id)
-            elif payload_type == "mcp_tool_call_end":
-                # The 0.144+ channel. Classification is by the invocation's
-                # server/tool pair (allowlist first, then the shared namespace
-                # rule; a None/absent server is rejected + counted — the field
-                # is always present in this shape, absence is drift).
-                call_id = payload.get("call_id")
-                call_key = call_id if isinstance(call_id, str) and call_id else None
-                invocation = payload.get("invocation")
-                if not isinstance(invocation, dict):
-                    # The invocation block itself is missing/renamed/non-dict:
-                    # the tool name is unrecoverable, so the line cannot be
-                    # classified at all. That state is itself drift for this
-                    # wire shape — count it so the NEXT channel/shape drift
-                    # surfaces in the counters instead of silently losing
-                    # evidence (same rule as the absent server key, one
-                    # level down; deliberately also counts foreign-tool
-                    # lines, which cannot be told apart without a tool name).
-                    _skip_once(call_key)
-                else:
-                    verdict = classify_codex_mcp_invocation(invocation.get("server"), invocation.get("tool"))
-                    if verdict is not None:
-                        if call_key is None:
-                            # Creation-tool line without a pairable call_id:
-                            # shape drift, skipped-but-counted (never guessed).
-                            evidence.record_skip()
-                        elif verdict == "accepted":
-                            # unwrap_codex_mcp_result reads the Ok branch only,
-                            # so the Err branch is unwrapped separately to keep
-                            # the refusal classifiable.
-                            _donate_once(
-                                call_key,
-                                unwrap_codex_mcp_result(payload.get("result")),
-                                refusal_text=unwrap_codex_mcp_error(payload.get("result")),
-                                tool=str(invocation.get("tool")),
-                            )
-                        else:
-                            _skip_once(call_key)
-            if model is None and payload_type not in _CODEX_MODEL_SCAN_EXCLUDED_PAYLOAD_TYPES:
-                model = _find_first_string_key(payload, "model")
+                # Reconciliation must retain out-of-order descriptors and
+                # outputs, but it must not accumulate or repeatedly decode an
+                # unbounded rollout. Make truncation an explicit evidence-health
+                # failure and one bounded skip instead of claiming completeness.
+                evidence_fragment_cap_exceeded = True
+
+            carrier_model = codex_model_from_record(obj)
+            if model is None and carrier_model is not None:
+                model = carrier_model
             info = payload.get("info")
             if isinstance(info, dict) and "total_token_usage" in info:
                 total_token_usage = info.get("total_token_usage")
@@ -8012,7 +8329,7 @@ def _read_codex_rollout_usage_uncached(
                     last_token_usage = None
                 token_event = (
                     event_timestamp,
-                    _find_first_string_key(payload, "model"),
+                    carrier_model,
                     _codex_token_delta(
                         current_value=current_total_usage,
                         last_value=last_token_usage,
@@ -8068,6 +8385,23 @@ def _read_codex_rollout_usage_uncached(
                     )
                 previous_total_usage = current_total_usage
                 turn_count += 1
+        _collect_codex_rollout_touched_paths(
+            handle,
+            source_snapshot=source_snapshot,
+            source_line_count=source_line_count,
+            tool_activity=tool_activity,
+            cwd=session_meta_cwd,
+        )
+    if evidence_fragment_cap_exceeded:
+        # A later fragment could contradict a retained call id. Without the
+        # complete bounded set, no partial donor is authoritative.
+        evidence.record_skip()
+        evidence_parse_incomplete = True
+    else:
+        evidence_parse_incomplete = reconcile_codex_evidence_fragments(
+            evidence_fragments,
+            evidence,
+        )
     if replay_probe_event is not None:
         token_usage_events.append(replay_probe_event)
     if (
@@ -8080,9 +8414,11 @@ def _read_codex_rollout_usage_uncached(
         _parse_stats["schema_drift_rollouts"] = _safe_nonnegative_int(
             _parse_stats.get("schema_drift_rollouts")
         ) + 1
-    rollout_tool_activity = _codex_tool_activity_from_calls(
-        tool_calls, cwd=session_meta_cwd
-    )
+    if evidence_parse_incomplete and _parse_stats is not None:
+        _parse_stats["evidence_schema_drift_rollouts"] = _safe_nonnegative_int(
+            _parse_stats.get("evidence_schema_drift_rollouts")
+        ) + 1
+    rollout_tool_activity = tool_activity.as_activity()
     if _observation_metadata is not None:
         _observation_metadata.update(
             {

--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -8278,8 +8278,11 @@ def _read_codex_rollout_usage_uncached(
             ):
                 # Reconciliation must retain out-of-order descriptors and
                 # outputs, but it must not accumulate or repeatedly decode an
-                # unbounded rollout. Make truncation an explicit evidence-health
-                # failure and one bounded skip instead of claiming completeness.
+                # unbounded rollout. A legacy output cannot be classified until
+                # its descriptor appears, so even an ultimately orphaned output
+                # counts toward this cap. Make truncation an explicit
+                # evidence-health failure and one bounded skip instead of
+                # claiming completeness.
                 evidence_fragment_cap_exceeded = True
 
             carrier_model = codex_model_from_record(obj)

--- a/src/agentacct/codex_rollout_adapter.py
+++ b/src/agentacct/codex_rollout_adapter.py
@@ -1,0 +1,1052 @@
+"""Compatibility boundary for Codex rollout records.
+
+Codex rollout JSONL is a persistence format, not agentacct's domain model. This
+module converts the historical carrier variants into logical MCP-call fragments,
+reconciles duplicate fragments deterministically, and selects model identity only
+from known Codex-owned paths. Token accounting and product projection remain in
+``client_usage`` and consume these normalized facts.
+"""
+
+from __future__ import annotations
+
+import json
+import unicodedata
+from dataclasses import dataclass, replace
+from typing import Any, Literal, Mapping
+
+from .log_evidence import (
+    EVIDENCED_EVENT_ID_RE,
+    LogEvidenceAccumulator,
+    classify_codex_function_call,
+    classify_codex_mcp_call_identity,
+    classify_refused_recording,
+    extract_created_event_id,
+    extract_created_event_id_from_payload,
+)
+
+
+_CodexRefusal = tuple[str | None, str | None, str]
+_CodexOutcomeClassification = Literal[
+    "success",
+    "failure",
+    "unknown",
+    "malformed",
+]
+_CodexOutcomeCarrier = Literal["function_output", "result", "error"]
+
+
+@dataclass(frozen=True)
+class CodexEvidenceOutcome:
+    """Privacy-bounded semantic outcome decoded from one Codex carrier."""
+
+    outcome_classification: _CodexOutcomeClassification
+    event_id: str | None = None
+    refusal: _CodexRefusal | None = None
+
+    def __post_init__(self) -> None:
+        if self.outcome_classification not in {
+            "success",
+            "failure",
+            "unknown",
+            "malformed",
+        }:
+            raise ValueError(
+                "unsupported Codex outcome classification: "
+                f"{self.outcome_classification!r}"
+            )
+        if self.event_id is not None and self.outcome_classification != "success":
+            raise ValueError("only a successful Codex outcome may carry an event_id")
+        if self.outcome_classification == "success" and self.event_id is None:
+            raise ValueError("a successful Codex outcome requires an event_id")
+        if self.event_id is not None and not EVIDENCED_EVENT_ID_RE.match(
+            self.event_id
+        ):
+            raise ValueError("Codex outcome event_id is malformed")
+        if self.refusal is not None and self.outcome_classification != "failure":
+            raise ValueError("only a failed Codex outcome may carry a refusal")
+
+
+@dataclass(frozen=True)
+class CodexEvidenceFragment:
+    """One privacy-bounded fact about a logical Codex MCP call.
+
+    Raw output and error text are decoded and discarded per JSONL line. Only a
+    created-event id, a frozen refusal classification, and structural flags may
+    survive until reconciliation at end of file.
+    """
+
+    call_id: str | None
+    role: Literal["descriptor", "output", "terminal"]
+    creation_tool_verdict: Literal["accepted", "rejected"] | None = None
+    creation_tool_name: str | None = None
+    outcome: CodexEvidenceOutcome | None = None
+    counts_as_evidence_skip: bool = False
+    has_schema_drift: bool = False
+
+    def __post_init__(self) -> None:
+        if (
+            self.call_id is not None
+            and validated_codex_identifier(self.call_id) != self.call_id
+        ):
+            raise ValueError("Codex evidence fragment call_id is malformed")
+        if self.role not in {"descriptor", "output", "terminal"}:
+            raise ValueError(f"unsupported Codex fragment role: {self.role!r}")
+        if self.creation_tool_verdict not in {None, "accepted", "rejected"}:
+            raise ValueError(
+                "unsupported Codex fragment creation-tool verdict: "
+                f"{self.creation_tool_verdict!r}"
+            )
+        if self.outcome is not None and not isinstance(
+            self.outcome,
+            CodexEvidenceOutcome,
+        ):
+            raise TypeError("Codex fragment outcome is invalid")
+        if not isinstance(self.counts_as_evidence_skip, bool) or not isinstance(
+            self.has_schema_drift,
+            bool,
+        ):
+            raise TypeError("Codex fragment flags must be bools")
+
+
+_CODEX_IDENTITY_TEXT_MAX = 240
+_CODEX_ACTION_NAME_TEXT_MAX = 120
+_CODEX_MODEL_TEXT_MAX = 120
+_CODEX_RESULT_TEXT_MAX = 1_000_000
+
+
+def validated_codex_identifier(
+    value: Any,
+    *,
+    max_length: int = _CODEX_IDENTITY_TEXT_MAX,
+) -> str | None:
+    """Return an exact bounded identifier, or ``None`` when it is unsafe."""
+
+    if not isinstance(value, str) or not value or len(value) > max_length:
+        return None
+    if value != value.strip() or any(
+        unicodedata.category(character).startswith("C") for character in value
+    ):
+        return None
+    # Never truncate an identity: truncation could merge distinct logical calls.
+    return value
+
+
+def codex_mcp_action_name(server: Any, tool: Any) -> str | None:
+    """Canonical Actions identity for an MCP server/tool pair."""
+
+    validated_server = validated_codex_identifier(server)
+    validated_tool = validated_codex_identifier(tool)
+    if validated_server is None or validated_tool is None:
+        return None
+    normalized_server = validated_server.removeprefix("mcp__").replace("-", "_")
+    if not normalized_server:
+        return None
+    action_name = f"mcp__{normalized_server}__{validated_tool}"
+    return validated_codex_identifier(
+        action_name,
+        max_length=_CODEX_ACTION_NAME_TEXT_MAX,
+    )
+
+
+def codex_function_action_name(namespace: Any, tool: Any) -> str | None:
+    """Action identity for a Codex ``function_call`` without namespace drift.
+
+    A namespace is not synonymous with MCP: Codex uses values such as
+    ``collaboration`` for built-in agent tools. Canonicalize only explicit MCP
+    namespaces and the historical agentacct registration namespaces on an
+    allowlisted creation call; otherwise preserve the bare built-in name.
+    """
+
+    normalized_tool = validated_codex_identifier(
+        tool,
+        max_length=_CODEX_ACTION_NAME_TEXT_MAX,
+    )
+    if normalized_tool is None:
+        return None
+    if isinstance(namespace, str) and namespace.startswith("mcp__"):
+        return codex_mcp_action_name(namespace, normalized_tool)
+    if (
+        namespace is not None
+        and classify_codex_function_call(normalized_tool, namespace) == "accepted"
+    ):
+        return codex_mcp_action_name(namespace, normalized_tool)
+    return normalized_tool
+
+
+_MALFORMED_CODEX_OUTCOME = CodexEvidenceOutcome(
+    outcome_classification="malformed"
+)
+
+
+def _single_codex_text_block(content: Any) -> str | None:
+    """Return the one non-empty text block emitted by a creation tool."""
+
+    if not isinstance(content, list) or len(content) != 1:
+        return None
+    block = content[0]
+    if not isinstance(block, Mapping) or block.get("type") != "text":
+        return None
+    text = block.get("text")
+    return text if isinstance(text, str) and text else None
+
+
+def _codex_success_outcome(text: str) -> CodexEvidenceOutcome:
+    """Reduce a structurally successful result without retaining its text."""
+
+    if len(text) > _CODEX_RESULT_TEXT_MAX:
+        return _MALFORMED_CODEX_OUTCOME
+    try:
+        event_id = extract_created_event_id(text)
+    except RecursionError:
+        return _MALFORMED_CODEX_OUTCOME
+    if event_id is None:
+        return _MALFORMED_CODEX_OUTCOME
+    return CodexEvidenceOutcome(
+        outcome_classification="success",
+        event_id=event_id,
+    )
+
+
+def _codex_success_outcome_from_payload(
+    payload: Mapping[str, Any],
+) -> CodexEvidenceOutcome:
+    """Reduce an already-decoded success payload without parsing it again."""
+
+    event_id = extract_created_event_id_from_payload(payload)
+    if event_id is None:
+        return _MALFORMED_CODEX_OUTCOME
+    return CodexEvidenceOutcome(
+        outcome_classification="success",
+        event_id=event_id,
+    )
+
+
+def _codex_failure_outcome_from_refusal(
+    refusal: _CodexRefusal,
+    *,
+    creation_tool_name: str | None,
+) -> CodexEvidenceOutcome:
+    embedded_tool, field, reason = refusal
+    if (
+        embedded_tool is not None
+        and creation_tool_name is not None
+        and embedded_tool != creation_tool_name
+    ):
+        return _MALFORMED_CODEX_OUTCOME
+    return CodexEvidenceOutcome(
+        outcome_classification="failure",
+        refusal=(embedded_tool or creation_tool_name, field, reason),
+    )
+
+
+def _codex_failure_outcome(
+    text: Any,
+    *,
+    creation_tool_name: str | None,
+) -> CodexEvidenceOutcome:
+    """Classify and discard one explicit Codex failure message."""
+
+    if not isinstance(text, str) or not text:
+        return _MALFORMED_CODEX_OUTCOME
+    if len(text) > _CODEX_RESULT_TEXT_MAX:
+        return CodexEvidenceOutcome(outcome_classification="failure")
+    refusal = classify_refused_recording(text)
+    if refusal is None:
+        return CodexEvidenceOutcome(outcome_classification="failure")
+    return _codex_failure_outcome_from_refusal(
+        refusal,
+        creation_tool_name=creation_tool_name,
+    )
+
+
+def _decode_codex_call_tool_result(
+    result: Mapping[str, Any],
+    *,
+    creation_tool_name: str | None,
+) -> CodexEvidenceOutcome:
+    """Decode one direct MCP ``CallToolResult`` mapping."""
+
+    if any(
+        discriminator in result
+        for discriminator in ("Ok", "Err", "error", "message")
+    ):
+        return _MALFORMED_CODEX_OUTCOME
+    is_error = result.get("isError", False)
+    if not isinstance(is_error, bool):
+        return _MALFORMED_CODEX_OUTCOME
+    text = _single_codex_text_block(result.get("content"))
+    if text is None:
+        return _MALFORMED_CODEX_OUTCOME
+    if is_error:
+        return _codex_failure_outcome(
+            text,
+            creation_tool_name=creation_tool_name,
+        )
+    return _codex_success_outcome(text)
+
+
+def _decode_codex_result_envelope(
+    value: Any,
+    *,
+    creation_tool_name: str | None,
+) -> CodexEvidenceOutcome:
+    """Decode legacy ``Ok``/``Err`` or direct MCP result envelopes."""
+
+    if not isinstance(value, Mapping):
+        return _MALFORMED_CODEX_OUTCOME
+    has_ok = "Ok" in value
+    has_err = "Err" in value
+    has_content = "content" in value
+    has_is_error = "isError" in value
+    has_message = "message" in value
+    has_error = "error" in value
+    has_direct_result_fields = (
+        has_content or has_is_error or has_message or has_error
+    )
+
+    if has_ok:
+        if has_err or has_direct_result_fields:
+            return _MALFORMED_CODEX_OUTCOME
+        nested = value.get("Ok")
+        if not isinstance(nested, Mapping):
+            return _MALFORMED_CODEX_OUTCOME
+        return _decode_codex_call_tool_result(
+            nested,
+            creation_tool_name=creation_tool_name,
+        )
+    if has_err:
+        if has_direct_result_fields:
+            return _MALFORMED_CODEX_OUTCOME
+        return _codex_failure_outcome(
+            value.get("Err"),
+            creation_tool_name=creation_tool_name,
+        )
+    if has_message or has_error:
+        # Current paginated failures carry message under the outer ``error``
+        # field. A message in a result envelope is an unsupported discriminator,
+        # not an alternate success/failure branch.
+        return _MALFORMED_CODEX_OUTCOME
+    if has_content or has_is_error:
+        return _decode_codex_call_tool_result(
+            value,
+            creation_tool_name=creation_tool_name,
+        )
+    return _MALFORMED_CODEX_OUTCOME
+
+
+def _decode_codex_function_output(
+    value: Any,
+    *,
+    creation_tool_name: str | None,
+) -> CodexEvidenceOutcome:
+    """Decode the historical split ``function_call_output`` value."""
+
+    if isinstance(value, Mapping):
+        return _decode_codex_result_envelope(
+            value,
+            creation_tool_name=creation_tool_name,
+        )
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _CODEX_RESULT_TEXT_MAX
+    ):
+        return _MALFORMED_CODEX_OUTCOME
+
+    candidates = [value]
+    output_marker = "Output:\n"
+    if output_marker in value:
+        candidates.insert(0, value.split(output_marker, 1)[1])
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except RecursionError:
+            return _MALFORMED_CODEX_OUTCOME
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, list):
+            text = _single_codex_text_block(parsed)
+            if text is None:
+                return _MALFORMED_CODEX_OUTCOME
+            refusal = classify_refused_recording(text)
+            if refusal is not None:
+                return _codex_failure_outcome_from_refusal(
+                    refusal,
+                    creation_tool_name=creation_tool_name,
+                )
+            return _codex_success_outcome(text)
+        if isinstance(parsed, Mapping):
+            transport_discriminators = ("Ok", "Err", "content", "isError")
+            if any(key in parsed for key in transport_discriminators):
+                if "event" in parsed:
+                    return _MALFORMED_CODEX_OUTCOME
+                return _decode_codex_result_envelope(
+                    parsed,
+                    creation_tool_name=creation_tool_name,
+                )
+            creation_outcome = _codex_success_outcome_from_payload(parsed)
+            if creation_outcome.outcome_classification == "success":
+                return creation_outcome
+            if "error" in parsed or "message" in parsed:
+                return _decode_codex_result_envelope(
+                    parsed,
+                    creation_tool_name=creation_tool_name,
+                )
+            return creation_outcome
+        return _MALFORMED_CODEX_OUTCOME
+
+    refusal = classify_refused_recording(value)
+    if refusal is not None:
+        return _codex_failure_outcome_from_refusal(
+            refusal,
+            creation_tool_name=creation_tool_name,
+        )
+    return CodexEvidenceOutcome(outcome_classification="unknown")
+
+
+def _decode_codex_call_outcome(
+    value: Any,
+    *,
+    carrier: _CodexOutcomeCarrier,
+    creation_tool_name: str | None,
+) -> CodexEvidenceOutcome:
+    """Decode one Codex outcome into an explicit, privacy-bounded state."""
+
+    if carrier == "function_output":
+        return _decode_codex_function_output(
+            value,
+            creation_tool_name=creation_tool_name,
+        )
+    if carrier == "result":
+        return _decode_codex_result_envelope(
+            value,
+            creation_tool_name=creation_tool_name,
+        )
+    if carrier == "error":
+        if not isinstance(value, Mapping):
+            return _MALFORMED_CODEX_OUTCOME
+        if any(
+            discriminator in value
+            for discriminator in ("Ok", "Err", "content", "isError")
+        ):
+            return _MALFORMED_CODEX_OUTCOME
+        return _codex_failure_outcome(
+            value.get("message"),
+            creation_tool_name=creation_tool_name,
+        )
+    raise ValueError(f"unsupported Codex outcome carrier: {carrier!r}")
+
+
+def _codex_function_descriptor_fragment(
+    payload: Mapping[str, Any],
+) -> CodexEvidenceFragment | None:
+    """Decode the call descriptor from Codex's split function-call carrier."""
+
+    creation_tool_verdict = classify_codex_function_call(
+        payload.get("name"), payload.get("namespace")
+    )
+    if creation_tool_verdict is None:
+        return None
+    call_id = validated_codex_identifier(payload.get("call_id"))
+    return CodexEvidenceFragment(
+        call_id=call_id,
+        role="descriptor",
+        creation_tool_verdict=creation_tool_verdict,
+        creation_tool_name=validated_codex_identifier(payload.get("name")),
+        counts_as_evidence_skip=call_id is None,
+        has_schema_drift=call_id is None,
+    )
+
+
+def _codex_function_output_fragment(
+    payload: Mapping[str, Any],
+) -> CodexEvidenceFragment | None:
+    """Decode the output half of Codex's split function-call carrier."""
+
+    call_id = validated_codex_identifier(payload.get("call_id"))
+    if call_id is None:
+        return None
+    outcome = _decode_codex_call_outcome(
+        payload.get("output"),
+        carrier="function_output",
+        creation_tool_name=None,
+    )
+    return CodexEvidenceFragment(
+        call_id=call_id,
+        role="output",
+        outcome=outcome,
+        has_schema_drift=outcome.outcome_classification == "malformed",
+    )
+
+
+def _codex_completed_terminal_fragment(
+    *,
+    call_id: str | None,
+    creation_tool_name: str,
+    result: Any,
+    has_identity_drift: bool,
+) -> CodexEvidenceFragment:
+    """Normalize one accepted terminal carrier with a completed result."""
+
+    outcome = _decode_codex_call_outcome(
+        result,
+        carrier="result",
+        creation_tool_name=creation_tool_name,
+    )
+    return CodexEvidenceFragment(
+        call_id=call_id,
+        role="terminal",
+        creation_tool_verdict="accepted",
+        creation_tool_name=creation_tool_name,
+        outcome=outcome,
+        counts_as_evidence_skip=call_id is None or outcome.event_id is None,
+        has_schema_drift=(
+            has_identity_drift or outcome.outcome_classification == "malformed"
+        ),
+    )
+
+
+def _codex_failed_terminal_fragment(
+    *,
+    call_id: str | None,
+    creation_tool_name: str,
+    error: Any,
+    result: Any,
+    has_identity_drift: bool,
+) -> CodexEvidenceFragment:
+    """Normalize one accepted paginated carrier whose call failed."""
+
+    has_error = error is not None
+    has_result = result is not None
+    if has_error == has_result:
+        outcome = _MALFORMED_CODEX_OUTCOME
+    else:
+        outcome = _decode_codex_call_outcome(
+            error if has_error else result,
+            carrier="error" if has_error else "result",
+            creation_tool_name=creation_tool_name,
+        )
+        if outcome.outcome_classification != "failure":
+            outcome = _MALFORMED_CODEX_OUTCOME
+    return CodexEvidenceFragment(
+        call_id=call_id,
+        role="terminal",
+        creation_tool_verdict="accepted",
+        creation_tool_name=creation_tool_name,
+        outcome=outcome,
+        counts_as_evidence_skip=True,
+        has_schema_drift=(
+            has_identity_drift or outcome.outcome_classification == "malformed"
+        ),
+    )
+
+
+def _codex_conflicted_paginated_outcome_fragment(
+    *,
+    call_id: str | None,
+    creation_tool_name: str,
+) -> CodexEvidenceFragment:
+    """Fail closed when mutually exclusive paginated outcomes coexist."""
+
+    return CodexEvidenceFragment(
+        call_id=call_id,
+        role="terminal",
+        creation_tool_verdict="accepted",
+        creation_tool_name=creation_tool_name,
+        outcome=_MALFORMED_CODEX_OUTCOME,
+        counts_as_evidence_skip=True,
+        has_schema_drift=True,
+    )
+
+
+def _codex_legacy_terminal_fragment(
+    payload: Mapping[str, Any],
+) -> CodexEvidenceFragment | None:
+    """Decode the historical ``mcp_tool_call_end`` terminal carrier."""
+
+    call_id = validated_codex_identifier(payload.get("call_id"))
+    invocation = payload.get("invocation")
+    if not isinstance(invocation, Mapping):
+        return CodexEvidenceFragment(
+            call_id=call_id,
+            role="terminal",
+            counts_as_evidence_skip=True,
+            has_schema_drift=True,
+        )
+    creation_tool_name = validated_codex_identifier(invocation.get("tool"))
+    if creation_tool_name is None:
+        return CodexEvidenceFragment(
+            call_id=call_id,
+            role="terminal",
+            counts_as_evidence_skip=True,
+            has_schema_drift=True,
+        )
+    server = invocation.get("server")
+    creation_tool_verdict = classify_codex_mcp_call_identity(
+        server,
+        creation_tool_name,
+    )
+    if creation_tool_verdict is None:
+        return None
+    has_identity_drift = (
+        call_id is None or not isinstance(server, str) or not server
+    )
+    if creation_tool_verdict == "rejected":
+        return CodexEvidenceFragment(
+            call_id=call_id,
+            role="terminal",
+            creation_tool_verdict=creation_tool_verdict,
+            creation_tool_name=creation_tool_name,
+            counts_as_evidence_skip=True,
+            has_schema_drift=has_identity_drift,
+        )
+    return _codex_completed_terminal_fragment(
+        call_id=call_id,
+        creation_tool_name=creation_tool_name,
+        result=payload.get("result"),
+        has_identity_drift=has_identity_drift,
+    )
+
+
+def _codex_paginated_terminal_fragment(
+    payload: Mapping[str, Any],
+) -> CodexEvidenceFragment | None:
+    """Decode Codex's current ``item_completed`` / ``McpToolCall`` carrier."""
+
+    item = payload.get("item")
+    if not isinstance(item, Mapping):
+        return CodexEvidenceFragment(
+            call_id=None,
+            role="terminal",
+            counts_as_evidence_skip=True,
+            has_schema_drift=True,
+        )
+    if item.get("type") != "McpToolCall":
+        # Other known TurnItems are irrelevant. An unknown wrapper carrying a
+        # creation-tool identity is evidence drift, not a safe reason to ignore
+        # a call that may otherwise have been agentacct evidence.
+        creation_tool_name = validated_codex_identifier(item.get("tool"))
+        creation_tool_verdict = classify_codex_mcp_call_identity(
+            item.get("server"),
+            creation_tool_name,
+        )
+        if creation_tool_verdict is None:
+            return None
+        return CodexEvidenceFragment(
+            call_id=validated_codex_identifier(item.get("id")),
+            role="terminal",
+            creation_tool_verdict=creation_tool_verdict,
+            creation_tool_name=creation_tool_name,
+            counts_as_evidence_skip=True,
+            has_schema_drift=True,
+        )
+
+    call_id = validated_codex_identifier(item.get("id"))
+    creation_tool_name = validated_codex_identifier(item.get("tool"))
+    if creation_tool_name is None:
+        return CodexEvidenceFragment(
+            call_id=call_id,
+            role="terminal",
+            counts_as_evidence_skip=True,
+            has_schema_drift=True,
+        )
+    server = item.get("server")
+    creation_tool_verdict = classify_codex_mcp_call_identity(
+        server,
+        creation_tool_name,
+    )
+    if creation_tool_verdict is None:
+        return None
+    has_identity_drift = (
+        call_id is None or not isinstance(server, str) or not server
+    )
+    if creation_tool_verdict == "rejected":
+        return CodexEvidenceFragment(
+            call_id=call_id,
+            role="terminal",
+            creation_tool_verdict=creation_tool_verdict,
+            creation_tool_name=creation_tool_name,
+            counts_as_evidence_skip=True,
+            has_schema_drift=has_identity_drift,
+        )
+
+    status = item.get("status")
+    result = item.get("result")
+    error = item.get("error")
+    if status == "completed":
+        if error is not None:
+            return _codex_conflicted_paginated_outcome_fragment(
+                call_id=call_id,
+                creation_tool_name=creation_tool_name,
+            )
+        return _codex_completed_terminal_fragment(
+            call_id=call_id,
+            creation_tool_name=creation_tool_name,
+            result=result,
+            has_identity_drift=has_identity_drift,
+        )
+    if status == "failed":
+        if error is not None and result is not None:
+            return _codex_conflicted_paginated_outcome_fragment(
+                call_id=call_id,
+                creation_tool_name=creation_tool_name,
+            )
+        return _codex_failed_terminal_fragment(
+            call_id=call_id,
+            creation_tool_name=creation_tool_name,
+            error=error,
+            result=result,
+            has_identity_drift=has_identity_drift,
+        )
+    return CodexEvidenceFragment(
+        call_id=call_id,
+        role="terminal",
+        creation_tool_verdict=creation_tool_verdict,
+        creation_tool_name=creation_tool_name,
+        outcome=_MALFORMED_CODEX_OUTCOME,
+        counts_as_evidence_skip=True,
+        has_schema_drift=True,
+    )
+
+
+def decode_codex_evidence_fragment(
+    record: Mapping[str, Any],
+) -> CodexEvidenceFragment | None:
+    """Decode one complete rollout record into a bounded evidence fragment.
+
+    Non-creation calls return None for evidence purposes. Malformed creation
+    carriers remain visible as bounded skips plus evidence-schema drift. The
+    outer record type is validated here so a payload under the wrong Codex
+    channel cannot acquire evidence authority.
+    """
+
+    payload = record.get("payload")
+    if not isinstance(payload, Mapping):
+        return None
+    payload_type = payload.get("type")
+    fragment: CodexEvidenceFragment | None
+    expected_record_type: str | None = None
+    if payload_type == "function_call":
+        fragment = _codex_function_descriptor_fragment(payload)
+        expected_record_type = "response_item"
+    elif payload_type == "function_call_output":
+        fragment = _codex_function_output_fragment(payload)
+        expected_record_type = "response_item"
+    elif payload_type == "mcp_tool_call_end":
+        fragment = _codex_legacy_terminal_fragment(payload)
+        expected_record_type = "event_msg"
+    elif payload_type == "item_completed":
+        fragment = _codex_paginated_terminal_fragment(payload)
+        expected_record_type = "event_msg"
+    else:
+        return None
+
+    if fragment is None or record.get("type") == expected_record_type:
+        return fragment
+    return replace(
+        fragment,
+        counts_as_evidence_skip=(
+            fragment.counts_as_evidence_skip or fragment.role != "output"
+        ),
+        has_schema_drift=True,
+    )
+
+
+def codex_record_may_contain_evidence(record: Mapping[str, Any]) -> bool:
+    """Cheap relevance check used only after the fragment scan cap is full."""
+
+    payload = record.get("payload")
+    if not isinstance(payload, Mapping):
+        return False
+    payload_type = payload.get("type")
+    if payload_type == "function_call":
+        return (
+            classify_codex_function_call(
+                payload.get("name"), payload.get("namespace")
+            )
+            is not None
+        )
+    if payload_type == "function_call_output":
+        return validated_codex_identifier(payload.get("call_id")) is not None
+    if payload_type == "mcp_tool_call_end":
+        invocation = payload.get("invocation")
+        if not isinstance(invocation, Mapping):
+            return True
+        creation_tool_name = validated_codex_identifier(invocation.get("tool"))
+        if creation_tool_name is None:
+            return True
+        return (
+            classify_codex_mcp_call_identity(
+                invocation.get("server"),
+                creation_tool_name,
+            )
+            is not None
+        )
+    if payload_type != "item_completed":
+        return False
+    item = payload.get("item")
+    if not isinstance(item, Mapping):
+        return True
+    if item.get("type") == "McpToolCall":
+        creation_tool_name = validated_codex_identifier(item.get("tool"))
+        if creation_tool_name is None:
+            return True
+        return (
+            classify_codex_mcp_call_identity(
+                item.get("server"),
+                creation_tool_name,
+            )
+            is not None
+        )
+    return (
+        classify_codex_mcp_call_identity(
+            item.get("server"),
+            validated_codex_identifier(item.get("tool")),
+        )
+        is not None
+    )
+
+
+def _bind_codex_refusal_to_tool(
+    refusal: _CodexRefusal | None,
+    creation_tool_name: str | None,
+) -> tuple[_CodexRefusal | None, bool]:
+    """Bind a split refusal to its descriptor and expose identity conflicts."""
+
+    if refusal is None:
+        return None, False
+    refusal_tool, field, reason = refusal
+    if (
+        refusal_tool is not None
+        and creation_tool_name is not None
+        and refusal_tool != creation_tool_name
+    ):
+        return None, True
+    if refusal_tool is None and creation_tool_name is not None:
+        return (creation_tool_name, field, reason), False
+    return refusal, False
+
+
+def _codex_refusal_sort_key(
+    refusal: _CodexRefusal | None,
+) -> tuple[bool, tuple[str, str, str]]:
+    """Prefer classifiable refusals, then make diagnostic choice stable."""
+
+    normalized_refusal = (
+        tuple(part or "" for part in refusal)
+        if refusal is not None
+        else ("", "", "")
+    )
+    return refusal is None, normalized_refusal
+
+
+def reconcile_codex_evidence_fragments(
+    fragments: list[CodexEvidenceFragment],
+    evidence: LogEvidenceAccumulator,
+) -> bool:
+    """Reduce carrier fragments to deterministic logical-call evidence.
+
+    Returns whether semantic evidence schema drift or an integrity conflict was
+    observed. A call can donate at most once and can contribute at most one
+    non-donating diagnostic, independent of fragment order.
+    """
+
+    fragments_by_call_id: dict[str, list[CodexEvidenceFragment]] = {}
+    evidence_parse_incomplete = False
+    for fragment in fragments:
+        if fragment.role != "output":
+            evidence_parse_incomplete = (
+                evidence_parse_incomplete or fragment.has_schema_drift
+            )
+        if fragment.call_id is None:
+            if fragment.counts_as_evidence_skip:
+                refusal = (
+                    fragment.outcome.refusal
+                    if fragment.outcome is not None
+                    else None
+                )
+                evidence.record_classified_skip(refusal)
+            continue
+        fragments_by_call_id.setdefault(fragment.call_id, []).append(fragment)
+
+    for call_fragments in fragments_by_call_id.values():
+        descriptor_fragments = [
+            fragment
+            for fragment in call_fragments
+            if fragment.role == "descriptor"
+        ]
+        output_fragments = [
+            fragment for fragment in call_fragments if fragment.role == "output"
+        ]
+        terminal_fragments = [
+            fragment
+            for fragment in call_fragments
+            if fragment.role == "terminal"
+        ]
+        accepted_descriptor_fragments = [
+            fragment
+            for fragment in descriptor_fragments
+            if fragment.creation_tool_verdict == "accepted"
+        ]
+        rejected_descriptor_fragments = [
+            fragment
+            for fragment in descriptor_fragments
+            if fragment.creation_tool_verdict == "rejected"
+        ]
+        accepted_terminal_fragments = [
+            fragment
+            for fragment in terminal_fragments
+            if fragment.creation_tool_verdict == "accepted"
+        ]
+        accepted_creation_tool_fragments = [
+            *accepted_descriptor_fragments,
+            *accepted_terminal_fragments,
+        ]
+        accepted_creation_tool_names = {
+            fragment.creation_tool_name
+            for fragment in accepted_creation_tool_fragments
+            if fragment.creation_tool_name is not None
+        }
+        outcomes_with_creation_tool: list[
+            tuple[CodexEvidenceOutcome, str | None]
+        ] = []
+        created_event_ids: list[str] = []
+        skip_refusals: list[_CodexRefusal | None] = []
+        has_refusal_tool_conflict = False
+
+        if accepted_descriptor_fragments:
+            bound_creation_tool_name = min(
+                (
+                    fragment.creation_tool_name
+                    for fragment in accepted_descriptor_fragments
+                    if fragment.creation_tool_name is not None
+                ),
+                default=None,
+            )
+            for output_fragment in output_fragments:
+                evidence_parse_incomplete = (
+                    evidence_parse_incomplete
+                    or output_fragment.has_schema_drift
+                )
+                outcome = output_fragment.outcome or _MALFORMED_CODEX_OUTCOME
+                outcomes_with_creation_tool.append(
+                    (outcome, bound_creation_tool_name)
+                )
+        if rejected_descriptor_fragments and output_fragments:
+            skip_refusals.append(None)
+
+        for terminal_fragment in terminal_fragments:
+            if terminal_fragment.creation_tool_verdict == "accepted":
+                outcomes_with_creation_tool.append(
+                    (
+                        terminal_fragment.outcome or _MALFORMED_CODEX_OUTCOME,
+                        terminal_fragment.creation_tool_name,
+                    )
+                )
+            elif (
+                terminal_fragment.counts_as_evidence_skip
+                or terminal_fragment.creation_tool_verdict == "rejected"
+            ):
+                skip_refusals.append(None)
+
+        for outcome, creation_tool_name in outcomes_with_creation_tool:
+            if (
+                outcome.outcome_classification == "success"
+                and outcome.event_id is not None
+            ):
+                created_event_ids.append(outcome.event_id)
+                continue
+            refusal, has_tool_identity_conflict = _bind_codex_refusal_to_tool(
+                outcome.refusal,
+                creation_tool_name,
+            )
+            has_refusal_tool_conflict = (
+                has_refusal_tool_conflict or has_tool_identity_conflict
+            )
+            skip_refusals.append(refusal)
+
+        distinct_created_event_ids = set(created_event_ids)
+        has_relevant_schema_drift = any(
+            fragment.has_schema_drift
+            for fragment in [*descriptor_fragments, *terminal_fragments]
+        ) or (
+            bool(accepted_descriptor_fragments)
+            and any(fragment.has_schema_drift for fragment in output_fragments)
+        )
+        has_integrity_conflict = (
+            len(distinct_created_event_ids) > 1
+            or len(accepted_creation_tool_names) > 1
+            or has_refusal_tool_conflict
+            or has_relevant_schema_drift
+        )
+        if has_integrity_conflict:
+            # Never choose between distinct successful ids, accepted tool
+            # identities, mismatched refusal identities, or malformed carriers.
+            evidence_parse_incomplete = True
+            created_event_ids = []
+            skip_refusals = [None]
+
+        if created_event_ids:
+            evidence.add_event_id(created_event_ids[0])
+        if skip_refusals:
+            # Prefer a refusal agentacct can actually classify, then choose
+            # deterministically so carrier reversal cannot change the bounded
+            # diagnostic row. Generic client/transport failures remain skips
+            # but must not hide a real server refusal for the same logical call.
+            selected_refusal = min(
+                skip_refusals,
+                key=_codex_refusal_sort_key,
+            )
+            evidence.record_classified_skip(selected_refusal)
+
+    return evidence_parse_incomplete
+
+
+def codex_model_from_record(record: Mapping[str, Any]) -> str | None:
+    """Read model identity only from exact Codex-owned record paths."""
+
+    payload = record.get("payload")
+    if not isinstance(payload, Mapping):
+        return None
+
+    def model_name_from_mapping(value: Any) -> str | None:
+        if not isinstance(value, Mapping):
+            return None
+        return validated_codex_identifier(
+            value.get("model"),
+            max_length=_CODEX_MODEL_TEXT_MAX,
+        )
+
+    outer_type = record.get("type")
+    payload_type = payload.get("type")
+    info = payload.get("info")
+    if outer_type == "session_meta":
+        return model_name_from_mapping(payload)
+    if outer_type == "turn_context":
+        return model_name_from_mapping(payload)
+    if outer_type == "world_state":
+        return model_name_from_mapping(payload.get("state"))
+    if outer_type == "event_msg" and payload_type == "thread_settings_applied":
+        return model_name_from_mapping(payload.get("thread_settings"))
+    if (
+        outer_type == "event_msg"
+        and payload_type in (None, "token_count")
+        and isinstance(info, Mapping)
+        and isinstance(info.get("total_token_usage"), Mapping)
+    ):
+        # Legacy/compatibility carrier used by persisted rollouts and fixtures.
+        return model_name_from_mapping(payload)
+    return None
+
+
+__all__ = [
+    "CodexEvidenceFragment",
+    "CodexEvidenceOutcome",
+    "codex_function_action_name",
+    "codex_mcp_action_name",
+    "codex_model_from_record",
+    "codex_record_may_contain_evidence",
+    "decode_codex_evidence_fragment",
+    "reconcile_codex_evidence_fragments",
+    "validated_codex_identifier",
+]

--- a/src/agentacct/log_evidence.py
+++ b/src/agentacct/log_evidence.py
@@ -120,8 +120,24 @@ _CODEX_ACCEPTED_NAMESPACES = frozenset(
 _CLAUDE_TOOL_PREFIX = "mcp__"
 
 
+def extract_created_event_id_from_payload(payload: Any) -> str | None:
+    """Extract one event id only from the exact creation-response shape."""
+
+    if not isinstance(payload, dict):
+        return None
+    event = payload.get("event")
+    if not isinstance(event, dict):
+        return None
+    if any(isinstance(payload.get(key), list) for key in ("events", "runs")):
+        return None
+    event_id = event.get("event_id")
+    if not isinstance(event_id, str) or not EVIDENCED_EVENT_ID_RE.match(event_id):
+        return None
+    return event_id
+
+
 def extract_created_event_id(text: str) -> str | None:
-    """Strict single-created-event shape check shared by every wire adapter.
+    """Strict single-created-event text check shared by every wire adapter.
 
     Accepts exactly the creation-tool payload shape: a JSON dict with a
     top-level ``"event"`` dict whose ``event_id`` is a well-formed evt id.
@@ -135,17 +151,7 @@ def extract_created_event_id(text: str) -> str | None:
         payload = json.loads(text)
     except (json.JSONDecodeError, ValueError):
         return None
-    if not isinstance(payload, dict):
-        return None
-    event = payload.get("event")
-    if not isinstance(event, dict):
-        return None
-    if any(isinstance(payload.get(key), list) for key in ("events", "runs")):
-        return None
-    event_id = event.get("event_id")
-    if not isinstance(event_id, str) or not EVIDENCED_EVENT_ID_RE.match(event_id):
-        return None
-    return event_id
+    return extract_created_event_id_from_payload(payload)
 
 
 # ---------------------------------------------------------------------------
@@ -545,16 +551,15 @@ def opencode_tool_creation_tool(name: Any) -> str | None:
     return None
 
 
-def classify_codex_mcp_invocation(server: Any, tool: Any) -> str | None:
-    """"accepted" / "rejected" / None for a codex mcp_tool_call_end invocation.
+def classify_codex_mcp_call_identity(server: Any, tool: Any) -> str | None:
+    """Classify a Codex MCP call as an accepted recording-tool identity.
 
-    Codex 0.144.0-alpha.4 dropped the duplicate ``function_call`` records for
-    MCP tools; the ``mcp_tool_call_end`` event_msg's ``invocation`` block
-    (``server``/``tool``) is now the only channel. Same allowlist-first rule
+    Applies equally to the legacy ``mcp_tool_call_end.invocation`` identity and
+    the paginated ``item_completed.item`` identity. Same allowlist-first rule
     as :func:`classify_codex_function_call`, with ONE deliberate difference:
-    the ``server`` field is always present in this shape, so a None/absent
-    server is REJECTED (skipped-but-counted — absence is drift), never
-    accepted the way an absent function_call namespace is.
+    terminal MCP carriers require a server, so None/absent is REJECTED
+    (skipped-but-counted), never accepted like an absent legacy
+    ``function_call`` namespace.
     """
 
     if not isinstance(tool, str) or tool not in SENTINEL_CREATION_TOOLS:
@@ -562,6 +567,12 @@ def classify_codex_mcp_invocation(server: Any, tool: Any) -> str | None:
     if server is None:
         return "rejected"
     return "accepted" if codex_namespace_matches_sentinel(server) else "rejected"
+
+
+def classify_codex_mcp_invocation(server: Any, tool: Any) -> str | None:
+    """Compatibility name for :func:`classify_codex_mcp_call_identity`."""
+
+    return classify_codex_mcp_call_identity(server, tool)
 
 
 def unwrap_codex_mcp_result(result: Any) -> str | None:
@@ -645,6 +656,14 @@ class LogEvidenceAccumulator:
         if event_id is None:
             self.record_skip(text, tool=tool)
             return
+        self.add_event_id(event_id)
+
+    def add_event_id(self, event_id: str) -> None:
+        """Add an already-normalized created-event id without retaining output."""
+
+        if not isinstance(event_id, str) or not EVIDENCED_EVENT_ID_RE.match(event_id):
+            self.record_skip()
+            return
         if event_id in self._seen:
             return
         self._seen.add(event_id)
@@ -663,6 +682,28 @@ class LogEvidenceAccumulator:
         refusal = classify_refused_recording(text, tool=tool)
         if refusal is not None:
             self._refused[refusal] += 1
+
+    def record_classified_skip(
+        self,
+        refusal: tuple[str | None, str | None, str] | None,
+    ) -> None:
+        """Count a skip after an adapter has dropped the original response text.
+
+        The tuple is re-normalized through the same frozen vocabularies used at
+        render time, so this path cannot turn adapter data into unbounded or
+        caller-controlled metadata.
+        """
+
+        self.evidenced_outputs_skipped += 1
+        if refusal is None:
+            return
+        rows = refused_recording_rows({refusal: 1})
+        if not rows:
+            return
+        row = rows[0]
+        self._refused[
+            (row["tool"], row["field"], row["reason_code"])
+        ] += 1
 
     @property
     def evidenced_event_id_total(self) -> int:

--- a/tests/test_client_usage.py
+++ b/tests/test_client_usage.py
@@ -1097,6 +1097,32 @@ def test_codex_dedupe_signature_distinguishes_missing_from_explicit_zero(tmp_pat
     assert event.deduplicated_usage_rows == 0
 
 
+def test_codex_rollout_survives_deeply_nested_json_line(tmp_path):
+    codex_home = _make_codex_home(tmp_path)
+    rollout_path = next((codex_home / "sessions").rglob("rollout-*.jsonl"))
+    deeply_nested_line = (
+        '{"type":"event_msg","payload":{"nested":'
+        + "[" * 10_000
+        + "0"
+        + "]" * 10_000
+        + "}}"
+    )
+    rollout_path.write_text(
+        rollout_path.read_text(encoding="utf-8") + deeply_nested_line + "\n",
+        encoding="utf-8",
+    )
+    parse_stats: dict[str, int] = {}
+
+    usage = client_usage_module._read_codex_rollout_usage(
+        rollout_path,
+        _parse_stats=parse_stats,
+    )
+
+    assert usage is not None
+    assert usage["total_tokens"] == 2_625
+    assert parse_stats["unparseable_rollouts"] == 1
+
+
 def test_codex_partial_or_invalid_rollout_never_uses_sqlite_input_fallback(tmp_path):
     codex_home = _make_codex_home(tmp_path)
     partial = {

--- a/tests/test_codex_actions.py
+++ b/tests/test_codex_actions.py
@@ -318,6 +318,84 @@ def test_discover_codex_populates_rollout_tool_activity(tmp_path):
     assert "tool_activity" not in worker.to_sentinel_event()["metadata"]
 
 
+def test_discover_codex_populates_paginated_mcp_tool_activity_once(tmp_path):
+    codex_home = _make_codex_home(tmp_path)
+    _add_codex_thread(
+        codex_home, session_id="worker", updated_at=300, model="gpt-5.5"
+    )
+    paginated_call = {
+        "timestamp": "2026-07-05T10:00:01.000Z",
+        "type": "event_msg",
+        "payload": {
+            "type": "item_completed",
+            "thread_id": "thread-redacted",
+            "turn_id": "turn-redacted",
+            "item": {
+                "type": "McpToolCall",
+                "id": "call_section",
+                "server": "agentacct",
+                "tool": "agentacct_record_section",
+                "arguments": {"section_id": "redacted"},
+                "status": "completed",
+                "duration": {"secs": 2, "nanos": 0},
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {"event": {"event_id": "evt_123456789abc"}}
+                            ),
+                        }
+                    ]
+                },
+            },
+        },
+    }
+    # The duplicate legacy terminal fragment carries the same logical call ID.
+    # Actions count logical calls, not rollout representations.
+    legacy_duplicate = {
+        "type": "event_msg",
+        "payload": {
+            "type": "mcp_tool_call_end",
+            "call_id": "call_section",
+            "invocation": {
+                "server": "agentacct",
+                "tool": "agentacct_record_section",
+                "arguments": {"section_id": "redacted"},
+            },
+            "result": {
+                "Ok": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {"event": {"event_id": "evt_123456789abc"}}
+                            ),
+                        }
+                    ]
+                }
+            },
+        },
+    }
+    _rewrite_rollout_with_tool_calls(
+        codex_home,
+        "worker",
+        "/work/project",
+        [paginated_call, legacy_duplicate],
+    )
+
+    observations: list = []
+    discover_codex_usage(
+        codex_home=codex_home, limit_sessions=10, _session_observations=observations
+    )
+
+    worker = next(o for o in observations if o.client_session_id == "worker")
+    assert worker.rollout_tool_activity["tool_category_counts"] == {"mcp": 1}
+    assert worker.rollout_tool_activity["tool_names"] == [
+        {"name": "mcp__agentacct__agentacct_record_section", "count": 1}
+    ]
+
+
 def test_import_local_emits_and_refreshes_codex_actions(tmp_path):
     from typer.testing import CliRunner
 

--- a/tests/test_codex_actions.py
+++ b/tests/test_codex_actions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import sqlite3
 
+import pytest
+
 from agentacct import client_usage as cu
 from agentacct.client_usage import discover_codex_usage
 from agentacct.tool_activity import (
@@ -27,6 +29,55 @@ from tests.test_client_usage import _make_codex_home, _add_codex_thread
 
 
 # --- pure extraction helpers ------------------------------------------------
+
+
+def _tool_activity_from_calls(
+    calls: list[tuple[str, object]],
+    *,
+    cwd: str | None,
+) -> dict[str, object]:
+    accumulator = cu._CodexToolActivityAccumulator()
+    identified_calls = [
+        (f"call-{index}", tool_name, arguments)
+        for index, (tool_name, arguments) in enumerate(calls)
+    ]
+    _record_calls_and_touched_paths(accumulator, identified_calls, cwd=cwd)
+    return accumulator.as_activity()
+
+
+def _record_calls_and_touched_paths(
+    accumulator: cu._CodexToolActivityAccumulator,
+    calls: list[tuple[object, object, object]],
+    *,
+    cwd: str | None,
+) -> None:
+    """Run the accumulator's identity and path phases over the same carriers."""
+
+    for source_line_number, (call_id, tool_name, arguments) in enumerate(
+        calls,
+        start=1,
+    ):
+        accumulator.record_call(
+            call_id,
+            tool_name,
+            arguments,
+            source_line_number=source_line_number,
+        )
+    for source_line_number, (call_id, tool_name, arguments) in enumerate(
+        calls,
+        start=1,
+    ):
+        if accumulator.expects_carrier_on_source_line(source_line_number):
+            accumulator.record_touched_paths(
+                source_line_number,
+                cu._CodexActionCarrier(
+                    call_id=call_id,
+                    action_name=tool_name,
+                    raw_arguments=arguments,
+                ),
+                cwd=cwd,
+            )
+    accumulator.finish_touched_path_scan(source_unchanged=True)
 
 
 def test_apply_patch_paths_parses_add_update_delete_move():
@@ -67,12 +118,14 @@ def test_command_text_from_js_exec_single_quoted():
     assert cu._codex_command_text("exec", js) == "ls -la"
 
 
-def test_command_text_skips_template_literal_and_garbage():
+def test_command_text_skips_unsupported_arguments():
     # A backtick/template cmd is deliberately skipped (honest undercount) rather
     # than captured half-parsed.
     assert cu._codex_command_text("exec", "tools.exec_command({cmd:`git ${x}`})") is None
     assert cu._codex_command_text("exec_command", "not json at all") is None
     assert cu._codex_command_text("exec_command", "") is None
+    deeply_nested_json = "[" * 10_000 + "0" + "]" * 10_000
+    assert cu._codex_command_text("exec_command", deeply_nested_json) is None
 
 
 def test_relativize_touched_path_keeps_relative_relativizes_under_cwd_drops_outside():
@@ -95,7 +148,7 @@ def test_tool_activity_from_calls_aggregates_all_signals():
         ("spawn_agent", "{}"),
         ("read_file", "{}"),  # unknown -> category "other", name kept
     ]
-    activity = cu._codex_tool_activity_from_calls(calls, cwd="/work/project")
+    activity = _tool_activity_from_calls(calls, cwd="/work/project")
     assert activity["tool_category_counts"] == {
         "agent": 1,
         "edit": 1,
@@ -121,13 +174,249 @@ def test_tool_activity_from_calls_dedupes_commands_and_paths():
         ("apply_patch", "*** Add File: a.py\n"),
         ("apply_patch", "*** Update File: a.py\n"),
     ]
-    activity = cu._codex_tool_activity_from_calls(calls, cwd=None)
+    activity = _tool_activity_from_calls(calls, cwd=None)
     assert activity["commands"] == ["ls"]
     assert activity["touched_files"] == ["a.py"]
 
 
+def test_touched_path_cap_counts_unique_paths_across_calls():
+    accumulator = cu._CodexToolActivityAccumulator(touched_path_cap=2)
+    calls = [
+        (call_id, "apply_patch", f"*** Update File: {path}\n")
+        for call_id, path in (
+            ("call-1", "repeated.py"),
+            ("call-2", "repeated.py"),
+            ("call-3", "later.py"),
+            ("call-4", "beyond-cap.py"),
+        )
+    ]
+    _record_calls_and_touched_paths(accumulator, calls, cwd=None)
+
+    activity = accumulator.as_activity()
+    assert activity["tool_category_counts"] == {"edit": 4}
+    assert activity["touched_files"] == ["repeated.py", "later.py"]
+
+
+@pytest.mark.parametrize(
+    ("same_call_paths", "expected_paths"),
+    [
+        (("a.py", "b.py"), ["a.py", "b.py", "c.py"]),
+        (("b.py", "a.py"), ["b.py", "a.py", "c.py"]),
+    ],
+)
+def test_touched_paths_merge_duplicate_calls_in_carrier_order(
+    same_call_paths: tuple[str, str],
+    expected_paths: list[str],
+):
+    accumulator = cu._CodexToolActivityAccumulator(touched_path_cap=3)
+    calls = [
+        ("duplicate-call", "apply_patch", f"*** Update File: {path}\n")
+        for path in same_call_paths
+    ]
+    calls.append(("later-call", "apply_patch", "*** Update File: c.py\n"))
+    _record_calls_and_touched_paths(accumulator, calls, cwd=None)
+
+    activity = accumulator.as_activity()
+    assert activity["tool_category_counts"] == {"edit": 2}
+    assert activity["touched_files"] == expected_paths
+
+
+@pytest.mark.parametrize(
+    "call_order",
+    [
+        ("conflicting-patch", "conflicting-command", "valid-patch"),
+        ("conflicting-command", "conflicting-patch", "valid-patch"),
+        ("conflicting-patch", "valid-patch", "conflicting-command"),
+        ("conflicting-command", "valid-patch", "conflicting-patch"),
+    ],
+)
+def test_conflicting_call_identity_does_not_consume_touched_path_cap(
+    call_order: tuple[str, str, str],
+):
+    accumulator = cu._CodexToolActivityAccumulator(touched_path_cap=1)
+    carriers = {
+        "conflicting-patch": (
+            "ambiguous-call",
+            "apply_patch",
+            "*** Update File: blocked.py\n",
+        ),
+        "conflicting-command": (
+            "ambiguous-call",
+            "exec_command",
+            json.dumps({"cmd": "pytest"}),
+        ),
+        "valid-patch": (
+            "valid-call",
+            "apply_patch",
+            "*** Update File: kept.py\n",
+        ),
+    }
+    _record_calls_and_touched_paths(
+        accumulator,
+        [carriers[carrier_name] for carrier_name in call_order],
+        cwd=None,
+    )
+
+    activity = accumulator.as_activity()
+    assert activity["tool_category_counts"] == {"edit": 1}
+    assert activity["tool_names"] == [{"name": "apply_patch", "count": 1}]
+    assert activity["touched_files"] == ["kept.py"]
+    assert "commands" not in activity
+
+
+def test_repeated_multi_file_calls_do_not_hide_later_distinct_path():
+    accumulator = cu._CodexToolActivityAccumulator(
+        carrier_cap=4,
+        touched_path_cap=3,
+    )
+    repeated_patch = "*** Update File: a.py\n*** Update File: b.py\n"
+    calls = [
+        ("call-1", "apply_patch", repeated_patch),
+        ("call-2", "apply_patch", repeated_patch),
+        ("call-3", "apply_patch", "*** Update File: c.py\n"),
+    ]
+    _record_calls_and_touched_paths(accumulator, calls, cwd=None)
+
+    assert accumulator.as_activity()["touched_files"] == ["a.py", "b.py", "c.py"]
+
+
+def test_touched_path_projection_retains_only_the_output_cap():
+    carrier_cap = 64
+    touched_path_cap = 2
+    accumulator = cu._CodexToolActivityAccumulator(
+        carrier_cap=carrier_cap,
+        touched_path_cap=touched_path_cap,
+    )
+    patch = "".join(
+        f"*** Update File: path-{index}.py\n" for index in range(200)
+    )
+    calls = [
+        (f"call-{call_index}", "apply_patch", patch)
+        for call_index in range(carrier_cap)
+    ]
+    _record_calls_and_touched_paths(accumulator, calls, cwd=None)
+
+    assert len(accumulator._carrier_identities_by_source_line) == carrier_cap
+    assert len(accumulator._touched_path_set) == touched_path_cap
+    assert all(
+        not hasattr(fact, "touched_paths")
+        for fact in accumulator._facts_by_call_id.values()
+        if fact is not None
+    )
+    assert accumulator.as_activity()["touched_files"] == [
+        "path-0.py",
+        "path-1.py",
+    ]
+
+
+def test_touched_path_scan_discards_paths_if_source_changes():
+    accumulator = cu._CodexToolActivityAccumulator()
+    accumulator.record_call(
+        "call-1",
+        "apply_patch",
+        "*** Update File: must-be-discarded.py\n",
+        source_line_number=1,
+    )
+    accumulator.record_touched_paths(
+        1,
+        cu._CodexActionCarrier(
+            call_id="call-1",
+            action_name="apply_patch",
+            raw_arguments="*** Update File: must-be-discarded.py\n",
+        ),
+        cwd=None,
+    )
+    accumulator.finish_touched_path_scan(source_unchanged=False)
+
+    activity = accumulator.as_activity()
+    assert activity["tool_category_counts"] == {"edit": 1}
+    assert "touched_files" not in activity
+
+
+def test_touched_path_scan_rejects_mutation_between_phases(tmp_path):
+    def rollout_line(path: str) -> str:
+        return json.dumps(
+            {
+                "type": "custom_tool_call",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "apply_patch",
+                    "call_id": "same-call",
+                    "input": f"*** Update File: {path}\n",
+                },
+            }
+        )
+
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text(rollout_line("first.py") + "\n", encoding="utf-8")
+    accumulator = cu._CodexToolActivityAccumulator()
+    with rollout.open("r", encoding="utf-8") as handle:
+        source_snapshot = cu._codex_open_file_snapshot(handle)
+        first_record = json.loads(handle.readline())
+        first_carrier = cu._codex_action_carrier(first_record["payload"])
+        assert first_carrier is not None
+        accumulator.record_call(
+            first_carrier.call_id,
+            first_carrier.action_name,
+            first_carrier.raw_arguments,
+            source_line_number=1,
+        )
+
+        # Same logical identity, different raw path. A mixed two-phase read must
+        # omit paths rather than attributing either snapshot's argument.
+        rollout.write_text(
+            rollout_line("must-not-be-attributed.py") + "\n",
+            encoding="utf-8",
+        )
+        cu._collect_codex_rollout_touched_paths(
+            handle,
+            source_snapshot=source_snapshot,
+            source_line_count=1,
+            tool_activity=accumulator,
+            cwd=None,
+        )
+
+    activity = accumulator.as_activity()
+    assert activity["tool_category_counts"] == {"edit": 1}
+    assert "touched_files" not in activity
+
+
+def test_anonymous_and_identified_calls_preserve_carrier_order():
+    accumulator = cu._CodexToolActivityAccumulator()
+    calls = [
+        (None, "exec_command", json.dumps({"cmd": "first"})),
+        ("identified", "exec_command", json.dumps({"cmd": "second"})),
+        (None, "exec_command", json.dumps({"cmd": "third"})),
+    ]
+    _record_calls_and_touched_paths(accumulator, calls, cwd=None)
+
+    assert accumulator.as_activity()["commands"] == ["first", "second", "third"]
+
+
 def test_tool_activity_empty_calls_is_empty():
-    assert cu._codex_tool_activity_from_calls([], cwd=None) == {}
+    assert _tool_activity_from_calls([], cwd=None) == {}
+
+
+def test_tool_activity_carrier_cap_bounds_duplicate_decoding():
+    accumulator = cu._CodexToolActivityAccumulator(carrier_cap=1)
+    _record_calls_and_touched_paths(
+        accumulator,
+        [
+            ("call-1", "exec_command", json.dumps({"cmd": "pytest -q"})),
+            (
+                "call-1",
+                "apply_patch",
+                "*** Add File: must-not-be-decoded.py\n",
+            ),
+        ],
+        cwd=None,
+    )
+
+    assert accumulator.as_activity() == {
+        "tool_category_counts": {"execute": 1},
+        "tool_names": [{"name": "exec_command", "count": 1}],
+        "commands": ["pytest -q"],
+    }
 
 
 # --- event build ------------------------------------------------------------
@@ -316,6 +605,65 @@ def test_discover_codex_populates_rollout_tool_activity(tmp_path):
     # The carrier is INTERNAL: it never leaks into the session observation event.
     assert "rollout_tool_activity" not in worker.to_sentinel_event()["metadata"]
     assert "tool_activity" not in worker.to_sentinel_event()["metadata"]
+
+
+def test_touched_path_before_session_meta_uses_authoritative_session_cwd(tmp_path):
+    codex_home = _make_codex_home(tmp_path)
+    _add_codex_thread(
+        codex_home, session_id="worker", updated_at=300, model="gpt-5.5"
+    )
+    rollout = next((codex_home / "sessions").rglob("*worker.jsonl"))
+    rollout.write_text(
+        "\n".join(
+            json.dumps(line)
+            for line in [
+                {
+                    "type": "custom_tool_call",
+                    "payload": {
+                        "type": "custom_tool_call",
+                        "name": "apply_patch",
+                        "call_id": "pre-meta-call",
+                        "input": (
+                            "*** Begin Patch\n"
+                            "*** Update File: /work/project/src/pre_meta.py\n"
+                            "*** End Patch\n"
+                        ),
+                    },
+                },
+                {
+                    "type": "session_meta",
+                    "payload": {"id": "worker", "cwd": "/work/project"},
+                },
+                {
+                    "type": "event_msg",
+                    "payload": {
+                        "info": {
+                            "total_token_usage": {
+                                "input_tokens": 100,
+                                "cached_input_tokens": 0,
+                                "output_tokens": 20,
+                                "reasoning_output_tokens": 0,
+                                "total_tokens": 120,
+                            }
+                        },
+                        "model": "gpt-5.5",
+                    },
+                },
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    observations: list = []
+    discover_codex_usage(
+        codex_home=codex_home,
+        limit_sessions=10,
+        _session_observations=observations,
+    )
+
+    worker = next(o for o in observations if o.client_session_id == "worker")
+    assert worker.rollout_tool_activity["touched_files"] == ["src/pre_meta.py"]
 
 
 def test_discover_codex_populates_paginated_mcp_tool_activity_once(tmp_path):

--- a/tests/test_codex_parse_cache.py
+++ b/tests/test_codex_parse_cache.py
@@ -67,6 +67,36 @@ def _make_codex_home(root: Path, *, model: str = "gpt-5.5") -> Path:
                         },
                     }
                 ),
+                json.dumps(
+                    {
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "item_completed",
+                            "item": {
+                                "type": "McpToolCall",
+                                "id": "call-cache-evidence",
+                                "server": "agentacct",
+                                "tool": "agentacct_record_section",
+                                "arguments": {},
+                                "status": "completed",
+                                "result": {
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": json.dumps(
+                                                {
+                                                    "event": {
+                                                        "event_id": "evt_ca11e0ca11e0"
+                                                    }
+                                                }
+                                            ),
+                                        }
+                                    ]
+                                },
+                            },
+                        },
+                    }
+                ),
             ]
         )
         + "\n",
@@ -169,6 +199,29 @@ def test_cache_hit_yields_identical_events_and_reuses_the_parse(tmp_path):
 
     # A hit is provably an identical re-parse: same events, cache or not.
     assert _event_signatures(baseline) == _event_signatures(cold) == _event_signatures(warm)
+    assert warm[0].evidenced_event_ids == ("evt_ca11e0ca11e0",)
+
+
+def test_parser_code_version_hashes_every_cached_projection_dependency(
+    monkeypatch,
+):
+    seen: list[str] = []
+    original_read_bytes = Path.read_bytes
+
+    def tracked_read_bytes(path: Path) -> bytes:
+        seen.append(path.name)
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", tracked_read_bytes)
+    monkeypatch.setattr(cu, "_CODEX_PARSER_CODE_VERSION", None)
+
+    assert cu._codex_parser_code_version() is not None
+    assert {
+        "client_usage.py",
+        "codex_rollout_adapter.py",
+        "log_evidence.py",
+        "tool_activity.py",
+    }.issubset(seen)
 
 
 def test_cache_invalidates_and_reparses_when_the_file_changes(tmp_path):

--- a/tests/test_codex_rollout_adapter.py
+++ b/tests/test_codex_rollout_adapter.py
@@ -1,0 +1,812 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentacct.codex_rollout_adapter import (
+    CodexEvidenceFragment,
+    CodexEvidenceOutcome,
+    _CODEX_RESULT_TEXT_MAX,
+    _CodexOutcomeCarrier,
+    _decode_codex_call_outcome,
+    codex_mcp_action_name,
+    codex_model_from_record,
+    codex_record_may_contain_evidence,
+    decode_codex_evidence_fragment,
+    reconcile_codex_evidence_fragments,
+    validated_codex_identifier,
+)
+from agentacct.log_evidence import LogEvidenceAccumulator
+
+
+TOOL = "agentacct_record_section"
+EVENT_ID = "evt_abc123abc123"
+
+
+def _created_event_text(event_id: str = EVENT_ID) -> str:
+    return json.dumps({"event": {"event_id": event_id}})
+
+
+def _call_tool_result(text: str, *, is_error: bool | None = None) -> dict:
+    result = {"content": [{"type": "text", "text": text}]}
+    if is_error is not None:
+        result["isError"] = is_error
+    return result
+
+
+@pytest.mark.parametrize(
+    (
+        "carrier",
+        "value",
+        "expected_outcome_classification",
+        "expected_event_id",
+    ),
+    [
+        ("result", _call_tool_result(_created_event_text()), "success", EVENT_ID),
+        (
+            "result",
+            _call_tool_result(_created_event_text(), is_error=False),
+            "success",
+            EVENT_ID,
+        ),
+        (
+            "result",
+            {"Ok": _call_tool_result(_created_event_text())},
+            "success",
+            EVENT_ID,
+        ),
+        ("result", _call_tool_result("tool failed", is_error=True), "failure", None),
+        (
+            "result",
+            {"Ok": _call_tool_result("tool failed", is_error=True)},
+            "failure",
+            None,
+        ),
+        ("result", {"Err": "tool failed"}, "failure", None),
+        ("error", {"message": "tool failed", "code": -32000}, "failure", None),
+        (
+            "function_output",
+            "Wall time: 0.1 seconds\nOutput:\n"
+            + json.dumps([{"type": "text", "text": _created_event_text()}]),
+            "success",
+            EVENT_ID,
+        ),
+        (
+            "function_output",
+            json.dumps([{"type": "text", "text": _created_event_text()}]),
+            "success",
+            EVENT_ID,
+        ),
+        ("function_output", _created_event_text(), "success", EVENT_ID),
+    ],
+)
+def test_decode_codex_call_outcome_accepts_supported_carriers(
+    carrier: _CodexOutcomeCarrier,
+    value: object,
+    expected_outcome_classification: str,
+    expected_event_id: str | None,
+) -> None:
+    outcome = _decode_codex_call_outcome(
+        value,
+        carrier=carrier,
+        creation_tool_name=TOOL,
+    )
+
+    assert outcome.outcome_classification == expected_outcome_classification
+    assert outcome.event_id == expected_event_id
+
+
+@pytest.mark.parametrize("extra_key", ["message", "error"])
+def test_function_output_creation_payload_ignores_non_identity_fields(
+    extra_key: str,
+) -> None:
+    payload = {
+        "event": {"event_id": EVENT_ID},
+        extra_key: "informational",
+    }
+
+    outcome = _decode_codex_call_outcome(
+        json.dumps(payload),
+        carrier="function_output",
+        creation_tool_name=TOOL,
+    )
+
+    assert outcome == CodexEvidenceOutcome(
+        outcome_classification="success",
+        event_id=EVENT_ID,
+    )
+
+
+@pytest.mark.parametrize(
+    "transport_fields",
+    [
+        {"Ok": _call_tool_result(_created_event_text())},
+        {"Err": "failed"},
+        {"content": []},
+        {"isError": False},
+    ],
+)
+def test_function_output_rejects_creation_payload_with_transport_discriminators(
+    transport_fields: dict,
+) -> None:
+    payload = {
+        "event": {"event_id": EVENT_ID},
+        **transport_fields,
+    }
+
+    outcome = _decode_codex_call_outcome(
+        json.dumps(payload),
+        carrier="function_output",
+        creation_tool_name=TOOL,
+    )
+
+    assert outcome == CodexEvidenceOutcome(outcome_classification="malformed")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"Ok": _call_tool_result(_created_event_text()), "Err": "failed"},
+        {"Ok": {**_call_tool_result(_created_event_text()), "Err": "failed"}},
+        {
+            "Ok": {
+                **_call_tool_result(_created_event_text()),
+                "Ok": _call_tool_result(_created_event_text()),
+            }
+        },
+        {"Ok": _call_tool_result(_created_event_text()), "content": []},
+        {"Err": "failed", "content": []},
+        {
+            **_call_tool_result(_created_event_text()),
+            "error": {"message": "failed"},
+        },
+        {
+            "Ok": {
+                **_call_tool_result(_created_event_text()),
+                "error": {"message": "failed"},
+            }
+        },
+        {
+            "Ok": _call_tool_result(_created_event_text()),
+            "error": {"message": "failed"},
+        },
+        {**_call_tool_result(_created_event_text()), "message": "failed"},
+        {**_call_tool_result(_created_event_text()), "isError": "false"},
+        {"Ok": {**_call_tool_result(_created_event_text()), "isError": "true"}},
+        {"message": "failed", "isError": False},
+        {"message": "failed"},
+        {"Ok": {}},
+        {"Err": ""},
+        {"message": ""},
+        {},
+        {"content": "not-a-list"},
+        {"content": []},
+        {
+            "content": [
+                {"type": "text", "text": _created_event_text()},
+                {"type": "text", "text": _created_event_text()},
+            ]
+        },
+        {
+            "content": [
+                {"type": "text", "text": _created_event_text()},
+                {"type": "image", "data": "private"},
+            ]
+        },
+    ],
+)
+def test_decode_codex_call_outcome_rejects_malformed_or_ambiguous_shapes(
+    value: object,
+) -> None:
+    outcome = _decode_codex_call_outcome(
+        value,
+        carrier="result",
+        creation_tool_name=TOOL,
+    )
+
+    assert outcome == CodexEvidenceOutcome(outcome_classification="malformed")
+
+
+@pytest.mark.parametrize(
+    ("carrier", "value"),
+    [
+        (
+            "result",
+            _call_tool_result(json.dumps({"unexpected_response": True})),
+        ),
+        (
+            "function_output",
+            json.dumps({"unexpected_response": True}),
+        ),
+    ],
+)
+def test_success_without_created_event_id_is_schema_drift(
+    carrier: _CodexOutcomeCarrier,
+    value: object,
+) -> None:
+    outcome = _decode_codex_call_outcome(
+        value,
+        carrier=carrier,
+        creation_tool_name=TOOL,
+    )
+    accumulator, drifted = _reconcile_same_call([outcome])
+
+    assert accumulator.evidenced_event_ids == []
+    assert accumulator.evidenced_outputs_skipped == 1
+    assert drifted is True
+
+
+@pytest.mark.parametrize(
+    (
+        "call_tool_result",
+        "expected_outcome",
+        "expected_refused_attempts",
+        "expected_schema_drift",
+    ),
+    [
+        (
+            _call_tool_result(
+                "Mcp error: -32602: summary must be <= 1200 characters",
+                is_error=True,
+            ),
+            CodexEvidenceOutcome(
+                outcome_classification="failure",
+                refusal=(TOOL, "summary", "narrative_over_limit"),
+            ),
+            [
+                {
+                    "tool": TOOL,
+                    "field": "summary",
+                    "reason_code": "narrative_over_limit",
+                    "count": 1,
+                }
+            ],
+            False,
+        ),
+        (
+            _call_tool_result(_created_event_text()),
+            CodexEvidenceOutcome(outcome_classification="malformed"),
+            [],
+            True,
+        ),
+    ],
+)
+def test_failed_paginated_result_only_accepts_only_explicit_tool_failure(
+    call_tool_result: dict[str, object],
+    expected_outcome: CodexEvidenceOutcome,
+    expected_refused_attempts: list[dict[str, object]],
+    expected_schema_drift: bool,
+) -> None:
+    paginated_completion_record = {
+        "type": "event_msg",
+        "payload": {
+            "type": "item_completed",
+            "item": {
+                "type": "McpToolCall",
+                "id": "call-1",
+                "server": "agentacct",
+                "tool": TOOL,
+                "status": "failed",
+                "result": call_tool_result,
+            },
+        },
+    }
+
+    terminal_fragment = decode_codex_evidence_fragment(
+        paginated_completion_record
+    )
+
+    assert terminal_fragment is not None
+    assert terminal_fragment.outcome == expected_outcome
+
+    evidence = LogEvidenceAccumulator()
+    has_schema_drift = reconcile_codex_evidence_fragments(
+        [terminal_fragment], evidence
+    )
+
+    assert evidence.evidenced_event_ids == []
+    assert evidence.evidenced_outputs_skipped == 1
+    assert evidence.refused_recording_attempts() == expected_refused_attempts
+    assert has_schema_drift is expected_schema_drift
+
+
+def _reconcile_same_call(
+    outcomes: list[CodexEvidenceOutcome],
+) -> tuple[LogEvidenceAccumulator, bool]:
+    accumulator = LogEvidenceAccumulator()
+    fragments = [
+        CodexEvidenceFragment(
+            call_id="call-1",
+            role="terminal",
+            creation_tool_verdict="accepted",
+            creation_tool_name=TOOL,
+            outcome=outcome,
+            counts_as_evidence_skip=outcome.event_id is None,
+            has_schema_drift=outcome.outcome_classification == "malformed",
+        )
+        for outcome in outcomes
+    ]
+    drifted = reconcile_codex_evidence_fragments(fragments, accumulator)
+    return accumulator, drifted
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    (
+        "outcomes",
+        "expected_ids",
+        "expected_skips",
+        "expected_drift",
+    ),
+    [
+        (
+            [
+                CodexEvidenceOutcome(
+                    outcome_classification="success", event_id=EVENT_ID
+                ),
+                CodexEvidenceOutcome(
+                    outcome_classification="success", event_id=EVENT_ID
+                ),
+            ],
+            [EVENT_ID],
+            0,
+            False,
+        ),
+        (
+            [
+                CodexEvidenceOutcome(
+                    outcome_classification="success", event_id=EVENT_ID
+                ),
+                CodexEvidenceOutcome(
+                    outcome_classification="success",
+                    event_id="evt_def456def456",
+                ),
+            ],
+            [],
+            1,
+            True,
+        ),
+        (
+            [
+                CodexEvidenceOutcome(
+                    outcome_classification="success", event_id=EVENT_ID
+                ),
+                CodexEvidenceOutcome(outcome_classification="failure"),
+            ],
+            [EVENT_ID],
+            1,
+            False,
+        ),
+        (
+            [
+                CodexEvidenceOutcome(
+                    outcome_classification="success", event_id=EVENT_ID
+                ),
+                CodexEvidenceOutcome(outcome_classification="unknown"),
+            ],
+            [EVENT_ID],
+            1,
+            False,
+        ),
+        (
+            [
+                CodexEvidenceOutcome(outcome_classification="failure"),
+                CodexEvidenceOutcome(
+                    outcome_classification="failure",
+                    refusal=(TOOL, "summary", "narrative_over_limit"),
+                ),
+            ],
+            [],
+            1,
+            False,
+        ),
+    ],
+)
+def test_same_call_outcomes_reconcile_order_independently(
+    outcomes: list[CodexEvidenceOutcome],
+    expected_ids: list[str],
+    expected_skips: int,
+    expected_drift: bool,
+    reverse: bool,
+) -> None:
+    ordered = list(reversed(outcomes)) if reverse else outcomes
+
+    accumulator, drifted = _reconcile_same_call(ordered)
+
+    assert accumulator.evidenced_event_ids == expected_ids
+    assert accumulator.evidenced_outputs_skipped == expected_skips
+    assert drifted is expected_drift
+
+
+def test_distinct_call_ids_do_not_cross_conflict() -> None:
+    accumulator = LogEvidenceAccumulator()
+    fragments = [
+        CodexEvidenceFragment(
+            call_id="success-call",
+            role="terminal",
+            creation_tool_verdict="accepted",
+            creation_tool_name=TOOL,
+            outcome=CodexEvidenceOutcome(
+                outcome_classification="success",
+                event_id=EVENT_ID,
+            ),
+        ),
+        CodexEvidenceFragment(
+            call_id="failed-call",
+            role="terminal",
+            creation_tool_verdict="accepted",
+            creation_tool_name=TOOL,
+            outcome=CodexEvidenceOutcome(outcome_classification="failure"),
+            counts_as_evidence_skip=True,
+        ),
+    ]
+
+    drifted = reconcile_codex_evidence_fragments(fragments, accumulator)
+
+    assert accumulator.evidenced_event_ids == [EVENT_ID]
+    assert accumulator.evidenced_outputs_skipped == 1
+    assert drifted is False
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    (
+        "output_outcome",
+        "output_has_schema_drift",
+        "terminal_outcome",
+        "expected_ids",
+    ),
+    [
+        (
+            CodexEvidenceOutcome(
+                outcome_classification="success",
+                event_id="evt_badbadbadbad",
+            ),
+            False,
+            CodexEvidenceOutcome(outcome_classification="failure"),
+            [],
+        ),
+        (
+            CodexEvidenceOutcome(outcome_classification="malformed"),
+            True,
+            CodexEvidenceOutcome(
+                outcome_classification="success",
+                event_id=EVENT_ID,
+            ),
+            [EVENT_ID],
+        ),
+    ],
+)
+def test_rejected_descriptor_cannot_lend_or_override_terminal_identity(
+    output_outcome: CodexEvidenceOutcome,
+    output_has_schema_drift: bool,
+    terminal_outcome: CodexEvidenceOutcome,
+    expected_ids: list[str],
+    reverse: bool,
+) -> None:
+    fragments = [
+        CodexEvidenceFragment(
+            call_id="call-1",
+            role="descriptor",
+            creation_tool_verdict="rejected",
+            creation_tool_name=TOOL,
+        ),
+        CodexEvidenceFragment(
+            call_id="call-1",
+            role="output",
+            outcome=output_outcome,
+            has_schema_drift=output_has_schema_drift,
+        ),
+        CodexEvidenceFragment(
+            call_id="call-1",
+            role="terminal",
+            creation_tool_verdict="accepted",
+            creation_tool_name=TOOL,
+            outcome=terminal_outcome,
+            counts_as_evidence_skip=terminal_outcome.event_id is None,
+        ),
+    ]
+    if reverse:
+        fragments.reverse()
+    accumulator = LogEvidenceAccumulator()
+
+    drifted = reconcile_codex_evidence_fragments(fragments, accumulator)
+
+    assert accumulator.evidenced_event_ids == expected_ids
+    assert accumulator.evidenced_outputs_skipped == 1
+    assert drifted is False
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_orphan_output_cannot_borrow_terminal_identity(reverse: bool) -> None:
+    fragments = [
+        CodexEvidenceFragment(
+            call_id="call-1",
+            role="terminal",
+            creation_tool_verdict="accepted",
+            creation_tool_name=TOOL,
+            outcome=CodexEvidenceOutcome(outcome_classification="failure"),
+            counts_as_evidence_skip=True,
+        ),
+        CodexEvidenceFragment(
+            call_id="call-1",
+            role="output",
+            outcome=CodexEvidenceOutcome(
+                outcome_classification="success",
+                event_id="evt_badbadbadbad",
+            ),
+        ),
+    ]
+    if reverse:
+        fragments.reverse()
+    accumulator = LogEvidenceAccumulator()
+
+    drifted = reconcile_codex_evidence_fragments(fragments, accumulator)
+
+    assert accumulator.evidenced_event_ids == []
+    assert accumulator.evidenced_outputs_skipped == 1
+    assert drifted is False
+
+
+def test_wrong_outer_carrier_is_visible_only_for_relevant_creation_calls() -> None:
+    creation_record = {
+        "type": "event_msg",
+        "payload": {
+            "type": "function_call",
+            "name": TOOL,
+            "call_id": "call-1",
+        },
+    }
+    unrelated_record = {
+        "type": "event_msg",
+        "payload": {
+            "type": "function_call",
+            "name": "read_file",
+            "call_id": "call-2",
+        },
+    }
+
+    fragment = decode_codex_evidence_fragment(creation_record)
+
+    assert fragment is not None
+    assert fragment.has_schema_drift is True
+    assert decode_codex_evidence_fragment(unrelated_record) is None
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_wrong_outer_descriptor_cannot_donate_through_a_valid_output(
+    reverse: bool,
+) -> None:
+    records = [
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "function_call",
+                "name": TOOL,
+                "call_id": "call-1",
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call-1",
+                "output": _created_event_text(),
+            },
+        },
+    ]
+    if reverse:
+        records.reverse()
+    fragments = [
+        fragment
+        for record in records
+        if (fragment := decode_codex_evidence_fragment(record)) is not None
+    ]
+    accumulator = LogEvidenceAccumulator()
+
+    drifted = reconcile_codex_evidence_fragments(fragments, accumulator)
+
+    assert accumulator.evidenced_event_ids == []
+    assert accumulator.evidenced_outputs_skipped == 1
+    assert drifted is True
+
+
+@pytest.mark.parametrize(
+    "call_id",
+    [
+        "",
+        "   ",
+        " call-1",
+        "call-1 ",
+        "call\n1",
+        "call\u200b1",
+        "x" * 241,
+    ],
+)
+def test_codex_identifier_rejects_ambiguous_or_unbounded_text(
+    call_id: str,
+) -> None:
+    assert validated_codex_identifier(call_id) is None
+
+
+@pytest.mark.parametrize(
+    ("server", "tool"),
+    [
+        ("agentacct\u200b", TOOL),
+        ("agentacct", f"{TOOL}\nprivate"),
+        ("s" * 121, TOOL),
+        ("agentacct", "t" * 121),
+    ],
+)
+def test_codex_mcp_action_name_rejects_unsafe_or_oversized_components(
+    server: str,
+    tool: str,
+) -> None:
+    assert codex_mcp_action_name(server, tool) is None
+
+
+def test_codex_mcp_action_name_canonicalizes_a_valid_server() -> None:
+    assert codex_mcp_action_name("mcp__agent-acct", TOOL) == (
+        f"mcp__agent_acct__{TOOL}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("carrier", "value"),
+    [
+        ("function_output", "x" * (_CODEX_RESULT_TEXT_MAX + 1)),
+        (
+            "result",
+            _call_tool_result("x" * (_CODEX_RESULT_TEXT_MAX + 1)),
+        ),
+    ],
+    ids=["function-output", "call-tool-result"],
+)
+def test_codex_success_text_is_bounded_before_reparsing(
+    carrier: _CodexOutcomeCarrier,
+    value: object,
+) -> None:
+    outcome = _decode_codex_call_outcome(
+        value,
+        carrier=carrier,
+        creation_tool_name=TOOL,
+    )
+
+    assert outcome == CodexEvidenceOutcome(outcome_classification="malformed")
+
+
+@pytest.mark.parametrize(
+    ("carrier", "value"),
+    [
+        ("function_output", "[" * 10_000 + "0" + "]" * 10_000),
+        (
+            "result",
+            _call_tool_result("[" * 10_000 + "0" + "]" * 10_000),
+        ),
+    ],
+    ids=["function-output", "call-tool-result"],
+)
+def test_codex_deeply_nested_result_text_is_malformed(
+    carrier: _CodexOutcomeCarrier,
+    value: object,
+) -> None:
+    outcome = _decode_codex_call_outcome(
+        value,
+        carrier=carrier,
+        creation_tool_name=TOOL,
+    )
+
+    assert outcome == CodexEvidenceOutcome(outcome_classification="malformed")
+
+
+@pytest.mark.parametrize(
+    ("carrier", "value"),
+    [
+        (
+            "result",
+            _call_tool_result(
+                "x" * (_CODEX_RESULT_TEXT_MAX + 1),
+                is_error=True,
+            ),
+        ),
+        ("error", {"message": "x" * (_CODEX_RESULT_TEXT_MAX + 1)}),
+    ],
+    ids=["call-tool-result", "error"],
+)
+def test_codex_failure_text_is_not_classified_beyond_bound(
+    carrier: _CodexOutcomeCarrier,
+    value: object,
+) -> None:
+    outcome = _decode_codex_call_outcome(
+        value,
+        carrier=carrier,
+        creation_tool_name=TOOL,
+    )
+
+    assert outcome == CodexEvidenceOutcome(outcome_classification="failure")
+
+
+def test_codex_model_selection_uses_only_authoritative_record_paths() -> None:
+    accepted = [
+        {"type": "session_meta", "payload": {"model": "gpt-meta"}},
+        {"type": "turn_context", "payload": {"model": "gpt-turn"}},
+        {
+            "type": "world_state",
+            "payload": {"state": {"model": "gpt-world"}},
+        },
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "thread_settings_applied",
+                "thread_settings": {"model": "gpt-settings"},
+            },
+        },
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "model": "gpt-token",
+                "info": {"total_token_usage": {}},
+            },
+        },
+    ]
+    assert [codex_model_from_record(record) for record in accepted] == [
+        "gpt-meta",
+        "gpt-turn",
+        "gpt-world",
+        "gpt-settings",
+        "gpt-token",
+    ]
+
+    rejected = [
+        {
+            "type": "session_meta",
+            "payload": {"base_instructions": {"model": "poison"}},
+        },
+        {
+            "type": "world_state",
+            "payload": {"state": {"personality": {"model": "poison"}}},
+        },
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "item_completed",
+                "item": {"arguments": {"model": "poison"}},
+            },
+        },
+        {"type": "session_meta", "payload": {"model": "x" * 121}},
+        {"type": "session_meta", "payload": {"model": "gpt\u200bpoison"}},
+        {"type": "session_meta", "payload": "not-an-object"},
+    ]
+    assert all(codex_model_from_record(record) is None for record in rejected)
+
+
+def test_post_cap_relevance_ignores_known_read_tools() -> None:
+    legacy_read = {
+        "payload": {
+            "type": "mcp_tool_call_end",
+            "invocation": {
+                "server": "agentacct",
+                "tool": "agentacct_list_events",
+            },
+        }
+    }
+    paginated_read = {
+        "payload": {
+            "type": "item_completed",
+            "item": {
+                "type": "McpToolCall",
+                "id": "call-1",
+                "server": "agentacct",
+                "tool": "agentacct_list_events",
+            },
+        }
+    }
+    malformed_terminal = {
+        "payload": {"type": "mcp_tool_call_end"},
+    }
+
+    assert codex_record_may_contain_evidence(legacy_read) is False
+    assert codex_record_may_contain_evidence(paginated_read) is False
+    assert codex_record_may_contain_evidence(malformed_terminal) is True

--- a/tests/test_codex_rollout_adapter.py
+++ b/tests/test_codex_rollout_adapter.py
@@ -391,6 +391,17 @@ def _reconcile_same_call(
         ),
         (
             [
+                CodexEvidenceOutcome(
+                    outcome_classification="success", event_id=EVENT_ID
+                ),
+                CodexEvidenceOutcome(outcome_classification="malformed"),
+            ],
+            [],
+            1,
+            True,
+        ),
+        (
+            [
                 CodexEvidenceOutcome(outcome_classification="failure"),
                 CodexEvidenceOutcome(
                     outcome_classification="failure",

--- a/tests/test_log_evidenced_linking.py
+++ b/tests/test_log_evidenced_linking.py
@@ -46,6 +46,7 @@ from agentacct.log_evidence import (
     extract_created_event_id,
 )
 from agentacct.service import SentinelService
+from agentacct.task_outcome import reduce_task_outcome
 from agentacct.work_ledger import build_work_ledger
 
 SESSION = "019f2303-6ae1-7000-8000-000000000001"
@@ -91,9 +92,7 @@ def _mcp_ok_result(payload: dict) -> dict:
 
 
 def _mcp_tool_call_end(server, tool: str, call_id: str, result, *, omit_server: bool = False) -> dict:
-    """Codex 0.144.0-alpha.4 wire shape: MCP calls exist ONLY as event_msg/
-    mcp_tool_call_end lines (the duplicate function_call records are gone).
-    Fully synthetic redacted fixture modeled on the documented shape."""
+    """Legacy terminal MCP carrier retained in some Codex rollouts."""
 
     invocation: dict = {"tool": tool, "arguments": {}}
     if not omit_server:
@@ -107,6 +106,68 @@ def _mcp_tool_call_end(server, tool: str, call_id: str, result, *, omit_server: 
             "invocation": invocation,
             "duration": {"secs": 2, "nanos": 0},
             "result": result,
+        },
+    }
+
+
+_MISSING = object()
+
+
+def _mcp_call_result(payload: dict, *, is_error: bool = False) -> dict:
+    """Current Codex direct CallToolResult shape (not the legacy Ok wrapper)."""
+
+    result = {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(payload, indent=2, sort_keys=True),
+            }
+        ]
+    }
+    if is_error:
+        result["isError"] = True
+    return result
+
+
+def _mcp_item_completed(
+    server,
+    tool: str,
+    call_id: str,
+    *,
+    status: str = "completed",
+    result=_MISSING,
+    error=_MISSING,
+    arguments: dict | None = None,
+    omit_id: bool = False,
+    omit_server: bool = False,
+) -> dict:
+    """Sanitized literal of Codex's current paginated MCP completion carrier."""
+
+    item: dict = {
+        "type": "McpToolCall",
+        "id": call_id,
+        "server": server,
+        "tool": tool,
+        "arguments": arguments or {},
+        "status": status,
+        "duration": {"secs": 2, "nanos": 0},
+    }
+    if omit_id:
+        item.pop("id")
+    if omit_server:
+        item.pop("server")
+    if result is not _MISSING:
+        item["result"] = result
+    if error is not _MISSING:
+        item["error"] = error
+    return {
+        "timestamp": "2026-07-05T10:00:01.000Z",
+        "type": "event_msg",
+        "payload": {
+            "type": "item_completed",
+            "thread_id": "thread-redacted",
+            "turn_id": "turn-redacted",
+            "item": item,
         },
     }
 
@@ -330,7 +391,410 @@ def test_no_evidence_event_metadata_is_byte_identical_to_pre_change_shape(tmp_pa
 
 
 # ---------------------------------------------------------------------------
-# Importer (codex 0.144+ mcp_tool_call_end channel)
+# Importer (current paginated item_completed / McpToolCall channel)
+# ---------------------------------------------------------------------------
+
+
+def test_codex_paginated_mcp_items_extract_all_creation_tools_and_ignore_reads(tmp_path) -> None:
+    tools_and_ids = [
+        ("agentacct_record_event", "evt_aa1001aa1001"),
+        ("agentacct_attach_client_context", "evt_bb2002bb2002"),
+        ("agentacct_record_section", "evt_cc3003cc3003"),
+        ("agentacct_record_agent_usage_debug", "evt_dd4004dd4004"),
+        ("agentacct_record_machine_check", "evt_ee5005ee5005"),
+    ]
+    lines = [
+        _mcp_item_completed(
+            "agentacct",
+            tool,
+            f"call_{index}",
+            result=_mcp_call_result(_creation_payload(event_id)),
+        )
+        for index, (tool, event_id) in enumerate(tools_and_ids)
+    ]
+    lines.append(
+        _mcp_item_completed(
+            "agentacct",
+            "agentacct_get_event_summary",
+            "call_read",
+            result=_mcp_call_result(_creation_payload("evt_deadbeef0001")),
+        )
+    )
+
+    event = _single_codex_event(_make_codex_home(tmp_path, lines))
+
+    assert list(event.evidenced_event_ids) == [event_id for _tool, event_id in tools_and_ids]
+    assert event.evidenced_event_id_total == 5
+    assert event.evidenced_outputs_skipped == 0
+
+
+def test_codex_paginated_mcp_items_fail_closed_without_hiding_refusals(tmp_path) -> None:
+    refusal = (
+        "tool call error: tool call failed for `agentacct/agentacct_record_section`\n\n"
+        "Caused by:\n    Mcp error: -32602: summary must be <= 1200 characters"
+    )
+    lines = [
+        _mcp_item_completed(
+            "agentacct",
+            "agentacct_record_section",
+            "call_ok",
+            result=_mcp_call_result(_creation_payload("evt_012301230123")),
+        ),
+        # A read tool is structurally irrelevant even when its result resembles
+        # a creation response.
+        _mcp_item_completed(
+            "agentacct",
+            "agentacct_list_events",
+            "call_read",
+            result=_mcp_call_result(_creation_payload("evt_deadbeef0002")),
+        ),
+        _mcp_item_completed(
+            "other-server",
+            "agentacct_record_section",
+            "call_foreign",
+            result=_mcp_call_result(_creation_payload("evt_badbadbad001")),
+        ),
+        _mcp_item_completed(
+            None,
+            "agentacct_record_section",
+            "call_no_server",
+            result=_mcp_call_result(_creation_payload("evt_badbadbad002")),
+            omit_server=True,
+        ),
+        _mcp_item_completed(
+            "agentacct",
+            "agentacct_record_section",
+            "call_refused",
+            status="failed",
+            error={"message": refusal},
+        ),
+        # CallToolResult-level failure is not a success merely because the item
+        # itself reached the completed state.
+        _mcp_item_completed(
+            "agentacct",
+            "agentacct_record_section",
+            "call_is_error",
+            result=_mcp_call_result(_creation_payload("evt_badbadbad003"), is_error=True),
+        ),
+        _mcp_item_completed(
+            "agentacct",
+            "agentacct_record_section",
+            "call_bad_content",
+            result={"content": "not-a-list"},
+        ),
+    ]
+
+    event = _single_codex_event(_make_codex_home(tmp_path, lines))
+
+    assert list(event.evidenced_event_ids) == ["evt_012301230123"]
+    assert event.evidenced_outputs_skipped == 5
+    assert list(event.refused_recording_attempts) == [
+        {
+            "tool": "agentacct_record_section",
+            "field": "summary",
+            "reason_code": "narrative_over_limit",
+            "count": 1,
+        }
+    ]
+    rendered = json.dumps(event.to_sentinel_event())
+    assert "deadbeef" not in rendered
+    assert "badbadbad" not in rendered
+    assert refusal not in rendered
+
+
+def test_codex_paginated_malformed_creation_items_raise_schema_drift(tmp_path) -> None:
+    missing_id = _mcp_item_completed(
+        "agentacct",
+        "agentacct_record_section",
+        "call_missing_id",
+        result=_mcp_call_result(_creation_payload("evt_101010101010")),
+        omit_id=True,
+    )
+    missing_server = _mcp_item_completed(
+        None,
+        "agentacct_record_section",
+        "call_missing_server",
+        result=_mcp_call_result(_creation_payload("evt_202020202020")),
+        omit_server=True,
+    )
+    unknown_status = _mcp_item_completed(
+        "agentacct",
+        "agentacct_record_section",
+        "call_unknown_status",
+        status="mystery",
+        result=_mcp_call_result(_creation_payload("evt_303030303030")),
+    )
+    missing_result = _mcp_item_completed(
+        "agentacct",
+        "agentacct_record_section",
+        "call_missing_result",
+    )
+    # Unknown/non-MCP paginated items are not evidence errors. This adapter is
+    # intentionally narrow instead of guessing every Codex TurnItem shape.
+    non_mcp_item = {
+        "type": "event_msg",
+        "payload": {
+            "type": "item_completed",
+            "item": {"type": "CommandExecution", "id": "cmd_1", "status": "completed"},
+        },
+    }
+    stats: dict[str, object] = {}
+    observations = []
+
+    events = discover_codex_usage(
+        codex_home=_make_codex_home(
+            tmp_path,
+            [missing_id, missing_server, unknown_status, missing_result, non_mcp_item],
+        ),
+        limit_sessions=10,
+        _discovery_stats=stats,
+        _session_observations=observations,
+    )
+
+    assert len(events) == 1
+    assert events[0].evidenced_event_ids == ()
+    assert events[0].evidenced_outputs_skipped == 4
+    assert events[0].source_parse_complete is False
+    assert observations[0].source_parse_complete is False
+    assert stats["error_codes"] == ["codex_rollout_schema_drift"]
+
+
+def test_codex_paginated_and_legacy_fragments_reconcile_order_independently(tmp_path) -> None:
+    success_id = "evt_414141414141"
+    for index, reverse in enumerate((False, True)):
+        duplicate_success = [
+            _mcp_item_completed(
+                "agentacct",
+                "agentacct_record_section",
+                "call_success",
+                result=_mcp_call_result(_creation_payload(success_id)),
+            ),
+            _mcp_tool_call_end(
+                "agentacct",
+                "agentacct_record_section",
+                "call_success",
+                _mcp_ok_result(_creation_payload(success_id)),
+            ),
+        ]
+        divergent = [
+            _mcp_item_completed(
+                "agentacct",
+                "agentacct_record_section",
+                "call_divergent",
+                status="failed",
+                error={"message": "tool call failed"},
+            ),
+            _mcp_tool_call_end(
+                "agentacct",
+                "agentacct_record_section",
+                "call_divergent",
+                _mcp_ok_result(_creation_payload("evt_515151515151")),
+            ),
+        ]
+        lines = duplicate_success + divergent
+        if reverse:
+            lines = [*reversed(duplicate_success), *reversed(divergent)]
+
+        event = _single_codex_event(_make_codex_home(tmp_path / f"order-{index}", lines))
+
+        assert list(event.evidenced_event_ids) == [success_id, "evt_515151515151"]
+        assert event.evidenced_event_id_total == 2
+        assert event.evidenced_outputs_skipped == 1
+
+
+def test_codex_conflicting_terminal_fragments_fail_closed_in_both_orders(tmp_path) -> None:
+    paginated = _mcp_item_completed(
+        "agentacct",
+        "agentacct_record_section",
+        "call_conflict",
+        result=_mcp_call_result(_creation_payload("evt_616161616161")),
+    )
+    legacy = _mcp_tool_call_end(
+        "agentacct",
+        "agentacct_record_section",
+        "call_conflict",
+        _mcp_ok_result(_creation_payload("evt_717171717171")),
+    )
+
+    for index, lines in enumerate(([paginated, legacy], [legacy, paginated])):
+        event = _single_codex_event(
+            _make_codex_home(tmp_path / f"conflict-{index}", list(lines))
+        )
+        assert event.evidenced_event_ids == ()
+        assert event.evidenced_event_id_total == 0
+        assert event.evidenced_outputs_skipped == 1
+
+
+def test_codex_paginated_jsonl_links_trusted_import_to_gradeable_receipt(tmp_path) -> None:
+    """The original symptom, through the public boundaries: a persisted MCP
+    response must turn a session-only observation into linked, verified work."""
+
+    store = tmp_path / "store"
+    service = SentinelService(store)
+    section = service.record_event(
+        {
+            "source": "codex",
+            "event_type": "section_completed",
+            "created_at": 200.0,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "codex",
+                "client_session_id": None,
+                "section_id": "paginated-regression",
+                "section_status": "completed",
+                "section_title": "Fix paginated Codex evidence",
+                "kind": "implementation",
+                "project_dir": "/work/project",
+            },
+        }
+    )
+    check = service.record_event(
+        {
+            "source": "codex",
+            "event_type": "machine_check",
+            "created_at": 210.0,
+            "metadata": {
+                "result": "passed",
+                "evidence_type": "test",
+                "summary": "regression passed",
+                "name": "pytest",
+                "exit_code": 0,
+                "section_id": "paginated-regression",
+                "client": "codex",
+                "client_session_id": None,
+                "project_dir": "/work/project",
+            },
+        }
+    )
+    codex_home = _make_codex_home(
+        tmp_path,
+        [
+            _mcp_item_completed(
+                "agentacct",
+                "agentacct_record_section",
+                "call_section",
+                result=_mcp_call_result(_creation_payload(section["event_id"])),
+            ),
+            _mcp_item_completed(
+                "agentacct",
+                "agentacct_record_machine_check",
+                "call_check",
+                result=_mcp_call_result(_creation_payload(check["event_id"])),
+            ),
+        ],
+    )
+
+    imported = CliRunner().invoke(
+        app,
+        [
+            "usage",
+            "import-local",
+            "--store-dir",
+            str(store),
+            "--client",
+            "codex",
+            "--codex-home",
+            str(codex_home),
+            "--json",
+        ],
+    )
+
+    assert imported.exit_code == 0, imported.output
+    client = TestClient(
+        create_local_api_app(store_dir=store, v1_auth_token="paginated-test-token")
+    )
+    task = client.get("/tasks").json()["tasks"][0]
+    assert len(task["work_items"]) == 1
+    assert reduce_task_outcome(task)["key"] == "verified"
+
+    headers = {"Authorization": "Bearer paginated-test-token"}
+    listing = client.get("/v1/tasks", headers=headers).json()
+    assert listing["total"] == 1
+    row = listing["tasks"][0]
+    assert row["decision_status"]["key"] == "verified"
+    assert row["evidence_strength"]["gradeable"] is True
+    receipt = client.get(
+        f"/v1/receipt?task={row['task_id']}", headers=headers
+    ).json()
+    assert receipt["axes"]["decision_status"]["key"] == "verified"
+    assert receipt["axes"]["evidence_strength"]["gradeable"] is True
+
+
+def test_codex_refresh_repairs_existing_same_token_row_with_paginated_evidence(tmp_path) -> None:
+    store = tmp_path / "store"
+    section = SentinelService(store).record_event(
+        {
+            "source": "codex",
+            "event_type": "section_completed",
+            "created_at": 200.0,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "codex",
+                "client_session_id": None,
+                "section_id": "refresh-regression",
+                "section_status": "completed",
+                "section_title": "Repair imported evidence",
+                "kind": "implementation",
+                "project_dir": "/work/project",
+            },
+        }
+    )
+    codex_home = _make_codex_home(tmp_path, [])
+    args = [
+        "usage",
+        "import-local",
+        "--store-dir",
+        str(store),
+        "--client",
+        "codex",
+        "--codex-home",
+        str(codex_home),
+        "--json",
+    ]
+    runner = CliRunner()
+    first = runner.invoke(app, args)
+    assert first.exit_code == 0, first.output
+
+    rollout = next((codex_home / "sessions").rglob("rollout-*.jsonl"))
+    rollout.write_text(
+        rollout.read_text(encoding="utf-8")
+        + json.dumps(
+            _mcp_item_completed(
+                "agentacct",
+                "agentacct_record_section",
+                "call_refresh",
+                result=_mcp_call_result(_creation_payload(section["event_id"])),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    ordinary = runner.invoke(app, args)
+    assert ordinary.exit_code == 0, ordinary.output
+    ordinary_rows = [
+        event
+        for event in SentinelService(store).list_all_events()
+        if event.get("event_type") == "model_usage"
+    ]
+    assert len(ordinary_rows) == 1
+    assert "evidenced_event_ids" not in ordinary_rows[0]["metadata"]
+
+    refreshed = runner.invoke(app, [*args, "--refresh"])
+    assert refreshed.exit_code == 0, refreshed.output
+    refreshed_rows = [
+        event
+        for event in SentinelService(store).list_all_events()
+        if event.get("event_type") == "model_usage"
+    ]
+    assert len(refreshed_rows) == 1
+    assert refreshed_rows[0]["metadata"]["evidenced_event_ids"] == [
+        section["event_id"]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Importer (legacy function/output and mcp_tool_call_end channels)
 # ---------------------------------------------------------------------------
 
 
@@ -570,6 +1034,26 @@ def test_codex_model_label_never_poisoned_by_tool_call_payloads(tmp_path) -> Non
     assert usage_foreign is not None
     assert usage_foreign.get("model") is None
 
+    # Current paginated MCP items put arguments under payload.item. One of
+    # agentacct's real creation tools has a legitimate argument NAMED model,
+    # so recursively scanning this envelope would mislabel and misprice the
+    # entire session.
+    poisoned_item = _mcp_item_completed(
+        "agentacct",
+        "agentacct_record_agent_usage_debug",
+        "call_item_poison",
+        arguments={"model": "gpt-poison"},
+        result=_mcp_call_result(_creation_payload("evt_66778899aabb")),
+    )
+    rollout_item = tmp_path / "rollout-item-poison.jsonl"
+    rollout_item.write_text(
+        "\n".join(json.dumps(line) for line in (poisoned_item, token_line_no_model)) + "\n",
+        encoding="utf-8",
+    )
+    usage_item = _read_codex_rollout_usage(rollout_item)
+    assert usage_item is not None
+    assert usage_item.get("model") is None
+
     # The legitimate carrier still labels the session — even when it appears
     # AFTER the tool line (the poisoned line no longer wins the first-scan).
     rollout_legit = tmp_path / "rollout-legit.jsonl"
@@ -579,6 +1063,15 @@ def test_codex_model_label_never_poisoned_by_tool_call_payloads(tmp_path) -> Non
     usage_legit = _read_codex_rollout_usage(rollout_legit)
     assert usage_legit is not None
     assert usage_legit.get("model") == "gpt-5.5"
+
+    rollout_item_legit = tmp_path / "rollout-item-legit.jsonl"
+    rollout_item_legit.write_text(
+        "\n".join(json.dumps(line) for line in (poisoned_item, _token_usage_line())) + "\n",
+        encoding="utf-8",
+    )
+    usage_item_legit = _read_codex_rollout_usage(rollout_item_legit)
+    assert usage_item_legit is not None
+    assert usage_item_legit.get("model") == "gpt-5.5"
 
 
 def test_classify_codex_mcp_invocation_and_unwrap_codex_mcp_result_units() -> None:

--- a/tests/test_log_evidenced_linking.py
+++ b/tests/test_log_evidenced_linking.py
@@ -560,7 +560,7 @@ def test_codex_paginated_malformed_creation_items_raise_schema_drift(tmp_path) -
     assert stats["error_codes"] == ["codex_rollout_evidence_schema_drift"]
 
 
-def test_codex_evidence_fragment_cap_invalidates_only_relevant_overflow(
+def test_codex_evidence_fragment_cap_only_invalidates_current_creation_overflow(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -615,6 +615,39 @@ def test_codex_evidence_fragment_cap_invalidates_only_relevant_overflow(
         assert event.evidenced_event_ids == expected_ids
         assert event.evidenced_outputs_skipped == expected_skips
         assert stats.get("error_codes", []) == expected_errors
+
+
+def test_codex_evidence_fragment_cap_counts_unpaired_legacy_outputs(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(client_usage_module, "_CODEX_EVIDENCE_FRAGMENT_CAP", 1)
+    retained_creation = _mcp_item_completed(
+        "agentacct",
+        "agentacct_record_section",
+        "call_retained",
+        result=_mcp_call_result(_creation_payload("evt_606060606060")),
+    )
+    unpaired_legacy_output = _function_output(
+        "call_unpaired",
+        _wrapped_output(_creation_payload("evt_deadbeef0004")),
+    )
+    stats: dict[str, object] = {}
+
+    events = discover_codex_usage(
+        codex_home=_make_codex_home(
+            tmp_path,
+            [retained_creation, unpaired_legacy_output],
+        ),
+        limit_sessions=10,
+        _discovery_stats=stats,
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.evidenced_event_ids == ()
+    assert event.evidenced_outputs_skipped == 1
+    assert stats["error_codes"] == ["codex_rollout_evidence_schema_drift"]
 
 
 def test_codex_duplicate_and_failed_sibling_fragments_are_order_independent(tmp_path) -> None:

--- a/tests/test_log_evidenced_linking.py
+++ b/tests/test_log_evidenced_linking.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 
+import agentacct.client_usage as client_usage_module
 from agentacct.api import create_local_api_app
 from agentacct.cli import app
 from agentacct.client_usage import ClientUsageEvent, discover_claude_code_usage, discover_codex_usage
@@ -554,12 +555,69 @@ def test_codex_paginated_malformed_creation_items_raise_schema_drift(tmp_path) -
     assert len(events) == 1
     assert events[0].evidenced_event_ids == ()
     assert events[0].evidenced_outputs_skipped == 4
-    assert events[0].source_parse_complete is False
-    assert observations[0].source_parse_complete is False
-    assert stats["error_codes"] == ["codex_rollout_schema_drift"]
+    assert events[0].source_parse_complete is True
+    assert observations[0].source_parse_complete is True
+    assert stats["error_codes"] == ["codex_rollout_evidence_schema_drift"]
 
 
-def test_codex_paginated_and_legacy_fragments_reconcile_order_independently(tmp_path) -> None:
+def test_codex_evidence_fragment_cap_invalidates_only_relevant_overflow(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(client_usage_module, "_CODEX_EVIDENCE_FRAGMENT_CAP", 1)
+    retained_event_id = "evt_404040404040"
+    retained_creation = _mcp_item_completed(
+        "agentacct",
+        "agentacct_record_section",
+        "call_retained",
+        result=_mcp_call_result(_creation_payload(retained_event_id)),
+    )
+    overflow_cases = [
+        (
+            "creation",
+            _mcp_item_completed(
+                "agentacct",
+                "agentacct_record_section",
+                "call_overflow",
+                result=_mcp_call_result(_creation_payload("evt_505050505050")),
+            ),
+            (),
+            1,
+            ["codex_rollout_evidence_schema_drift"],
+        ),
+        (
+            "read",
+            _mcp_item_completed(
+                "agentacct",
+                "agentacct_list_events",
+                "call_read",
+                result=_mcp_call_result(_creation_payload("evt_deadbeef0003")),
+            ),
+            (retained_event_id,),
+            0,
+            [],
+        ),
+    ]
+
+    for name, overflow_record, expected_ids, expected_skips, expected_errors in overflow_cases:
+        stats: dict[str, object] = {}
+        events = discover_codex_usage(
+            codex_home=_make_codex_home(
+                tmp_path / name,
+                [retained_creation, overflow_record],
+            ),
+            limit_sessions=10,
+            _discovery_stats=stats,
+        )
+
+        assert len(events) == 1
+        event = events[0]
+        assert event.evidenced_event_ids == expected_ids
+        assert event.evidenced_outputs_skipped == expected_skips
+        assert stats.get("error_codes", []) == expected_errors
+
+
+def test_codex_duplicate_and_failed_sibling_fragments_are_order_independent(tmp_path) -> None:
     success_id = "evt_414141414141"
     for index, reverse in enumerate((False, True)):
         duplicate_success = [
@@ -718,79 +776,6 @@ def test_codex_paginated_jsonl_links_trusted_import_to_gradeable_receipt(tmp_pat
     ).json()
     assert receipt["axes"]["decision_status"]["key"] == "verified"
     assert receipt["axes"]["evidence_strength"]["gradeable"] is True
-
-
-def test_codex_refresh_repairs_existing_same_token_row_with_paginated_evidence(tmp_path) -> None:
-    store = tmp_path / "store"
-    section = SentinelService(store).record_event(
-        {
-            "source": "codex",
-            "event_type": "section_completed",
-            "created_at": 200.0,
-            "metadata": {
-                "sentinel_semantic_kind": "section",
-                "client": "codex",
-                "client_session_id": None,
-                "section_id": "refresh-regression",
-                "section_status": "completed",
-                "section_title": "Repair imported evidence",
-                "kind": "implementation",
-                "project_dir": "/work/project",
-            },
-        }
-    )
-    codex_home = _make_codex_home(tmp_path, [])
-    args = [
-        "usage",
-        "import-local",
-        "--store-dir",
-        str(store),
-        "--client",
-        "codex",
-        "--codex-home",
-        str(codex_home),
-        "--json",
-    ]
-    runner = CliRunner()
-    first = runner.invoke(app, args)
-    assert first.exit_code == 0, first.output
-
-    rollout = next((codex_home / "sessions").rglob("rollout-*.jsonl"))
-    rollout.write_text(
-        rollout.read_text(encoding="utf-8")
-        + json.dumps(
-            _mcp_item_completed(
-                "agentacct",
-                "agentacct_record_section",
-                "call_refresh",
-                result=_mcp_call_result(_creation_payload(section["event_id"])),
-            )
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-    ordinary = runner.invoke(app, args)
-    assert ordinary.exit_code == 0, ordinary.output
-    ordinary_rows = [
-        event
-        for event in SentinelService(store).list_all_events()
-        if event.get("event_type") == "model_usage"
-    ]
-    assert len(ordinary_rows) == 1
-    assert "evidenced_event_ids" not in ordinary_rows[0]["metadata"]
-
-    refreshed = runner.invoke(app, [*args, "--refresh"])
-    assert refreshed.exit_code == 0, refreshed.output
-    refreshed_rows = [
-        event
-        for event in SentinelService(store).list_all_events()
-        if event.get("event_type") == "model_usage"
-    ]
-    assert len(refreshed_rows) == 1
-    assert refreshed_rows[0]["metadata"]["evidenced_event_ids"] == [
-        section["event_id"]
-    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Codex recording succeeds, but current Codex rollouts persist completed MCP
results as `event_msg → item_completed → McpToolCall`. The importer recognized
only the legacy `function_call` / `function_call_output` pair and
`mcp_tool_call_end`.

When recorded events do not already carry a `client_session_id`, a validated
created-event ID is the remaining provenance link to the Codex session. It
becomes authoritative only through a trust-marked local row that passes linker
validation. Ignoring the new carrier dropped those IDs: the session was
observed, but its section and check could not become linked, gradeable work.

## What changed

> **Central difference:** Codex and agentacct recording are unchanged. The
> importer now recognizes the current carrier and converts current and legacy
> records into the same logical-call representation.

| Stage | Before | After |
|---|---|---|
| Rollout import | `item_completed/McpToolCall` ignored for evidence | Current and legacy carriers normalized by call ID |
| Trusted donor metadata | Created event IDs absent | `evidenced_event_ids` carried by local usage or selected observation rows |
| Exact regression case | Session observed; zero linked work items | Matching section/check linked to one session; verified and gradeable |

### Concrete example at the break site

A successful `agentacct_record_section` call is already on disk in this
sanitized current-carrier shape:

```json
{
  "type": "event_msg",
  "payload": {
    "type": "item_completed",
    "item": {
      "type": "McpToolCall",
      "id": "call_section",
      "server": "agentacct",
      "tool": "agentacct_record_section",
      "status": "completed",
      "result": {
        "content": [
          {"type": "text", "text": "{\"event\":{\"event_id\":\"evt_012301230123\"}}"}
        ]
      }
    }
  }
}
```

The event ID exists. The break was in the rollout dispatch inside
`_read_codex_rollout_usage_uncached`, before donor or linker validation:

```python
# Before (simplified)
if payload_type == "function_call":
    remember_legacy_descriptor()
elif payload_type == "function_call_output":
    decode_legacy_output()
elif payload_type == "mcp_tool_call_end":
    decode_legacy_terminal()
# BREAK: no item_completed branch, so the ID never reaches evidenced_event_ids.

# After (simplified)
for record in rollout:
    if len(fragments) < 5_000:
        if (fragment := decode_codex_evidence_fragment(record)) is not None:
            fragments.append(fragment)
    elif codex_record_may_contain_evidence(record):
        relevant_overflow = True

if relevant_overflow:
    evidence.record_skip()  # Never trust a partial fragment set.
else:
    reconcile_codex_evidence_fragments(fragments, evidence)

project_to_usage_or_observation(evidence.as_usage_fields())
```

Those fields become `metadata.evidenced_event_ids` on the local usage row, or on
the selected observation when no usage donor is available. This is an importer
compatibility bug, not a recording failure.

### Before — event IDs are stranded

```mermaid
sequenceDiagram
    autonumber
    participant C as Codex
    participant S as agentacct service / event log
    participant R as Codex rollout JSONL
    participant I as Previous importer
    participant U as Task / receipt UI

    C->>S: record completed section and later passing check
    S-->>C: return both created event IDs
    C->>R: persist results as item_completed / McpToolCall
    I->>R: read rollout
    R-->>I: current carriers containing the event IDs
    I-->>I: carrier unsupported and event IDs omitted
    I->>S: import usage or observation without evidenced_event_ids
    U->>S: build task and receipt
    S-->>U: session observed but no linked work item
    U-->>U: not gradeable
```

### After — event IDs reach the receipt

```mermaid
sequenceDiagram
    autonumber
    participant C as Codex
    participant S as agentacct service / event log
    participant R as Codex rollout JSONL
    participant I as Updated importer + adapter
    participant U as Task / receipt UI

    C->>S: record completed section and later passing check
    S-->>C: return both created event IDs
    C->>R: persist results as item_completed / McpToolCall
    I->>R: read rollout
    R-->>I: current carriers containing the event IDs
    I-->>I: normalize bounded fragments and reconcile by valid call ID
    I->>S: write local usage or selected observation with evidenced_event_ids
    U->>S: build task and receipt
    S->>S: validate donor and project both events onto one session
    S->>S: join check within that session to section by shared section_id
    S-->>U: attributed completed work with current passing check
    U-->>U: verified decision, gradeable work, self-checked evidence
```

The endpoint is the exact regression case: a completed implementation section
and a later passing machine check share a `section_id`, the recorded events have
no other trusted session join key, and attribution is unambiguous. `Gradeable`
and `verified` remain separate; the MCP-recorded check is self-checked evidence,
not independent verification.

## Implementation and safety

- A compatibility adapter decodes current `item_completed/McpToolCall`, legacy
  `mcp_tool_call_end`, and split legacy function/output carriers into bounded
  fragments.
- Fragments reconcile after the scan by validated logical call ID. Duplicate
  representations are order-independent and donate at most one event ID.
- Exact creation server/tool allowlists are unchanged. A clean failed or unknown
  duplicate does not suppress a valid receipt. Malformed carriers, conflicting
  successful IDs, and identity conflicts invalidate that logical call and report
  evidence drift; other call IDs still reconcile independently.
- If evidence exceeds the 5,000-fragment cap, a later potentially relevant
  carrier discards all candidate IDs from that rollout and reports one skip plus
  evidence drift. Known non-creation current carriers do not trigger overflow;
  legacy split outputs count until their descriptor is seen because they cannot
  be classified safely in isolation.
- Actions first reconcile up to 5,000 carrier identities and scrubbed commands,
  then re-scan the same open file, decoding only retained carrier lines, to
  collect touched paths from final valid calls. A source-snapshot or carrier
  mismatch during either scan clears touched paths only; counts and commands
  remain.
- Raw MCP results and patch bodies are not retained across lines. Nested result
  decoding and all retained adapter/Actions state are capped.
- Evidence drift is reported separately from token-usage drift, and parse-cache
  fingerprints include every projection dependency.

## Review guide

1. **Reproduce the bug first — `edb58e9`:** read
   `test_codex_paginated_jsonl_links_trusted_import_to_gradeable_receipt` in
   `tests/test_log_evidenced_linking.py`.
2. **Review the compatibility boundary:**
   `src/agentacct/codex_rollout_adapter.py` and
   `tests/test_codex_rollout_adapter.py`. Read the implementation in this order:
   `CodexEvidenceFragment` (the bounded vocabulary) →
   `decode_codex_evidence_fragment` (carrier dispatch) →
   `_codex_paginated_terminal_fragment` (the missing current-carrier route) →
   `reconcile_codex_evidence_fragments` (one decision per logical call). The
   intervening outcome helpers decode supported result envelopes; the action
   and model helpers provide separately bounded importer normalization.
3. **Review importer and Actions integration:**
   `src/agentacct/client_usage.py`, `tests/test_codex_actions.py`, and
   `tests/test_codex_parse_cache.py`.
4. **Review trust projection and end-to-end behavior:**
   `src/agentacct/log_evidence.py` and `tests/test_log_evidenced_linking.py`.
5. **Finish with user-facing scope:**
   `docs/coding-agent-integrations.md` and `CHANGELOG.md`.

## Verification

- The regression-only commit fails at the public boundary with zero linked
  `work_items`; fixed HEAD passes and asserts `verified` plus `gradeable=true`.
- 368 focused tests pass with one unchanged Starlette deprecation warning.
- GitHub CI passes on Python 3.11, 3.12, and 3.13.
- Changed modules compile and `git diff --check` passes.

<details>
<summary>Exact focused test command</summary>

```bash
.venv/bin/pytest -q \
  tests/test_client_usage.py \
  tests/test_codex_actions.py \
  tests/test_codex_parse_cache.py \
  tests/test_codex_rollout_adapter.py \
  tests/test_hooks_codex.py \
  tests/test_log_evidenced_linking.py \
  tests/test_tool_activity.py
```

</details>

## Scope

- No migration or automatic backfill. Existing rows change only when explicitly
  revisited.
- The existing 200 retained-evidence-ID limit remains unchanged.
- No local Codex MCP or hook configuration is included.

Closes #117
