### PR TITLE
ci(app): add Milestone 1 visual reference candidates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test visual snapshot CLI
         run: ./Tests/visual-snapshots-cli-tests.sh
+      - name: Test dashboard reference candidate packaging
+        run: ./Tests/dashboard-reference-candidate-cli-tests.py
       - name: Run Swift tests
         run: swift test
       - name: Detect canonical visual renderer

--- a/.github/workflows/visual-reference-candidates.yml
+++ b/.github/workflows/visual-reference-candidates.yml
@@ -1,0 +1,130 @@
+name: visual reference candidates
+run-name: Visual reference candidate for ${{ inputs.ref }}
+
+"on":
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Full commit SHA to render from this repository
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: visual-reference-candidate-${{ inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  render:
+    name: Render candidate (${{ matrix.replica }})
+    runs-on: macos-26
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        replica: [a, b]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+      TZ: UTC
+    steps:
+      - name: Validate requested commit
+        env:
+          REQUESTED_COMMIT: ${{ inputs.ref }}
+        run: |
+          if [[ ! "$REQUESTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ref must be a full lowercase 40-character commit SHA" >&2
+            exit 2
+          fi
+      - name: Check out trusted candidate tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+      - name: Check out requested source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          path: source
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Verify checked-out source identity
+        env:
+          REQUESTED_COMMIT: ${{ inputs.ref }}
+        run: |
+          actual_commit="$(git -C source rev-parse HEAD)"
+          if [[ "$actual_commit" != "$REQUESTED_COMMIT" ]]; then
+            echo "requested $REQUESTED_COMMIT but checked out $actual_commit" >&2
+            exit 2
+          fi
+      - name: Check canonical renderer
+        id: renderer
+        run: |
+          renderer_id="$(trusted/apps/agentacct/Scripts/visual-snapshots check-environment)"
+          echo "renderer_id=$renderer_id" >> "$GITHUB_OUTPUT"
+      - name: Run deterministic dashboard render tests
+        working-directory: source/apps/agentacct
+        run: swift test --filter DashboardSnapshotHarnessTests
+      - name: Build release renderer
+        working-directory: source/apps/agentacct
+        run: swift build -c release
+      - name: Render dashboard candidate
+        working-directory: source/apps/agentacct
+        run: |
+          candidate_root="$RUNNER_TEMP/dashboard-reference-candidate"
+          mkdir -p "$candidate_root/images"
+          .build/release/agentacct \
+            --snapshot-dashboard-fixture \
+            Tests/agentacctTests/Fixtures/dashboard.json \
+            "$candidate_root/images"
+      - name: Package candidate manifest
+        env:
+          RENDERER_ID: ${{ steps.renderer.outputs.renderer_id }}
+          REQUESTED_COMMIT: ${{ inputs.ref }}
+        run: |
+          : "${ImageOS:?GitHub-hosted runner did not set ImageOS}"
+          : "${ImageVersion:?GitHub-hosted runner did not set ImageVersion}"
+          trusted/apps/agentacct/Scripts/package-dashboard-reference-candidate \
+            --images "$RUNNER_TEMP/dashboard-reference-candidate/images" \
+            --output "$RUNNER_TEMP/dashboard-reference-candidate/manifest.json" \
+            --source-commit "$REQUESTED_COMMIT" \
+            --renderer-id "$RENDERER_ID" \
+            --runner-image "$ImageOS" \
+            --runner-image-version "$ImageVersion"
+      - name: Upload replica
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-reference-candidate-${{ inputs.ref }}-${{ matrix.replica }}
+          path: ${{ runner.temp }}/dashboard-reference-candidate
+          if-no-files-found: error
+          retention-days: 1
+
+  verify:
+    name: Verify independent candidates
+    needs: render
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download replica A
+        uses: actions/download-artifact@v4
+        with:
+          name: dashboard-reference-candidate-${{ inputs.ref }}-a
+          path: replicas/a
+      - name: Download replica B
+        uses: actions/download-artifact@v4
+        with:
+          name: dashboard-reference-candidate-${{ inputs.ref }}-b
+          path: replicas/b
+      - name: Require byte-identical bundles
+        run: diff --recursive --brief --no-dereference replicas/a replicas/b
+      - name: Upload verified candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-reference-candidate-${{ inputs.ref }}
+          path: replicas/a
+          if-no-files-found: error
+          retention-days: 14

--- a/apps/agentacct/Scripts/package-dashboard-reference-candidate
+++ b/apps/agentacct/Scripts/package-dashboard-reference-candidate
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Validate and describe a dashboard reference-image candidate bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import struct
+import tempfile
+import zlib
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+EXPECTED_IMAGES = {
+    "dashboard-minimum-dark.png": (1920, 1120),
+    "dashboard-minimum-light.png": (1920, 1120),
+    "dashboard-reference-dark.png": (2240, 1600),
+    "dashboard-reference-light.png": (2240, 1600),
+}
+FULL_COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+SAFE_RENDERER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+class CandidateError(ValueError):
+    """A candidate bundle violated the promotion contract."""
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate dashboard PNGs and write a deterministic candidate manifest."
+    )
+    parser.add_argument("--images", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--renderer-id", required=True)
+    parser.add_argument("--runner-image", required=True)
+    parser.add_argument("--runner-image-version", required=True)
+    return parser.parse_args()
+
+
+def single_line(name: str, value: str) -> str:
+    if not value or value.strip() != value or "\n" in value or "\r" in value:
+        raise CandidateError(f"{name} must be a non-empty single-line value")
+    return value
+
+
+def validate_identity(arguments: argparse.Namespace) -> None:
+    if FULL_COMMIT_PATTERN.fullmatch(arguments.source_commit) is None:
+        raise CandidateError("source commit must be a full lowercase 40-character Git SHA")
+    if SAFE_RENDERER_PATTERN.fullmatch(arguments.renderer_id) is None:
+        raise CandidateError("renderer id must be a safe path component")
+    single_line("runner image", arguments.runner_image)
+    single_line("runner image version", arguments.runner_image_version)
+
+
+def checked_png_dimensions(path: Path) -> tuple[int, int]:
+    if path.is_symlink() or not path.is_file():
+        raise CandidateError(f"candidate image must be a regular file: {path.name}")
+
+    data = path.read_bytes()
+    if not data.startswith(PNG_SIGNATURE):
+        raise CandidateError(f"candidate image is not a PNG: {path.name}")
+
+    offset = len(PNG_SIGNATURE)
+    dimensions: tuple[int, int] | None = None
+    saw_image_data = False
+    saw_end = False
+    while offset < len(data):
+        if len(data) - offset < 12:
+            raise CandidateError(f"candidate PNG is truncated: {path.name}")
+        length = struct.unpack(">I", data[offset : offset + 4])[0]
+        chunk_type = data[offset + 4 : offset + 8]
+        chunk_end = offset + 12 + length
+        if chunk_end > len(data):
+            raise CandidateError(f"candidate PNG is truncated: {path.name}")
+        chunk_data = data[offset + 8 : offset + 8 + length]
+        expected_crc = struct.unpack(">I", data[offset + 8 + length : chunk_end])[0]
+        actual_crc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+        if actual_crc != expected_crc:
+            raise CandidateError(f"candidate PNG has an invalid checksum: {path.name}")
+
+        if dimensions is None:
+            if chunk_type != b"IHDR" or length != 13:
+                raise CandidateError(f"candidate PNG has an invalid header: {path.name}")
+            width, height = struct.unpack(">II", chunk_data[:8])
+            dimensions = (width, height)
+        elif chunk_type == b"IHDR":
+            raise CandidateError(f"candidate PNG has more than one header: {path.name}")
+        elif chunk_type == b"IDAT":
+            saw_image_data = True
+
+        offset = chunk_end
+        if chunk_type == b"IEND":
+            if length != 0 or not saw_image_data or offset != len(data):
+                raise CandidateError(f"candidate PNG has an invalid end marker: {path.name}")
+            saw_end = True
+            break
+
+    if dimensions is None or not saw_image_data or not saw_end:
+        raise CandidateError(f"candidate PNG is incomplete: {path.name}")
+    return dimensions
+
+
+def candidate_artifacts(images: Path) -> list[dict[str, object]]:
+    if not images.is_dir():
+        raise CandidateError(f"candidate image directory does not exist: {images}")
+
+    actual_names = {path.name for path in images.iterdir()}
+    expected_names = set(EXPECTED_IMAGES)
+    if actual_names != expected_names:
+        missing = sorted(expected_names - actual_names)
+        unexpected = sorted(actual_names - expected_names)
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected: {', '.join(unexpected)}")
+        raise CandidateError("candidate image inventory mismatch (" + "; ".join(details) + ")")
+
+    artifacts = []
+    for filename, expected_dimensions in EXPECTED_IMAGES.items():
+        path = images / filename
+        dimensions = checked_png_dimensions(path)
+        if dimensions != expected_dimensions:
+            expected_width, expected_height = expected_dimensions
+            actual_width, actual_height = dimensions
+            raise CandidateError(
+                f"candidate image {filename} must be {expected_width}x{expected_height}; "
+                f"got {actual_width}x{actual_height}"
+            )
+        artifacts.append(
+            {
+                "filename": filename,
+                "pixel_height": dimensions[1],
+                "pixel_width": dimensions[0],
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+        )
+    return artifacts
+
+
+def write_manifest(path: Path, manifest: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as temporary:
+            temporary.write(payload)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        validate_identity(arguments)
+        manifest = {
+            "artifacts": candidate_artifacts(arguments.images),
+            "renderer_id": arguments.renderer_id,
+            "runner_image": {
+                "name": single_line("runner image", arguments.runner_image),
+                "version": single_line(
+                    "runner image version", arguments.runner_image_version
+                ),
+            },
+            "schema_version": 1,
+            "source_commit": arguments.source_commit,
+        }
+        write_manifest(arguments.output, manifest)
+    except (CandidateError, OSError) as error:
+        raise SystemExit(f"package-dashboard-reference-candidate: {error}") from error
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/agentacct/Tests/README.md
+++ b/apps/agentacct/Tests/README.md
@@ -59,6 +59,55 @@ GitHub displays a changed PNG as a
 [2-up, swipe, or onion-skin comparison](https://docs.github.com/en/repositories/working-with-files/using-files/working-with-non-code-files#rendering-and-diffing-images).
 The reference update is therefore the reviewer-facing before/after artifact.
 
+## Request an authoritative candidate remotely
+
+Developer machines are not authoritative renderers. To generate a candidate
+without using or reconfiguring a developer's Mac, push the source commit to
+this repository and request its full lowercase commit SHA:
+
+```bash
+source_commit="$(git rev-parse HEAD)"
+gh workflow run visual-reference-candidates.yml -f ref="$source_commit"
+```
+
+The commit must exist in this repository; a local-only commit or a commit that
+exists only in a fork cannot be checked out. Find the resulting manual run and
+download its verified artifact after it succeeds:
+
+```bash
+gh run list --workflow visual-reference-candidates.yml --event workflow_dispatch --limit 5
+gh run watch <run-id>
+gh run download <run-id> \
+  --name "dashboard-reference-candidate-$source_commit" \
+  --dir /tmp/agentacct-dashboard-reference-candidate
+```
+
+The artifact contains `manifest.json` and an `images` directory with the four
+dashboard PNGs. The manifest binds the bundle to the source commit, canonical
+renderer, hosted-runner image, exact dimensions, and SHA-256 of every image.
+
+The workflow has no repository write permission or secrets. It checks out the
+workflow's own commit as trusted tooling, checks out the requested source into
+a separate directory without persisted credentials, and fails before rendering
+unless the host matches the exact canonical renderer. Two fresh macOS runners
+then run the deterministic dashboard tests, build the release renderer, and
+package independent candidates. A separate Linux job publishes the 14-day
+verified artifact only when the two complete bundles are byte-identical.
+
+A successful run proves repeatable generation; it does not approve a visual
+change. Before promotion, verify the manifest's source and renderer identities
+and inspect every light/dark and minimum/reference PNG. This workflow never
+records, commits, or replaces reviewed references. Keep candidate generation
+and baseline approval as separate review gates.
+
+| Failure | Meaning |
+| --- | --- |
+| invalid or unreachable commit | the input is not a full commit in this repository |
+| canonical renderer check | GitHub's mutable host image drifted; perform an explicit renderer migration |
+| dashboard test, build, or render | the requested source cannot produce the fixed review matrix |
+| candidate packaging | the image inventory, PNG structure, dimensions, or identity evidence is invalid |
+| independent bundle comparison | the renderer or host image was not reproducible; no verified candidate is published |
+
 ## Selecting tests
 
 The canonical identity is the specifier reported by `swift test list`. The CLI

--- a/apps/agentacct/Tests/dashboard-reference-candidate-cli-tests.py
+++ b/apps/agentacct/Tests/dashboard-reference-candidate-cli-tests.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Dependency-free CLI tests for dashboard reference candidate packaging."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+APP_DIR = TESTS_DIR.parent
+PACKAGER = APP_DIR / "Scripts" / "package-dashboard-reference-candidate"
+REFERENCE_ROOT = TESTS_DIR / "agentacctTests" / "ReferenceImages"
+SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+RENDERER_ID = "macos-test-build-xcode-test-build-arm64-2x"
+EXPECTED_DIMENSIONS = {
+    "dashboard-minimum-dark.png": (1920, 1120),
+    "dashboard-minimum-light.png": (1920, 1120),
+    "dashboard-reference-dark.png": (2240, 1600),
+    "dashboard-reference-light.png": (2240, 1600),
+}
+
+
+def run_packager(images: Path, output: Path, **overrides: str) -> subprocess.CompletedProcess[str]:
+    values = {
+        "source_commit": SOURCE_COMMIT,
+        "renderer_id": RENDERER_ID,
+        "runner_image": "macos-test-arm64",
+        "runner_image_version": "20260827.1",
+        **overrides,
+    }
+    return subprocess.run(
+        [
+            str(PACKAGER),
+            "--images",
+            str(images),
+            "--output",
+            str(output),
+            "--source-commit",
+            values["source_commit"],
+            "--renderer-id",
+            values["renderer_id"],
+            "--runner-image",
+            values["runner_image"],
+            "--runner-image-version",
+            values["runner_image_version"],
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_failure(result: subprocess.CompletedProcess[str], message: str) -> None:
+    require(result.returncode != 0, message)
+
+
+def main() -> None:
+    reference_directories = sorted(
+        path
+        for path in REFERENCE_ROOT.iterdir()
+        if path.is_dir()
+        and {image.name for image in path.glob("*.png")} == set(EXPECTED_DIMENSIONS)
+    )
+    require(reference_directories, "expected at least one complete reference directory")
+
+    with tempfile.TemporaryDirectory(prefix="agentacct-candidate-tests-") as temporary:
+        temporary_root = Path(temporary)
+        images = temporary_root / "images"
+        shutil.copytree(reference_directories[0], images)
+        output = temporary_root / "manifest.json"
+
+        first = run_packager(images, output)
+        require(first.returncode == 0, first.stderr)
+        first_payload = output.read_bytes()
+        manifest = json.loads(first_payload)
+        require(manifest["schema_version"] == 1, "manifest schema version changed")
+        require(manifest["source_commit"] == SOURCE_COMMIT, "manifest lost source identity")
+        require(manifest["renderer_id"] == RENDERER_ID, "manifest lost renderer identity")
+        require(
+            manifest["runner_image"]
+            == {"name": "macos-test-arm64", "version": "20260827.1"},
+            "manifest lost hosted runner image identity",
+        )
+
+        artifacts = manifest["artifacts"]
+        require(
+            [artifact["filename"] for artifact in artifacts] == sorted(EXPECTED_DIMENSIONS),
+            "manifest artifact order is not deterministic",
+        )
+        for artifact in artifacts:
+            filename = artifact["filename"]
+            require(
+                (artifact["pixel_width"], artifact["pixel_height"])
+                == EXPECTED_DIMENSIONS[filename],
+                f"manifest recorded incorrect dimensions for {filename}",
+            )
+            expected_hash = hashlib.sha256((images / filename).read_bytes()).hexdigest()
+            require(artifact["sha256"] == expected_hash, f"manifest hash is wrong for {filename}")
+
+        second = run_packager(images, output)
+        require(second.returncode == 0, second.stderr)
+        require(output.read_bytes() == first_payload, "identical input changed manifest bytes")
+
+        invalid_commit = run_packager(
+            images, temporary_root / "invalid-commit.json", source_commit="main"
+        )
+        require_failure(invalid_commit, "packager accepted a branch instead of a full commit")
+        require("full lowercase 40-character Git SHA" in invalid_commit.stderr, invalid_commit.stderr)
+
+        missing_images = temporary_root / "missing"
+        shutil.copytree(images, missing_images)
+        (missing_images / "dashboard-minimum-dark.png").unlink()
+        missing = run_packager(missing_images, temporary_root / "missing.json")
+        require_failure(missing, "packager accepted an incomplete matrix")
+        require("inventory mismatch" in missing.stderr, missing.stderr)
+
+        unexpected_images = temporary_root / "unexpected"
+        shutil.copytree(images, unexpected_images)
+        shutil.copy(
+            unexpected_images / "dashboard-minimum-dark.png",
+            unexpected_images / "unreviewed.png",
+        )
+        unexpected = run_packager(unexpected_images, temporary_root / "unexpected.json")
+        require_failure(unexpected, "packager accepted an unexpected PNG")
+        require("unexpected: unreviewed.png" in unexpected.stderr, unexpected.stderr)
+
+        extra_file_images = temporary_root / "extra-file"
+        shutil.copytree(images, extra_file_images)
+        (extra_file_images / "notes.txt").write_text("not part of the candidate", encoding="utf-8")
+        extra_file = run_packager(extra_file_images, temporary_root / "extra-file.json")
+        require_failure(extra_file, "packager accepted an unexpected non-image file")
+        require("unexpected: notes.txt" in extra_file.stderr, extra_file.stderr)
+
+        wrong_dimensions = temporary_root / "wrong-dimensions"
+        shutil.copytree(images, wrong_dimensions)
+        shutil.copy(
+            wrong_dimensions / "dashboard-minimum-dark.png",
+            wrong_dimensions / "dashboard-reference-dark.png",
+        )
+        wrong_size = run_packager(wrong_dimensions, temporary_root / "wrong-size.json")
+        require_failure(wrong_size, "packager accepted incorrect dimensions")
+        require("must be 2240x1600; got 1920x1120" in wrong_size.stderr, wrong_size.stderr)
+
+        malformed_images = temporary_root / "malformed"
+        shutil.copytree(images, malformed_images)
+        (malformed_images / "dashboard-reference-light.png").write_bytes(b"not a PNG")
+        malformed = run_packager(malformed_images, temporary_root / "malformed.json")
+        require_failure(malformed, "packager accepted a malformed PNG")
+        require("is not a PNG" in malformed.stderr, malformed.stderr)
+
+        corrupt_images = temporary_root / "corrupt"
+        shutil.copytree(images, corrupt_images)
+        corrupt_image = corrupt_images / "dashboard-reference-light.png"
+        corrupt_bytes = bytearray(corrupt_image.read_bytes())
+        corrupt_bytes[len(corrupt_bytes) // 2] ^= 1
+        corrupt_image.write_bytes(corrupt_bytes)
+        corrupt = run_packager(corrupt_images, temporary_root / "corrupt.json")
+        require_failure(corrupt, "packager accepted a PNG with a corrupt chunk")
+        require("invalid checksum" in corrupt.stderr, corrupt.stderr)
+
+        symlinked_images = temporary_root / "symlinked"
+        shutil.copytree(images, symlinked_images)
+        linked_image = symlinked_images / "dashboard-reference-light.png"
+        linked_image.unlink()
+        linked_image.symlink_to(images / "dashboard-reference-light.png")
+        symlinked = run_packager(symlinked_images, temporary_root / "symlinked.json")
+        require_failure(symlinked, "packager accepted a symlinked candidate")
+        require("must be a regular file" in symlinked.stderr, symlinked.stderr)
+
+    print("dashboard reference candidate CLI tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_visual_reference_workflow.py
+++ b/tests/test_visual_reference_workflow.py
@@ -1,0 +1,112 @@
+"""Structural safety checks for on-demand visual reference candidates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "visual-reference-candidates.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _combined_steps(job: dict) -> str:
+    return "\n".join(str(step) for step in job["steps"])
+
+
+def test_visual_reference_workflow_is_manual_and_read_only() -> None:
+    workflow = _workflow()
+    assert set(workflow["on"]) == {"workflow_dispatch"}
+    requested_ref = workflow["on"]["workflow_dispatch"]["inputs"]["ref"]
+    assert requested_ref["required"] is True
+    assert requested_ref["type"] == "string"
+    assert workflow["permissions"] == {"contents": "read"}
+
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "pull_request_target" not in text
+    assert "contents: write" not in text
+    assert "secrets." not in text
+
+
+def test_visual_reference_workflow_uses_two_fresh_canonical_renderers() -> None:
+    render = _workflow()["jobs"]["render"]
+    assert render["runs-on"] == "macos-26"
+    assert render["strategy"]["fail-fast"] is False
+    assert render["strategy"]["matrix"]["replica"] == ["a", "b"]
+    assert render["env"] == {
+        "DEVELOPER_DIR": "/Applications/Xcode_26.6.app/Contents/Developer",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "TZ": "UTC",
+    }
+
+    steps = render["steps"]
+    step_names = [step["name"] for step in steps]
+    assert step_names.index("Check canonical renderer") < step_names.index(
+        "Run deterministic dashboard render tests"
+    )
+    combined = _combined_steps(render)
+    assert "^[0-9a-f]{40}$" in combined
+    assert "visual-snapshots check-environment" in combined
+    assert "DashboardSnapshotHarnessTests" in combined
+    assert "swift build -c release" in combined
+
+
+def test_visual_reference_workflow_keeps_trusted_tools_outside_requested_source() -> None:
+    render = _workflow()["jobs"]["render"]
+    checkout_steps = [step for step in render["steps"] if step.get("uses") == "actions/checkout@v4"]
+    assert len(checkout_steps) == 2
+    assert checkout_steps[0]["with"] == {
+        "ref": "${{ github.workflow_sha }}",
+        "path": "trusted",
+        "persist-credentials": False,
+    }
+    assert checkout_steps[1]["with"] == {
+        "ref": "${{ inputs.ref }}",
+        "path": "source",
+        "fetch-depth": 1,
+        "persist-credentials": False,
+    }
+
+    combined = _combined_steps(render)
+    assert "trusted/apps/agentacct/Scripts/visual-snapshots" in combined
+    assert "trusted/apps/agentacct/Scripts/package-dashboard-reference-candidate" in combined
+    assert "source/apps/agentacct" in combined
+    assert "AGENTACCT_SNAPSHOT_MODE=record" not in combined
+
+
+def test_visual_reference_workflow_packages_traceable_replica_bundles() -> None:
+    render = _workflow()["jobs"]["render"]
+    combined = _combined_steps(render)
+    assert "--source-commit" in combined
+    assert "--renderer-id" in combined
+    assert "--runner-image" in combined
+    assert "--runner-image-version" in combined
+    assert "ImageOS" in combined
+    assert "ImageVersion" in combined
+
+    upload = next(step for step in render["steps"] if step["name"] == "Upload replica")
+    assert upload["with"]["retention-days"] == 1
+    assert upload["with"]["if-no-files-found"] == "error"
+    assert "matrix.replica" in upload["with"]["name"]
+
+
+def test_visual_reference_workflow_promotes_only_identical_replicas_to_artifact() -> None:
+    verify = _workflow()["jobs"]["verify"]
+    assert verify["needs"] == "render"
+    assert verify["runs-on"] == "ubuntu-latest"
+    combined = _combined_steps(verify)
+    assert "dashboard-reference-candidate-${{ inputs.ref }}-a" in combined
+    assert "dashboard-reference-candidate-${{ inputs.ref }}-b" in combined
+    assert "diff --recursive --brief --no-dereference replicas/a replicas/b" in combined
+
+    final_upload = next(step for step in verify["steps"] if step["name"] == "Upload verified candidate")
+    assert final_upload["with"]["name"] == "dashboard-reference-candidate-${{ inputs.ref }}"
+    assert final_upload["with"]["path"] == "replicas/a"
+    assert final_upload["with"]["retention-days"] == 14
+    assert final_upload["with"]["if-no-files-found"] == "error"


### PR DESCRIPTION
## Why

Reviewed SwiftUI reference images depend on the exact macOS and Xcode renderer. Developer machines vary, so candidate generation needs an authoritative on-demand path that does not use or reconfigure anyone's daily-use Mac.

## Central difference

Before this change, CI could render review artifacts incidentally but had no explicit, traceable contract for authoritative candidates. After it, a maintainer supplies a full source commit SHA; two fresh canonical macOS workers render independently, trusted tooling validates and packages the results, and a separate job publishes only a byte-identical bundle.

## Design and safety

- Manual `workflow_dispatch` only, with repository contents read-only and no secrets or persisted Git credentials.
- Trusted packaging and renderer-identity tools are checked out from the workflow commit, separately from the requested source.
- The job fails closed unless the runner matches the exact canonical renderer.
- The packager accepts exactly four regular PNG files, validates their structure, checksums, and fixed dimensions, and records source, renderer, runner-image, and SHA-256 evidence in a deterministic manifest.
- Two independent candidates must be byte-identical before the verified artifact is retained for 14 days.
- Candidate generation never records, replaces, commits, or approves reviewed reference images.

Operational dependency: #138 updates the canonical renderer identity to the current hosted macOS 26.6 image. Until it lands, this workflow is expected to fail closed at the renderer check.

## Review map

1. `.github/workflows/visual-reference-candidates.yml` — the on-demand trust boundary and two-replica verification flow.
2. `apps/agentacct/Scripts/package-dashboard-reference-candidate` — the candidate inventory, PNG, identity, and manifest contract.
3. `apps/agentacct/Tests/dashboard-reference-candidate-cli-tests.py` and `tests/test_visual_reference_workflow.py` — malformed-input and workflow-safety coverage.
4. `apps/agentacct/Tests/README.md` and `.github/workflows/tests.yml` — operator instructions, failure meanings, and continuous packaging coverage.

## Verification

- `./Tests/dashboard-reference-candidate-cli-tests.py && ./Tests/visual-snapshots-cli-tests.sh`
- `uv run --frozen --with pytest pytest -q tests/test_visual_reference_workflow.py tests/test_publish_workflow.py` — 11 passed
- `swift test` — 34 passed, 1 intentional visual-baseline skip, 0 failures
- `swift build -c release`
- Two independently rendered and packaged local bundles compared byte-identical
- `git diff --check origin/main...HEAD`

The hosted dual-runner dispatch is intentionally deferred until #138 lands because the workflow's renderer check is fail-closed.

## Scope

This is Milestone 1: hosted candidate generation only. It does not import or promote candidates, update reviewed baselines, add canary monitoring, or configure a personal Mac mini/self-hosted runner.
