### PR TITLE
chore(release): 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.4] — 2026-08-25
+
+Fixes Codex session recording for newly-onboarded users: agentacct MCP receipts
+recorded by current Codex now link into gradeable work items instead of being
+dropped.
+
 ### Fixed
 
 - Read Codex's paginated `item_completed` / `McpToolCall` rollout records
@@ -14,7 +20,7 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   representations are reconciled by logical call id. A clean failed or unknown
   duplicate does not suppress a valid receipt; malformed carriers, identity
   conflicts, and conflicting successful event ids invalidate that logical call
-  and report evidence schema drift.
+  and report evidence schema drift. (#123)
 
 ## [0.9.3] — 2026-08-23
 
@@ -671,7 +677,8 @@ across all of them. Ships alongside the first signed, notarized macOS app.
   `agentacct-claude`, and `agentacct-codex` console scripts. Local-first,
   observe-only, no telemetry, no provider API keys. Python ≥ 3.11 on macOS / Linux.
 
-[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.9.3...HEAD
+[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/mikehasa/agentacct/releases/tag/v0.9.4
 [0.9.3]: https://github.com/mikehasa/agentacct/releases/tag/v0.9.3
 [0.9.2]: https://github.com/mikehasa/agentacct/releases/tag/v0.9.2
 [0.9.1]: https://github.com/mikehasa/agentacct/releases/tag/v0.9.1

--- a/apps/agentacct/Scripts/build-app.sh
+++ b/apps/agentacct/Scripts/build-app.sh
@@ -38,7 +38,7 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
     <key>CFBundleIdentifier</key><string>dev.agentacct.app</string>
     <key>CFBundleName</key><string>agentacct</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.9.3</string>
+    <key>CFBundleShortVersionString</key><string>0.9.4</string>
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <key>LSUIElement</key><true/>
     <key>NSHighResolutionCapable</key><true/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentacct"
-version = "0.9.3"
+version = "0.9.4"
 description = "Local-first Agent Work Intelligence for coding agents: usage truth, recorded work, and honest joins"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release 0.9.4.

**Ships:** the Codex paginated MCP evidence fix (#123) — current Codex `item_completed` / `McpToolCall` rollout records now link agentacct MCP receipts into gradeable work items (fixes the newly-onboarded-user recording gap, #117), with legacy carriers still supported.

**Version bump (3 places):** `pyproject.toml`, `apps/agentacct/Scripts/build-app.sh` (CFBundleShortVersionString), `CHANGELOG.md`.

**DMG:** rebuilt + signed + notarized for this release — the DMG embeds the frozen Python CLI, so the #123 fix has to ship in a fresh build (the 0.9.1 DMG reused by 0.9.2/0.9.3 predates the fix).