### PR TITLE
fix(app): align mixed-detail dashboard tiles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
 
 jobs:
+  swift-app:
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Swift app tests
+        run: swift test --package-path apps/agentacct
+
   pytest:
     runs-on: ubuntu-latest
     strategy:

--- a/apps/agentacct/Package.swift
+++ b/apps/agentacct/Package.swift
@@ -8,6 +8,11 @@ let package = Package(
         .executableTarget(
             name: "agentacct",
             path: "Sources/agentacct"
+        ),
+        .testTarget(
+            name: "agentacctTests",
+            dependencies: ["agentacct"],
+            path: "Tests/agentacctTests"
         )
     ]
 )

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -202,6 +202,7 @@ struct PanelTile: View {
     let label: String
     let value: String
     var detail: String? = nil
+    var reservesDetailSpace = true
     var accent: Color = Theme.text
 
     var body: some View {
@@ -210,13 +211,20 @@ struct PanelTile: View {
                 .font(Type.tileLabel)
                 .tracking(0.7)
                 .foregroundStyle(Theme.textFaint)
+                .lineLimit(1)
             Text(value)
                 .font(Type.metric)
                 .foregroundStyle(accent)
-            if let detail {
-                Text(detail)
+                .lineLimit(1)
+            if detail != nil || reservesDetailSpace {
+                // Mixed rows reserve three single-line slots so absent detail
+                // cannot change card geometry or enter the accessibility tree.
+                Text(detail ?? " ")
                     .font(Type.tiny)
                     .foregroundStyle(Theme.textFaint)
+                    .lineLimit(1)
+                    .opacity(detail == nil ? 0 : 1)
+                    .accessibilityHidden(detail == nil)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/agentacct/Sources/agentacct/UsagePane.swift
+++ b/apps/agentacct/Sources/agentacct/UsagePane.swift
@@ -188,13 +188,17 @@ struct UsagePane: View {
         if let usage = dashboard.usage {
             if let totals = usage.totals {
                 HStack(spacing: 8) {
-                    PanelTile(label: "\(dashboard.usageDays)d cost", value: totals.costText, accent: Theme.blue)
+                    PanelTile(label: "\(dashboard.usageDays)d cost", value: totals.costText,
+                              reservesDetailSpace: false, accent: Theme.blue)
                     PanelTile(label: "\(dashboard.usageDays)d fresh tokens",
-                              value: totals.freshTokens.map(UsageTotals.compact) ?? "—")
+                              value: totals.freshTokens.map(UsageTotals.compact) ?? "—",
+                              reservesDetailSpace: false)
                     PanelTile(label: "cache read",
-                              value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—")
+                              value: totals.cacheReadTokens.map(UsageTotals.compact) ?? "—",
+                              reservesDetailSpace: false)
                     PanelTile(label: "sessions",
-                              value: totals.sessions.map(String.init) ?? "—")
+                              value: totals.sessions.map(String.init) ?? "—",
+                              reservesDetailSpace: false)
                 }
             }
             if let periods = usage.byPeriod, periods.count > 1 {

--- a/apps/agentacct/Tests/agentacctTests/PanelTileLayoutTests.swift
+++ b/apps/agentacct/Tests/agentacctTests/PanelTileLayoutTests.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import XCTest
+
+@testable import agentacct
+
+final class PanelTileLayoutTests: XCTestCase {
+    @MainActor
+    func testPanelTileHeightDoesNotDependOnDetailPresence() throws {
+        for width in [226.0, 243.0, 266.0] {
+            let withoutDetail = try renderedHeight(detail: nil, width: width)
+            for detail in ["reference", "provider-reported account-wide usage"] {
+                let withDetail = try renderedHeight(detail: detail, width: width)
+
+                XCTAssertEqual(
+                    withoutDetail,
+                    withDetail,
+                    "PanelTile height changed for detail at width \(width)"
+                )
+            }
+        }
+    }
+
+    @MainActor
+    private func renderedHeight(detail: String?, width: CGFloat) throws -> Int {
+        let tile = PanelTile(
+            label: "today · fresh tokens",
+            value: "297.4k",
+            detail: detail
+        )
+        .frame(width: width)
+        .fixedSize(horizontal: false, vertical: true)
+        .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: tile)
+        renderer.scale = 1
+        return try XCTUnwrap(renderer.cgImage).height
+    }
+}

--- a/apps/agentacct/Tests/agentacctTests/PanelTileLayoutTests.swift
+++ b/apps/agentacct/Tests/agentacctTests/PanelTileLayoutTests.swift
@@ -21,11 +21,28 @@ final class PanelTileLayoutTests: XCTestCase {
     }
 
     @MainActor
-    private func renderedHeight(detail: String?, width: CGFloat) throws -> Int {
+    func testPanelTileCanOmitReservedDetailSpaceForCompactRows() throws {
+        let standardHeight = try renderedHeight(detail: nil, width: 243)
+        let compactHeight = try renderedHeight(
+            detail: nil,
+            width: 243,
+            reservesDetailSpace: false
+        )
+
+        XCTAssertLessThan(compactHeight, standardHeight)
+    }
+
+    @MainActor
+    private func renderedHeight(
+        detail: String?,
+        width: CGFloat,
+        reservesDetailSpace: Bool = true
+    ) throws -> Int {
         let tile = PanelTile(
             label: "today · fresh tokens",
             value: "297.4k",
-            detail: detail
+            detail: detail,
+            reservesDetailSpace: reservesDetailSpace
         )
         .frame(width: width)
         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Why

The Dashboard renders four metric cards in one row, but TODAY · FRESH TOKENS has no detail line. PanelTile previously removed that line entirely, making the card 58 px high while its siblings were 73 px high; the surrounding HStack then centered the shorter card vertically.

Fixes #118.

## What changed

- Make mixed-detail PanelTile rows reserve a single-line detail slot by default.
- Keep absent detail invisible and out of the accessibility tree.
- Keep label, value, and detail slots single-line so content length cannot change card geometry.
- Preserve the intentionally compact all-metric Usage summary through an explicit opt-out.
- Add a Swift test target, geometry regression coverage, and a bounded macOS CI job.

## Commit structure

1. 215000e — test(app): cover mixed-detail tile alignment
   - Compiles and fails on the original implementation: 58 px versus 73 px at widths 226, 243, and 266.
2. 6694004 — fix(app): align mixed-detail dashboard tiles
   - Makes the regression green and adds compact-row coverage plus CI.

## Verification

- Red commit: focused Swift test failed for the intended height mismatch.
- Final tree: swift test --package-path apps/agentacct — 2 passed, 0 failed.
- Final tree: swift build --package-path apps/agentacct -c release — passed.
- Existing synthetic snapshot flow — Dashboard and Usage reviewed in light and dark modes.
- git diff --check origin/main...HEAD — passed.
- GitHub Actions workflow YAML parsed successfully.

## Review order

1. Theme.swift — the component geometry and accessibility invariant.
2. UsagePane.swift — the deliberate compact-row opt-out.
3. PanelTileLayoutTests.swift — regression matrix and compact-mode coverage.
4. Package.swift and tests.yml — test target and CI execution.

## Scope

No Python behavior, dependencies, migrations, or tracked screenshot assets changed.