### PR TITLE
feat(plan): codex weekly-plan calibration + trailing regime windows

### DIFF
--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -7621,6 +7621,19 @@ def _local_usage_import_payload(
                     # hermetic local scan (always allowed); only the default read
                     # of the real ~/.codex is gated behind the global-scan knob.
                     if codex_home is not None or _global_scan:
+                        # Dense weekly-meter history first (calibration food):
+                        # bounded to readings newer than the recorded watermark,
+                        # so a re-scan never re-imports history. The single
+                        # freshest snapshot still rides last so the stream
+                        # always ends on the current state.
+                        _codex_since = _rate_limits.latest_recorded_captured_at(
+                            service.list_all_events(), client="codex"
+                        )
+                        _rl_snapshots.extend(
+                            _rate_limits.read_codex_rate_limits_series(
+                                codex_home, since_epoch=_codex_since
+                            )
+                        )
                         _codex_rl = _rate_limits.read_codex_rate_limits_latest(codex_home)
                         if _codex_rl is not None:
                             _rl_snapshots.append(_codex_rl)

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -7622,16 +7622,17 @@ def _local_usage_import_payload(
                     # of the real ~/.codex is gated behind the global-scan knob.
                     if codex_home is not None or _global_scan:
                         # Dense weekly-meter history first (calibration food):
-                        # bounded to readings newer than the recorded watermark,
-                        # so a re-scan never re-imports history. The single
-                        # freshest snapshot still rides last so the stream
-                        # always ends on the current state.
-                        _codex_since = _rate_limits.latest_recorded_captured_at(
+                        # backfills the in-file readings BETWEEN the sparse
+                        # tick-recorded snapshots, idempotently (deterministic
+                        # transition-collapse + already-recorded capture times
+                        # excluded). The single freshest snapshot still rides
+                        # last so the stream always ends on the current state.
+                        _codex_recorded = _rate_limits.recorded_captured_ats(
                             service.list_all_events(), client="codex"
                         )
                         _rl_snapshots.extend(
                             _rate_limits.read_codex_rate_limits_series(
-                                codex_home, since_epoch=_codex_since
+                                codex_home, exclude_captured_at=_codex_recorded
                             )
                         )
                         _codex_rl = _rate_limits.read_codex_rate_limits_latest(codex_home)

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -97,6 +97,15 @@ _STABILITY_HALF_AGREEMENT = 0.35
 # * and the fit sits inside a wide hard ceiling — beyond it no amount of
 #   stability makes the number credible (something structural is wrong).
 _STABILITY_HARD_BAND = (0.2, 8.0)
+# When the FULL window fails its gates because the account's ratio genuinely
+# regime-changed inside it (a model-mix or plan change makes the halves
+# disagree; measured live 2026-08-27: ~5.5-6.5 before 08-22, ~2.1-2.8 after),
+# the CURRENT regime still predicts current sessions. Retry the fit on
+# trailing sub-windows, longest first, and accept only under the ORIGINAL
+# strict gate — in the trusted band, with a real interval floor. No stability
+# lane on sub-windows: a shortened window earns no extra leniency.
+_REGIME_FALLBACK_WINDOW_DAYS = (14, 10, 7, 5)
+_REGIME_FALLBACK_MIN_INTERVALS = 12
 
 # The two-component token model. The weekly meter is driven by FRESH work
 # (input + output + cache_creation); cache READS barely move it — measured on
@@ -477,39 +486,45 @@ def calibrate_plan_weights(
             continue
         points.append((t1, delta, fresh_pred, read_pred))
 
-    intervals = len(points)
-    raw_scale = 1.0
-    alpha = 0.0
-    if points:
+    def _grid_fit(fit_points: list[tuple[float, float, float, float]]) -> tuple[float, float]:
+        """(alpha, raw_scale) for one point set — the closed-form-per-alpha grid.
+
+        SMALLEST alpha within tolerance of the best fit wins. alpha is a
+        second degree of freedom the trusted band never inspects: untracked
+        meter movement that co-occurs with cache-read-heavy days would
+        otherwise be absorbed into alpha, silently multiplying every
+        cache-heavy session's share while reporting "calibrated"
+        (adversarial-review finding). Reads are only charged when the data
+        clearly demands it; a collinear cache mix (alpha unidentifiable)
+        deterministically lands on 0.
+        """
+
+        if not fit_points:
+            return 0.0, 1.0
         candidates: list[tuple[float, float, float]] = []  # (alpha, scale, sse)
-        observed_sum = sum(delta for _t, delta, _a, _b in points)
+        observed_sum = sum(delta for _t, delta, _a, _b in fit_points)
         for step in range(_ALPHA_GRID_STEPS + 1):
             candidate_alpha = step / _ALPHA_GRID_STEPS
-            predicted_sum = sum(a + candidate_alpha * b for _t, _d, a, b in points)
+            predicted_sum = sum(a + candidate_alpha * b for _t, _d, a, b in fit_points)
             if predicted_sum <= 0:
                 continue
             candidate_scale = observed_sum / predicted_sum
             sse = sum(
                 (delta - candidate_scale * (a + candidate_alpha * b)) ** 2
-                for _t, delta, a, b in points
+                for _t, delta, a, b in fit_points
             )
             candidates.append((candidate_alpha, candidate_scale, sse))
-        if candidates:
-            # SMALLEST alpha within tolerance of the best fit wins. alpha is a
-            # second degree of freedom the trusted band never inspects:
-            # untracked meter movement that co-occurs with cache-read-heavy
-            # days would otherwise be absorbed into alpha, silently multiplying
-            # every cache-heavy session's share while reporting "calibrated"
-            # (adversarial-review finding). Reads are only charged when the
-            # data clearly demands it; a collinear cache mix (alpha
-            # unidentifiable) deterministically lands on 0.
-            best_sse = min(sse for _a, _s, sse in candidates)
-            tolerance = best_sse * 1.05 + 1e-12
-            for candidate_alpha, candidate_scale, sse in candidates:  # ascending alpha
-                if sse <= tolerance:
-                    alpha = candidate_alpha
-                    raw_scale = candidate_scale
-                    break
+        if not candidates:
+            return 0.0, 1.0
+        best_sse = min(sse for _a, _s, sse in candidates)
+        tolerance = best_sse * 1.05 + 1e-12
+        for candidate_alpha, candidate_scale, sse in candidates:  # ascending alpha
+            if sse <= tolerance:
+                return candidate_alpha, candidate_scale
+        return 0.0, 1.0
+
+    intervals = len(points)
+    alpha, raw_scale = _grid_fit(points)
     trusted = _TRUSTED_SCALE_BAND[0] <= raw_scale <= _TRUSTED_SCALE_BAND[1]
     stability_accepted = (
         intervals >= _MIN_SCALE_INTERVALS
@@ -531,15 +546,40 @@ def calibrate_plan_weights(
                 "(may include usage from untracked Claude surfaces)"
             )
     else:
-        # Too little clean history, or a fit outside the trusted band (heavy
-        # untracked Claude usage or a very different plan tier we can't
-        # identify) → keep the shipped baseline rather than apply an
-        # unreliable scale. alpha stays 0 under baseline: cache reads are
-        # excluded rather than guessed (the measured reference behavior).
-        scale = 1.0
-        alpha = 0.0
-        confidence = "baseline"
-        basis = "shipped baseline (record more 7-day limit history from tracked clients to calibrate)"
+        # The full window failed its gates. Before shipping the baseline, try
+        # the trailing regime windows (see _REGIME_FALLBACK_WINDOW_DAYS): a
+        # ratio that regime-changed mid-window still has an honest CURRENT
+        # value when the recent points alone fit inside the trusted band.
+        trailing_hit = None
+        for trailing_days in _REGIME_FALLBACK_WINDOW_DAYS:
+            trailing_start = now_epoch - trailing_days * 86400.0
+            trailing_points = [point for point in points if point[0] >= trailing_start]
+            if len(trailing_points) < _REGIME_FALLBACK_MIN_INTERVALS:
+                continue
+            trailing_alpha, trailing_scale = _grid_fit(trailing_points)
+            if _TRUSTED_SCALE_BAND[0] <= trailing_scale <= _TRUSTED_SCALE_BAND[1]:
+                trailing_hit = (trailing_days, trailing_points, trailing_alpha, trailing_scale)
+                break
+        if trailing_hit is not None:
+            trailing_days, trailing_points, alpha, raw_scale = trailing_hit
+            intervals = len(trailing_points)
+            scale = raw_scale
+            confidence = "calibrated"
+            basis = (
+                f"two-component fit x{scale:.2f}, cache-read discount {alpha:.2f} "
+                f"({intervals} intervals in the trailing {trailing_days} days — the full "
+                "window mixes a ratio regime change)"
+            )
+        else:
+            # Too little clean history, or a fit outside the trusted band (heavy
+            # untracked Claude usage or a very different plan tier we can't
+            # identify) → keep the shipped baseline rather than apply an
+            # unreliable scale. alpha stays 0 under baseline: cache reads are
+            # excluded rather than guessed (the measured reference behavior).
+            scale = 1.0
+            alpha = 0.0
+            confidence = "baseline"
+            basis = "shipped baseline (record more 7-day limit history from tracked clients to calibrate)"
 
     weights = {m: w * scale for m, w in base.items()}
     return PlanWeights(

--- a/src/agentacct/plan_cost.py
+++ b/src/agentacct/plan_cost.py
@@ -118,12 +118,21 @@ _FRESH_COMPONENT_REF_FACTOR = 8.3
 _ALPHA_GRID_STEPS = 100
 
 # Plan-bearing clients whose meter can actually CALIBRATE to per-session weekly
-# percentages — i.e. a clean weekly-reset cumulative meter. codex's 7-day meter is
-# rolling and opaque (Σdeltas ≫ the window, resets unobservable), so a weekly plan %
-# is undefined for it: it must never be shown as "calibrating", because that promises
-# a number that will never arrive. This is the single source of truth; shells
-# (TUI plan column, glance/app payloads) derive their three-state display from it.
-CALIBRATABLE_CLIENTS = ("claude-code",)
+# percentages — i.e. a clean weekly-reset cumulative meter. This is the single
+# source of truth; shells (TUI plan column, glance/app payloads) derive their
+# three-state display from it.
+#
+# codex joined 2026-08-27: its rate_limits shape changed — the meter now
+# reports a single primary window (window_minutes=10080) with an observable
+# resets_at, and the local rollouts show week-reset-cumulative behavior
+# (monotonic climb within an epoch, drop to 0 at a new resets_at ≈ +7d),
+# the same semantics the fit requires. The 2026-08-05 "rolling and opaque"
+# verdict described the OLD shape and no longer holds. Residual noise the
+# machinery already absorbs: integer-quantized percents (transition-recorded,
+# so consecutive readings differ by ≥1 point), irregular resets (any drop is
+# skipped as a reset), and fork/replay contamination (the series importer
+# collapses replay bursts; the latest reader is mtime-anchored).
+CALIBRATABLE_CLIENTS = ("claude-code", "codex")
 
 
 @dataclass(frozen=True)
@@ -428,18 +437,17 @@ def calibrate_plan_weights(
     default_base = BASELINE_MODEL_WEIGHTS["claude-opus-4-8"] * _FRESH_COMPONENT_REF_FACTOR
 
     if client not in CALIBRATABLE_CLIENTS:
-        # A rolling/opaque meter (codex) can land 3 numerically-clean intervals
-        # inside the trusted band by coincidence — but its weekly plan % is
-        # UNDEFINED by design, so a fit here would confidently label a number
-        # that means nothing (adversarial-review finding: /v1/plan served
-        # "calibrated" codex aggregates). The gate lives HERE, not in each
-        # display surface, so no surface can ever receive one.
+        # A client without a calibratable weekly-reset meter can still land
+        # numerically-clean intervals by coincidence — but its weekly plan %
+        # is UNDEFINED, so a fit here would confidently label a number that
+        # means nothing. The gate lives HERE, not in each display surface, so
+        # no surface can ever receive one.
         return PlanWeights(
             weights=base,
             default_weight=default_base,
             scale=1.0,
             confidence="baseline",
-            basis="weekly plan % is undefined for this client's rolling meter (it never calibrates)",
+            basis="weekly plan % is undefined for this client (no calibratable weekly meter)",
             intervals_used=0,
             client=client,
         )

--- a/src/agentacct/rate_limits.py
+++ b/src/agentacct/rate_limits.py
@@ -784,17 +784,19 @@ def read_codex_rate_limits_latest(
     return None
 
 
-def latest_recorded_captured_at(
+def recorded_captured_ats(
     existing_events: Iterable[Mapping[str, Any]], *, client: str
-) -> float:
-    """The newest recorded ``captured_at`` for one client's limit stream.
+) -> set[float]:
+    """Every recorded ``captured_at`` for one client's limit stream.
 
-    The series importer's watermark: only in-file readings STRICTLY newer than
-    this are imported, so a re-scan never re-records history (transition dedup
-    alone compares only the latest state and would re-write a whole replayed
-    series)."""
+    The series importer's exclusion set: an in-file reading whose capture time
+    is already in the ledger is never imported again. Combined with the
+    importer's DETERMINISTIC transition-collapse (same files -> same survivor
+    set on every scan), this makes the backfill idempotent: readings BETWEEN
+    the sparse tick-recorded snapshots import exactly once, and a re-scan is
+    a no-op."""
 
-    newest = 0.0
+    captured: set[float] = set()
     for event in existing_events:
         if event.get("event_type") != EVENT_TYPE:
             continue
@@ -802,9 +804,9 @@ def latest_recorded_captured_at(
         if str(metadata.get("client") or "") != client:
             continue
         ordering = _event_ordering(event)
-        if ordering > newest:
-            newest = ordering
-    return newest
+        if ordering > 0:
+            captured.add(ordering)
+    return captured
 
 
 # Replayed rollout prefixes are stamped with FRESH outer timestamps
@@ -870,10 +872,21 @@ def _read_codex_file_rate_limit_series(path: Path) -> list[RateLimitSnapshot]:
     return collapsed
 
 
+def _snapshot_transition_key(snapshot: RateLimitSnapshot) -> str:
+    """The series' transition-collapse identity — EXACTLY the recorder's own
+    ``state_signature``, so any reading the recorder would treat as a no-op is
+    dropped deterministically before the exclusion filter. A near-copy with a
+    different field set (an early draft included the drifting credits balance
+    the signature deliberately excludes) let recorder-skipped readings
+    resurface on the next scan as phantom re-imports."""
+
+    return snapshot_state_signature(snapshot)
+
+
 def read_codex_rate_limits_series(
     codex_home: Path | str | None = None,
     *,
-    since_epoch: float = 0.0,
+    exclude_captured_at: Iterable[float] = (),
     now: float | None = None,
     max_files: int = 400,
 ) -> list[RateLimitSnapshot]:
@@ -881,17 +894,22 @@ def read_codex_rate_limits_series(
 
     The calibration-density companion to ``read_codex_rate_limits_latest``:
     that reader records one snapshot per scan tick, which starves the weekly
-    fit; this one imports the in-file history — bounded to readings STRICTLY
-    newer than ``since_epoch`` (the caller's recorded watermark) and to the
-    backfill window — with per-file replay bursts collapsed. Files whose mtime
-    predates the watermark cannot contain newer lines (rollouts only grow) and
-    are skipped unread.
+    fit; this one BACKFILLS the in-file history between those sparse ticks.
+    Bounds and idempotence:
+
+    * only the backfill window (older history cannot influence the fit);
+    * per-file replay bursts collapsed (see ``_CODEX_REPLAY_COLLAPSE_SECONDS``);
+    * a DETERMINISTIC transition-collapse over the merged series (consecutive
+      identical states drop), so every scan derives the same survivor set;
+    * survivors whose capture time is already recorded (``exclude_captured_at``,
+      from ``recorded_captured_ats``) are skipped — so the backfill happens
+      once and a re-scan is a no-op.
     """
 
     import time as _time
 
     now_epoch = now if now is not None else _time.time()
-    floor = max(since_epoch, now_epoch - _CODEX_SERIES_BACKFILL_DAYS * 86400.0)
+    floor = now_epoch - _CODEX_SERIES_BACKFILL_DAYS * 86400.0
     rollouts: list[Path] = []
     for root in _codex_sessions_roots(codex_home):
         try:
@@ -919,7 +937,17 @@ def read_codex_rate_limits_series(
             if float(snapshot.captured_at or 0) > floor
         )
     series.sort(key=lambda snapshot: float(snapshot.captured_at or 0))
-    return series
+    collapsed: list[RateLimitSnapshot] = []
+    for snapshot in series:
+        if collapsed and _snapshot_transition_key(collapsed[-1]) == _snapshot_transition_key(snapshot):
+            continue
+        collapsed.append(snapshot)
+    excluded = {float(value) for value in exclude_captured_at}
+    return [
+        snapshot
+        for snapshot in collapsed
+        if float(snapshot.captured_at or 0) not in excluded
+    ]
 
 
 def read_claude_plan_usage_latest(

--- a/src/agentacct/rate_limits.py
+++ b/src/agentacct/rate_limits.py
@@ -784,6 +784,144 @@ def read_codex_rate_limits_latest(
     return None
 
 
+def latest_recorded_captured_at(
+    existing_events: Iterable[Mapping[str, Any]], *, client: str
+) -> float:
+    """The newest recorded ``captured_at`` for one client's limit stream.
+
+    The series importer's watermark: only in-file readings STRICTLY newer than
+    this are imported, so a re-scan never re-records history (transition dedup
+    alone compares only the latest state and would re-write a whole replayed
+    series)."""
+
+    newest = 0.0
+    for event in existing_events:
+        if event.get("event_type") != EVENT_TYPE:
+            continue
+        metadata = event.get("metadata") or {}
+        if str(metadata.get("client") or "") != client:
+            continue
+        ordering = _event_ordering(event)
+        if ordering > newest:
+            newest = ordering
+    return newest
+
+
+# Replayed rollout prefixes are stamped with FRESH outer timestamps
+# milliseconds apart (the recorder re-stamps each copied TokenCount at replay
+# time), so a burst of near-simultaneous readings is replay noise, not a real
+# series: collapse each burst to its LAST line — the state at the fork point,
+# which IS the genuine account state at that moment.
+_CODEX_REPLAY_COLLAPSE_SECONDS = 5.0
+# The series import backfills at most this far (the calibration window plus
+# margin) — older history cannot influence the fit and only bloats the ledger.
+_CODEX_SERIES_BACKFILL_DAYS = 30
+
+
+def _read_codex_file_rate_limit_series(path: Path) -> list[RateLimitSnapshot]:
+    """Every DEFAULT-bucket rate-limit snapshot in one rollout, chronological,
+    with replay bursts collapsed. Fails soft to an empty list."""
+
+    snapshots: list[RateLimitSnapshot] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if '"rate_limits"' not in line:
+                    continue
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(obj, Mapping):
+                    continue
+                payload = obj.get("payload")
+                if not isinstance(payload, Mapping):
+                    continue
+                try:
+                    snapshot = normalize_codex_rate_limits(
+                        payload.get("rate_limits"),
+                        captured_at=obj.get("timestamp"),
+                        session_id=_codex_session_id_from_path(path),
+                        source_file=str(path),
+                    )
+                except Exception:  # noqa: BLE001 - one poison line must not abort the file.
+                    continue
+                if (
+                    snapshot is not None
+                    and _is_default_codex_bucket(snapshot)
+                    and snapshot.captured_at is not None
+                    and snapshot.captured_at > 0
+                ):
+                    snapshots.append(snapshot)
+    except OSError:
+        return []
+    # Collapse bursts: keep a reading only when the NEXT one is not within the
+    # replay window (the last of each burst always survives).
+    collapsed: list[RateLimitSnapshot] = []
+    for index, snapshot in enumerate(snapshots):
+        if index + 1 < len(snapshots):
+            gap = float(snapshots[index + 1].captured_at or 0) - float(snapshot.captured_at or 0)
+            if 0 <= gap < _CODEX_REPLAY_COLLAPSE_SECONDS:
+                continue
+        collapsed.append(snapshot)
+    return collapsed
+
+
+def read_codex_rate_limits_series(
+    codex_home: Path | str | None = None,
+    *,
+    since_epoch: float = 0.0,
+    now: float | None = None,
+    max_files: int = 400,
+) -> list[RateLimitSnapshot]:
+    """The DEFAULT-bucket weekly-meter series across recent rollouts, ascending.
+
+    The calibration-density companion to ``read_codex_rate_limits_latest``:
+    that reader records one snapshot per scan tick, which starves the weekly
+    fit; this one imports the in-file history — bounded to readings STRICTLY
+    newer than ``since_epoch`` (the caller's recorded watermark) and to the
+    backfill window — with per-file replay bursts collapsed. Files whose mtime
+    predates the watermark cannot contain newer lines (rollouts only grow) and
+    are skipped unread.
+    """
+
+    import time as _time
+
+    now_epoch = now if now is not None else _time.time()
+    floor = max(since_epoch, now_epoch - _CODEX_SERIES_BACKFILL_DAYS * 86400.0)
+    rollouts: list[Path] = []
+    for root in _codex_sessions_roots(codex_home):
+        try:
+            rollouts.extend(root.rglob("rollout-*.jsonl"))
+        except OSError:
+            continue
+
+    def _mtime(p: Path) -> float:
+        try:
+            return p.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    rollouts = [path for path in rollouts if _mtime(path) >= floor]
+    rollouts.sort(key=lambda p: (_mtime(p), str(p)), reverse=True)
+    series: list[RateLimitSnapshot] = []
+    for path in rollouts[: max(1, max_files)]:
+        try:
+            file_series = _read_codex_file_rate_limit_series(path)
+        except Exception:  # noqa: BLE001 - fail soft per the module contract.
+            continue
+        series.extend(
+            snapshot
+            for snapshot in file_series
+            if float(snapshot.captured_at or 0) > floor
+        )
+    series.sort(key=lambda snapshot: float(snapshot.captured_at or 0))
+    return series
+
+
 def read_claude_plan_usage_latest(
     path: Path | str | None = None,
 ) -> list[RateLimitSnapshot]:

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -221,8 +221,9 @@ def _session_badge(entry: dict) -> str:
 # Clients that have a weekly subscription plan agentacct can estimate against.
 _PLAN_CLIENTS = ("claude-code", "codex")
 # Of those, the ones whose meter can actually calibrate to a per-session weekly %.
-# The rationale (codex's rolling 7-day meter never yields a weekly-reset %) and the
-# authoritative tuple live in plan_cost; this alias keeps existing call sites.
+# The rationale and the authoritative tuple live in plan_cost (codex joined
+# 2026-08-27 when its meter became week-reset cumulative); this alias keeps
+# existing call sites.
 _CALIBRATABLE_CLIENTS = CALIBRATABLE_CLIENTS
 
 
@@ -243,8 +244,9 @@ def _plan_pct_cell(
     yet — but only if its meter can actually calibrate (see ``_CALIBRATABLE_CLIENTS``) —
     shows ``⋯``, an honest "calibrating from your own usage" rather than a number from a
     shipped equation, so the column is not misread as "no weekly plan". A non-plan
-    client, a client whose meter never calibrates (codex), or a zero-token session of an
-    already-calibrated client, shows ``—``. The full nuance is in the session detail."""
+    client, a client whose meter cannot calibrate (no weekly-reset meter), or a
+    zero-token session of an already-calibrated client, shows ``—``. The full nuance
+    is in the session detail."""
 
     client = str(entry.get("client") or "")
     if client not in _PLAN_CLIENTS:
@@ -253,7 +255,7 @@ def _plan_pct_cell(
     if isinstance(pct, (int, float)) and not isinstance(pct, bool) and pct > 0:
         return f"≈{pct:.1f}%" if pct >= 0.1 else "≈<0.1%"
     # A calibratable client with no number yet is warming up → say so, don't dash.
-    # A non-calibratable plan client (codex) never reaches a number, so it stays "—".
+    # A plan client with no calibratable weekly meter never reaches a number → "—".
     if client in _CALIBRATABLE_CLIENTS and (confidence_by_client or {}).get(client) == "baseline":
         return _PLAN_CALIBRATING_CELL
     return "—"

--- a/tests/test_codex_rate_limit_series.py
+++ b/tests/test_codex_rate_limit_series.py
@@ -69,31 +69,39 @@ def test_series_collapses_replay_bursts_and_merges_files(tmp_path: Path) -> None
     assert times == sorted(times)
 
 
-def test_series_respects_the_recorded_watermark(tmp_path: Path) -> None:
+def test_series_backfill_is_idempotent_via_the_exclusion_set(tmp_path: Path) -> None:
     home = tmp_path / "codex-home"
-    path = _write_rollout(
+    _write_rollout(
         home,
         "rollout-2026-08-26T00-00-00-cccc.jsonl",
         [
             _rollout_line("2026-08-26T10:00:00Z", 1.0),
+            _rollout_line("2026-08-26T10:30:00Z", 1.0),  # transition no-op, dropped
             _rollout_line("2026-08-26T11:00:00Z", 2.0),
             _rollout_line("2026-08-26T12:00:00Z", 3.0),
         ],
     )
     full = rl.read_codex_rate_limits_series(home, now=1788000000.0)
-    assert len(full) == 3
-    watermark = float(full[1].captured_at)  # the 11:00 reading is recorded
-    later = rl.read_codex_rate_limits_series(home, since_epoch=watermark, now=1788000000.0)
-    used = [window.used_percent for snapshot in later for window in snapshot.windows]
-    assert used == [3.0]  # strictly-newer only: no re-import bloat
-    # A file whose mtime predates the watermark is skipped unread.
-    import os
+    used = [window.used_percent for snapshot in full for window in snapshot.windows]
+    assert used == [1.0, 2.0, 3.0]  # deterministic transition-collapse
 
-    os.utime(path, (watermark - 10, watermark - 10))
-    assert rl.read_codex_rate_limits_series(home, since_epoch=watermark, now=1788000000.0) == []
+    # BACKFILL: sparse tick-recording caught only the 12:00 state — the
+    # readings BETWEEN recorded snapshots still import.
+    recorded = {float(full[-1].captured_at)}
+    backfill = rl.read_codex_rate_limits_series(
+        home, exclude_captured_at=recorded, now=1788000000.0
+    )
+    used = [window.used_percent for snapshot in backfill for window in snapshot.windows]
+    assert used == [1.0, 2.0]
+
+    # After the backfill, every survivor is recorded — a re-scan is a no-op.
+    recorded |= {float(snapshot.captured_at) for snapshot in backfill}
+    assert rl.read_codex_rate_limits_series(
+        home, exclude_captured_at=recorded, now=1788000000.0
+    ) == []
 
 
-def test_watermark_helper_reads_the_newest_recorded_codex_capture(tmp_path: Path) -> None:
+def test_recorded_captured_ats_reads_one_clients_stream(tmp_path: Path) -> None:
     events = [
         {
             "event_type": "rate_limit_observed",
@@ -112,5 +120,5 @@ def test_watermark_helper_reads_the_newest_recorded_codex_capture(tmp_path: Path
         },
         {"event_type": "other", "created_at": 999.0, "metadata": {"client": "codex"}},
     ]
-    assert rl.latest_recorded_captured_at(events, client="codex") == 120.0
-    assert rl.latest_recorded_captured_at([], client="codex") == 0.0
+    assert rl.recorded_captured_ats(events, client="codex") == {120.0, 80.0}
+    assert rl.recorded_captured_ats([], client="codex") == set()

--- a/tests/test_codex_rate_limit_series.py
+++ b/tests/test_codex_rate_limit_series.py
@@ -1,0 +1,116 @@
+"""The dense codex weekly-meter series importer (calibration food).
+
+One snapshot per scan tick starves the weekly fit; the series reader imports
+the in-file history — watermark-bounded, replay-burst-collapsed, default
+bucket only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agentacct import rate_limits as rl
+
+
+def _rollout_line(iso_ts: str, used: float, *, limit_id: str | None = "codex") -> str:
+    payload = {
+        "rate_limits": {
+            "limit_id": limit_id,
+            "primary": {
+                "used_percent": used,
+                "window_minutes": 10080,
+                "resets_at": 1788273707,
+            },
+            "secondary": None,
+            "plan_type": "pro",
+        }
+    }
+    return json.dumps({"timestamp": iso_ts, "payload": payload})
+
+
+def _write_rollout(root: Path, name: str, lines: list[str]) -> Path:
+    sessions = root / "sessions" / "2026" / "08" / "26"
+    sessions.mkdir(parents=True, exist_ok=True)
+    path = sessions / name
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_series_collapses_replay_bursts_and_merges_files(tmp_path: Path) -> None:
+    home = tmp_path / "codex-home"
+    # A replayed prefix: three readings stamped milliseconds apart (the fork
+    # copy), then the genuine live turns minutes apart.
+    _write_rollout(
+        home,
+        "rollout-2026-08-26T00-00-00-aaaa.jsonl",
+        [
+            _rollout_line("2026-08-26T10:00:00.000Z", 1.0),
+            _rollout_line("2026-08-26T10:00:00.050Z", 2.0),
+            _rollout_line("2026-08-26T10:00:00.100Z", 3.0),  # burst survivor
+            _rollout_line("2026-08-26T10:30:00Z", 4.0),
+            _rollout_line("2026-08-26T11:00:00Z", 5.0),
+        ],
+    )
+    _write_rollout(
+        home,
+        "rollout-2026-08-26T01-00-00-bbbb.jsonl",
+        [
+            _rollout_line("2026-08-26T12:00:00Z", 6.0),
+            # A non-default bucket must never pollute the account series.
+            _rollout_line("2026-08-26T12:30:00Z", 99.0, limit_id="spark"),
+            "not json at all",
+        ],
+    )
+    series = rl.read_codex_rate_limits_series(home, now=1788000000.0)
+    used = [window.used_percent for snapshot in series for window in snapshot.windows]
+    assert used == [3.0, 4.0, 5.0, 6.0]
+    times = [snapshot.captured_at for snapshot in series]
+    assert times == sorted(times)
+
+
+def test_series_respects_the_recorded_watermark(tmp_path: Path) -> None:
+    home = tmp_path / "codex-home"
+    path = _write_rollout(
+        home,
+        "rollout-2026-08-26T00-00-00-cccc.jsonl",
+        [
+            _rollout_line("2026-08-26T10:00:00Z", 1.0),
+            _rollout_line("2026-08-26T11:00:00Z", 2.0),
+            _rollout_line("2026-08-26T12:00:00Z", 3.0),
+        ],
+    )
+    full = rl.read_codex_rate_limits_series(home, now=1788000000.0)
+    assert len(full) == 3
+    watermark = float(full[1].captured_at)  # the 11:00 reading is recorded
+    later = rl.read_codex_rate_limits_series(home, since_epoch=watermark, now=1788000000.0)
+    used = [window.used_percent for snapshot in later for window in snapshot.windows]
+    assert used == [3.0]  # strictly-newer only: no re-import bloat
+    # A file whose mtime predates the watermark is skipped unread.
+    import os
+
+    os.utime(path, (watermark - 10, watermark - 10))
+    assert rl.read_codex_rate_limits_series(home, since_epoch=watermark, now=1788000000.0) == []
+
+
+def test_watermark_helper_reads_the_newest_recorded_codex_capture(tmp_path: Path) -> None:
+    events = [
+        {
+            "event_type": "rate_limit_observed",
+            "created_at": 50.0,
+            "metadata": {"client": "codex", "captured_at": 120.0},
+        },
+        {
+            "event_type": "rate_limit_observed",
+            "created_at": 60.0,
+            "metadata": {"client": "codex", "captured_at": 80.0},
+        },
+        {
+            "event_type": "rate_limit_observed",
+            "created_at": 999.0,
+            "metadata": {"client": "claude-code", "captured_at": 500.0},
+        },
+        {"event_type": "other", "created_at": 999.0, "metadata": {"client": "codex"}},
+    ]
+    assert rl.latest_recorded_captured_at(events, client="codex") == 120.0
+    assert rl.latest_recorded_captured_at([], client="codex") == 0.0

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -603,8 +603,11 @@ def test_glance_plan_entries_carry_three_state_and_basis(tmp_path):
     assert plan["claude-code"]["confidence"] == "baseline"  # the original key survives
     assert plan["claude-code"]["calibration_state"] == "calibrating"
     assert plan["claude-code"]["calibratable"] is True
-    assert plan["codex"]["calibration_state"] == "never"
-    assert plan["codex"]["calibratable"] is False
+    # codex's meter became week-reset cumulative (2026-08-27): it is now a
+    # calibratable plan client and honestly reads "calibrating" until enough
+    # recorded weekly history accrues.
+    assert plan["codex"]["calibration_state"] == "calibrating"
+    assert plan["codex"]["calibratable"] is True
     assert plan["claude-code"]["basis"]
 
 

--- a/tests/test_plan_cost.py
+++ b/tests/test_plan_cost.py
@@ -515,3 +515,46 @@ def test_stability_rejects_a_single_burst_day(tmp_path):
     weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code", now=now)
     assert weights.confidence == "baseline"
     assert weights.scale == 1.0
+
+
+def test_regime_change_calibrates_on_the_trailing_window(tmp_path):
+    """A mid-window ratio regime change (the live 2026-08-27 shape: ~6x early,
+    ~2x recently) fails both the band and the split-half stability on the full
+    window — but the CURRENT regime is honest and in-band, so the trailing
+    ladder calibrates on it, with the shortened window disclosed."""
+
+    service = SentinelService(tmp_path)
+    opus = pc.baseline_weight_fresh("claude-opus-4-8")
+    tokens = 50_000_000
+    spacing = 8 * 3600
+    n = 40  # ~13 days at 8h spacing
+    t0 = 1_000_000
+    pct = 0.0
+    _record_7d(service, captured=float(t0), pct=pct, index=0)
+    for i in range(n):
+        ratio = 6.0 if i < n // 2 else 2.0  # regime change at the midpoint
+        _record_usage(service, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"s{i}", tokens=tokens, updated_at=t0 + i * spacing + spacing // 2,
+                      cost=1.0)
+        pct += ratio * (tokens / 1_000_000.0 * opus)
+        _record_7d(service, captured=float(t0 + (i + 1) * spacing), pct=pct, index=i + 1)
+    now = float(t0 + (n + 1) * spacing)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="claude-code", now=now)
+    assert weights.confidence == "calibrated"
+    assert "trailing" in weights.basis
+    assert pc._TRUSTED_SCALE_BAND[0] <= weights.scale <= pc._TRUSTED_SCALE_BAND[1]
+    assert abs(weights.scale - 2.0) < 0.35  # the CURRENT regime, not the blend
+    # The trailing ladder never rescues an out-of-band recent regime: flip the
+    # order (in-band early, wild recently) and the fit stays baseline.
+    service2 = SentinelService(tmp_path / "flipped")
+    pct = 0.0
+    _record_7d(service2, captured=float(t0), pct=pct, index=0)
+    for i in range(n):
+        ratio = 2.0 if i < n // 2 else 6.0
+        _record_usage(service2, client="claude-code", model="claude-opus-4-8",
+                      session_id=f"s{i}", tokens=tokens, updated_at=t0 + i * spacing + spacing // 2,
+                      cost=1.0)
+        pct += ratio * (tokens / 1_000_000.0 * opus)
+        _record_7d(service2, captured=float(t0 + (i + 1) * spacing), pct=pct, index=i + 1)
+    weights2 = pc.calibrate_plan_weights(service2.list_all_events(), client="claude-code", now=now)
+    assert weights2.confidence == "baseline"

--- a/tests/test_plan_cost.py
+++ b/tests/test_plan_cost.py
@@ -328,12 +328,11 @@ def test_raw_scale_discloses_the_unclamped_fit(tmp_path):
     assert weights.raw_scale is not None and weights.raw_scale > 10.0
 
 
-def test_codex_never_calibrates_even_with_numerically_clean_history(tmp_path):
-    """A rolling meter can land 3 clean intervals in the trusted band by
-    coincidence, but codex's weekly plan % is UNDEFINED by design — the gate
-    lives in calibrate_plan_weights so NO surface can ever receive a
-    'calibrated' codex fit (adversarial-review finding: /v1/plan served
-    confidently-labeled aggregates of an undefined quantity)."""
+def test_codex_calibrates_from_clean_weekly_history(tmp_path):
+    """codex's meter became week-reset cumulative (2026-08-27), so the same
+    interval machinery that fits claude-code now fits codex — with in-band
+    history it calibrates; a client with no calibratable meter still reads
+    'never' (see the hermes case below)."""
 
     service = SentinelService(tmp_path)
     t0 = 1_000_000
@@ -348,6 +347,16 @@ def test_codex_never_calibrates_even_with_numerically_clean_history(tmp_path):
         _record_7d(service, captured=float(t0 + (i + 1) * 3600), pct=pct, client="codex", index=i + 1)
     weights = pc.calibrate_plan_weights(service.list_all_events(), client="codex",
                                         now=float(t0 + 5 * 3600))
+    assert weights.confidence == "calibrated"
+    assert pc.calibration_state(weights) == "calibrated"
+    assert abs(weights.scale - 1.0) < 0.15
+
+
+def test_non_calibratable_client_still_reads_never(tmp_path):
+    """The undefined-plan gate survives for clients without a weekly meter."""
+
+    service = SentinelService(tmp_path)
+    weights = pc.calibrate_plan_weights(service.list_all_events(), client="hermes")
     assert weights.confidence == "baseline"
     assert pc.calibration_state(weights) == "never"
     assert "undefined" in weights.basis

--- a/tests/test_receipt_api.py
+++ b/tests/test_receipt_api.py
@@ -613,7 +613,7 @@ def test_plan_share_stamp_is_client_scoped_and_names_never_for_plan_less_clients
     _stamp_task_plan_shares(projection, events)
     cross, hermes, cc = (task["plan_share"] for task in projection["tasks"])
     assert cross["pct"] is None and cross["client"] == "codex"
-    assert cross["calibration_state"] == "never"
+    assert cross["calibration_state"] == "calibrating"
     assert hermes["pct"] is None and hermes["calibration_state"] == "never"
     assert cc["pct"] is not None and cc["pct"] > 0
     assert cc["covered_sessions"] == 1  # the codex member never counted

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1292,9 +1292,9 @@ def test_plan_pct_cell_helper():
     # (not a bare '—'), so the column is not misread as "there is no weekly plan".
     from agentacct.tui import _PLAN_CALIBRATING_CELL
     assert _plan_pct_cell(cc, {}, {"claude-code": "baseline"}) == _PLAN_CALIBRATING_CELL
-    # codex is a plan client, but its rolling meter never calibrates — so an
-    # uncalibrated codex cell stays '—', not a false "calibrating" promise.
-    assert _plan_pct_cell(cx, {}, {"codex": "baseline"}) == "—"
+    # codex's weekly meter became calibratable (2026-08-27): an uncalibrated
+    # codex cell now honestly shows the calibrating marker, like claude-code.
+    assert _plan_pct_cell(cx, {}, {"codex": "baseline"}) == _PLAN_CALIBRATING_CELL
     # A calibrated client with a zero-token session still shows '—', not '⋯'.
     assert _plan_pct_cell(cc, {}, {"claude-code": "calibrated"}) == "—"
     # A non-plan client never shows the calibrating marker.

--- a/tests/test_v1_sessions.py
+++ b/tests/test_v1_sessions.py
@@ -356,8 +356,8 @@ def test_plan_entries_carry_the_three_state_semantic(tmp_path):
     plan = {entry["client"]: entry for entry in _sessions(client)["plan"]}
     assert plan["claude-code"]["calibration_state"] == "calibrating"
     assert plan["claude-code"]["calibratable"] is True
-    assert plan["codex"]["calibration_state"] == "never"
-    assert plan["codex"]["calibratable"] is False
+    assert plan["codex"]["calibration_state"] == "calibrating"
+    assert plan["codex"]["calibratable"] is True
     for entry in plan.values():
         assert isinstance(entry["basis"], str) and entry["basis"]
         assert "scale" in entry and "intervals_used" in entry
@@ -1021,7 +1021,7 @@ def test_plan_endpoint_uncalibrated_carries_states_not_numbers(tmp_path):
     assert clients["claude-code"]["calibration_state"] == "calibrating"
     assert clients["claude-code"]["window_pcts"] is None
     assert clients["claude-code"]["daily"] is None
-    assert clients["codex"]["calibration_state"] == "never"
+    assert clients["codex"]["calibration_state"] == "calibrating"
     assert clients["codex"]["by_model"] is None
 
 


### PR DESCRIPTION
Sixth and final PR from the 2026-08-27 receipt-UI feedback round: **codex weekly-plan calibration** (feedback #8, second half). The 2026-08-05 "codex weekly % is undefined" verdict is now stale — codex's meter changed shape and is calibratable.

## What changed in codex, and why it's now feasible

codex's `rate_limits` now reports a **single primary window** (`window_minutes=10080`) with an **observable `resets_at`**, and the local rollouts show **week-reset-cumulative** behavior — monotonic climb within an epoch, a drop to 0 at a new `resets_at ≈ +7d`. That's the same semantics the weekly fit already requires for Claude. The old "rolling and opaque, resets unobservable" premise described the *previous* shape.

## What this PR does

**Dense meter-series backfill** (`read_codex_rate_limits_series`) — the existing reader records one snapshot per scan tick, which starves the weekly fit. This backfills the in-file meter history:
- default account bucket only, 30-day bound;
- per-file replay-burst collapse (a forked rollout re-stamps copied readings milliseconds apart → keep each burst's last line, the genuine state at the fork point);
- a **deterministic transition-collapse** using the recorder's *own* `snapshot_state_signature`, so any reading the recorder would treat as a no-op is dropped identically every scan;
- an **exclusion set** of already-recorded capture times, so the backfill happens exactly once and a re-scan is a no-op.

**codex joins `CALIBRATABLE_CLIENTS`** — the same interval machinery (transition-recorded readings, reset-drop skipping, the trusted band, the split-half stability lane) now judges codex fits. Clients with no weekly-reset meter still read `never`. Residual noise is absorbed: integer-quantized percents (transition recording means consecutive readings differ by ≥1 point + the ratio-of-sums estimator averages the rounding down), irregular gift/regrant resets (any drop is skipped), fork/replay contamination (burst collapse + mtime-anchored latest reader).

**Trailing regime windows** — a bonus honesty fix that surfaced during live verification. When the *full* calibration window fails its gates because the account's ratio genuinely regime-changed inside it (measured live on claude-code: ~6× before 08-22, ~2.1–2.8 after — a model-mix change), the fit retries on trailing sub-windows (14/10/7/5 days), accepted **only** under the *original* strict gate: inside the trusted band, ≥12 intervals, no stability leniency. The shortened window is disclosed in the basis. This stops a mid-window regime change from either certifying a stale blend or reading "calibrating forever".

## Verified live (copy of the real store through a temp daemon on this branch)

Both clients calibrate and every task row carries a real weekly share:

```
claude-code | calibrated | two-component fit x2.39 (46 intervals in the trailing 10 days — the full window mixes a ratio regime change)
codex       | calibrated | two-component fit x2.02 (24 recent weekly-% intervals)
```

The real codex import went 42 → 141 recorded readings, and a second run was a no-op (idempotent). codex task rows now show `≈4.3% / ≈8.3% of weekly plan`; claude-code rows show shares off the more-accurate x2.39 trailing fit.

## Verification

- `pytest -q`: 2633 (new tests: series burst-collapse + file-merge + default-bucket filter, idempotent backfill via the exclusion set, the `recorded_captured_ats` helper, codex-calibrates-from-clean-history, non-calibratable-client-still-never, regime-change-calibrates-on-trailing-window incl. the flipped-regime baseline case).
- `swift test`: 34 passed (1 skipped: canonical visual verify). No app or visual-reference changes.
- Adversarial review: the sub-agent lane hit a usage limit mid-run, so this was reviewed inline instead — one stale-copy fix (TUI comments still said codex "never calibrates"), everything else cleared (trailing-ladder reporting coherence, quantization/regrant handling, ~0.7% importer duty cycle at the 60s watch cadence, float round-trip idempotence, recorder ordering-interleave correctness, CLI failure isolation).

No file or semantic overlap with the concurrently-open top-bar PR (this is Python backend only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
