### PR TITLE
feat(receipt): user resolve lane for findings and blockers

### DIFF
--- a/apps/agentacct/Sources/agentacct/DashboardPane.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardPane.swift
@@ -54,13 +54,19 @@ struct DashboardWorkItem: Identifiable {
     /// A superseded finding's failed check belongs to the finding that
     /// superseded it — it never resurfaces as needing review (keeps this
     /// predicate agreeing with the Work tab's Attention bucket).
+    /// Keys whose failed checks no longer demand review: a later same-scope
+    /// pass superseded them, or a human explicitly resolved the finding.
+    private static let settledFindingKeys: Set<String> = [
+        "finding_superseded", "finding_resolved_by_user",
+    ]
+
     var needsReview: Bool {
-        (failedChecks > 0 && outcomeKey != "finding_superseded")
+        (failedChecks > 0 && !Self.settledFindingKeys.contains(outcomeKey))
             || ["finding", "failed", "blocked"].contains(outcomeKey)
     }
 
     var hasFinding: Bool {
-        (failedChecks > 0 && outcomeKey != "finding_superseded")
+        (failedChecks > 0 && !Self.settledFindingKeys.contains(outcomeKey))
             || ["finding", "failed"].contains(outcomeKey)
     }
 

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -124,14 +124,23 @@ final class DashboardStore: ObservableObject {
 
     /// One Task's full Receipt. 404 (task unknown / recorded elsewhere) is a
     /// first-class message; a CANCELLED fetch (the user picked another Task)
-    /// writes nothing so a late error can't mask the fresh receipt.
+    /// writes nothing so a late error can't mask the fresh receipt. A
+    /// generation token guards against UNCANCELLED racers too (a disposition
+    /// post's refresh runs in its own unstructured Task): only the newest
+    /// fetch may write, so a late straggler can never wedge another task's
+    /// page. A same-task refresh keeps the current receipt on screen instead
+    /// of unmounting the record page for the rebuild.
+    private var receiptGeneration = 0
+
     func fetchReceipt(taskId: String) async {
-        receipt = nil
+        receiptGeneration += 1
+        let generation = receiptGeneration
+        if receipt?.taskId != taskId { receipt = nil }
         receiptError = nil
         do {
             let encoded = taskId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? taskId
             let payload: Receipt = try await client.getAuthed("/v1/receipt?task=\(encoded)")
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, generation == receiptGeneration else { return }
             receipt = payload
             receiptError = nil
         } catch is CancellationError {
@@ -139,10 +148,10 @@ final class DashboardStore: ObservableObject {
         } catch let error as URLError where error.code == .cancelled {
             return
         } catch GlanceClientError.http(404) {
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, generation == receiptGeneration else { return }
             receiptError = "this Task is not in the store (it may have been recorded elsewhere)"
         } catch {
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, generation == receiptGeneration else { return }
             receiptError = "receipt fetch failed: \(error.localizedDescription)"
         }
     }
@@ -174,10 +183,27 @@ final class DashboardStore: ObservableObject {
             "action": action,
             "expected_revision": expectedRevision,
         ]
-        if let note, !note.isEmpty { body["note"] = note }
+        // The server rejects control characters and >1200 chars in a note;
+        // normalize what a paste can legally contain instead of bouncing the
+        // user off a 409 for invisible newlines.
+        let normalizedNote = note?
+            .components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+            .prefix(1200)
+        if let normalizedNote, !normalizedNote.isEmpty { body["note"] = String(normalizedNote) }
         if let targetDigest { body["target_digest"] = targetDigest }
         if let blockedEventId { body["blocked_event_id"] = blockedEventId }
-        let _: DispositionResponse = try await client.postAuthed("/v1/disposition", body: body)
+        do {
+            let _: DispositionResponse = try await client.postAuthed("/v1/disposition", body: body)
+        } catch {
+            // A conflict means the state moved under us — refresh so the
+            // controls re-render with the CURRENT revision instead of
+            // re-offering the stale one forever, then surface the error.
+            if let refreshTaskId { await fetchReceipt(taskId: refreshTaskId) }
+            await fetchReceipts()
+            throw error
+        }
         if let refreshTaskId {
             await fetchReceipt(taskId: refreshTaskId)
         }

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -157,6 +157,33 @@ final class DashboardStore: ObservableObject {
         )
     }
 
+    /// Record one human attention disposition (finding or blocker) and refresh
+    /// the open receipt so the new state is what the user sees next. Throws
+    /// with the daemon's own conflict/not-found detail on failure.
+    func postDisposition(
+        kind: String,
+        action: String,
+        expectedRevision: Int,
+        note: String?,
+        targetDigest: String? = nil,
+        blockedEventId: String? = nil,
+        refreshTaskId: String? = nil
+    ) async throws {
+        var body: [String: Any] = [
+            "kind": kind,
+            "action": action,
+            "expected_revision": expectedRevision,
+        ]
+        if let note, !note.isEmpty { body["note"] = note }
+        if let targetDigest { body["target_digest"] = targetDigest }
+        if let blockedEventId { body["blocked_event_id"] = blockedEventId }
+        let _: DispositionResponse = try await client.postAuthed("/v1/disposition", body: body)
+        if let refreshTaskId {
+            await fetchReceipt(taskId: refreshTaskId)
+        }
+        await fetchReceipts()
+    }
+
     /// Preload one session's deep view into `preloadedSessions` (snapshot support).
     func preloadSession(client clientName: String, sessionId: String) async {
         if let detail = try? await loadSession(client: clientName, sessionId: sessionId) {
@@ -187,6 +214,13 @@ final class DashboardStore: ObservableObject {
             errorText = "usage range fetch failed: \(error.localizedDescription)"
         }
     }
+}
+
+/// The POST /v1/disposition acknowledgement: the chain's new state.
+struct DispositionResponse: Decodable {
+    let ok: Bool?
+    let state: String?
+    let revision: Int?
 }
 
 /// The menu bar → main window selection channel.

--- a/apps/agentacct/Sources/agentacct/GlanceClient.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceClient.swift
@@ -131,6 +131,44 @@ final class GlanceClient {
         return try JSONDecoder().decode(T.self, from: data)
     }
 
+    /// The bearer-gated /v1 POST lane — the app's first user-originated write
+    /// (dispositions). JSON in, JSON out; a non-2xx status surfaces the
+    /// daemon's own detail message so honesty copy ("blocker changed…")
+    /// reaches the user verbatim.
+    func postAuthed<T: Decodable>(_ path: String, body: [String: Any]) async throws -> T {
+        let discovery = try loadDiscovery()
+        let host = discovery.host ?? "127.0.0.1"
+        guard let url = URL(string: "http://\(host):\(discovery.port)\(path)") else {
+            throw GlanceClientError.transport("bad daemon URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(discovery.token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw GlanceClientError.transport(error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw GlanceClientError.transport("not an HTTP response")
+        }
+        guard http.statusCode == 200 else {
+            if let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let detail = payload["detail"] as? String {
+                throw GlanceClientError.transport(detail)
+            }
+            throw GlanceClientError.http(http.statusCode)
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw GlanceClientError.transport("payload decode failed: \(error.localizedDescription)")
+        }
+    }
+
     private func get<T: Decodable>(_ path: String, discovery: Discovery) async throws -> T {
         let host = discovery.host ?? "127.0.0.1"
         guard let url = URL(string: "http://\(host):\(discovery.port)\(path)") else {

--- a/apps/agentacct/Sources/agentacct/GlanceClient.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceClient.swift
@@ -37,6 +37,14 @@ enum GlanceClientError: Error, CustomStringConvertible {
     }
 }
 
+// Without LocalizedError, `error.localizedDescription` renders the generic
+// Cocoa "couldn't be completed" — hiding the daemon's own conflict copy that
+// postAuthed extracts verbatim. This conformance is what lets a 409's
+// "blocker changed…" actually reach the user.
+extension GlanceClientError: LocalizedError {
+    var errorDescription: String? { description }
+}
+
 struct GlanceSnapshot {
     let glance: Glance
     let daemonVersion: String
@@ -136,7 +144,18 @@ final class GlanceClient {
     /// daemon's own detail message so honesty copy ("blocker changed…")
     /// reaches the user verbatim.
     func postAuthed<T: Decodable>(_ path: String, body: [String: Any]) async throws -> T {
-        let discovery = try loadDiscovery()
+        do {
+            return try await postOnce(path, body: body, discovery: loadDiscovery())
+        } catch GlanceClientError.http(401) {
+            // Same reader contract as every GET: the daemon restarted with a
+            // fresh per-boot token — re-read the discovery file and retry once.
+            return try await postOnce(path, body: body, discovery: loadDiscovery())
+        }
+    }
+
+    private func postOnce<T: Decodable>(
+        _ path: String, body: [String: Any], discovery: Discovery
+    ) async throws -> T {
         let host = discovery.host ?? "127.0.0.1"
         guard let url = URL(string: "http://\(host):\(discovery.port)\(path)") else {
             throw GlanceClientError.transport("bad daemon URL")

--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -549,6 +549,116 @@ private struct ActionListDisclosure: View {
     }
 }
 
+// MARK: - Disposition controls
+
+/// The human attention controls for one finding or blocker: Mark reviewed,
+/// Resolve… (note REQUIRED — recorded as your assertion, never machine
+/// verification), Reopen. Posts the append-only disposition through the
+/// daemon and surfaces its own conflict copy verbatim ("blocker changed…"),
+/// so optimistic-concurrency refusals read as facts, not mystery failures.
+struct DispositionControls: View {
+    let kind: String
+    let state: String
+    let revision: Int
+    let taskId: String
+    var targetDigest: String? = nil
+    var blockedEventId: String? = nil
+    @EnvironmentObject var dashboard: DashboardStore
+    @State private var resolvePopoverShown = false
+    @State private var note = ""
+    @State private var busy = false
+    @State private var errorText: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: Space.s) {
+                if busy {
+                    ProgressView().controlSize(.small)
+                } else {
+                    if state == "open" {
+                        actionButton("Mark reviewed") { post("mark_reviewed", note: nil) }
+                    }
+                    if state != "resolved" {
+                        Button {
+                            resolvePopoverShown = true
+                        } label: {
+                            Text("Resolve…").font(Type.captionSemibold).foregroundStyle(Theme.accent)
+                        }
+                        .buttonStyle(QuietButtonStyle())
+                        .accessibilityIdentifier("disposition.resolve.\(kind)")
+                        .popover(isPresented: $resolvePopoverShown, arrowEdge: .bottom) {
+                            resolveSheet
+                        }
+                    }
+                    if state != "open" {
+                        actionButton("Reopen") { post("reopen", note: nil) }
+                    }
+                }
+            }
+            if let errorText {
+                Text(verbatim: errorText)
+                    .font(Type.dataSmall).foregroundStyle(Theme.coral)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func actionButton(_ label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label).font(Type.captionSemibold).foregroundStyle(Theme.accent)
+        }
+        .buttonStyle(QuietButtonStyle())
+        .accessibilityIdentifier("disposition.\(label.lowercased().replacingOccurrences(of: " ", with: "-")).\(kind)")
+    }
+
+    private var resolveSheet: some View {
+        VStack(alignment: .leading, spacing: Space.s) {
+            CapsLabel(text: "Resolve \(kind)")
+            Text("Say what resolved it — recorded as your assertion, never machine verification.")
+                .font(Type.caption).foregroundStyle(Theme.muted)
+                .fixedSize(horizontal: false, vertical: true)
+            TextField("e.g. fixed by hand in a later commit", text: $note, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .font(Type.body)
+                .lineLimit(2...4)
+                .frame(width: 300)
+            HStack {
+                Spacer()
+                Button {
+                    resolvePopoverShown = false
+                    post("resolve", note: note)
+                } label: {
+                    Text("Record resolve").font(Type.captionSemibold)
+                }
+                .disabled(note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityIdentifier("disposition.record-resolve.\(kind)")
+            }
+        }
+        .padding(Space.l)
+    }
+
+    private func post(_ action: String, note: String?) {
+        busy = true
+        errorText = nil
+        Task {
+            do {
+                try await dashboard.postDisposition(
+                    kind: kind,
+                    action: action,
+                    expectedRevision: revision,
+                    note: note,
+                    targetDigest: targetDigest,
+                    blockedEventId: blockedEventId,
+                    refreshTaskId: taskId
+                )
+            } catch {
+                errorText = error.localizedDescription
+            }
+            busy = false
+        }
+    }
+}
+
 // MARK: - Blocker callout
 
 /// WHY a Task is blocked, in the agent's own words, right under the headline —
@@ -557,6 +667,7 @@ private struct ActionListDisclosure: View {
 /// later steps completed after it (never re-grading the sticky blocked word).
 struct BlockerCallout: View {
     let blocker: ReceiptBlocker
+    let taskId: String
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -604,6 +715,23 @@ struct BlockerCallout: View {
                 // step in this count even when its latest status moved on.
                 Text("+\(count - 1) more step\(count == 2 ? "" : "s") with recorded blockers in Sessions & steps below")
                     .font(Type.dataSmall).foregroundStyle(Theme.muted)
+            }
+            if let state = blocker.disposition?.state, state != "open" {
+                Text(verbatim: "marked \(state) by you"
+                     + (blocker.disposition?.note.map { " — \($0)" } ?? ""))
+                    .font(Type.dataSmall).foregroundStyle(Theme.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            // Resolve/review this exact blocker. Snapshots skip the controls
+            // (the offscreen renderer cannot drive popovers or POSTs).
+            if !SnapshotMode.enabled, let blockedEventId = blocker.blockedEventId {
+                DispositionControls(
+                    kind: "blocker",
+                    state: blocker.disposition?.state ?? "open",
+                    revision: blocker.dispositionRevision ?? 0,
+                    taskId: taskId,
+                    blockedEventId: blockedEventId
+                )
             }
         }
         .padding(Space.l)
@@ -693,6 +821,7 @@ struct RecordCoverageCard: View {
 /// an agent-reported pass stays ink — the source chip says why.
 struct RecordChecksCard: View {
     let evidence: ReceiptEvidenceDim
+    let taskId: String
 
     var body: some View {
         Card(padding: Space.xl) {
@@ -718,7 +847,7 @@ struct RecordChecksCard: View {
                         if index > 0 {
                             Rectangle().fill(Theme.hairline).frame(height: 1)
                         }
-                        RecordCheckRow(check: check)
+                        RecordCheckRow(check: check, taskId: taskId)
                     }
                 }
             }
@@ -732,6 +861,7 @@ struct RecordChecksCard: View {
 /// the plain one-liner: the offscreen renderer can't drive the toggle.
 private struct RecordCheckRow: View {
     let check: ReceiptCheck
+    let taskId: String
     @State private var expanded = false
 
     private var mark: (symbol: String, tint: Color) {
@@ -845,6 +975,25 @@ private struct RecordCheckRow: View {
                check.commandRedacted != true, check.artifactUrl == nil, check.artifactRef == nil {
                 Text("no further detail recorded for this check")
                     .font(Type.dataSmall).foregroundStyle(Theme.muted)
+            }
+            // A surfaced failing check carries its human attention handle:
+            // review/resolve it here instead of leaving the red forever.
+            if let finding = check.finding {
+                if let state = finding.state, state != "open" {
+                    Text(verbatim: "marked \(state) by you"
+                         + (finding.note.map { " — \($0)" } ?? ""))
+                        .font(Type.dataSmall).foregroundStyle(Theme.muted)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if !SnapshotMode.enabled, let digest = finding.targetDigest {
+                    DispositionControls(
+                        kind: "finding",
+                        state: finding.state ?? "open",
+                        revision: finding.revision ?? 0,
+                        taskId: taskId,
+                        targetDigest: digest
+                    )
+                }
             }
         }
     }

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -479,7 +479,7 @@ enum DecisionTintClass {
         case "blocked", "failed", "finding": return .danger
         case "in_progress", "started", "checkpoint": return .accent
         case "reported", "resolved", "mostly_done", "handed_off", "finding_superseded",
-             "finding_resolved_by_user":
+             "finding_resolved_by_user", "blocker_resolved_by_user":
             return .claimed
         case "ended_open": return .inferredStop
         case "verified": return .verified

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -478,7 +478,8 @@ enum DecisionTintClass {
         switch key {
         case "blocked", "failed", "finding": return .danger
         case "in_progress", "started", "checkpoint": return .accent
-        case "reported", "resolved", "mostly_done", "handed_off", "finding_superseded":
+        case "reported", "resolved", "mostly_done", "handed_off", "finding_superseded",
+             "finding_resolved_by_user":
             return .claimed
         case "ended_open": return .inferredStop
         case "verified": return .verified

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -507,7 +507,8 @@ struct ReceiptDecision: Decodable {
 }
 
 /// Why a Task reads blocked: the newest agent-recorded blocker (preferring the
-/// newest one that carries text), plus the staleness facts beside it.
+/// newest one that carries text), plus the staleness facts beside it — and the
+/// write handle for a human disposition on that exact blocker.
 struct ReceiptBlocker: Decodable {
     let stepTitle: String?
     let sectionId: String?
@@ -516,15 +517,52 @@ struct ReceiptBlocker: Decodable {
     let updatedAt: Double?
     let blockedStepCount: Int?
     let laterCompletedSteps: Int?
+    // Disposition write handle: the exact blocked event + the optimistic
+    // revision a POST /v1/disposition must echo.
+    let blockedEventId: String?
+    let dispositionRevision: Int?
+    let disposition: ReceiptDispositionState?
 
     enum CodingKeys: String, CodingKey {
-        case text
+        case text, disposition
         case stepTitle = "step_title"
         case sectionId = "section_id"
         case nextStep = "next_step"
         case updatedAt = "updated_at"
         case blockedStepCount = "blocked_step_count"
         case laterCompletedSteps = "later_completed_steps"
+        case blockedEventId = "blocked_event_id"
+        case dispositionRevision = "disposition_revision"
+    }
+}
+
+/// One human attention disposition (finding or blocker): append-only chain
+/// state served by the daemon. Never machine verification.
+struct ReceiptDispositionState: Decodable {
+    let state: String?
+    let revision: Int?
+    let note: String?
+    let updatedAt: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case state, revision, note
+        case updatedAt = "updated_at"
+    }
+}
+
+/// The disposition handle a failing check row carries when it is a surfaced
+/// finding episode of this store.
+struct ReceiptCheckFinding: Decodable {
+    let targetDigest: String?
+    let state: String?
+    let revision: Int?
+    let attentionOpen: Bool?
+    let note: String?
+
+    enum CodingKeys: String, CodingKey {
+        case state, revision, note
+        case targetDigest = "target_digest"
+        case attentionOpen = "attention_open"
     }
 }
 
@@ -860,11 +898,14 @@ struct ReceiptCheck: Decodable, Identifiable {
     let commandRedacted: Bool?
     let artifactRef: String?
     let artifactUrl: String?
+    // Present only on a failing check that is a surfaced finding episode —
+    // the handle the disposition controls post with.
+    let finding: ReceiptCheckFinding?
 
     var id: String { "\(name ?? "check")-\(result ?? "")-\(exitCode ?? 0)" }
 
     enum CodingKeys: String, CodingKey {
-        case kind, name, result, scope, source, superseded, at, summary, files
+        case kind, name, result, scope, source, superseded, at, summary, files, finding
         case exitCode = "exit_code"
         case commandRedacted = "command_redacted"
         case artifactRef = "artifact_ref"

--- a/apps/agentacct/Sources/agentacct/WorkPane.swift
+++ b/apps/agentacct/Sources/agentacct/WorkPane.swift
@@ -53,7 +53,7 @@ enum WorkGroup: String, CaseIterable, Identifiable {
         case "finding", "failed", "blocked": return .attention
         case "verified": return .verified
         case "reported", "resolved", "mostly_done", "finding_superseded",
-             "finding_resolved_by_user":
+             "finding_resolved_by_user", "blocker_resolved_by_user":
             return .reported
         case "in_progress", "started", "checkpoint": return .inProgress
         case "observed": return .observed
@@ -128,6 +128,8 @@ enum DecisionLegend {
               definition: "Steps finished, some still open — later work moved elsewhere."),
         .init(key: "handed_off", label: "Handed off",
               definition: "The agent deliberately stopped and passed the work on."),
+        .init(key: "blocker_resolved_by_user", label: "Blocker resolved",
+              definition: "You marked the recorded blocker resolved — not a completion claim, not machine verification."),
         .init(key: "finding_resolved_by_user", label: "Finding resolved",
               definition: "You marked the finding resolved; the failing check stays in history — not machine verification."),
         .init(key: "finding_superseded", label: "Finding superseded",

--- a/apps/agentacct/Sources/agentacct/WorkPane.swift
+++ b/apps/agentacct/Sources/agentacct/WorkPane.swift
@@ -52,7 +52,9 @@ enum WorkGroup: String, CaseIterable, Identifiable {
         switch key {
         case "finding", "failed", "blocked": return .attention
         case "verified": return .verified
-        case "reported", "resolved", "mostly_done", "finding_superseded": return .reported
+        case "reported", "resolved", "mostly_done", "finding_superseded",
+             "finding_resolved_by_user":
+            return .reported
         case "in_progress", "started", "checkpoint": return .inProgress
         case "observed": return .observed
         case "handed_off", "ended_open": return .stopped
@@ -126,6 +128,8 @@ enum DecisionLegend {
               definition: "Steps finished, some still open — later work moved elsewhere."),
         .init(key: "handed_off", label: "Handed off",
               definition: "The agent deliberately stopped and passed the work on."),
+        .init(key: "finding_resolved_by_user", label: "Finding resolved",
+              definition: "You marked the finding resolved; the failing check stays in history — not machine verification."),
         .init(key: "finding_superseded", label: "Finding superseded",
               definition: "A check failed, but a later run of the same check passed."),
         .init(key: "ended_open", label: "Ended open",
@@ -897,7 +901,7 @@ struct WorkRecordPage: View {
             // and a coral "blocker" box under a Failed badge would re-merge
             // the two vocabularies the receipt keeps apart.
             if let blocker = receipt.axes.decisionStatus.blocker, blocker.text != nil {
-                BlockerCallout(blocker: blocker)
+                BlockerCallout(blocker: blocker, taskId: receipt.taskId)
                     .padding(.top, Space.xs)
             }
         }
@@ -945,7 +949,7 @@ struct WorkRecordPage: View {
     private var mainColumn: some View {
         VStack(alignment: .leading, spacing: Space.xl) {
             RecordDimensionsCard(receipt: receipt)
-            RecordChecksCard(evidence: receipt.dimensions.evidence)
+            RecordChecksCard(evidence: receipt.dimensions.evidence, taskId: receipt.taskId)
         }
     }
 

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -14,7 +14,7 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
-from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi import Body, FastAPI, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .activation import ActivationStateStore
@@ -63,6 +63,7 @@ from .cost import (
 )
 from .evidence_store import EVIDENCE_STORE_DIRNAME
 from .finding_disposition import (
+    FindingDispositionConflict,
     FindingDispositionNotFound,
     disposition_for_event,
     finding_target_digest,
@@ -2201,7 +2202,82 @@ def _dashboard_task_projection(data: _DashboardPageData) -> dict[str, Any]:
         disposition_events=data.events,
         form_secret=data.task_csrf_token,
     )
+    _apply_blocker_dispositions_to_projection(projection, events=data.events)
     return data.task_identity.decorate_projection(projection) if data.task_identity is not None else projection
+
+
+def _apply_blocker_dispositions_to_projection(
+    projection: Mapping[str, Any], *, events: list[dict[str, Any]]
+) -> None:
+    """Stamp each blocked work item with its human attention disposition.
+
+    Replays the blocker-attention chains (the finding machinery with the
+    blocker event type) and, for every item whose ``current_blocked_event_id``
+    resolves to a raw ledger event, stamps the item with the chain's state:
+
+    * ``blocker_disposition_state`` — open/reviewed/resolved (absent = open);
+    * ``blocker_disposition`` — {state, revision, note, updated_at} for the UI;
+    * ``blocker_target_revision`` — the optimistic-concurrency revision a
+      write must echo.
+
+    Read-time only; the agent's recorded events are never touched. The outcome
+    reducer consumes the stamp so a human-resolved blocker stops forcing the
+    Task's decision word (the machine resolution lane stays separate).
+    """
+
+    from .finding_disposition import (
+        BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+        BLOCKER_DISPOSITION_EVENT_TYPE,
+        finding_target_digest,
+        reduce_finding_dispositions,
+    )
+
+    chains = reduce_finding_dispositions(
+        events,
+        event_type=BLOCKER_DISPOSITION_EVENT_TYPE,
+        authority_scope=BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+    )
+    wanted_ids: set[str] = set()
+    for task in projection.get("tasks", []):
+        if not isinstance(task, Mapping):
+            continue
+        for item in task.get("work_items", []) or []:
+            if isinstance(item, Mapping):
+                blocked_id = str(item.get("current_blocked_event_id") or "")
+                if blocked_id:
+                    wanted_ids.add(blocked_id)
+    if not wanted_ids:
+        return
+    raw_by_id = {
+        str(event.get("event_id") or ""): event
+        for event in events
+        if str(event.get("event_id") or "") in wanted_ids
+    }
+    for task in projection.get("tasks", []):
+        if not isinstance(task, Mapping):
+            continue
+        for item in task.get("work_items", []) or []:
+            if not isinstance(item, dict):
+                continue
+            blocked_id = str(item.get("current_blocked_event_id") or "")
+            raw = raw_by_id.get(blocked_id)
+            if raw is None:
+                continue
+            digest = finding_target_digest(raw)
+            if digest is None:
+                continue
+            state = chains.states.get(digest)
+            revision = state.revision if state is not None else 0
+            item["blocker_target_revision"] = revision
+            if state is None or digest in chains.invalid_targets:
+                continue
+            item["blocker_disposition_state"] = state.state
+            item["blocker_disposition"] = {
+                "state": state.state,
+                "revision": state.revision,
+                "note": state.note,
+                "updated_at": state.updated_at,
+            }
 
 
 # ---------------------------------------------------------------------------
@@ -2973,6 +3049,115 @@ def create_local_api_app(
             title=_task_title(selected),
             latest_store_activity_at=latest_store_activity(tasks),
         )
+
+    @app.post("/v1/disposition")
+    def v1_disposition(
+        request: Request, payload: dict[str, Any] = Body(...)
+    ) -> dict[str, Any]:
+        """Record ONE human attention transition for a surfaced finding or a
+        recorded blocker — the first user-originated write on the /v1 lane.
+
+        Bearer-gated like every /v1 route; the body must echo the optimistic
+        ``expected_revision`` the caller displayed, so a concurrent change is
+        a 409, never a silent overwrite. A resolve REQUIRES a note. The write
+        appends a server-validated disposition event (see finding_disposition)
+        — it never rewrites machine evidence or the agent's recorded events,
+        and the response is the chain's new state, not a re-graded outcome.
+        """
+
+        _require_v1_token(request)
+        kind = str(payload.get("kind") or "").strip()
+        action = str(payload.get("action") or "").strip()
+        raw_note = payload.get("note")
+        note = raw_note.strip() if isinstance(raw_note, str) and raw_note.strip() else None
+        expected_revision = payload.get("expected_revision")
+        if (
+            isinstance(expected_revision, bool)
+            or not isinstance(expected_revision, int)
+            or expected_revision < 0
+        ):
+            raise HTTPException(
+                status_code=400, detail="expected_revision must be a non-negative integer"
+            )
+        idempotency_key = str(payload.get("idempotency_key") or "").strip()
+        try:
+            if kind == "finding":
+                digest = str(payload.get("target_digest") or "").strip()
+                projection = _v1_task_projection()
+                episode = resolve_finding_episode(projection, digest=digest)
+                target = (
+                    episode.get("failure_event")
+                    if isinstance(episode.get("failure_event"), dict)
+                    else None
+                )
+                if target is None:
+                    raise FindingDispositionNotFound("finding target is unavailable")
+                assignment_context = (
+                    episode.get("assignment_context")
+                    if isinstance(episode.get("assignment_context"), dict)
+                    else {}
+                )
+                task_scope = (
+                    assignment_context.get("task_scope")
+                    if isinstance(assignment_context.get("task_scope"), dict)
+                    else None
+                )
+                full_digest = finding_target_digest(target)
+                if not idempotency_key:
+                    idempotency_key = f"v1:finding:{full_digest}:{expected_revision}:{action}"
+                recorded = service.record_finding_disposition(
+                    target_event=target,
+                    action=action,
+                    expected_revision=expected_revision,
+                    note=note,
+                    idempotency_key=idempotency_key,
+                    task_scope=task_scope,
+                    transport="v1",
+                )
+            elif kind == "blocker":
+                blocked_event_id = str(payload.get("blocked_event_id") or "").strip()
+                if not blocked_event_id:
+                    raise HTTPException(status_code=400, detail="blocked_event_id is required")
+                events = service.list_all_events()
+                target = next(
+                    (
+                        event
+                        for event in events
+                        if str(event.get("event_id") or "") == blocked_event_id
+                    ),
+                    None,
+                )
+                if target is None:
+                    raise FindingDispositionNotFound(
+                        "blocker target event is not in this ledger"
+                    )
+                if not idempotency_key:
+                    idempotency_key = f"v1:blocker:{blocked_event_id}:{expected_revision}:{action}"
+                recorded = service.record_blocker_disposition(
+                    target_event=target,
+                    action=action,
+                    expected_revision=expected_revision,
+                    note=note,
+                    idempotency_key=idempotency_key,
+                    transport="v1",
+                )
+            else:
+                raise HTTPException(status_code=400, detail="kind must be finding or blocker")
+        except FindingDispositionNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except FindingDispositionConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        metadata = (
+            recorded.get("metadata") if isinstance(recorded.get("metadata"), Mapping) else {}
+        )
+        return {
+            "ok": True,
+            "kind": kind,
+            "action": action,
+            "state": metadata.get("next_state"),
+            "revision": metadata.get("revision"),
+            "event_id": recorded.get("event_id"),
+        }
 
     @app.get("/v1/ingestion")
     def v1_ingestion(request: Request) -> dict[str, Any]:

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -3080,6 +3080,12 @@ def create_local_api_app(
                 status_code=400, detail="expected_revision must be a non-negative integer"
             )
         idempotency_key = str(payload.get("idempotency_key") or "").strip()
+        # The v1: namespace is the endpoint's own deterministic key space; a
+        # caller-squatted key there would permanently 409 later UI actions.
+        if idempotency_key.startswith("v1:"):
+            raise HTTPException(
+                status_code=400, detail="idempotency_key may not use the reserved v1: prefix"
+            )
         try:
             if kind == "finding":
                 digest = str(payload.get("target_digest") or "").strip()
@@ -3118,6 +3124,21 @@ def create_local_api_app(
                 blocked_event_id = str(payload.get("blocked_event_id") or "").strip()
                 if not blocked_event_id:
                     raise HTTPException(status_code=400, detail="blocked_event_id is required")
+                # Same quarantine as the finding lane: only a blocker some read
+                # surface actually SHOWS is disposable — the id must be a
+                # surfaced work item's current blocked event.
+                projection = _v1_task_projection()
+                surfaced_blocked_ids = {
+                    str(item.get("current_blocked_event_id") or "")
+                    for task in projection.get("tasks", [])
+                    if isinstance(task, Mapping)
+                    for item in (task.get("work_items") or [])
+                    if isinstance(item, Mapping)
+                }
+                if blocked_event_id not in surfaced_blocked_ids:
+                    raise FindingDispositionNotFound(
+                        "no surfaced blocker matches that event id"
+                    )
                 events = service.list_all_events()
                 target = next(
                     (

--- a/src/agentacct/finding_disposition.py
+++ b/src/agentacct/finding_disposition.py
@@ -24,6 +24,16 @@ FINDING_DISPOSITION_SOURCE = "agent-chronicle-dashboard"
 FINDING_DISPOSITION_AUTHORITY_SCOPE = "finding_attention_only"
 FINDING_TARGET_SCHEMA = "agent-chronicle.finding-target.v1"
 
+# The blocker sibling: the SAME chain machinery (target digests, optimistic
+# revisions, idempotency, operation digests) replayed for a different target
+# kind — the exact agent-recorded blocked step event instead of a failed
+# check. A human disposition here records only whether the user still wants
+# that blocker highlighted; it never rewrites the agent's recorded event and
+# never counts as the evidence-backed machine resolution lane
+# (``resolves_blocked_event_id``), which stays agent-only.
+BLOCKER_DISPOSITION_EVENT_TYPE = "blocker_disposition"
+BLOCKER_DISPOSITION_AUTHORITY_SCOPE = "blocker_attention_only"
+
 FINDING_ACTIONS = {"mark_reviewed", "resolve", "reopen", "reinstate"}
 FINDING_STATES = {"open", "reviewed", "resolved"}
 _HEX_64 = re.compile(r"^[0-9a-f]{64}$")
@@ -164,15 +174,20 @@ def disposition_transition(prior_state: str, action: str) -> str | None:
     return None
 
 
-def is_trusted_finding_disposition_event(event: Mapping[str, Any]) -> bool:
+def is_trusted_finding_disposition_event(
+    event: Mapping[str, Any],
+    *,
+    event_type: str = FINDING_DISPOSITION_EVENT_TYPE,
+    authority_scope: str = FINDING_DISPOSITION_AUTHORITY_SCOPE,
+) -> bool:
     metadata = event.get("metadata") if isinstance(event.get("metadata"), Mapping) else {}
     return bool(
-        event.get("event_type") == FINDING_DISPOSITION_EVENT_TYPE
+        event.get("event_type") == event_type
         and event.get("source") == FINDING_DISPOSITION_SOURCE
-        and metadata.get("sentinel_semantic_kind") == FINDING_DISPOSITION_EVENT_TYPE
+        and metadata.get("sentinel_semantic_kind") == event_type
         and metadata.get(FINDING_DISPOSITION_CONTRACT_KEY)
         == FINDING_DISPOSITION_CONTRACT_VERSION
-        and metadata.get("authority_scope") == FINDING_DISPOSITION_AUTHORITY_SCOPE
+        and metadata.get("authority_scope") == authority_scope
         and metadata.get("authoritative_for_check_result") is False
         and metadata.get("actor") == "dashboard-user"
     )
@@ -196,8 +211,15 @@ def _bounded_text(value: str, *, maximum: int, allow_empty: bool = False) -> boo
 
 def reduce_finding_dispositions(
     events: Iterable[Mapping[str, Any]],
+    *,
+    event_type: str = FINDING_DISPOSITION_EVENT_TYPE,
+    authority_scope: str = FINDING_DISPOSITION_AUTHORITY_SCOPE,
 ) -> FindingDispositionProjection:
-    """Replay only server-trusted, internally consistent disposition chains."""
+    """Replay only server-trusted, internally consistent disposition chains.
+
+    The chain machinery is target-kind agnostic; pass the blocker event
+    type/scope to replay blocker-attention chains with the same guarantees.
+    """
 
     states: dict[str, FindingDispositionState] = {}
     accepted = 0
@@ -206,7 +228,9 @@ def reduce_finding_dispositions(
     invalid_targets: set[str] = set()
 
     for event in events:
-        if not is_trusted_finding_disposition_event(event):
+        if not is_trusted_finding_disposition_event(
+            event, event_type=event_type, authority_scope=authority_scope
+        ):
             continue
         metadata = event.get("metadata") if isinstance(event.get("metadata"), Mapping) else {}
         target_event_id = str(metadata.get("target_failure_event_id") or "").strip()

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -99,6 +99,9 @@ _DECISION_ASSERTED_BY: dict[str, str] = {
     "verified": "machine",
     "finding": "machine",
     "finding_superseded": "machine",
+    # Every standing failure carries a human "resolved" disposition — the
+    # machine fact stays in history; the ATTENTION claim is the human's.
+    "finding_resolved_by_user": "human",
     # ``failed`` is refined out of ``blocked`` from an agent-recorded work status,
     # not a machine check — so it is an agent report, exactly like ``blocked``.
     "failed": "agent_report",
@@ -118,6 +121,10 @@ _DECISION_ASSERTED_BY: dict[str, str] = {
 _DECISION_STATEMENTS: dict[str, str] = {
     "verified": "Recorded machine evidence verifies the latest outcome.",
     "finding": "A recorded check found an issue in the work being reviewed.",
+    "finding_resolved_by_user": (
+        "You marked the recorded finding resolved; the failing check stays in history — "
+        "this is not machine verification."
+    ),
     "finding_superseded": (
         "A recorded check failed, but a later same-scope check passed; the finding is kept "
         "in history and is not a verified outcome."
@@ -135,6 +142,11 @@ _DECISION_STATEMENTS: dict[str, str] = {
     "in_progress": "This Task is still in progress.",
     "observed": "agentacct observed this Task but no outcome was recorded.",
     "unknown": "agentacct observed this Task but no outcome was recorded.",
+}
+
+# Display-label overrides for keys whose mechanical Title Case reads wrong.
+_DECISION_LABELS: dict[str, str] = {
+    "finding_resolved_by_user": "Finding resolved",
 }
 
 _SUCCESS_STATUSES = {"completed", "passed", "resolved"}
@@ -249,10 +261,45 @@ def _check_source(check: Mapping[str, Any]) -> str:
 def _project_checks(task: Mapping[str, Any]) -> list[dict[str, Any]]:
     """Shape the Task's latest-per-identity checks for the Evidence dimension."""
 
+    from .finding_disposition import finding_target_digest
+
+    # The surfaced finding-episode index, keyed by target digest, so a failing
+    # check row can carry its own disposition handle (state + revision + the
+    # digest a /v1 disposition write names). Only SURFACED episodes get a
+    # handle — a failure outside this store's scope stays un-disposable here,
+    # the same quarantine the write path enforces.
+    episodes = (
+        task.get("finding_episodes")
+        if isinstance(task.get("finding_episodes"), list)
+        else []
+    )
+    episode_by_digest = {
+        str(episode.get("target_digest") or ""): episode
+        for episode in episodes
+        if isinstance(episode, Mapping) and episode.get("target_digest")
+    }
+
     shaped: list[dict[str, Any]] = []
     for check in latest_task_checks(task):
         if not isinstance(check, Mapping):
             continue
+        finding_handle = None
+        if _text(check.get("result")).lower() in {"failed", "error"}:
+            digest = finding_target_digest(check)
+            episode = episode_by_digest.get(str(digest or ""))
+            if episode is not None:
+                latest = (
+                    episode.get("latest_disposition")
+                    if isinstance(episode.get("latest_disposition"), Mapping)
+                    else {}
+                )
+                finding_handle = {
+                    "target_digest": str(digest),
+                    "state": _text(episode.get("disposition_state")) or "open",
+                    "revision": int(episode.get("revision") or 0),
+                    "attention_open": bool(episode.get("attention_open")),
+                    "note": _text(latest.get("note")) or None,
+                }
         files = check.get("files") if isinstance(check.get("files"), list) else []
         shaped.append(
             {
@@ -278,6 +325,9 @@ def _project_checks(task: Mapping[str, Any]) -> list[dict[str, Any]]:
                 "command_redacted": bool(check.get("command_redacted")),
                 "artifact_ref": _text(check.get("artifact_ref")) or None,
                 "artifact_url": _text(check.get("artifact_url")) or None,
+                # The human-attention handle for a surfaced failing check
+                # (None on passes and on failures outside this store's scope).
+                "finding": finding_handle,
             }
         )
     return shaped
@@ -498,16 +548,20 @@ def _decision_status(
             key = "failed"
 
     attention = _text(canonical.get("finding_attention_state"))
+    # Every standing failure human-resolved -> a DISTINCT decision word, so
+    # every surface (app groups/tints, TUI, CLI) files the task done-ish by
+    # vocabulary alone. The failing checks stay in the evidence dimension;
+    # this never touches evidence strength.
+    if key == "finding" and attention == "resolved":
+        key = "finding_resolved_by_user"
     asserted_by = _DECISION_ASSERTED_BY.get(key, "none")
-    # A finding a human has reviewed or resolved is now a HUMAN assertion — and
-    # (crucially) this never touches evidence strength.
-    if key == "finding" and attention in {"reviewed", "resolved"}:
+    # A finding a human has reviewed (but not resolved) stays a red finding
+    # with a HUMAN assertion.
+    if key == "finding" and attention == "reviewed":
         asserted_by = "human"
 
     statement = _DECISION_STATEMENTS.get(key, _DECISION_STATEMENTS["unknown"])
-    if key == "finding" and attention == "resolved":
-        statement = "You marked the recorded finding resolved; this is not machine verification."
-    elif key == "finding" and attention == "reviewed":
+    if key == "finding" and attention == "reviewed":
         statement = "Every current finding was reviewed; no passing check has replaced the failed evidence."
 
     # The newest blocker's own words (agent-recorded text, next step, when, and
@@ -519,7 +573,7 @@ def _decision_status(
 
     return {
         "key": key,
-        "label": key.replace("_", " ").title(),
+        "label": _DECISION_LABELS.get(key, key.replace("_", " ").title()),
         "statement": statement,
         "asserted_by": asserted_by,
         "finding_attention_state": attention or None,

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -102,6 +102,7 @@ _DECISION_ASSERTED_BY: dict[str, str] = {
     # Every standing failure carries a human "resolved" disposition — the
     # machine fact stays in history; the ATTENTION claim is the human's.
     "finding_resolved_by_user": "human",
+    "blocker_resolved_by_user": "human",
     # ``failed`` is refined out of ``blocked`` from an agent-recorded work status,
     # not a machine check — so it is an agent report, exactly like ``blocked``.
     "failed": "agent_report",
@@ -125,6 +126,10 @@ _DECISION_STATEMENTS: dict[str, str] = {
         "You marked the recorded finding resolved; the failing check stays in history — "
         "this is not machine verification."
     ),
+    "blocker_resolved_by_user": (
+        "You marked the recorded blocker resolved; the step's recorded state stays in "
+        "history — not a completion claim and not machine verification."
+    ),
     "finding_superseded": (
         "A recorded check failed, but a later same-scope check passed; the finding is kept "
         "in history and is not a verified outcome."
@@ -147,6 +152,7 @@ _DECISION_STATEMENTS: dict[str, str] = {
 # Display-label overrides for keys whose mechanical Title Case reads wrong.
 _DECISION_LABELS: dict[str, str] = {
     "finding_resolved_by_user": "Finding resolved",
+    "blocker_resolved_by_user": "Blocker resolved",
 }
 
 _SUCCESS_STATUSES = {"completed", "passed", "resolved"}

--- a/src/agentacct/service.py
+++ b/src/agentacct/service.py
@@ -2067,6 +2067,9 @@ class SentinelService:
                         "authority_scope": BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
                         "authoritative_for_check_result": False,
                         "actor": "dashboard-user",
+                        # Post-hoc audit only (which lane carried the write);
+                        # never part of the trust contract or the digests.
+                        "transport": transport,
                         "target_failure_event_id": target_event_id,
                         "target_event_digest": target_event_digest,
                         "target_finding_digest": target_blocker_digest,

--- a/src/agentacct/service.py
+++ b/src/agentacct/service.py
@@ -27,6 +27,8 @@ from .event_log import (
     serialize_event,
 )
 from .finding_disposition import (
+    BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+    BLOCKER_DISPOSITION_EVENT_TYPE,
     FINDING_DISPOSITION_AUTHORITY_SCOPE,
     FINDING_DISPOSITION_CONTRACT_KEY,
     FINDING_DISPOSITION_CONTRACT_VERSION,
@@ -1893,6 +1895,210 @@ class SentinelService:
                     "finding idempotency key belongs to a different operation"
                 )
         return None
+
+    def record_blocker_disposition(
+        self,
+        *,
+        target_event: Mapping[str, Any],
+        action: str,
+        expected_revision: int,
+        note: str | None,
+        idempotency_key: str,
+        transport: str = "dashboard",
+    ) -> dict[str, Any]:
+        """Atomically append one user attention transition for an exact
+        recorded blocker (the agent's ``blocked`` section event).
+
+        The finding sibling's contract, replayed for a work-event target:
+        server-validated chain, optimistic revision, idempotent replay, and a
+        currency check against the section's LATER events (a newer blocked
+        event supersedes the target; a terminal ``completed`` cleared it).
+        The agent's recorded event is never rewritten, and this never mints
+        the evidence-backed machine resolution lane
+        (``resolves_blocked_event_id``) — a human "resolved" stays a human
+        assertion with ``authoritative_for_check_result: False``.
+        """
+
+        if action not in {"mark_reviewed", "resolve", "reopen"}:
+            raise FindingDispositionConflict("unsupported blocker disposition action")
+        if isinstance(expected_revision, bool) or not isinstance(expected_revision, int) or expected_revision < 0:
+            raise FindingDispositionConflict("blocker revision must be a non-negative integer")
+        if not isinstance(idempotency_key, str) or not idempotency_key or len(idempotency_key) > 240:
+            raise FindingDispositionConflict("blocker idempotency key is invalid")
+        if any(char in idempotency_key for char in "\r\n\x00"):
+            raise FindingDispositionConflict("blocker idempotency key is invalid")
+        normalized_note = _normalize_finding_disposition_note(note, action=action)
+
+        target_event_id = str(target_event.get("event_id") or "").strip()
+        target_metadata = (
+            target_event.get("metadata")
+            if isinstance(target_event.get("metadata"), Mapping)
+            else {}
+        )
+        section_id = str(target_metadata.get("section_id") or "").strip()
+        target_status = str(target_metadata.get("section_status") or "").strip().lower()
+        target_client = str(target_metadata.get("client") or "").strip()
+        target_session = str(target_metadata.get("client_session_id") or "").strip()
+        if (
+            not target_event_id
+            or not section_id
+            or target_status != "blocked"
+            or str(target_metadata.get("sentinel_semantic_kind") or "") != "section"
+        ):
+            raise FindingDispositionNotFound("blocker target is not a recorded blocked step")
+        target_event_digest = canonical_event_digest(target_event)
+        target_blocker_digest = finding_target_digest(target_event)
+        if target_blocker_digest is None:
+            raise FindingDispositionNotFound("blocker target is not addressable")
+        target_series_digest = hashlib.sha256(
+            json.dumps(
+                {
+                    "client": target_client,
+                    "client_session_id": target_session,
+                    "schema": "agent-chronicle.blocker-target.v1",
+                    "section_id": section_id,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()
+        operation_digest = finding_operation_digest(
+            target_event_id=target_event_id,
+            target_event_digest=target_event_digest,
+            target_finding_digest=target_blocker_digest,
+            target_check_key_digest=target_series_digest,
+            action=action,
+            expected_revision=expected_revision,
+            note=normalized_note,
+        )
+
+        with self._events_write_lock():
+            existing_events, unparseable_lines = self._partition_existing_for_rewrite()
+            if unparseable_lines:
+                raise FindingDispositionConflict(
+                    "blocker state is unavailable while the event ledger contains unreadable lines"
+                )
+            disposition_projection = reduce_finding_dispositions(
+                existing_events,
+                event_type=BLOCKER_DISPOSITION_EVENT_TYPE,
+                authority_scope=BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+            )
+            for existing in existing_events:
+                if not is_trusted_finding_disposition_event(
+                    existing,
+                    event_type=BLOCKER_DISPOSITION_EVENT_TYPE,
+                    authority_scope=BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+                ):
+                    continue
+                metadata = existing.get("metadata")
+                if not isinstance(metadata, dict) or metadata.get("idempotency_key") != idempotency_key:
+                    continue
+                existing_target = str(metadata.get("target_finding_digest") or "")
+                if existing_target in disposition_projection.invalid_targets:
+                    raise FindingDispositionConflict(
+                        "blocker disposition history is conflicting or corrupt"
+                    )
+                if metadata.get("operation_digest") == operation_digest:
+                    return existing
+                raise FindingDispositionConflict(
+                    "blocker idempotency key belongs to a different operation"
+                )
+
+            # Currency, from the section's own later events: the ledger clears
+            # a blocker on ``completed`` and replaces the current blocked event
+            # on a newer ``blocked`` — mirror both without rebuilding the
+            # (multi-second) full ledger under this lock.
+            target_seen = False
+            target_time = float(target_event.get("created_at") or 0.0)
+            for existing in existing_events:
+                metadata = existing.get("metadata")
+                if not isinstance(metadata, Mapping):
+                    continue
+                if str(metadata.get("sentinel_semantic_kind") or "") != "section":
+                    continue
+                if str(metadata.get("section_id") or "").strip() != section_id:
+                    continue
+                if str(metadata.get("client") or "").strip() != target_client:
+                    continue
+                if str(metadata.get("client_session_id") or "").strip() != target_session:
+                    continue
+                event_id = str(existing.get("event_id") or "")
+                if event_id == target_event_id:
+                    target_seen = True
+                    continue
+                event_time = float(existing.get("created_at") or 0.0)
+                if event_time <= target_time:
+                    continue
+                status = str(metadata.get("section_status") or "").strip().lower()
+                if status == "completed":
+                    raise FindingDispositionConflict(
+                        "blocker was cleared by a later completed step"
+                    )
+                if status == "blocked":
+                    raise FindingDispositionConflict(
+                        "a newer blocker replaced this one; target the newest"
+                    )
+            if not target_seen:
+                raise FindingDispositionNotFound("blocker target event is not in this ledger")
+
+            if target_blocker_digest in disposition_projection.invalid_targets:
+                raise FindingDispositionConflict(
+                    "blocker disposition history is conflicting or corrupt"
+                )
+            current = disposition_projection.states.get(target_blocker_digest)
+            current_state = current.state if current is not None else "open"
+            current_revision = current.revision if current is not None else 0
+            if current_revision != expected_revision:
+                raise FindingDispositionConflict(
+                    "blocker changed or was resolved by a newer action"
+                )
+            next_state = disposition_transition(current_state, action)
+            if next_state is None:
+                raise FindingDispositionConflict("blocker disposition transition is invalid")
+
+            event = mark_trusted_finding_disposition(
+                {
+                    "source": FINDING_DISPOSITION_SOURCE,
+                    "event_type": BLOCKER_DISPOSITION_EVENT_TYPE,
+                    "run_id": target_event.get("run_id"),
+                    "metadata": {
+                        "sentinel_semantic_kind": BLOCKER_DISPOSITION_EVENT_TYPE,
+                        "authority_scope": BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+                        "authoritative_for_check_result": False,
+                        "actor": "dashboard-user",
+                        "target_failure_event_id": target_event_id,
+                        "target_event_digest": target_event_digest,
+                        "target_finding_digest": target_blocker_digest,
+                        "target_source_type": target_event.get("source_type"),
+                        "target_source": target_event.get("source"),
+                        "target_client": target_event.get("client"),
+                        "target_namespace_fingerprint": (
+                            target_event.get("namespace_fingerprint")
+                            or target_event.get("session_namespace_fingerprint")
+                        ),
+                        "target_project_identity": target_event.get("project_identity"),
+                        "target_check_key_digest": target_series_digest,
+                        "target_section_id": section_id,
+                        "target_section_client": target_client,
+                        "target_client_session_id": target_session,
+                        "action": action,
+                        "expected_revision": expected_revision,
+                        "revision": expected_revision + 1,
+                        "prior_state": current_state,
+                        "next_state": next_state,
+                        "note": normalized_note,
+                        "idempotency_key": idempotency_key,
+                        "operation_digest": operation_digest,
+                    },
+                }
+            )
+            recorded = self._prepare_recorded_event(event)
+            self._ensure_trailing_newline()
+            self._append_ledger_events([recorded], fsync=True)
+
+        self.evidence.shadow_v1_event(recorded, transport=transport)
+        return recorded
 
     def _partition_existing_for_rewrite(self) -> tuple[list[dict[str, Any]], list[str]]:
         """Return (parsed events, unparseable raw lines) preserving both.

--- a/src/agentacct/task_intelligence.py
+++ b/src/agentacct/task_intelligence.py
@@ -121,6 +121,8 @@ def _state_axes(
         in {
             "finding",
             "finding_superseded",
+        "finding_resolved_by_user",
+        "blocker_resolved_by_user",
             "blocked",
             "verified",
             "reported",

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -715,6 +715,28 @@ def reduce_task_outcome(
         key = "observed"
     else:
         all_successful = all(status in _SUCCESS_STATUSES for status in statuses)
+        # A human-dismissed blocker must never fall into the "reported" chain:
+        # the agent never claimed done — its last word on that step was
+        # "blocked", and a human withdrew the attention claim. When every
+        # non-successful step is exactly such a dismissed blocker, the Task's
+        # word is the HUMAN's action, asserted by the human — never a
+        # fabricated agent completion report and never verified.
+        non_success_all_dismissed = not all_successful and all(
+            status in _SUCCESS_STATUSES or _blocker_resolved_by_user(item)
+            for item, status in zip(items, statuses)
+        )
+        if non_success_all_dismissed:
+            return {
+                "key": "blocker_resolved_by_user",
+                "finding": None,
+                "verification": None,
+                "latest_checks": checks,
+                "blocker": None,
+                "max_work_updated_at": max_work_updated_at,
+                "open_step_count": open_step_count,
+                "handoff_current": handoff_current,
+                **step_counts,
+            }
         passing_checks = [event for event in checks if _text(event.get("result")).lower() == "passed"]
         checks_are_current = bool(checks) and all(
             _text(event.get("result")).lower() == "passed"

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -525,10 +525,21 @@ def reduce_task_outcome(
     # failed check may explain the blocker, but it must never demote a
     # recorded ``blocked``/``failed`` step (or explicit blocker text) into a
     # non-actionable finding.
+    # A human "resolved" disposition (server-validated append-only chain, see
+    # finding_disposition) withdraws the blocker's ATTENTION claim: the item's
+    # recorded status/text stay untouched in the data, but it no longer forces
+    # the Task's decision word — the reduction falls through to whatever else
+    # is true. Deliberately weaker than the evidence-backed machine resolution
+    # lane (which rewrites latest_status to ``resolved``); a human dismissal
+    # never fabricates a terminal success.
+    def _blocker_resolved_by_user(item: Mapping[str, Any]) -> bool:
+        return _text(item.get("blocker_disposition_state")).lower() == "resolved"
+
     blocked_items = [
         item
         for item, status in zip(items, statuses)
-        if status in _BLOCKED_STATUSES or _text(item.get("blocker"))
+        if (status in _BLOCKED_STATUSES or _text(item.get("blocker")))
+        and not _blocker_resolved_by_user(item)
     ]
     if blocked_items:
         def _item_time(item: Mapping[str, Any]) -> float:
@@ -558,6 +569,15 @@ def reduce_task_outcome(
             "updated_at": newest_at or None,
             "blocked_step_count": len(blocked_items),
             "later_completed_steps": later_completed_steps,
+            # The write handle for a user disposition on THIS blocker: the
+            # exact blocked event plus the optimistic revision to echo.
+            "blocked_event_id": _text(newest.get("current_blocked_event_id")) or None,
+            "disposition_revision": _integer(newest.get("blocker_target_revision")),
+            "disposition": (
+                dict(newest["blocker_disposition"])
+                if isinstance(newest.get("blocker_disposition"), Mapping)
+                else None
+            ),
         }
         return {
             "key": "blocked",

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1177,6 +1177,8 @@ def _receipt_decision_color(key: str) -> str:
         "handed_off": "blue",
         "resolved": "blue",
         "finding_superseded": "blue",
+        "finding_resolved_by_user": "blue",
+        "blocker_resolved_by_user": "blue",
     }.get(key, "dim")
 
 

--- a/tests/test_disposition_v1.py
+++ b/tests/test_disposition_v1.py
@@ -1,0 +1,328 @@
+"""POST /v1/disposition — the user resolve lane for findings and blockers.
+
+The write is bearer-gated, optimistic-concurrency-checked, append-only, and
+never machine verification: a finding fully human-resolved gets the distinct
+``finding_resolved_by_user`` decision word; a blocker human-resolved simply
+stops forcing the Task's decision word while the agent's recorded events stay
+untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentacct.finding_disposition import (
+    BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+    BLOCKER_DISPOSITION_EVENT_TYPE,
+    FindingDispositionConflict,
+    reduce_finding_dispositions,
+)
+from agentacct.service import SentinelService
+
+from tests.test_receipt_api import (
+    NS,
+    _app,
+    _auth,
+    _record_passing_check,
+    _record_section,
+    _record_usage,
+)
+
+
+def _record_failed_check(
+    service: SentinelService, *, session_id: str, section_id: str, at: float
+) -> None:
+    service.record_event(
+        {
+            "event_id": f"evt_check_fail_{session_id}_{section_id}",
+            "created_at": at,
+            "source": "claude-code",
+            "event_type": "machine_check",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "evidence",
+                "client": "claude-code",
+                "client_session_id": session_id,
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": section_id,
+                "name": "pytest",
+                "evidence_type": "test",
+                "command": "pytest -q",
+                "exit_code": 1,
+                "result": "failed",
+                "project_dir": "/tmp/project",
+            },
+        }
+    )
+
+
+def _ledger_blocked_event_id(
+    service: SentinelService, *, section_id: str, blocker: str | None = None
+) -> str:
+    """The server-assigned id of the NEWEST matching blocked event
+    (record_event rewrites caller-supplied ids AND timestamps)."""
+
+    matches = [
+        event
+        for event in service.list_all_events()
+        if isinstance(event.get("metadata"), dict)
+        and event["metadata"].get("section_id") == section_id
+        and event["metadata"].get("section_status") == "blocked"
+        and (blocker is None or event["metadata"].get("blocker") == blocker)
+    ]
+    assert matches
+    return str(max(matches, key=lambda event: float(event.get("created_at") or 0.0))["event_id"])
+
+
+def _record_blocked_section(
+    service: SentinelService,
+    *,
+    session_id: str,
+    section_id: str,
+    at: float,
+    blocker: str = "waiting for approval",
+) -> str:
+    service.record_event(
+        {
+            "event_id": f"evt_section_{session_id}_{section_id}_blocked",
+            "created_at": at,
+            "source": "claude-code",
+            "event_type": "section_blocked",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "claude-code",
+                "client_session_id": session_id,
+                "project_dir": "/tmp/project",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": section_id,
+                "section_status": "blocked",
+                "section_title": "Publish the site",
+                "blocker": blocker,
+                "next_step": "ask the user",
+                "kind": "implementation",
+            },
+        }
+    )
+    return _ledger_blocked_event_id(service, section_id=section_id, blocker=blocker)
+
+
+def _task_rows(client, **params):
+    return client.get("/v1/tasks", headers=_auth(), params=params).json()["tasks"]
+
+
+def test_blocker_resolve_end_to_end_moves_the_task_off_blocked(tmp_path: Path) -> None:
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    _record_section(service, session_id="s1", section_id="sec-a", status="started", at=110.0)
+    blocked_id = _record_blocked_section(service, session_id="s1", section_id="sec-a", at=120.0)
+
+    client = _app(tmp_path)
+    rows = _task_rows(client)
+    assert rows[0]["decision_status"]["key"] == "blocked"
+    blocker = rows[0]["decision_status"]["blocker"]
+    assert blocker["blocked_event_id"] == blocked_id
+    assert blocker["disposition_revision"] == 0
+
+    # Resolve requires a note.
+    refused = client.post(
+        "/v1/disposition",
+        headers=_auth(),
+        json={
+            "kind": "blocker",
+            "action": "resolve",
+            "expected_revision": 0,
+            "blocked_event_id": blocked_id,
+        },
+    )
+    assert refused.status_code == 409
+
+    response = client.post(
+        "/v1/disposition",
+        headers=_auth(),
+        json={
+            "kind": "blocker",
+            "action": "resolve",
+            "expected_revision": 0,
+            "note": "approved and shipped by hand",
+            "blocked_event_id": blocked_id,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "resolved"
+    assert body["revision"] == 1
+
+    rows = _task_rows(client)
+    # The human resolution withdraws the blocker's attention claim; the Task
+    # falls through to its natural non-blocked state (never a fabricated
+    # completion — the step stays blocked in the DATA).
+    assert rows[0]["decision_status"]["key"] != "blocked"
+    assert rows[0]["decision_status"]["blocker"] is None
+
+    # Stale revision now conflicts (409), never silently overwrites.
+    stale = client.post(
+        "/v1/disposition",
+        headers=_auth(),
+        json={
+            "kind": "blocker",
+            "action": "resolve",
+            "expected_revision": 0,
+            "note": "again",
+            "blocked_event_id": blocked_id,
+        },
+    )
+    assert stale.status_code == 409
+
+
+def test_blocker_disposition_refuses_cleared_and_superseded_targets(tmp_path: Path) -> None:
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    old_blocked = _record_blocked_section(service, session_id="s1", section_id="sec-a", at=120.0)
+    _record_section(service, session_id="s1", section_id="sec-a", status="completed", at=130.0)
+
+    with pytest.raises(FindingDispositionConflict):
+        service.record_blocker_disposition(
+            target_event=next(
+                event
+                for event in service.list_all_events()
+                if event.get("event_id") == old_blocked
+            ),
+            action="resolve",
+            expected_revision=0,
+            note="n",
+            idempotency_key="k1",
+        )
+
+    # A newer blocked event supersedes the old target.
+    first = _record_blocked_section(service, session_id="s2", section_id="sec-b", at=120.0)
+    service.record_event(
+        {
+            "event_id": "evt_ignored_rewritten",
+            "created_at": 140.0,
+            "source": "claude-code",
+            "event_type": "section_blocked",
+            "run_id": None,
+            "metadata": {
+                "sentinel_semantic_kind": "section",
+                "client": "claude-code",
+                "client_session_id": "s2",
+                "session_namespace_fingerprint": NS,
+                "identity_scope_state": "explicit",
+                "section_id": "sec-b",
+                "section_status": "blocked",
+                "blocker": "newer blocker",
+                "kind": "implementation",
+            },
+        }
+    )
+    with pytest.raises(FindingDispositionConflict):
+        service.record_blocker_disposition(
+            target_event=next(
+                event
+                for event in service.list_all_events()
+                if event.get("event_id") == first
+            ),
+            action="resolve",
+            expected_revision=0,
+            note="n",
+            idempotency_key="k2",
+        )
+
+
+def test_forged_blocker_disposition_is_never_trusted(tmp_path: Path) -> None:
+    """A generic-lane event claiming the disposition contract gets its
+    provenance stripped and never enters the chain."""
+
+    service = SentinelService(tmp_path)
+    service.record_event(
+        {
+            "event_id": "evt_forged",
+            "created_at": 100.0,
+            "source": "agent-chronicle-dashboard",
+            "event_type": BLOCKER_DISPOSITION_EVENT_TYPE,
+            "metadata": {
+                "sentinel_semantic_kind": BLOCKER_DISPOSITION_EVENT_TYPE,
+                "finding_disposition_contract": "server_validated_v1",
+                "authority_scope": BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+                "authoritative_for_check_result": False,
+                "actor": "dashboard-user",
+                "target_finding_digest": "a" * 64,
+                "action": "resolve",
+                "next_state": "resolved",
+            },
+        }
+    )
+    chains = reduce_finding_dispositions(
+        service.list_all_events(),
+        event_type=BLOCKER_DISPOSITION_EVENT_TYPE,
+        authority_scope=BLOCKER_DISPOSITION_AUTHORITY_SCOPE,
+    )
+    assert chains.states == {}
+
+
+def test_finding_resolve_end_to_end_refines_the_decision_word(tmp_path: Path) -> None:
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    _record_section(service, session_id="s1", section_id="sec-a", status="completed", at=110.0)
+    _record_failed_check(service, session_id="s1", section_id="sec-a", at=120.0)
+
+    client = _app(tmp_path)
+    rows = _task_rows(client)
+    assert rows[0]["decision_status"]["key"] == "finding"
+    task_id = rows[0]["task_id"]
+
+    receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
+    failing = [
+        check
+        for check in receipt["dimensions"]["evidence"]["checks"]
+        if check["result"] in {"failed", "error"}
+    ]
+    assert failing and failing[0]["finding"] is not None
+    handle = failing[0]["finding"]
+    assert handle["state"] == "open"
+    assert handle["revision"] == 0
+
+    response = client.post(
+        "/v1/disposition",
+        headers=_auth(),
+        json={
+            "kind": "finding",
+            "action": "resolve",
+            "expected_revision": handle["revision"],
+            "note": "fixed by hand afterwards",
+            "target_digest": handle["target_digest"],
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["state"] == "resolved"
+
+    rows = _task_rows(client)
+    decision = rows[0]["decision_status"]
+    assert decision["key"] == "finding_resolved_by_user"
+    assert decision["label"] == "Finding resolved"
+    assert decision["asserted_by"] == "human"
+
+    receipt = client.get(f"/v1/receipt?task={task_id}", headers=_auth()).json()
+    # The failing check stays in the evidence dimension — evidence is never
+    # rewritten by a human disposition.
+    failing = [
+        check
+        for check in receipt["dimensions"]["evidence"]["checks"]
+        if check["result"] in {"failed", "error"}
+    ]
+    assert failing and failing[0]["finding"]["state"] == "resolved"
+    assert failing[0]["finding"]["note"] == "fixed by hand afterwards"
+
+
+def test_disposition_requires_the_bearer_token(tmp_path: Path) -> None:
+    client = _app(tmp_path)
+    response = client.post(
+        "/v1/disposition",
+        json={"kind": "finding", "action": "resolve", "expected_revision": 0},
+    )
+    assert response.status_code in {401, 403}

--- a/tests/test_disposition_v1.py
+++ b/tests/test_disposition_v1.py
@@ -158,11 +158,15 @@ def test_blocker_resolve_end_to_end_moves_the_task_off_blocked(tmp_path: Path) -
     assert body["revision"] == 1
 
     rows = _task_rows(client)
-    # The human resolution withdraws the blocker's attention claim; the Task
-    # falls through to its natural non-blocked state (never a fabricated
-    # completion — the step stays blocked in the DATA).
-    assert rows[0]["decision_status"]["key"] != "blocked"
-    assert rows[0]["decision_status"]["blocker"] is None
+    # The human resolution withdraws the blocker's attention claim. The
+    # landing word is the HUMAN's action — never "reported" (the agent never
+    # claimed done; its last recorded word was "blocked") and never verified.
+    decision = rows[0]["decision_status"]
+    assert decision["key"] == "blocker_resolved_by_user"
+    assert decision["label"] == "Blocker resolved"
+    assert decision["asserted_by"] == "human"
+    assert "not a completion claim" in decision["statement"]
+    assert decision["blocker"] is None
 
     # Stale revision now conflicts (409), never silently overwrites.
     stale = client.post(
@@ -326,3 +330,72 @@ def test_disposition_requires_the_bearer_token(tmp_path: Path) -> None:
         json={"kind": "finding", "action": "resolve", "expected_revision": 0},
     )
     assert response.status_code in {401, 403}
+
+
+def test_mixed_completed_and_human_resolved_blocker_lands_on_the_human_word(tmp_path: Path) -> None:
+    """Completed steps beside a human-dismissed blocker: the dismissal must
+    stay visible at the decision level (not silently upgraded to 'reported')."""
+
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    _record_section(service, session_id="s1", section_id="sec-done", status="completed", at=110.0)
+    blocked_id = _record_blocked_section(service, session_id="s1", section_id="sec-b", at=120.0)
+
+    client = _app(tmp_path)
+    response = client.post(
+        "/v1/disposition",
+        headers=_auth(),
+        json={
+            "kind": "blocker",
+            "action": "resolve",
+            "expected_revision": 0,
+            "note": "handled by hand",
+            "blocked_event_id": blocked_id,
+        },
+    )
+    assert response.status_code == 200
+    decision = _task_rows(client)[0]["decision_status"]
+    assert decision["key"] == "blocker_resolved_by_user"
+    assert decision["asserted_by"] == "human"
+
+
+def test_disposition_rejects_reserved_and_unsurfaced_handles(tmp_path: Path) -> None:
+    service = SentinelService(tmp_path)
+    _record_usage(service, session_id="s1", at=100.0)
+    blocked_id = _record_blocked_section(service, session_id="s1", section_id="sec-a", at=120.0)
+    client = _app(tmp_path)
+
+    # The v1: idempotency namespace is the endpoint's own.
+    squatted = client.post(
+        "/v1/disposition",
+        headers=_auth(),
+        json={
+            "kind": "blocker",
+            "action": "resolve",
+            "expected_revision": 0,
+            "note": "n",
+            "blocked_event_id": blocked_id,
+            "idempotency_key": "v1:blocker:squat:0:resolve",
+        },
+    )
+    assert squatted.status_code == 400
+
+    # Only a SURFACED blocker is disposable — an arbitrary ledger event id
+    # (here: a usage event's id) is a 404, mirroring the finding quarantine.
+    other_id = next(
+        str(event.get("event_id"))
+        for event in service.list_all_events()
+        if event.get("event_type") != "section_blocked"
+    )
+    unsurfaced = client.post(
+        "/v1/disposition",
+        headers=_auth(),
+        json={
+            "kind": "blocker",
+            "action": "resolve",
+            "expected_revision": 0,
+            "note": "n",
+            "blocked_event_id": other_id,
+        },
+    )
+    assert unsurfaced.status_code == 404

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -278,7 +278,10 @@ def test_human_resolved_finding_is_human_asserted_but_not_evidence_verified() ->
         finding_episodes=episodes,
     )
     receipt = _receipt(task)
-    assert receipt["axes"]["decision_status"]["key"] == "finding"
+    # A fully human-resolved finding gets its own decision WORD (so every
+    # surface files it done-ish by vocabulary alone), asserted by the human.
+    assert receipt["axes"]["decision_status"]["key"] == "finding_resolved_by_user"
+    assert receipt["axes"]["decision_status"]["label"] == "Finding resolved"
     assert receipt["axes"]["decision_status"]["asserted_by"] == "human"
     assert "not machine verification" in receipt["axes"]["decision_status"]["statement"]
     # A failing check is not positive proof — evidence reaches no CHECKED tier,


### PR DESCRIPTION
Fifth of six PRs from the 2026-08-27 receipt-UI feedback round: **the user resolve lane** (feedback #7, second half) — red findings/blockers finally have an honest exit that isn't "wait for a machine check to supersede it".

## What changes

**Daemon**

- `POST /v1/disposition` — the /v1 lane's first user-originated write (bearer-gated like every /v1 route). Records one attention transition (`mark_reviewed` / `resolve` / `reopen`) for a **surfaced finding** (`target_digest`) or a **recorded blocker** (`blocked_event_id`). Optimistic `expected_revision` must echo the state the caller displayed (409 on conflict, never a silent overwrite); **resolve requires a note**; caller idempotency keys can't squat the reserved `v1:` namespace; blocker writes are quarantined to *surfaced* blockers exactly like the finding lane.
- `record_blocker_disposition` — the dormant finding-disposition machinery (server-validated append-only chains, target digests, idempotent replay, forgery-stripping on every generic ingest lane) replayed for a work-event target, with currency checked against the section's later events (a newer blocked event supersedes; a terminal `completed` cleared it). The agent's recorded events are never rewritten, and this never mints the evidence-backed machine resolution lane.
- **Honest landing words.** A fully human-resolved finding reads `finding_resolved_by_user` ("Finding resolved", asserted by *human*); a task whose only non-successful steps are human-dismissed blockers reads `blocker_resolved_by_user` ("Blocker resolved", asserted by *human*) — **never** a fabricated "the agent reported completing work", and never `verified`. Failing checks stay untouched in the evidence dimension; evidence strength never moves on a human action.
- Receipt payloads carry the write handles: failing-check rows get a `finding` handle (digest/state/revision/note), the blocker detail gets `blocked_event_id` + revision + disposition.

**App**

- `DispositionControls` on failing check rows and on the blocker callout: *Mark reviewed* / *Resolve…* (a note-required popover) / *Reopen* — posting through the app's first `/v1` POST, with the daemon's own conflict copy shown verbatim (`GlanceClientError` now conforms to `LocalizedError`, which also repairs every pre-existing fetch-error string). Notes are normalized (newlines collapsed, 1200 cap) so a paste can't bounce off a server 409; a failed post refreshes so the controls re-offer the current revision.
- The new human-resolved words join the claimed (blue) family, the Reported group, the legend, and leave Needs review.
- `fetchReceipt` gains a generation guard (a late refresh can no longer wedge another task's page) and keeps a same-task receipt mounted during refresh.

## Verified end-to-end on a copy of the live store

The real 3-blocker codex task (设计 agentacct 产品 Logo — the exact receipt from the feedback) was resolved blocker-by-blocker through the endpoint: the callout advanced to the next blocker each round, and the task landed on **Mostly Done** — the red badge has an exit, and nothing was fabricated along the way.

## Verification

- `pytest -q`: 2628 (7 new tests: e2e landing-word for solo and mixed tasks, cleared/superseded currency conflicts, forged-event rejection, reserved-key + unsurfaced-handle refusals, finding e2e with the key refinement, bearer gate).
- `swift test`: 34 passed (1 skipped: canonical visual verify). Dashboard baselines untouched.
- Adversarial review (3 lenses + refutation): 4 must-fix + 9 minor; all four must-fix and seven of the minors addressed. Noted follow-ups (accepted, low-stakes): a text-less blocked step has no in-app resolve affordance (raw API only), and session-level badges stay conservative after a human resolve, matching the machine lane's documented divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
