### PR TITLE
feat(plan): accept stable out-of-band calibration fits; weekly-plan share on receipts

### DIFF
--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -419,8 +419,12 @@ struct RecordDimensionsCard: View {
             tokensLine = "tokens: " + parts.joined(separator: " · ")
         }
         guard let cost = dim.estimatedCostUsd else {
-            guard let tokensLine else { return "no priced usage" }
-            return "no priced usage\n" + tokensLine
+            // The share is token-derived, not dollar-derived — an unpriced
+            // task with a calibrated share still states it.
+            var absent = "no priced usage"
+            if let share = dim.planShare?.text { absent += " · \(share)" }
+            guard let tokensLine else { return absent }
+            return absent + "\n" + tokensLine
         }
         let display = receiptCostDisplay(cost, complete: dim.costComplete, confidence: dim.costConfidence)
         var line = "\(display) · \(costBasisLabel(dim.costBasis))\((dim.costComplete ?? true) ? "" : " (partial)")"

--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -111,6 +111,7 @@ struct RecordSummaryStrip: View {
         if let usd = cost.estimatedCostUsd {
             var qualifier = costBasisLabel(cost.costBasis)
             if cost.costComplete == false { qualifier += " · partial" }
+            if let pct = Fmt.planPct(cost.planShare?.pct) { qualifier += " · \(pct) wkly" }
             costCell = Cell(
                 id: "cost",
                 label: "Est. cost",
@@ -423,6 +424,12 @@ struct RecordDimensionsCard: View {
         }
         let display = receiptCostDisplay(cost, complete: dim.costComplete, confidence: dim.costConfidence)
         var line = "\(display) · \(costBasisLabel(dim.costBasis))\((dim.costComplete ?? true) ? "" : " (partial)")"
+        // The task's share of the weekly plan — shown only once calibrated
+        // (the daemon sends null until then; absence stays a named state on
+        // the Limits pane, never a number here).
+        if let share = dim.planShare?.text {
+            line += " · \(share)"
+        }
         if let tokensLine { line += "\n" + tokensLine }
         return line
     }

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -610,17 +610,45 @@ struct ReceiptEvidence: Decodable {
     }
 }
 
+/// A Task's share of its client's weekly plan — daemon-computed sum of the
+/// member sessions' calibrated per-session percentages. Calibrated-or-nothing:
+/// ``pct`` is nil (never 0) until the fit is calibrated, and
+/// ``calibrationState`` names why.
+struct ReceiptPlanShare: Decodable {
+    let pct: Double?
+    let client: String?
+    let calibrationState: String?
+    let coveredSessions: Int?
+    let sessionCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case pct, client
+        case calibrationState = "calibration_state"
+        case coveredSessions = "covered_sessions"
+        case sessionCount = "session_count"
+    }
+
+    /// "≈X.X% of weekly plan" — nil when not calibrated (absence stays named
+    /// by the calibration state, never rendered as a number).
+    var text: String? {
+        guard let formatted = Fmt.planPct(pct) else { return nil }
+        return "\(formatted) of weekly plan"
+    }
+}
+
 struct ReceiptCost: Decodable {
     let estimatedCostUsd: Double?
     let costBasis: String?
     let costConfidence: String?
     let costComplete: Bool?
+    let planShare: ReceiptPlanShare?
 
     enum CodingKeys: String, CodingKey {
         case estimatedCostUsd = "estimated_cost_usd"
         case costBasis = "cost_basis"
         case costConfidence = "cost_confidence"
         case costComplete = "cost_complete"
+        case planShare = "plan_share"
     }
 
     /// None-never-$0: an absent estimate is "—", never a fabricated zero.
@@ -799,6 +827,7 @@ struct ReceiptCostDim: Decodable {
     let costBasis: String?
     let costConfidence: String?
     let costComplete: Bool?
+    let planShare: ReceiptPlanShare?
     let tokens: ReceiptCostTokens?
     let provenance: [String]?
     let gaps: [String]?
@@ -808,6 +837,7 @@ struct ReceiptCostDim: Decodable {
         case costBasis = "cost_basis"
         case costConfidence = "cost_confidence"
         case costComplete = "cost_complete"
+        case planShare = "plan_share"
         case tokens
         case provenance, gaps
     }

--- a/apps/agentacct/Sources/agentacct/WorkPane.swift
+++ b/apps/agentacct/Sources/agentacct/WorkPane.swift
@@ -608,10 +608,12 @@ private struct WorkTableRow: View {
     @ViewBuilder
     private var costCell: some View {
         let cost = DashboardWorkItem(task: task).cost
+        let planText = Fmt.planPct(task.cost.planShare?.pct).map { "\($0) of weekly plan" }
         if cost == "—" {
             Text("unpriced").font(Type.dataSmall).foregroundStyle(Theme.muted)
         } else {
             Text(cost).font(Type.dataSmall).foregroundStyle(Theme.ink)
+                .help(planText ?? "")
         }
     }
 
@@ -763,10 +765,14 @@ private struct WorkRailRow: View {
                         Text(cost == "—" ? "unpriced" : cost)
                             .font(Type.dataSmall).foregroundStyle(Theme.muted)
                     }
-                    // Who did the work, and how fresh it is — both already in
-                    // the summary payload; absence stays silent, never dashed.
+                    // Who did the work, how fresh, and the weekly-plan share
+                    // when calibrated — all from the summary payload; absence
+                    // stays silent, never dashed.
                     if task.primaryRoot?.client != nil || task.lastActivityAt != nil {
                         HStack(spacing: 4) {
+                            // The client name yields (truncates) first; the ago
+                            // and the compact plan share stay whole (hover
+                            // carries the share's full sentence).
                             if let client = task.primaryRoot?.client {
                                 Text(client)
                                     .font(Type.dataSmall).foregroundStyle(Theme.muted)
@@ -777,6 +783,14 @@ private struct WorkRailRow: View {
                                     Text("·").font(Type.dataSmall).foregroundStyle(Theme.muted)
                                 }
                                 Text(ago).font(Type.dataSmall).foregroundStyle(Theme.muted)
+                                    .fixedSize()
+                            }
+                            Spacer(minLength: 4)
+                            if let pct = Fmt.planPct(task.cost.planShare?.pct) {
+                                Text(pct)
+                                    .font(Type.dataSmall).foregroundStyle(Theme.muted)
+                                    .fixedSize()
+                                    .help("\(pct) of the weekly \(task.cost.planShare?.client ?? "") plan")
                             }
                         }
                     }

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -1990,23 +1990,31 @@ def _stamp_task_plan_shares(projection: Mapping[str, Any], events: list[dict[str
             for member in (task.get("session_keys") or [])
             if isinstance(member, Mapping)
         ]
+        primary = task.get("primary_root")
+        client = str(primary.get("client") or "") if isinstance(primary, Mapping) else ""
         covered = 0
         total_pct = 0.0
         for member in members:
-            key = (
-                str(member.get("client") or ""),
-                str(member.get("client_session_id") or ""),
-            )
+            member_client = str(member.get("client") or "")
+            # One client, one plan: the share is labelled with the primary
+            # root's client, so only that client's member sessions may
+            # contribute — a cross-client continuation must never sum another
+            # plan's percentages under this label.
+            if member_client != client:
+                continue
+            key = (member_client, str(member.get("client_session_id") or ""))
             pct = session_pcts.get(key)
             if pct is not None:
                 covered += 1
                 total_pct += float(pct)
-        primary = task.get("primary_root")
-        client = str(primary.get("client") or "") if isinstance(primary, Mapping) else ""
+        # A client outside the plan lane (hermes/opencode/...) is honestly
+        # "never" — its meter has no calibratable weekly plan — instead of a
+        # null that reads as "unknown".
+        state = states.get(client) or ("never" if client else None)
         task["plan_share"] = {
             "pct": total_pct if covered else None,
             "client": client or None,
-            "calibration_state": states.get(client),
+            "calibration_state": state,
             "covered_sessions": covered,
             "session_count": len(members),
         }
@@ -2400,9 +2408,12 @@ def build_store_task_projection(
     event-level reducer this assembly ultimately calls through the page-data
     path) — shadowing that import broke the /tasks route once already."""
 
-    return _dashboard_task_projection(
-        build_page_data(store_dir, continuation_snapshot=continuation_snapshot)
-    )
+    data = build_page_data(store_dir, continuation_snapshot=continuation_snapshot)
+    projection = _dashboard_task_projection(data)
+    # Same stamp the /v1 lane applies, so `agentacct receipt` / the TUI can
+    # never disagree with the app about a task's weekly-plan share.
+    _stamp_task_plan_shares(projection, data.events)
+    return projection
 
 
 def surfaced_finding_episodes(projection: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -1960,6 +1960,58 @@ def _apply_finding_dispositions_to_projection(
     return projection
 
 
+def _stamp_task_plan_shares(projection: Mapping[str, Any], events: list[dict[str, Any]]) -> None:
+    """Stamp each projected Task with its weekly-plan share.
+
+    A Task's share is the SUM of its member sessions' calibrated per-session
+    plan percentages — raw per-session values (never the root-folded display
+    numbers), so members are counted exactly once. Uses the same one-shot
+    computation the glance lane uses (``plan_status_and_session_pcts``), so a
+    receipt and the menu bar can never disagree about a session's share.
+    Calibrated-or-nothing: with no calibrated fit for the Task's client the
+    ``pct`` is null and ``calibration_state`` says why — never a fabricated 0.
+    ``covered_sessions`` names how many members actually carried a share, so a
+    partial sum is disclosed instead of passed off as complete.
+    """
+
+    from .glance import plan_status_and_session_pcts
+
+    plan_entries, session_pcts, _weights, _records = plan_status_and_session_pcts(events)
+    states = {
+        str(entry.get("client") or ""): str(entry.get("calibration_state") or "") or None
+        for entry in plan_entries
+        if isinstance(entry, Mapping)
+    }
+    for task in projection.get("tasks", []):
+        if not isinstance(task, dict):
+            continue
+        members = [
+            member
+            for member in (task.get("session_keys") or [])
+            if isinstance(member, Mapping)
+        ]
+        covered = 0
+        total_pct = 0.0
+        for member in members:
+            key = (
+                str(member.get("client") or ""),
+                str(member.get("client_session_id") or ""),
+            )
+            pct = session_pcts.get(key)
+            if pct is not None:
+                covered += 1
+                total_pct += float(pct)
+        primary = task.get("primary_root")
+        client = str(primary.get("client") or "") if isinstance(primary, Mapping) else ""
+        task["plan_share"] = {
+            "pct": total_pct if covered else None,
+            "client": client or None,
+            "calibration_state": states.get(client),
+            "covered_sessions": covered,
+            "session_count": len(members),
+        }
+
+
 def _dashboard_task_projection(data: _DashboardPageData) -> dict[str, Any]:
     sessions = data.rollup_sessions
     work_items = data.work_items
@@ -2839,6 +2891,9 @@ def create_local_api_app(
             # case verified on the live store.
             ledger = _derived_work_ledger(events, fingerprint=fingerprint)
             projection = _dashboard_task_projection(_page_data(events=events, ledger=ledger))
+            # Weekly-plan shares ride the same cached projection: deterministic
+            # from the same event log, so the cache key already covers them.
+            _stamp_task_plan_shares(projection, events)
             v1_receipt_projection_cache["projection"] = (fingerprint, time.time(), projection)
             return projection
 

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -74,15 +74,25 @@ _TRUSTED_SCALE_BAND = (0.5, 2.5)
 # forever" for any account whose true tokens→meter ratio sits past the edge (a
 # smaller plan tier, or baseline weights that have drifted for a new model mix)
 # — the fit was being re-rejected on 130+ clean intervals whose split halves
-# agreed within ~12%. Untracked-usage inflation is already excluded per-interval
-# by the A+B>0 gate above, so a PERSISTENT, split-half-stable ratio is a
-# property of the account, not noise. Requirements, all of them:
+# agreed within ~12%. A PERSISTENT, time-split-stable ratio sustained across
+# weeks is a property of the account, not noise. KNOWN LIMIT, disclosed in the
+# basis: the A+B>0 gate above excludes only intervals with ZERO tracked tokens;
+# untracked Claude usage (desktop app / claude.ai) that consistently co-occurs
+# with tracked work still inflates the fitted ratio, and if that habit is
+# steady it is stable too — the accepted scale maps tracked tokens to the
+# ACCOUNT-WIDE meter, which is exactly what the share numbers then mean.
+# Requirements, all of them:
 # * at least this many clean intervals (noise averages out far above the
 #   3-interval floor),
 _STABILITY_MIN_INTERVALS = 24
-# * each chronological half of the fit window independently lands within this
-#   relative distance of the full fit (a drifting or bimodal ratio never
-#   qualifies),
+# * the fit window spans at least this much wall clock, split at its time
+#   midpoint with at least this many intervals in EACH half — a single heavy
+#   day can mint 24+ readings whose "halves" are its own morning and
+#   afternoon, and must never self-certify,
+_STABILITY_MIN_WINDOW_SPAN_SECONDS = 7 * 86400.0
+_STABILITY_MIN_HALF_INTERVALS = 6
+# * each time-half independently lands within this relative distance of the
+#   full fit (a drifting or bimodal ratio never qualifies),
 _STABILITY_HALF_AGREEMENT = 0.35
 # * and the fit sits inside a wide hard ceiling — beyond it no amount of
 #   stability makes the number credible (something structural is wrong).
@@ -125,8 +135,9 @@ class PlanWeights:
     times the fitted ``scale``. ``alpha`` is the fitted cache-read discount in
     [0, 1] — a cache-read token counts as ``alpha`` fresh tokens (measured ~0
     on the reference account). ``confidence`` is ``calibrated`` when the fit
-    came from enough recorded 7-day history and landed in the trusted band,
-    else ``baseline``. ``raw_scale`` preserves the pre-band fit for the
+    came from enough recorded 7-day history and landed in the trusted band
+    (or, outside it, passed the split-half stability acceptance), else
+    ``baseline``. ``raw_scale`` preserves the pre-band fit for the
     calibration-progress disclosure. ``default_weight`` applies to a model
     absent from ``weights``.
     """
@@ -335,24 +346,34 @@ def _component_tokens_between(
 
 
 def _stable_out_of_band_fit(
-    points: list[tuple[float, float, float]],
+    points: list[tuple[float, float, float, float]],
     *,
     alpha: float,
     raw_scale: float,
 ) -> bool:
     """Should an out-of-band fit be accepted anyway? See the stability
     constants above for the contract. ``points`` are the clean intervals in
-    chronological order; each half's ratio-of-sums scale (at the already-chosen
-    alpha) must independently agree with the full fit."""
+    chronological order as ``(t, delta, A, B)``; the window is split at its
+    TIME midpoint (never by count — a burst day must not become both halves),
+    and each half's ratio-of-sums scale (at the already-chosen alpha) must
+    independently agree with the full fit."""
 
     if len(points) < _STABILITY_MIN_INTERVALS:
         return False
     if not (_STABILITY_HARD_BAND[0] <= raw_scale <= _STABILITY_HARD_BAND[1]):
         return False
-    half = len(points) // 2
-    for chunk in (points[:half], points[half:]):
-        observed = sum(delta for delta, _a, _b in chunk)
-        predicted = sum(a + alpha * b for _d, a, b in chunk)
+    first_t = points[0][0]
+    last_t = points[-1][0]
+    if last_t - first_t < _STABILITY_MIN_WINDOW_SPAN_SECONDS:
+        return False
+    split_t = (first_t + last_t) / 2.0
+    early = [point for point in points if point[0] <= split_t]
+    late = [point for point in points if point[0] > split_t]
+    for chunk in (early, late):
+        if len(chunk) < _STABILITY_MIN_HALF_INTERVALS:
+            return False
+        observed = sum(delta for _t, delta, _a, _b in chunk)
+        predicted = sum(a + alpha * b for _t, _d, a, b in chunk)
         if predicted <= 0:
             return False
         chunk_scale = observed / predicted
@@ -377,8 +398,10 @@ def calibrate_plan_weights(
     Σobserved / Σ(A + alpha×B) for a given alpha; alpha is chosen on a [0, 1]
     grid by residual (closed-form per point, no iterative optimizer). Only
     intervals whose movement our tracked-client tokens can explain
-    (``A + B > 0``) contribute, and the fitted scale is applied only inside
-    the trusted band; otherwise the shipped baseline is kept. This guards the
+    (``A + B > 0``) contribute, and the fitted scale is applied when it lands
+    inside the trusted band — or, outside it, when it passes the split-half
+    stability acceptance (see the stability constants); otherwise the shipped
+    baseline is kept. This guards the
     estimate's known blind spot: the 7-day meter is ACCOUNT-WIDE (Claude
     desktop app, claude.ai, other machines all move it) while our tokens cover
     only tracked clients, so movement with no local tokens is untracked usage
@@ -423,9 +446,10 @@ def calibrate_plan_weights(
 
     series = seven_day_series(events, client=client)
     window_start = now_epoch - _CALIBRATION_WINDOW_DAYS * 86400.0
-    # (delta, A, B) per clean interval: observed movement, fresh-component
-    # prediction, cache-read prediction.
-    points: list[tuple[float, float, float]] = []
+    # (t, delta, A, B) per clean interval: interval end time, observed
+    # movement, fresh-component prediction, cache-read prediction. The time
+    # rides along for the stability split (chronological — series is sorted).
+    points: list[tuple[float, float, float, float]] = []
     for (t0, p0), (t1, p1) in zip(series, series[1:]):
         if not (0 < t1 - t0 <= _MAX_INTERVAL_SECONDS):
             continue
@@ -443,23 +467,23 @@ def calibrate_plan_weights(
         # over-state every session, so skip it.
         if fresh_pred + read_pred <= 0:
             continue
-        points.append((delta, fresh_pred, read_pred))
+        points.append((t1, delta, fresh_pred, read_pred))
 
     intervals = len(points)
     raw_scale = 1.0
     alpha = 0.0
     if points:
         candidates: list[tuple[float, float, float]] = []  # (alpha, scale, sse)
-        observed_sum = sum(delta for delta, _a, _b in points)
+        observed_sum = sum(delta for _t, delta, _a, _b in points)
         for step in range(_ALPHA_GRID_STEPS + 1):
             candidate_alpha = step / _ALPHA_GRID_STEPS
-            predicted_sum = sum(a + candidate_alpha * b for _d, a, b in points)
+            predicted_sum = sum(a + candidate_alpha * b for _t, _d, a, b in points)
             if predicted_sum <= 0:
                 continue
             candidate_scale = observed_sum / predicted_sum
             sse = sum(
                 (delta - candidate_scale * (a + candidate_alpha * b)) ** 2
-                for delta, a, b in points
+                for _t, delta, a, b in points
             )
             candidates.append((candidate_alpha, candidate_scale, sse))
         if candidates:
@@ -494,7 +518,10 @@ def calibrate_plan_weights(
             f"({intervals} recent weekly-% intervals)"
         )
         if stability_accepted:
-            basis += "; outside the usual band, accepted on split-half stability"
+            basis += (
+                "; outside the usual band, accepted on split-half stability "
+                "(may include usage from untracked Claude surfaces)"
+            )
     else:
         # Too little clean history, or a fit outside the trusted band (heavy
         # untracked Claude usage or a very different plan tier we can't
@@ -790,8 +817,22 @@ def plan_status_entry(weights: PlanWeights) -> dict[str, Any]:
             f"{weights.intervals_used} intervals recorded; the fit"
             + (f" (x{raw:.2f})" if raw is not None else "")
             + f" is outside the trusted band [{_TRUSTED_SCALE_BAND[0]}, {_TRUSTED_SCALE_BAND[1]}]"
-            " — heavy untracked usage or a plan change can cause this"
         )
+        beyond_ceiling = raw is not None and not (
+            _STABILITY_HARD_BAND[0] <= raw <= _STABILITY_HARD_BAND[1]
+        )
+        if beyond_ceiling:
+            # Honest terminal state, not a spinner: past the stability ceiling
+            # no amount of history calibrates this ratio.
+            detail += (
+                f" and beyond the stability ceiling [{_STABILITY_HARD_BAND[0]}, {_STABILITY_HARD_BAND[1]}]"
+                " — it will not calibrate at this ratio (heavy untracked usage or a plan change can cause this)"
+            )
+        else:
+            detail += (
+                " — it calibrates once it holds split-half stable across "
+                f"{_STABILITY_MIN_INTERVALS}+ intervals spanning a week or more"
+            )
     return {
         "client": weights.client,
         "confidence": weights.confidence,
@@ -804,6 +845,9 @@ def plan_status_entry(weights: PlanWeights) -> dict[str, Any]:
         "intervals_needed": _MIN_SCALE_INTERVALS,
         "raw_scale": weights.raw_scale,
         "trusted_band": list(_TRUSTED_SCALE_BAND),
+        # The stability-acceptance ceiling for out-of-band fits, so a shell can
+        # explain the full acceptance region, not just the inner band.
+        "stability_band": list(_STABILITY_HARD_BAND),
         "state_detail": detail,
     }
 

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -69,6 +69,24 @@ _CALIBRATION_WINDOW_DAYS = 21
 # very different plan tier — neither of which we can identify — so we keep the shipped
 # baseline rather than apply an unreliable (over- or under-stating) scale.
 _TRUSTED_SCALE_BAND = (0.5, 2.5)
+# An out-of-band fit is still ACCEPTED when the evidence is overwhelming and
+# internally consistent: a fixed band alone turned "calibrating" into "rejected
+# forever" for any account whose true tokens→meter ratio sits past the edge (a
+# smaller plan tier, or baseline weights that have drifted for a new model mix)
+# — the fit was being re-rejected on 130+ clean intervals whose split halves
+# agreed within ~12%. Untracked-usage inflation is already excluded per-interval
+# by the A+B>0 gate above, so a PERSISTENT, split-half-stable ratio is a
+# property of the account, not noise. Requirements, all of them:
+# * at least this many clean intervals (noise averages out far above the
+#   3-interval floor),
+_STABILITY_MIN_INTERVALS = 24
+# * each chronological half of the fit window independently lands within this
+#   relative distance of the full fit (a drifting or bimodal ratio never
+#   qualifies),
+_STABILITY_HALF_AGREEMENT = 0.35
+# * and the fit sits inside a wide hard ceiling — beyond it no amount of
+#   stability makes the number credible (something structural is wrong).
+_STABILITY_HARD_BAND = (0.2, 8.0)
 
 # The two-component token model. The weekly meter is driven by FRESH work
 # (input + output + cache_creation); cache READS barely move it — measured on
@@ -316,6 +334,33 @@ def _component_tokens_between(
     return fresh, reads
 
 
+def _stable_out_of_band_fit(
+    points: list[tuple[float, float, float]],
+    *,
+    alpha: float,
+    raw_scale: float,
+) -> bool:
+    """Should an out-of-band fit be accepted anyway? See the stability
+    constants above for the contract. ``points`` are the clean intervals in
+    chronological order; each half's ratio-of-sums scale (at the already-chosen
+    alpha) must independently agree with the full fit."""
+
+    if len(points) < _STABILITY_MIN_INTERVALS:
+        return False
+    if not (_STABILITY_HARD_BAND[0] <= raw_scale <= _STABILITY_HARD_BAND[1]):
+        return False
+    half = len(points) // 2
+    for chunk in (points[:half], points[half:]):
+        observed = sum(delta for delta, _a, _b in chunk)
+        predicted = sum(a + alpha * b for _d, a, b in chunk)
+        if predicted <= 0:
+            return False
+        chunk_scale = observed / predicted
+        if abs(chunk_scale - raw_scale) > _STABILITY_HALF_AGREEMENT * raw_scale:
+            return False
+    return True
+
+
 def calibrate_plan_weights(
     events: list[dict[str, Any]],
     *,
@@ -434,7 +479,12 @@ def calibrate_plan_weights(
                     raw_scale = candidate_scale
                     break
     trusted = _TRUSTED_SCALE_BAND[0] <= raw_scale <= _TRUSTED_SCALE_BAND[1]
-    if intervals >= _MIN_SCALE_INTERVALS and trusted:
+    stability_accepted = (
+        intervals >= _MIN_SCALE_INTERVALS
+        and not trusted
+        and _stable_out_of_band_fit(points, alpha=alpha, raw_scale=raw_scale)
+    )
+    if intervals >= _MIN_SCALE_INTERVALS and (trusted or stability_accepted):
         scale = raw_scale
         confidence = "calibrated"
         # A plain string, not a %-format template — no %% escaping (a literal
@@ -443,6 +493,8 @@ def calibrate_plan_weights(
             f"two-component fit x{scale:.2f}, cache-read discount {alpha:.2f} "
             f"({intervals} recent weekly-% intervals)"
         )
+        if stability_accepted:
+            basis += "; outside the usual band, accepted on split-half stability"
     else:
         # Too little clean history, or a fit outside the trusted band (heavy
         # untracked Claude usage or a very different plan tier we can't

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -767,6 +767,9 @@ def _cost_dimension(task: Mapping[str, Any]) -> dict[str, Any]:
         "cost_basis": cost_basis,
         "cost_confidence": cost_confidence,
         "cost_complete": cost_complete,
+        # The Task's share of the client's weekly plan (projection-stamped;
+        # calibrated-or-nothing — pct is null with the state naming why).
+        "plan_share": _mapping(task.get("plan_share")) or None,
         "tokens": {
             "fresh": int(usage.get("fresh_tokens") or 0),
             "cache_creation": int(usage.get("cache_creation_tokens") or 0),
@@ -1090,6 +1093,9 @@ def build_receipt_summary(
             "estimated_cost_usd": usage.get("estimated_cost_usd"),
             "cost_basis": _text(usage.get("cost_basis")) or None,
             "cost_complete": bool(usage.get("cost_complete")),
+            # The weekly-plan share for list rows (same projection stamp the
+            # detail receipt carries — the two can never disagree).
+            "plan_share": _mapping(task.get("plan_share")) or None,
         },
         "session_count": int(task.get("session_count") or 0),
         # The primary root's {client, client_session_id} — the one id a list row

--- a/tests/test_plan_cost.py
+++ b/tests/test_plan_cost.py
@@ -410,19 +410,24 @@ def test_session_plan_pcts():
 # ---------------------------------------------------------------------------
 
 
-def _consistent_history(service, *, ratio, intervals, tokens=50_000_000, t0=1_000_000):
-    """A weekly-%% history whose movement is a constant ``ratio`` x baseline."""
+def _consistent_history(service, *, ratio, intervals, tokens=50_000_000, t0=1_000_000,
+                        spacing=8 * 3600):
+    """A weekly-%% history whose movement is a constant ``ratio`` x baseline.
+
+    Default spacing (8h) makes 24+ intervals span more than a week, so the
+    stability lane's wall-clock requirement is satisfied; a burst test passes
+    a tighter spacing explicitly."""
     opus = pc.baseline_weight_fresh("claude-opus-4-8")
     move = ratio * (tokens / 1_000_000.0 * opus)
     pct = 0.0
     _record_7d(service, captured=float(t0), pct=pct, index=0)
     for i in range(intervals):
         _record_usage(service, client="claude-code", model="claude-opus-4-8",
-                      session_id=f"s{i}", tokens=tokens, updated_at=t0 + i * 3600 + 1800,
+                      session_id=f"s{i}", tokens=tokens, updated_at=t0 + i * spacing + spacing // 2,
                       cost=1.0)
         pct += move
-        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
-    return float(t0 + (intervals + 1) * 3600)
+        _record_7d(service, captured=float(t0 + (i + 1) * spacing), pct=pct, index=i + 1)
+    return float(t0 + (intervals + 1) * spacing)
 
 
 def test_stability_accepts_persistent_out_of_band_fit(tmp_path):
@@ -449,17 +454,18 @@ def test_stability_rejects_a_drifting_out_of_band_fit(tmp_path):
     opus = pc.baseline_weight_fresh("claude-opus-4-8")
     tokens = 50_000_000
     n = pc._STABILITY_MIN_INTERVALS + 2
+    spacing = 8 * 3600
     pct = 0.0
     _record_7d(service, captured=float(t0), pct=pct, index=0)
     for i in range(n):
         ratio = 2.0 if i < n // 2 else 7.0
         _record_usage(service, client="claude-code", model="claude-opus-4-8",
-                      session_id=f"s{i}", tokens=tokens, updated_at=t0 + i * 3600 + 1800,
+                      session_id=f"s{i}", tokens=tokens, updated_at=t0 + i * spacing + spacing // 2,
                       cost=1.0)
         pct += ratio * (tokens / 1_000_000.0 * opus)
-        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+        _record_7d(service, captured=float(t0 + (i + 1) * spacing), pct=pct, index=i + 1)
     weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
-                                        now=float(t0 + (n + 1) * 3600))
+                                        now=float(t0 + (n + 1) * spacing))
     assert weights.confidence == "baseline"
     assert weights.scale == 1.0
 
@@ -483,6 +489,20 @@ def test_stability_needs_more_than_the_minimum_interval_floor(tmp_path):
 
     service = SentinelService(tmp_path)
     now = _consistent_history(service, ratio=4.0, intervals=6)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code", now=now)
+    assert weights.confidence == "baseline"
+    assert weights.scale == 1.0
+
+
+def test_stability_rejects_a_single_burst_day(tmp_path):
+    """24+ hourly readings from ONE heavy day are numerically stable but span
+    far less than the required wall clock — a burst must never self-certify
+    (its "halves" are just the morning and afternoon of the same anomaly)."""
+
+    service = SentinelService(tmp_path)
+    now = _consistent_history(service, ratio=4.0,
+                              intervals=pc._STABILITY_MIN_INTERVALS + 2,
+                              spacing=3600)
     weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code", now=now)
     assert weights.confidence == "baseline"
     assert weights.scale == 1.0

--- a/tests/test_plan_cost.py
+++ b/tests/test_plan_cost.py
@@ -403,3 +403,86 @@ def test_session_plan_pcts():
     assert abs(pcts["s1"] - (100 * 0.01 + 10 * 0.10)) < 1e-9  # 1.0 + 1.0 = 2.0
     assert abs(pcts["s2"] - 0.5) < 1e-9                       # 50M fresh × 0.01
     assert abs(pcts["s4"] - 0.5) < 1e-9                       # 100M reads × 0.01 × α=0.5
+
+
+# ---------------------------------------------------------------------------
+# stability acceptance for out-of-band fits
+# ---------------------------------------------------------------------------
+
+
+def _consistent_history(service, *, ratio, intervals, tokens=50_000_000, t0=1_000_000):
+    """A weekly-%% history whose movement is a constant ``ratio`` x baseline."""
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
+    move = ratio * (tokens / 1_000_000.0 * opus)
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(intervals):
+        _record_usage(service, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"s{i}", tokens=tokens, updated_at=t0 + i * 3600 + 1800,
+                      cost=1.0)
+        pct += move
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    return float(t0 + (intervals + 1) * 3600)
+
+
+def test_stability_accepts_persistent_out_of_band_fit(tmp_path):
+    """The trusted band alone turned an out-of-band account into 'calibrating
+    forever' (the live failure: raw fit x2.74 vs band cap 2.5, re-rejected on
+    133 clean intervals). A fit outside the band is now accepted when the
+    interval count is high and both chronological halves independently agree."""
+
+    service = SentinelService(tmp_path)
+    now = _consistent_history(service, ratio=4.0, intervals=pc._STABILITY_MIN_INTERVALS + 2)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code", now=now)
+    assert weights.confidence == "calibrated"
+    assert abs(weights.scale - 4.0) < 0.4
+    assert "split-half stability" in weights.basis
+
+
+def test_stability_rejects_a_drifting_out_of_band_fit(tmp_path):
+    """Halves that disagree (the ratio drifted 2x -> 7x mid-window) must NOT be
+    stability-accepted: a moving ratio is noise or a regime change, not an
+    account property."""
+
+    service = SentinelService(tmp_path)
+    t0 = 1_000_000
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
+    tokens = 50_000_000
+    n = pc._STABILITY_MIN_INTERVALS + 2
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(n):
+        ratio = 2.0 if i < n // 2 else 7.0
+        _record_usage(service, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"s{i}", tokens=tokens, updated_at=t0 + i * 3600 + 1800,
+                      cost=1.0)
+        pct += ratio * (tokens / 1_000_000.0 * opus)
+        _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, index=i + 1)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code",
+                                        now=float(t0 + (n + 1) * 3600))
+    assert weights.confidence == "baseline"
+    assert weights.scale == 1.0
+
+
+def test_stability_rejects_beyond_the_hard_ceiling(tmp_path):
+    """No amount of stability makes a fit beyond the hard ceiling credible."""
+
+    service = SentinelService(tmp_path)
+    ceiling_ratio = pc._STABILITY_HARD_BAND[1] * 1.5
+    now = _consistent_history(service, ratio=ceiling_ratio,
+                              intervals=pc._STABILITY_MIN_INTERVALS + 2,
+                              tokens=20_000_000)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code", now=now)
+    assert weights.confidence == "baseline"
+
+
+def test_stability_needs_more_than_the_minimum_interval_floor(tmp_path):
+    """A stable-looking out-of-band fit on only a handful of intervals stays
+    baseline — the stability lane requires an order more evidence than the
+    in-band floor of 3."""
+
+    service = SentinelService(tmp_path)
+    now = _consistent_history(service, ratio=4.0, intervals=6)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code", now=now)
+    assert weights.confidence == "baseline"
+    assert weights.scale == 1.0

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -528,3 +528,92 @@ def test_calibrated_store_serves_matching_plan_share_on_rows_and_receipts(tmp_pa
     task_id = rows[0]["task_id"]
     receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
     assert receipt["dimensions"]["cost"]["plan_share"] == share
+
+
+def test_stability_accepted_store_serves_shares_end_to_end(tmp_path: Path) -> None:
+    """A persistent OUT-OF-BAND account (the live failure shape) must calibrate
+    through the stability lane and serve task shares on the wire."""
+
+    from agentacct import plan_cost as pc
+    import time as _time
+
+    service = SentinelService(tmp_path)
+    spacing = 8 * 3600
+    n = pc._STABILITY_MIN_INTERVALS + 2
+    t0 = _time.time() - (n + 2) * spacing  # ~9 days back, inside the 21-day window
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
+    ratio = 4.0  # outside the trusted band (2.5), inside the stability ceiling
+    pct = 0.0
+    _record_7d_reading(service, captured=t0, pct=pct, index=0)
+    for i in range(n):
+        _record_bulk_usage(service, session_id=f"cal{i}",
+                           at=t0 + i * spacing + spacing // 2, tokens=20_000_000)
+        pct += ratio * (20.0 * opus)
+        _record_7d_reading(service, captured=t0 + (i + 1) * spacing, pct=pct, index=i + 1)
+
+    client = _app(tmp_path)
+    plan = client.get("/v1/plan?days=7", headers=_auth()).json()
+    cc = next(entry for entry in plan["clients"] if entry["client"] == "claude-code")
+    assert cc["calibration_state"] == "calibrated"
+    assert "split-half stability" in cc["basis"]
+    assert "untracked" in cc["basis"]  # the blind spot stays disclosed
+
+    rows = client.get("/v1/tasks", headers=_auth()).json()["tasks"]
+    share = rows[0]["cost"]["plan_share"]
+    assert share["calibration_state"] == "calibrated"
+    assert share["pct"] is not None and share["pct"] > 0
+
+
+def test_plan_share_stamp_is_client_scoped_and_names_never_for_plan_less_clients(
+    tmp_path: Path,
+) -> None:
+    """Unit contract of the stamp: only the labelled client's members may
+    contribute to the sum (a cross-client continuation must not mix plans),
+    and a client outside the plan lane reads 'never', not null."""
+
+    from agentacct.api import _stamp_task_plan_shares
+    from agentacct import plan_cost as pc
+    import time as _time
+
+    service = SentinelService(tmp_path)
+    t0 = _time.time() - 30 * 3600
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
+    pct = 1.0
+    _record_7d_reading(service, captured=t0, pct=pct, index=0)
+    for i in range(4):
+        _record_bulk_usage(service, session_id=f"cal{i}",
+                           at=t0 + i * 3600 + 1800, tokens=50_000_000)
+        pct += 50.0 * opus
+        _record_7d_reading(service, captured=t0 + (i + 1) * 3600, pct=pct, index=i + 1)
+    events = service.list_all_events()
+
+    projection = {
+        "tasks": [
+            {  # codex-primary task with a claude-code member: cc pct must NOT
+               # be summed under the codex label.
+                "primary_root": {"client": "codex", "client_session_id": "cx1"},
+                "session_keys": [
+                    {"client": "codex", "client_session_id": "cx1"},
+                    {"client": "claude-code", "client_session_id": "cal0"},
+                ],
+            },
+            {  # plan-less client: state must read "never", not null.
+                "primary_root": {"client": "hermes", "client_session_id": "h1"},
+                "session_keys": [{"client": "hermes", "client_session_id": "h1"}],
+            },
+            {  # the calibrated client still sums its own members.
+                "primary_root": {"client": "claude-code", "client_session_id": "cal1"},
+                "session_keys": [
+                    {"client": "claude-code", "client_session_id": "cal1"},
+                    {"client": "codex", "client_session_id": "cx9"},
+                ],
+            },
+        ]
+    }
+    _stamp_task_plan_shares(projection, events)
+    cross, hermes, cc = (task["plan_share"] for task in projection["tasks"])
+    assert cross["pct"] is None and cross["client"] == "codex"
+    assert cross["calibration_state"] == "never"
+    assert hermes["pct"] is None and hermes["calibration_state"] == "never"
+    assert cc["pct"] is not None and cc["pct"] > 0
+    assert cc["covered_sessions"] == 1  # the codex member never counted

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -422,3 +422,109 @@ def test_proxy_usage_events_are_order_invariant() -> None:
 
     assert build_proxy_usage_events(ascending) == build_proxy_usage_events(descending)
     assert build_proxy_usage_events(cost_events) == build_proxy_usage_events(ascending)
+
+
+# ---------------------------------------------------------------------------
+# weekly-plan share on task rows and receipts
+# ---------------------------------------------------------------------------
+
+
+def _record_7d_reading(service: SentinelService, *, captured: float, pct: float, index: int) -> None:
+    service.record_event(
+        {
+            "event_id": f"evt_rl_cal_{index}",
+            "created_at": captured,
+            "source": "claude-code",
+            "event_type": "rate_limit_observed",
+            "metadata": {
+                "client": "claude-code",
+                "captured_at": captured,
+                "windows": [{"kind": "7d", "window_minutes": 10080, "used_percent": pct}],
+            },
+        }
+    )
+
+
+def _record_bulk_usage(service: SentinelService, *, session_id: str, at: float, tokens: int) -> None:
+    from agentacct.client_usage import ClientUsageEvent
+
+    event = ClientUsageEvent(
+        client="claude-code",
+        client_session_id=session_id,
+        source_path=Path(f"/tmp/claude-code/{session_id}.jsonl"),
+        title=None,
+        cwd="/tmp/project",
+        model="claude-opus-4-8",
+        input_tokens=tokens,
+        output_tokens=0,
+        cached_input_tokens=0,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_tokens_reported=True,
+        cache_read_tokens_reported=True,
+        reasoning_output_tokens=0,
+        provider_name="claude-code",
+        started_at=at,
+        updated_at=at,
+        turn_count=1,
+        usage_row_lane="model:claude-opus-4-8",
+        source_namespace_fingerprint=NS,
+        input_tokens_reported=True,
+        output_tokens_reported=True,
+        reasoning_output_tokens_reported=True,
+        total_tokens=tokens,
+        total_tokens_reported=True,
+    ).to_sentinel_event()
+    event["estimated_cost_usd"] = 1.0
+    event["cost_confidence"] = "estimated_from_tokens"
+    service.record_event(event, trusted_usage_import=True)
+
+
+def test_uncalibrated_store_serves_null_plan_share_with_state(tmp_path: Path) -> None:
+    """Calibrated-or-nothing on the wire: without 7-day history the share is
+    null (never 0) and the calibration state says why."""
+
+    service = SentinelService(tmp_path)
+    import time as _time
+
+    _record_bulk_usage(service, session_id="s1", at=_time.time() - 3600, tokens=1_000_000)
+    client = _app(tmp_path)
+    rows = client.get("/v1/tasks", headers=_auth()).json()["tasks"]
+    assert rows
+    share = rows[0]["cost"]["plan_share"]
+    assert share["pct"] is None
+    assert share["calibration_state"] == "calibrating"
+    assert share["client"] == "claude-code"
+    assert share["session_count"] >= 1
+
+
+def test_calibrated_store_serves_matching_plan_share_on_rows_and_receipts(tmp_path: Path) -> None:
+    """With enough in-band 7-day history the task rows carry a positive weekly
+    share, and the detail receipt carries the SAME stamp (one computation)."""
+
+    from agentacct import plan_cost as pc
+    import time as _time
+
+    service = SentinelService(tmp_path)
+    t0 = _time.time() - 30 * 3600  # inside the 21-day calibration window
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
+    pct = 1.0
+    _record_7d_reading(service, captured=t0, pct=pct, index=0)
+    for i in range(4):
+        _record_bulk_usage(
+            service, session_id=f"cal{i}", at=t0 + i * 3600 + 1800, tokens=50_000_000
+        )
+        pct += 50.0 * opus  # meter moves exactly what the baseline predicts (scale ~1)
+        _record_7d_reading(service, captured=t0 + (i + 1) * 3600, pct=pct, index=i + 1)
+
+    client = _app(tmp_path)
+    rows = client.get("/v1/tasks", headers=_auth()).json()["tasks"]
+    assert rows
+    share = rows[0]["cost"]["plan_share"]
+    assert share["calibration_state"] == "calibrated"
+    assert share["pct"] is not None and share["pct"] > 0
+    assert share["covered_sessions"] >= 1
+
+    task_id = rows[0]["task_id"]
+    receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
+    assert receipt["dimensions"]["cost"]["plan_share"] == share


### PR DESCRIPTION
Third of six PRs from the 2026-08-27 receipt-UI feedback round: **fix the permanently-stuck plan calibration** (feedback #8a) and **put the weekly-plan share on receipts** (feedback #2/#3).

## The calibration fix

The live account's fit (x2.87–2.89 across ~129 clean intervals, split halves agreeing within ~12%) sat just past the trusted band's 2.5 cap, so every recompute re-rejected it — "calibrating" was in fact "rejected forever", and the entire plan-% feature was dark on this machine since installation.

An out-of-band fit is now **accepted** when the evidence is overwhelming and internally consistent, all of:
- ≥ 24 clean intervals (vs the in-band floor of 3),
- the fit window spans **a week+ of wall clock**, split at its **time midpoint**, ≥ 6 intervals in each half — a single heavy day minting 24 readings can never self-certify,
- each time-half's independent fit within 35% of the full fit,
- the fit inside a hard ceiling (0.2–8.0); beyond it the state honestly reads as terminal ("will not calibrate at this ratio"), not "calibrating" forever.

The known blind spot is disclosed, not denied: the per-interval tracked-tokens gate excludes only fully-untracked intervals, so the basis states the accepted scale maps tracked tokens to the **account-wide** meter and "may include usage from untracked Claude surfaces".

## Weekly share on receipts

- The v1 task projection stamps every task with `plan_share`: the sum of its member sessions' calibrated per-session weekly percentages (raw values, counted once, **client-scoped** — a cross-client continuation never mixes plans), the client, its calibration state (plan-less clients read `never`, not null), and covered/total session counts. Calibrated-or-nothing: `pct` is null with the state naming why — never a fabricated 0.
- Receipt summary rows and the receipt cost dimension carry the same stamp; the CLI/TUI store projection gets it too, so no surface can disagree.
- App: cost dimension reads `≈X% of weekly plan` beside the dollars (unpriced tasks included), the summary strip qualifier appends `≈X% wkly`, rail rows show the compact share right-aligned with a hover sentence, and the table cost cell explains itself on hover.

## Verified live (copy of the real store through a temp daemon on this branch)

- claude-code flips to **calibrated**: "two-component fit x2.89 … (128 recent weekly-% intervals); outside the usual band, accepted on split-half stability (may include usage from untracked Claude surfaces)".
- Task rows carry real shares (e.g. yesterday's brand-site session ≈22.4% of the weekly plan); codex tasks honestly serve `pct: null, state: never`.
- Renders eyeballed: cost line, summary strip, rail (client truncates first; the share stays whole).

## Verification

- `pytest -q`: 2621 passed (9 new: stability accept/drift/burst/ceiling/floor, API end-to-end for both in-band and stability-accepted stores, client-scoped stamp unit contract).
- `swift test`: 33 passed (1 skipped: canonical-renderer visual verify). Dashboard baselines untouched.
- Adversarial review (3 lenses + refutation): 3 must-fix + 6 minor, all addressed — including the time-split/burst hole, the untracked-usage disclosure, and the cross-client stamp scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
