### PR TITLE
feat(app): validate and promote visual reference candidates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -38,6 +43,7 @@ jobs:
   macos-app:
     name: macOS app and dashboard snapshots
     runs-on: macos-26
+    timeout-minutes: 20
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
       LANG: en_US.UTF-8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,13 +24,13 @@ jobs:
         # and is tracked as a separate follow-up.
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history: the Gate 1 evidence-binding test verifies git
           # provenance of recovery evidence and fails closed on a shallow
           # checkout that cannot see the referenced commits.
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package
@@ -53,7 +53,7 @@ jobs:
       run:
         working-directory: apps/agentacct
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Test visual snapshot CLI
         run: ./Tests/visual-snapshots-cli-tests.sh
       - name: Test dashboard reference candidate packaging
@@ -80,7 +80,7 @@ jobs:
         run: ./Scripts/visual-snapshots verify DashboardVisualRegressionTests
       - name: Upload dashboard visual failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dashboard-diff-${{ github.sha }}
           path: ${{ runner.temp }}/agentacct-dashboard-diff/*.png
@@ -100,7 +100,7 @@ jobs:
             "$RUNNER_TEMP/agentacct-dashboard-review"
       - name: Upload dashboard review matrix
         if: ${{ !cancelled() && steps.review_render.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dashboard-review-${{ github.sha }}
           path: ${{ runner.temp }}/agentacct-dashboard-review/*.png
@@ -108,7 +108,7 @@ jobs:
           retention-days: 14
       - name: Upload canonical dashboard baseline candidates
         if: ${{ !cancelled() && steps.visual-renderer.outputs.canonical == 'true' && steps.visual_references.outcome == 'failure' && steps.review_render.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dashboard-baseline-candidate-macos-26.5.2-25F84-xcode-26.6-17F113-arm64-2x-${{ github.sha }}
           path: ${{ runner.temp }}/agentacct-dashboard-review/*.png

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,8 @@ jobs:
         run: ./Tests/visual-snapshots-cli-tests.sh
       - name: Test dashboard reference candidate packaging
         run: ./Tests/dashboard-reference-candidate-cli-tests.py
+      - name: Test dashboard reference candidate intake
+        run: ./Tests/dashboard-reference-candidate-intake-cli-tests.py
       - name: Run Swift tests
         run: swift test
       - name: Detect canonical visual renderer

--- a/.github/workflows/visual-reference-candidates.yml
+++ b/.github/workflows/visual-reference-candidates.yml
@@ -35,7 +35,7 @@ jobs:
             exit 2
           fi
       - name: Check out requested source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           path: source
@@ -69,13 +69,13 @@ jobs:
       TZ: UTC
     steps:
       - name: Check out trusted candidate tooling
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.workflow_sha }}
           path: trusted
           persist-credentials: false
       - name: Check out requested source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.preflight.outputs.source_commit }}
           path: source
@@ -125,7 +125,7 @@ jobs:
             --runner-image "$ImageOS" \
             --runner-image-version "$ImageVersion"
       - name: Upload replica
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dashboard-reference-candidate-${{ inputs.ref }}-${{ matrix.replica }}
           path: ${{ runner.temp }}/dashboard-reference-candidate
@@ -139,19 +139,19 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download replica A
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dashboard-reference-candidate-${{ inputs.ref }}-a
           path: replicas/a
       - name: Download replica B
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dashboard-reference-candidate-${{ inputs.ref }}-b
           path: replicas/b
       - name: Require byte-identical bundles
         run: diff --recursive --brief --no-dereference replicas/a replicas/b
       - name: Upload verified candidate
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dashboard-reference-candidate-${{ inputs.ref }}
           path: replicas/a

--- a/.github/workflows/visual-reference-candidates.yml
+++ b/.github/workflows/visual-reference-candidates.yml
@@ -13,23 +13,18 @@ permissions:
   contents: read
 
 concurrency:
-  group: visual-reference-candidate-${{ inputs.ref }}
+  # Preserve an in-progress proof, retain only the newest pending request, and
+  # never allocate more than the two required canonical macOS replicas at once.
+  group: visual-reference-candidates
   cancel-in-progress: false
 
 jobs:
-  render:
-    name: Render candidate (${{ matrix.replica }})
-    runs-on: macos-26
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        replica: [a, b]
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
-      LANG: en_US.UTF-8
-      LC_ALL: en_US.UTF-8
-      TZ: UTC
+  preflight:
+    name: Validate candidate request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      source_commit: ${{ steps.source.outputs.commit }}
     steps:
       - name: Validate requested commit
         env:
@@ -39,6 +34,40 @@ jobs:
             echo "ref must be a full lowercase 40-character commit SHA" >&2
             exit 2
           fi
+      - name: Check out requested source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          path: source
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Verify checked-out source identity
+        id: source
+        env:
+          REQUESTED_COMMIT: ${{ inputs.ref }}
+        run: |
+          actual_commit="$(git -C source rev-parse HEAD)"
+          if [[ "$actual_commit" != "$REQUESTED_COMMIT" ]]; then
+            echo "requested $REQUESTED_COMMIT but checked out $actual_commit" >&2
+            exit 2
+          fi
+          echo "commit=$actual_commit" >> "$GITHUB_OUTPUT"
+
+  render:
+    name: Render candidate (${{ matrix.replica }})
+    needs: preflight
+    runs-on: macos-26
+    timeout-minutes: 20
+    strategy:
+      fail-fast: true
+      matrix:
+        replica: [a, b]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+      TZ: UTC
+    steps:
       - name: Check out trusted candidate tooling
         uses: actions/checkout@v4
         with:
@@ -48,13 +77,13 @@ jobs:
       - name: Check out requested source
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.preflight.outputs.source_commit }}
           path: source
           fetch-depth: 1
           persist-credentials: false
       - name: Verify checked-out source identity
         env:
-          REQUESTED_COMMIT: ${{ inputs.ref }}
+          REQUESTED_COMMIT: ${{ needs.preflight.outputs.source_commit }}
         run: |
           actual_commit="$(git -C source rev-parse HEAD)"
           if [[ "$actual_commit" != "$REQUESTED_COMMIT" ]]; then
@@ -84,7 +113,7 @@ jobs:
       - name: Package candidate manifest
         env:
           RENDERER_ID: ${{ steps.renderer.outputs.renderer_id }}
-          REQUESTED_COMMIT: ${{ inputs.ref }}
+          REQUESTED_COMMIT: ${{ needs.preflight.outputs.source_commit }}
         run: |
           : "${ImageOS:?GitHub-hosted runner did not set ImageOS}"
           : "${ImageVersion:?GitHub-hosted runner did not set ImageVersion}"

--- a/apps/agentacct/Scripts/dashboard_reference_candidate.py
+++ b/apps/agentacct/Scripts/dashboard_reference_candidate.py
@@ -7,6 +7,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import struct
 import tempfile
 import zlib
@@ -312,3 +313,85 @@ def validate_candidate_bundle(
     if normalized_artifacts != actual_artifacts:
         raise CandidateError("candidate manifest does not match the candidate image bytes")
     return manifest
+
+
+def _copy_regular_file(source: Path, destination: Path) -> None:
+    with source.open("rb") as source_stream, destination.open("xb") as destination_stream:
+        shutil.copyfileobj(source_stream, destination_stream, length=1024 * 1024)
+        destination_stream.flush()
+        os.fsync(destination_stream.fileno())
+
+
+def _sync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def promote_candidate_bundle(
+    candidate: Path,
+    expected_source_commit: object,
+    expected_renderer_id: object,
+    references_root: Path,
+) -> tuple[Path, bool]:
+    manifest = validate_candidate_bundle(
+        candidate,
+        expected_source_commit,
+        expected_renderer_id,
+    )
+    if references_root.is_symlink() or not references_root.is_dir():
+        raise CandidateError("reference root must be an existing regular directory")
+
+    renderer_id = validate_renderer_id(manifest["renderer_id"])
+    destination = references_root / renderer_id
+    if destination.is_symlink():
+        raise CandidateError("reference destination must not be a symlink")
+    if destination.exists():
+        existing_artifacts = candidate_artifacts(destination)
+        if existing_artifacts == manifest["artifacts"]:
+            return destination, False
+
+    staging: Path | None = Path(
+        tempfile.mkdtemp(prefix=f".{renderer_id}.candidate-", dir=references_root)
+    )
+    staging.chmod(0o755)
+    backup: Path | None = None
+    try:
+        for filename in EXPECTED_IMAGES:
+            _copy_regular_file(candidate / "images" / filename, staging / filename)
+        if candidate_artifacts(staging) != manifest["artifacts"]:
+            raise CandidateError("staged reference bytes do not match the validated candidate")
+        _sync_directory(staging)
+
+        if destination.exists():
+            backup = Path(
+                tempfile.mkdtemp(prefix=f".{renderer_id}.backup-", dir=references_root)
+            )
+            backup.rmdir()
+            os.replace(destination, backup)
+        try:
+            os.replace(staging, destination)
+            staging = None
+        except OSError:
+            if backup is not None:
+                os.replace(backup, destination)
+                backup = None
+            raise
+        _sync_directory(references_root)
+
+        if backup is not None:
+            shutil.rmtree(backup)
+            backup = None
+            _sync_directory(references_root)
+    finally:
+        if staging is not None and staging.exists():
+            shutil.rmtree(staging)
+        if backup is not None and backup.exists():
+            if not destination.exists():
+                os.replace(backup, destination)
+            else:
+                shutil.rmtree(backup)
+
+    return destination, True

--- a/apps/agentacct/Scripts/dashboard_reference_candidate.py
+++ b/apps/agentacct/Scripts/dashboard_reference_candidate.py
@@ -60,10 +60,10 @@ def validate_renderer_id(value: object) -> str:
 def checked_png_dimensions(path: Path) -> tuple[int, int]:
     if path.is_symlink() or not path.is_file():
         raise CandidateError(f"candidate image must be a regular file: {path.name}")
-    if path.stat().st_size > MAX_PNG_BYTES:
+    with path.open("rb") as stream:
+        data = stream.read(MAX_PNG_BYTES + 1)
+    if len(data) > MAX_PNG_BYTES:
         raise CandidateError(f"candidate image exceeds {MAX_PNG_BYTES} bytes: {path.name}")
-
-    data = path.read_bytes()
     if not data.startswith(PNG_SIGNATURE):
         raise CandidateError(f"candidate image is not a PNG: {path.name}")
 
@@ -109,8 +109,12 @@ def checked_png_dimensions(path: Path) -> tuple[int, int]:
 
 def file_sha256(path: Path) -> str:
     digest = hashlib.sha256()
+    total = 0
     with path.open("rb") as stream:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            total += len(chunk)
+            if total > MAX_PNG_BYTES:
+                raise CandidateError(f"candidate image exceeds {MAX_PNG_BYTES} bytes: {path.name}")
             digest.update(chunk)
     return digest.hexdigest()
 
@@ -223,10 +227,12 @@ def _exact_keys(value: object, name: str, expected: set[str]) -> dict[str, objec
 def _load_manifest(path: Path) -> dict[str, object]:
     if path.is_symlink() or not path.is_file():
         raise CandidateError("candidate manifest must be a regular file")
-    if path.stat().st_size > MAX_MANIFEST_BYTES:
-        raise CandidateError(f"candidate manifest exceeds {MAX_MANIFEST_BYTES} bytes")
     try:
-        payload = path.read_text(encoding="utf-8")
+        with path.open("rb") as stream:
+            raw_payload = stream.read(MAX_MANIFEST_BYTES + 1)
+        if len(raw_payload) > MAX_MANIFEST_BYTES:
+            raise CandidateError(f"candidate manifest exceeds {MAX_MANIFEST_BYTES} bytes")
+        payload = raw_payload.decode("utf-8")
         parsed = json.loads(
             payload,
             object_pairs_hook=_unique_object,
@@ -317,7 +323,14 @@ def validate_candidate_bundle(
 
 def _copy_regular_file(source: Path, destination: Path) -> None:
     with source.open("rb") as source_stream, destination.open("xb") as destination_stream:
-        shutil.copyfileobj(source_stream, destination_stream, length=1024 * 1024)
+        total = 0
+        for chunk in iter(lambda: source_stream.read(1024 * 1024), b""):
+            total += len(chunk)
+            if total > MAX_PNG_BYTES:
+                raise CandidateError(
+                    f"candidate image exceeds {MAX_PNG_BYTES} bytes: {source.name}"
+                )
+            destination_stream.write(chunk)
         destination_stream.flush()
         os.fsync(destination_stream.fileno())
 

--- a/apps/agentacct/Scripts/dashboard_reference_candidate.py
+++ b/apps/agentacct/Scripts/dashboard_reference_candidate.py
@@ -343,6 +343,54 @@ def _sync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
+def _temporary_directory(references_root: Path, prefix: str) -> Path:
+    path = Path(tempfile.mkdtemp(prefix=prefix, dir=references_root))
+    path.chmod(0o755)
+    return path
+
+
+def _install_staged_references(
+    staging: Path,
+    destination: Path,
+    references_root: Path,
+) -> Path | None:
+    """Install staging and restore the previous directory if commit fails."""
+    backup: Path | None = None
+    installed = False
+    try:
+        if destination.exists():
+            backup = _temporary_directory(
+                references_root,
+                f".{destination.name}.backup-",
+            )
+            backup.rmdir()
+            os.replace(destination, backup)
+
+        os.replace(staging, destination)
+        installed = True
+        _sync_directory(references_root)
+    except OSError:
+        try:
+            if installed:
+                os.replace(destination, staging)
+            if backup is not None:
+                os.replace(backup, destination)
+                backup = None
+        except OSError as rollback_error:
+            backup_hint = (
+                f"; the previous references remain at {backup}"
+                if backup is not None and backup.exists()
+                else ""
+            )
+            raise CandidateError(
+                "reference promotion failed and rollback could not restore the previous "
+                f"directory{backup_hint}"
+            ) from rollback_error
+        raise
+
+    return backup
+
+
 def promote_candidate_bundle(
     candidate: Path,
     expected_source_commit: object,
@@ -366,11 +414,10 @@ def promote_candidate_bundle(
         if existing_artifacts == manifest["artifacts"]:
             return destination, False
 
-    staging: Path | None = Path(
-        tempfile.mkdtemp(prefix=f".{renderer_id}.candidate-", dir=references_root)
+    staging = _temporary_directory(
+        references_root,
+        f".{renderer_id}.candidate-",
     )
-    staging.chmod(0o755)
-    backup: Path | None = None
     try:
         for filename in EXPECTED_IMAGES:
             _copy_regular_file(candidate / "images" / filename, staging / filename)
@@ -378,33 +425,17 @@ def promote_candidate_bundle(
             raise CandidateError("staged reference bytes do not match the validated candidate")
         _sync_directory(staging)
 
-        if destination.exists():
-            backup = Path(
-                tempfile.mkdtemp(prefix=f".{renderer_id}.backup-", dir=references_root)
-            )
-            backup.rmdir()
-            os.replace(destination, backup)
-        try:
-            os.replace(staging, destination)
-            staging = None
-        except OSError:
-            if backup is not None:
-                os.replace(backup, destination)
-                backup = None
-            raise
-        _sync_directory(references_root)
-
+        backup = _install_staged_references(staging, destination, references_root)
         if backup is not None:
-            shutil.rmtree(backup)
-            backup = None
-            _sync_directory(references_root)
-    finally:
-        if staging is not None and staging.exists():
-            shutil.rmtree(staging)
-        if backup is not None and backup.exists():
-            if not destination.exists():
-                os.replace(backup, destination)
-            else:
+            try:
                 shutil.rmtree(backup)
+            except OSError as error:
+                raise CandidateError(
+                    "references were promoted, but the previous reference backup could not "
+                    f"be removed: {backup}"
+                ) from error
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging)
 
     return destination, True

--- a/apps/agentacct/Scripts/dashboard_reference_candidate.py
+++ b/apps/agentacct/Scripts/dashboard_reference_candidate.py
@@ -1,0 +1,314 @@
+"""Shared validation for dashboard reference-image candidate bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import struct
+import tempfile
+import zlib
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+EXPECTED_IMAGES = {
+    "dashboard-minimum-dark.png": (1920, 1120),
+    "dashboard-minimum-light.png": (1920, 1120),
+    "dashboard-reference-dark.png": (2240, 1600),
+    "dashboard-reference-light.png": (2240, 1600),
+}
+FULL_COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+SAFE_RENDERER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+MAX_MANIFEST_BYTES = 64 * 1024
+MAX_PNG_BYTES = 64 * 1024 * 1024
+
+
+class CandidateError(ValueError):
+    """A candidate bundle violated the promotion contract."""
+
+
+def single_line(name: str, value: object) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or value.strip() != value
+        or "\n" in value
+        or "\r" in value
+    ):
+        raise CandidateError(f"{name} must be a non-empty single-line string")
+    return value
+
+
+def validate_source_commit(value: object) -> str:
+    source_commit = single_line("source commit", value)
+    if FULL_COMMIT_PATTERN.fullmatch(source_commit) is None:
+        raise CandidateError("source commit must be a full lowercase 40-character Git SHA")
+    return source_commit
+
+
+def validate_renderer_id(value: object) -> str:
+    renderer_id = single_line("renderer id", value)
+    if SAFE_RENDERER_PATTERN.fullmatch(renderer_id) is None:
+        raise CandidateError("renderer id must be a safe path component")
+    return renderer_id
+
+
+def checked_png_dimensions(path: Path) -> tuple[int, int]:
+    if path.is_symlink() or not path.is_file():
+        raise CandidateError(f"candidate image must be a regular file: {path.name}")
+    if path.stat().st_size > MAX_PNG_BYTES:
+        raise CandidateError(f"candidate image exceeds {MAX_PNG_BYTES} bytes: {path.name}")
+
+    data = path.read_bytes()
+    if not data.startswith(PNG_SIGNATURE):
+        raise CandidateError(f"candidate image is not a PNG: {path.name}")
+
+    offset = len(PNG_SIGNATURE)
+    dimensions: tuple[int, int] | None = None
+    saw_image_data = False
+    saw_end = False
+    while offset < len(data):
+        if len(data) - offset < 12:
+            raise CandidateError(f"candidate PNG is truncated: {path.name}")
+        length = struct.unpack(">I", data[offset : offset + 4])[0]
+        chunk_type = data[offset + 4 : offset + 8]
+        chunk_end = offset + 12 + length
+        if chunk_end > len(data):
+            raise CandidateError(f"candidate PNG is truncated: {path.name}")
+        chunk_data = data[offset + 8 : offset + 8 + length]
+        expected_crc = struct.unpack(">I", data[offset + 8 + length : chunk_end])[0]
+        actual_crc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+        if actual_crc != expected_crc:
+            raise CandidateError(f"candidate PNG has an invalid checksum: {path.name}")
+
+        if dimensions is None:
+            if chunk_type != b"IHDR" or length != 13:
+                raise CandidateError(f"candidate PNG has an invalid header: {path.name}")
+            width, height = struct.unpack(">II", chunk_data[:8])
+            dimensions = (width, height)
+        elif chunk_type == b"IHDR":
+            raise CandidateError(f"candidate PNG has more than one header: {path.name}")
+        elif chunk_type == b"IDAT":
+            saw_image_data = True
+
+        offset = chunk_end
+        if chunk_type == b"IEND":
+            if length != 0 or not saw_image_data or offset != len(data):
+                raise CandidateError(f"candidate PNG has an invalid end marker: {path.name}")
+            saw_end = True
+            break
+
+    if dimensions is None or not saw_image_data or not saw_end:
+        raise CandidateError(f"candidate PNG is incomplete: {path.name}")
+    return dimensions
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def candidate_artifacts(images: Path) -> list[dict[str, object]]:
+    if images.is_symlink() or not images.is_dir():
+        raise CandidateError(f"candidate image directory must be a regular directory: {images}")
+
+    actual_names = {path.name for path in images.iterdir()}
+    expected_names = set(EXPECTED_IMAGES)
+    if actual_names != expected_names:
+        missing = sorted(expected_names - actual_names)
+        unexpected = sorted(actual_names - expected_names)
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected: {', '.join(unexpected)}")
+        raise CandidateError("candidate image inventory mismatch (" + "; ".join(details) + ")")
+
+    artifacts = []
+    for filename, expected_dimensions in EXPECTED_IMAGES.items():
+        path = images / filename
+        dimensions = checked_png_dimensions(path)
+        if dimensions != expected_dimensions:
+            expected_width, expected_height = expected_dimensions
+            actual_width, actual_height = dimensions
+            raise CandidateError(
+                f"candidate image {filename} must be {expected_width}x{expected_height}; "
+                f"got {actual_width}x{actual_height}"
+            )
+        artifacts.append(
+            {
+                "filename": filename,
+                "pixel_height": dimensions[1],
+                "pixel_width": dimensions[0],
+                "sha256": file_sha256(path),
+            }
+        )
+    return artifacts
+
+
+def build_manifest(
+    images: Path,
+    source_commit: object,
+    renderer_id: object,
+    runner_image: object,
+    runner_image_version: object,
+) -> dict[str, object]:
+    return {
+        "artifacts": candidate_artifacts(images),
+        "renderer_id": validate_renderer_id(renderer_id),
+        "runner_image": {
+            "name": single_line("runner image", runner_image),
+            "version": single_line("runner image version", runner_image_version),
+        },
+        "schema_version": 1,
+        "source_commit": validate_source_commit(source_commit),
+    }
+
+
+def write_manifest(path: Path, manifest: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as temporary:
+            temporary.write(payload)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CandidateError(f"candidate manifest contains duplicate key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> object:
+    raise CandidateError(f"candidate manifest contains invalid JSON constant: {value}")
+
+
+def _exact_keys(value: object, name: str, expected: set[str]) -> dict[str, object]:
+    if type(value) is not dict:
+        raise CandidateError(f"candidate manifest {name} must be an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected: {', '.join(unexpected)}")
+        raise CandidateError(
+            f"candidate manifest {name} fields mismatch (" + "; ".join(details) + ")"
+        )
+    return value
+
+
+def _load_manifest(path: Path) -> dict[str, object]:
+    if path.is_symlink() or not path.is_file():
+        raise CandidateError("candidate manifest must be a regular file")
+    if path.stat().st_size > MAX_MANIFEST_BYTES:
+        raise CandidateError(f"candidate manifest exceeds {MAX_MANIFEST_BYTES} bytes")
+    try:
+        payload = path.read_text(encoding="utf-8")
+        parsed = json.loads(
+            payload,
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise CandidateError(f"candidate manifest is not valid UTF-8 JSON: {error}") from error
+    return _exact_keys(
+        parsed,
+        "top-level",
+        {"artifacts", "renderer_id", "runner_image", "schema_version", "source_commit"},
+    )
+
+
+def validate_candidate_bundle(
+    candidate: Path,
+    expected_source_commit: object,
+    expected_renderer_id: object,
+) -> dict[str, object]:
+    if candidate.is_symlink() or not candidate.is_dir():
+        raise CandidateError("candidate must be a regular directory")
+    actual_root_names = {path.name for path in candidate.iterdir()}
+    if actual_root_names != {"images", "manifest.json"}:
+        missing = sorted({"images", "manifest.json"} - actual_root_names)
+        unexpected = sorted(actual_root_names - {"images", "manifest.json"})
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected: {', '.join(unexpected)}")
+        raise CandidateError("candidate root inventory mismatch (" + "; ".join(details) + ")")
+
+    manifest = _load_manifest(candidate / "manifest.json")
+    if type(manifest["schema_version"]) is not int or manifest["schema_version"] != 1:
+        raise CandidateError("candidate manifest schema_version must be integer 1")
+
+    source_commit = validate_source_commit(manifest["source_commit"])
+    requested_source_commit = validate_source_commit(expected_source_commit)
+    if source_commit != requested_source_commit:
+        raise CandidateError(
+            f"candidate source commit is {source_commit}; expected {requested_source_commit}"
+        )
+
+    renderer_id = validate_renderer_id(manifest["renderer_id"])
+    requested_renderer_id = validate_renderer_id(expected_renderer_id)
+    if renderer_id != requested_renderer_id:
+        raise CandidateError(
+            f"candidate renderer is {renderer_id}; expected {requested_renderer_id}"
+        )
+
+    runner = _exact_keys(manifest["runner_image"], "runner_image", {"name", "version"})
+    single_line("runner image", runner["name"])
+    single_line("runner image version", runner["version"])
+
+    artifacts = manifest["artifacts"]
+    if type(artifacts) is not list or len(artifacts) != len(EXPECTED_IMAGES):
+        raise CandidateError(
+            f"candidate manifest artifacts must contain exactly {len(EXPECTED_IMAGES)} entries"
+        )
+    normalized_artifacts = []
+    for index, (filename, dimensions) in enumerate(EXPECTED_IMAGES.items()):
+        artifact = _exact_keys(
+            artifacts[index],
+            f"artifact {index}",
+            {"filename", "pixel_height", "pixel_width", "sha256"},
+        )
+        if artifact["filename"] != filename:
+            raise CandidateError(
+                f"candidate manifest artifact {index} must describe {filename}"
+            )
+        expected_width, expected_height = dimensions
+        if type(artifact["pixel_width"]) is not int or artifact["pixel_width"] != expected_width:
+            raise CandidateError(f"candidate manifest width is invalid for {filename}")
+        if type(artifact["pixel_height"]) is not int or artifact["pixel_height"] != expected_height:
+            raise CandidateError(f"candidate manifest height is invalid for {filename}")
+        if (
+            type(artifact["sha256"]) is not str
+            or SHA256_PATTERN.fullmatch(artifact["sha256"]) is None
+        ):
+            raise CandidateError(f"candidate manifest SHA-256 is invalid for {filename}")
+        normalized_artifacts.append(dict(artifact))
+
+    actual_artifacts = candidate_artifacts(candidate / "images")
+    if normalized_artifacts != actual_artifacts:
+        raise CandidateError("candidate manifest does not match the candidate image bytes")
+    return manifest

--- a/apps/agentacct/Scripts/package-dashboard-reference-candidate
+++ b/apps/agentacct/Scripts/package-dashboard-reference-candidate
@@ -4,29 +4,9 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
-import json
-import os
 from pathlib import Path
-import re
-import struct
-import tempfile
-import zlib
 
-
-PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
-EXPECTED_IMAGES = {
-    "dashboard-minimum-dark.png": (1920, 1120),
-    "dashboard-minimum-light.png": (1920, 1120),
-    "dashboard-reference-dark.png": (2240, 1600),
-    "dashboard-reference-light.png": (2240, 1600),
-}
-FULL_COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
-SAFE_RENDERER_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
-
-
-class CandidateError(ValueError):
-    """A candidate bundle violated the promotion contract."""
+from dashboard_reference_candidate import CandidateError, build_manifest, write_manifest
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -42,140 +22,16 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def single_line(name: str, value: str) -> str:
-    if not value or value.strip() != value or "\n" in value or "\r" in value:
-        raise CandidateError(f"{name} must be a non-empty single-line value")
-    return value
-
-
-def validate_identity(arguments: argparse.Namespace) -> None:
-    if FULL_COMMIT_PATTERN.fullmatch(arguments.source_commit) is None:
-        raise CandidateError("source commit must be a full lowercase 40-character Git SHA")
-    if SAFE_RENDERER_PATTERN.fullmatch(arguments.renderer_id) is None:
-        raise CandidateError("renderer id must be a safe path component")
-    single_line("runner image", arguments.runner_image)
-    single_line("runner image version", arguments.runner_image_version)
-
-
-def checked_png_dimensions(path: Path) -> tuple[int, int]:
-    if path.is_symlink() or not path.is_file():
-        raise CandidateError(f"candidate image must be a regular file: {path.name}")
-
-    data = path.read_bytes()
-    if not data.startswith(PNG_SIGNATURE):
-        raise CandidateError(f"candidate image is not a PNG: {path.name}")
-
-    offset = len(PNG_SIGNATURE)
-    dimensions: tuple[int, int] | None = None
-    saw_image_data = False
-    saw_end = False
-    while offset < len(data):
-        if len(data) - offset < 12:
-            raise CandidateError(f"candidate PNG is truncated: {path.name}")
-        length = struct.unpack(">I", data[offset : offset + 4])[0]
-        chunk_type = data[offset + 4 : offset + 8]
-        chunk_end = offset + 12 + length
-        if chunk_end > len(data):
-            raise CandidateError(f"candidate PNG is truncated: {path.name}")
-        chunk_data = data[offset + 8 : offset + 8 + length]
-        expected_crc = struct.unpack(">I", data[offset + 8 + length : chunk_end])[0]
-        actual_crc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
-        if actual_crc != expected_crc:
-            raise CandidateError(f"candidate PNG has an invalid checksum: {path.name}")
-
-        if dimensions is None:
-            if chunk_type != b"IHDR" or length != 13:
-                raise CandidateError(f"candidate PNG has an invalid header: {path.name}")
-            width, height = struct.unpack(">II", chunk_data[:8])
-            dimensions = (width, height)
-        elif chunk_type == b"IHDR":
-            raise CandidateError(f"candidate PNG has more than one header: {path.name}")
-        elif chunk_type == b"IDAT":
-            saw_image_data = True
-
-        offset = chunk_end
-        if chunk_type == b"IEND":
-            if length != 0 or not saw_image_data or offset != len(data):
-                raise CandidateError(f"candidate PNG has an invalid end marker: {path.name}")
-            saw_end = True
-            break
-
-    if dimensions is None or not saw_image_data or not saw_end:
-        raise CandidateError(f"candidate PNG is incomplete: {path.name}")
-    return dimensions
-
-
-def candidate_artifacts(images: Path) -> list[dict[str, object]]:
-    if not images.is_dir():
-        raise CandidateError(f"candidate image directory does not exist: {images}")
-
-    actual_names = {path.name for path in images.iterdir()}
-    expected_names = set(EXPECTED_IMAGES)
-    if actual_names != expected_names:
-        missing = sorted(expected_names - actual_names)
-        unexpected = sorted(actual_names - expected_names)
-        details = []
-        if missing:
-            details.append(f"missing: {', '.join(missing)}")
-        if unexpected:
-            details.append(f"unexpected: {', '.join(unexpected)}")
-        raise CandidateError("candidate image inventory mismatch (" + "; ".join(details) + ")")
-
-    artifacts = []
-    for filename, expected_dimensions in EXPECTED_IMAGES.items():
-        path = images / filename
-        dimensions = checked_png_dimensions(path)
-        if dimensions != expected_dimensions:
-            expected_width, expected_height = expected_dimensions
-            actual_width, actual_height = dimensions
-            raise CandidateError(
-                f"candidate image {filename} must be {expected_width}x{expected_height}; "
-                f"got {actual_width}x{actual_height}"
-            )
-        artifacts.append(
-            {
-                "filename": filename,
-                "pixel_height": dimensions[1],
-                "pixel_width": dimensions[0],
-                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
-            }
-        )
-    return artifacts
-
-
-def write_manifest(path: Path, manifest: dict[str, object]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
-    temporary_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as temporary:
-            temporary.write(payload)
-            temporary.flush()
-            os.fsync(temporary.fileno())
-            temporary_path = Path(temporary.name)
-        os.replace(temporary_path, path)
-        temporary_path = None
-    finally:
-        if temporary_path is not None:
-            temporary_path.unlink(missing_ok=True)
-
-
 def main() -> int:
     arguments = parse_arguments()
     try:
-        validate_identity(arguments)
-        manifest = {
-            "artifacts": candidate_artifacts(arguments.images),
-            "renderer_id": arguments.renderer_id,
-            "runner_image": {
-                "name": single_line("runner image", arguments.runner_image),
-                "version": single_line(
-                    "runner image version", arguments.runner_image_version
-                ),
-            },
-            "schema_version": 1,
-            "source_commit": arguments.source_commit,
-        }
+        manifest = build_manifest(
+            arguments.images,
+            arguments.source_commit,
+            arguments.renderer_id,
+            arguments.runner_image,
+            arguments.runner_image_version,
+        )
         write_manifest(arguments.output, manifest)
     except (CandidateError, OSError) as error:
         raise SystemExit(f"package-dashboard-reference-candidate: {error}") from error

--- a/apps/agentacct/Scripts/promote-dashboard-reference-candidate
+++ b/apps/agentacct/Scripts/promote-dashboard-reference-candidate
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Promote one explicitly reviewed dashboard candidate into reference files."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dashboard_reference_candidate import CandidateError, promote_candidate_bundle
+
+
+APP_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_REFERENCE_ROOT = APP_DIR / "Tests" / "agentacctTests" / "ReferenceImages"
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and promote an explicitly reviewed dashboard reference candidate."
+    )
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--renderer-id", required=True)
+    parser.add_argument(
+        "--references-root",
+        type=Path,
+        default=DEFAULT_REFERENCE_ROOT,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--reviewed",
+        action="store_true",
+        required=True,
+        help="Confirm that all four candidate images were visually reviewed.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        destination, changed = promote_candidate_bundle(
+            arguments.candidate,
+            arguments.source_commit,
+            arguments.renderer_id,
+            arguments.references_root,
+        )
+    except (CandidateError, OSError) as error:
+        raise SystemExit(f"promote-dashboard-reference-candidate: {error}") from error
+
+    if changed:
+        print(
+            f"Promoted four reviewed reference images to {destination}. "
+            "Review the Git diff before committing."
+        )
+    else:
+        print(f"Reviewed references already match {destination}; no files changed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/agentacct/Scripts/validate-dashboard-reference-candidate
+++ b/apps/agentacct/Scripts/validate-dashboard-reference-candidate
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Fail closed when a downloaded dashboard candidate is not trustworthy."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dashboard_reference_candidate import CandidateError, validate_candidate_bundle
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a downloaded dashboard reference candidate without changing files."
+    )
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--renderer-id", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        manifest = validate_candidate_bundle(
+            arguments.candidate,
+            arguments.source_commit,
+            arguments.renderer_id,
+        )
+    except (CandidateError, OSError) as error:
+        raise SystemExit(f"validate-dashboard-reference-candidate: {error}") from error
+
+    print(
+        "Validated dashboard reference candidate: "
+        f"{manifest['source_commit']} on {manifest['renderer_id']} "
+        f"({len(manifest['artifacts'])} images)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/agentacct/Scripts/visual-snapshots
+++ b/apps/agentacct/Scripts/visual-snapshots
@@ -23,6 +23,7 @@ usage() {
   cat >&2 <<'EOF'
 usage:
   ./Scripts/visual-snapshots list [test-selector-or-path ...]
+  ./Scripts/visual-snapshots platform-id
   ./Scripts/visual-snapshots check-environment
   ./Scripts/visual-snapshots verify [test-selector-or-path ...]
   ./Scripts/visual-snapshots record [test-selector-or-path ...]
@@ -198,9 +199,15 @@ run_selected() {
 action="$1"
 shift
 case "$action" in
-  list|check-environment|verify|record) ;;
+  list|platform-id|check-environment|verify|record) ;;
   *) usage ;;
 esac
+
+if [[ "$action" == "platform-id" ]]; then
+  [[ $# -eq 0 ]] || usage
+  printf '%s\n' "$platform_id"
+  exit 0
+fi
 
 if [[ "$action" == "check-environment" ]]; then
   [[ $# -eq 0 ]] || usage

--- a/apps/agentacct/Tests/README.md
+++ b/apps/agentacct/Tests/README.md
@@ -158,10 +158,20 @@ PNG diff before committing it.
 The workflow has no repository write permission or secrets. It checks out the
 workflow's own commit as trusted tooling, checks out the requested source into
 a separate directory without persisted credentials, and fails before rendering
-unless the host matches the exact canonical renderer. Two fresh macOS runners
-then run the deterministic dashboard tests, build the release renderer, and
-package independent candidates. A separate Linux job publishes the 14-day
-verified artifact only when the two complete bundles are byte-identical.
+unless the host matches the exact canonical renderer. A cheap Linux preflight
+rejects malformed or unreachable commits before macOS capacity is allocated.
+Two fresh macOS runners then run the deterministic dashboard tests, build the
+release renderer, and package independent candidates. A separate Linux job
+publishes the 14-day verified artifact only when the two complete bundles are
+byte-identical.
+
+Candidate generation is manual and globally serialized: one request may use
+the two required macOS replicas, while at most the newest additional request
+waits. An in-progress proof is not cancelled, but a failed replica cancels its
+peer because no verified bundle can then be published. Unverified replica
+artifacts expire after one day; only the verified bundle is retained for 14
+days. Ordinary branch CI separately cancels superseded runs for the same PR or
+branch and bounds every job with a timeout.
 
 A successful run proves repeatable generation; it does not approve a visual
 change. Before promotion, verify the manifest's source and renderer identities

--- a/apps/agentacct/Tests/README.md
+++ b/apps/agentacct/Tests/README.md
@@ -25,6 +25,13 @@ Check whether the current host exactly matches the reviewed-reference renderer:
 ./Scripts/visual-snapshots check-environment
 ```
 
+Read the repository's declared renderer identity without checking the current
+host or running Swift tests:
+
+```bash
+./Scripts/visual-snapshots platform-id
+```
+
 This project currently discovers `DashboardVisualRegressionTests`. An empty
 list remains valid for another project or branch before its first visual suite.
 
@@ -59,21 +66,23 @@ If `check-environment` rejects the local Mac, never override the platform ID or
 record that machine's pixels under the canonical directory. Push the UI branch
 for review instead. The macOS CI job keeps rendering after an intentional
 baseline mismatch and, only when its renderer is canonical, uploads
-`dashboard-baseline-candidate-<platform-id>-<sha>`. After reviewing all four
-images, download that artifact and copy its PNGs into the matching directory:
+`dashboard-baseline-candidate-<platform-id>-<sha>`. That single-run artifact is
+a review aid: download and inspect it to understand the mismatch, but do not
+copy it directly into reviewed references because it has no manifest or second
+independent replica.
 
 ```bash
 gh run download <run-id> \
   --name dashboard-baseline-candidate-<platform-id>-<sha> \
   --dir /tmp/agentacct-dashboard-baseline
-cp /tmp/agentacct-dashboard-baseline/dashboard-*.png \
-  Tests/agentacctTests/ReferenceImages/<platform-id>/
-git diff -- Tests/agentacctTests/ReferenceImages
+open /tmp/agentacct-dashboard-baseline
 ```
 
-Commit the reviewed references with the UI change and let the next CI run prove
-that the canonical renderer matches them. CI never writes accepted references
-back to the repository.
+For promotion, request the authoritative two-replica candidate for the same
+source SHA and follow the validation and promotion flow below. Commit the
+reviewed references with the UI change and let the next CI run prove that the
+canonical renderer matches them. CI never writes accepted references back to
+the repository.
 
 GitHub displays a changed PNG as a
 [2-up, swipe, or onion-skin comparison](https://docs.github.com/en/repositories/working-with-files/using-files/working-with-non-code-files#rendering-and-diffing-images).
@@ -106,6 +115,46 @@ The artifact contains `manifest.json` and an `images` directory with the four
 dashboard PNGs. The manifest binds the bundle to the source commit, canonical
 renderer, hosted-runner image, exact dimensions, and SHA-256 of every image.
 
+Validate the downloaded bundle against the commit you requested and the
+renderer declared by the source checkout. Do not copy the expected renderer
+from the candidate manifest; that would make the candidate assert its own
+trust boundary.
+
+```bash
+candidate_dir=/tmp/agentacct-dashboard-reference-candidate
+renderer_id="$(./Scripts/visual-snapshots platform-id)"
+./Scripts/validate-dashboard-reference-candidate \
+  --candidate "$candidate_dir" \
+  --source-commit "$source_commit" \
+  --renderer-id "$renderer_id"
+open "$candidate_dir/images"
+```
+
+Validation is read-only and does not depend on the developer's macOS version.
+It rejects unknown or duplicate manifest fields, malformed identities, extra
+files, symlinks, invalid PNG structure or dimensions, and any manifest hash
+that does not match the downloaded bytes. Inspect every light/dark and
+minimum/reference image after validation.
+
+Only after that visual review, promote the exact validated set:
+
+```bash
+./Scripts/promote-dashboard-reference-candidate \
+  --candidate "$candidate_dir" \
+  --source-commit "$source_commit" \
+  --renderer-id "$renderer_id" \
+  --reviewed
+git status --short -- Tests/agentacctTests/ReferenceImages
+git diff --stat -- Tests/agentacctTests/ReferenceImages
+```
+
+Promotion repeats the full validation, requires an explicit review
+confirmation, stages all four files before replacing the renderer directory,
+and restores the original directory if the replacement fails. An already
+identical candidate is a no-op. The command never renders locally, stages Git
+changes, commits, pushes, or approves the visual change; review the resulting
+PNG diff before committing it.
+
 The workflow has no repository write permission or secrets. It checks out the
 workflow's own commit as trusted tooling, checks out the requested source into
 a separate directory without persisted credentials, and fails before rendering
@@ -127,6 +176,8 @@ and baseline approval as separate review gates.
 | dashboard test, build, or render | the requested source cannot produce the fixed review matrix |
 | candidate packaging | the image inventory, PNG structure, dimensions, or identity evidence is invalid |
 | independent bundle comparison | the renderer or host image was not reproducible; no verified candidate is published |
+| downloaded candidate validation | identity, schema, inventory, PNG, dimension, or hash evidence does not match |
+| candidate promotion | visual review was not confirmed or the existing reference destination is unsafe to replace |
 
 ## Selecting tests
 

--- a/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
+++ b/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
@@ -26,7 +26,7 @@ OTHER_COMMIT = "89abcdef0123456789abcdef0123456789abcdef"
 RENDERER_ID = "macos-test-build-xcode-test-build-arm64-2x"
 
 sys.path.insert(0, str(APP_DIR / "Scripts"))
-from dashboard_reference_candidate import promote_candidate_bundle  # noqa: E402
+import dashboard_reference_candidate  # noqa: E402
 
 
 def run(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -246,7 +246,7 @@ def main() -> None:
             side_effect=fail_staging_swap,
         ):
             try:
-                promote_candidate_bundle(
+                dashboard_reference_candidate.promote_candidate_bundle(
                     changed_candidate,
                     SOURCE_COMMIT,
                     RENDERER_ID,
@@ -267,6 +267,48 @@ def main() -> None:
         require(
             [path.name for path in rollback_root.iterdir()] == [RENDERER_ID],
             "failed directory swap left staging or backup directories behind",
+        )
+
+        sync_failure_root = root / "sync-failure-references"
+        sync_failure_root.mkdir()
+        sync_failure_destination = sync_failure_root / RENDERER_ID
+        shutil.copytree(reference_directories[0], sync_failure_destination)
+        sync_failure_before = {
+            path.name: path.read_bytes() for path in sync_failure_destination.iterdir()
+        }
+        real_sync_directory = dashboard_reference_candidate._sync_directory
+
+        def fail_reference_root_sync(path: Path) -> None:
+            if path == sync_failure_root:
+                raise OSError("simulated reference-root sync failure")
+            real_sync_directory(path)
+
+        with mock.patch(
+            "dashboard_reference_candidate._sync_directory",
+            side_effect=fail_reference_root_sync,
+        ):
+            try:
+                dashboard_reference_candidate.promote_candidate_bundle(
+                    changed_candidate,
+                    SOURCE_COMMIT,
+                    RENDERER_ID,
+                    sync_failure_root,
+                )
+            except OSError as error:
+                require("simulated reference-root sync failure" in str(error), str(error))
+            else:
+                raise AssertionError("promotion sync failure did not propagate")
+        require(
+            {
+                path.name: path.read_bytes()
+                for path in sync_failure_destination.iterdir()
+            }
+            == sync_failure_before,
+            "failed reference-root sync did not restore the original references",
+        )
+        require(
+            [path.name for path in sync_failure_root.iterdir()] == [RENDERER_ID],
+            "failed reference-root sync left staging or backup directories behind",
         )
 
         before_wrong_identity = {

--- a/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
+++ b/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
@@ -172,6 +172,13 @@ def main() -> None:
         require_failure(duplicate_result, "validator accepted a duplicate manifest key")
         require("duplicate key" in duplicate_result.stderr, duplicate_result.stderr)
 
+        oversized_manifest = root / "oversized-manifest"
+        shutil.copytree(candidate, oversized_manifest)
+        (oversized_manifest / "manifest.json").write_bytes(b" " * (64 * 1024 + 1))
+        oversized_result = validate(oversized_manifest)
+        require_failure(oversized_result, "validator accepted an oversized manifest")
+        require("manifest exceeds" in oversized_result.stderr, oversized_result.stderr)
+
         unknown_field = root / "unknown-field"
         shutil.copytree(candidate, unknown_field)
         unknown_manifest_path = unknown_field / "manifest.json"

--- a/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
+++ b/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
@@ -4,20 +4,29 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import shutil
 import subprocess
+import struct
+import sys
 import tempfile
+from unittest import mock
+import zlib
 
 
 TESTS_DIR = Path(__file__).resolve().parent
 APP_DIR = TESTS_DIR.parent
 PACKAGER = APP_DIR / "Scripts" / "package-dashboard-reference-candidate"
 VALIDATOR = APP_DIR / "Scripts" / "validate-dashboard-reference-candidate"
+PROMOTER = APP_DIR / "Scripts" / "promote-dashboard-reference-candidate"
 REFERENCE_ROOT = TESTS_DIR / "agentacctTests" / "ReferenceImages"
 SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567"
 OTHER_COMMIT = "89abcdef0123456789abcdef0123456789abcdef"
 RENDERER_ID = "macos-test-build-xcode-test-build-arm64-2x"
+
+sys.path.insert(0, str(APP_DIR / "Scripts"))
+from dashboard_reference_candidate import promote_candidate_bundle  # noqa: E402
 
 
 def run(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -36,6 +45,10 @@ def require_failure(result: subprocess.CompletedProcess[str], message: str) -> N
 def package_candidate(candidate: Path, images: Path) -> None:
     candidate.mkdir()
     shutil.copytree(images, candidate / "images")
+    write_manifest(candidate)
+
+
+def write_manifest(candidate: Path) -> None:
     result = run(
         [
             str(PACKAGER),
@@ -73,6 +86,49 @@ def validate(candidate: Path, **overrides: str) -> subprocess.CompletedProcess[s
             values["renderer_id"],
         ]
     )
+
+
+def promote(
+    candidate: Path,
+    references_root: Path,
+    *,
+    reviewed: bool = True,
+    **overrides: str,
+) -> subprocess.CompletedProcess[str]:
+    values = {
+        "source_commit": SOURCE_COMMIT,
+        "renderer_id": RENDERER_ID,
+        **overrides,
+    }
+    command = [
+        str(PROMOTER),
+        "--candidate",
+        str(candidate),
+        "--source-commit",
+        values["source_commit"],
+        "--renderer-id",
+        values["renderer_id"],
+        "--references-root",
+        str(references_root),
+    ]
+    if reviewed:
+        command.append("--reviewed")
+    return run(command)
+
+
+def add_png_text_chunk(path: Path) -> None:
+    payload = path.read_bytes()
+    require(payload[-8:-4] == b"IEND", "test PNG does not end in IEND")
+    chunk_type = b"tEXt"
+    chunk_data = b"agentacct\x00reviewed-candidate"
+    checksum = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+    chunk = (
+        struct.pack(">I", len(chunk_data))
+        + chunk_type
+        + chunk_data
+        + struct.pack(">I", checksum)
+    )
+    path.write_bytes(payload[:-12] + chunk + payload[-12:])
 
 
 def main() -> None:
@@ -141,6 +197,116 @@ def main() -> None:
         symlink_result = validate(symlinked_manifest)
         require_failure(symlink_result, "validator accepted a symlinked manifest")
         require("regular file" in symlink_result.stderr, symlink_result.stderr)
+
+        references_root = root / "references"
+        references_root.mkdir()
+        destination = references_root / RENDERER_ID
+        shutil.copytree(reference_directories[0], destination)
+
+        not_reviewed = promote(candidate, references_root, reviewed=False)
+        require_failure(not_reviewed, "promoter accepted a candidate without review confirmation")
+        require("--reviewed" in not_reviewed.stderr, not_reviewed.stderr)
+
+        unchanged = promote(candidate, references_root)
+        require(unchanged.returncode == 0, unchanged.stderr)
+        require("no files changed" in unchanged.stdout, unchanged.stdout)
+
+        changed_candidate = root / "changed-candidate"
+        shutil.copytree(candidate, changed_candidate)
+        add_png_text_chunk(changed_candidate / "images" / "dashboard-minimum-dark.png")
+        write_manifest(changed_candidate)
+
+        rollback_root = root / "rollback-references"
+        rollback_root.mkdir()
+        rollback_destination = rollback_root / RENDERER_ID
+        shutil.copytree(reference_directories[0], rollback_destination)
+        rollback_before = {
+            path.name: path.read_bytes() for path in rollback_destination.iterdir()
+        }
+        real_replace = os.replace
+
+        def fail_staging_swap(source: object, destination_path: object) -> None:
+            source_path = Path(source)
+            if (
+                source_path.name.startswith(f".{RENDERER_ID}.candidate-")
+                and Path(destination_path) == rollback_destination
+            ):
+                raise OSError("simulated candidate swap failure")
+            real_replace(source, destination_path)
+
+        with mock.patch(
+            "dashboard_reference_candidate.os.replace",
+            side_effect=fail_staging_swap,
+        ):
+            try:
+                promote_candidate_bundle(
+                    changed_candidate,
+                    SOURCE_COMMIT,
+                    RENDERER_ID,
+                    rollback_root,
+                )
+            except OSError as error:
+                require("simulated candidate swap failure" in str(error), str(error))
+            else:
+                raise AssertionError("promotion swap failure did not propagate")
+        require(
+            {
+                path.name: path.read_bytes()
+                for path in rollback_destination.iterdir()
+            }
+            == rollback_before,
+            "failed directory swap did not restore the original references",
+        )
+        require(
+            [path.name for path in rollback_root.iterdir()] == [RENDERER_ID],
+            "failed directory swap left staging or backup directories behind",
+        )
+
+        before_wrong_identity = {
+            path.name: path.read_bytes() for path in destination.iterdir()
+        }
+        rejected_promotion = promote(
+            changed_candidate,
+            references_root,
+            source_commit=OTHER_COMMIT,
+        )
+        require_failure(rejected_promotion, "promoter accepted the wrong source identity")
+        require(
+            {path.name: path.read_bytes() for path in destination.iterdir()}
+            == before_wrong_identity,
+            "failed promotion changed references",
+        )
+
+        promoted = promote(changed_candidate, references_root)
+        require(promoted.returncode == 0, promoted.stderr)
+        require("Promoted four reviewed reference images" in promoted.stdout, promoted.stdout)
+        require(
+            {path.name: path.read_bytes() for path in destination.iterdir()}
+            == {
+                path.name: path.read_bytes()
+                for path in (changed_candidate / "images").iterdir()
+            },
+            "promotion did not install the complete candidate set",
+        )
+
+        repeated = promote(changed_candidate, references_root)
+        require(repeated.returncode == 0, repeated.stderr)
+        require("no files changed" in repeated.stdout, repeated.stdout)
+
+        symlink_root = root / "symlink-references"
+        symlink_root.mkdir()
+        (symlink_root / RENDERER_ID).symlink_to(reference_directories[0])
+        symlink_destination = promote(candidate, symlink_root)
+        require_failure(symlink_destination, "promoter followed a destination symlink")
+        require("must not be a symlink" in symlink_destination.stderr, symlink_destination.stderr)
+
+        (destination / "notes.txt").write_text("unexpected", encoding="utf-8")
+        unexpected_destination = promote(candidate, references_root)
+        require_failure(
+            unexpected_destination,
+            "promoter replaced a destination with unexpected files",
+        )
+        require("inventory mismatch" in unexpected_destination.stderr, unexpected_destination.stderr)
 
     print("dashboard reference candidate intake CLI tests passed")
 

--- a/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
+++ b/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Dependency-free CLI tests for downloaded reference candidate validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+APP_DIR = TESTS_DIR.parent
+PACKAGER = APP_DIR / "Scripts" / "package-dashboard-reference-candidate"
+VALIDATOR = APP_DIR / "Scripts" / "validate-dashboard-reference-candidate"
+REFERENCE_ROOT = TESTS_DIR / "agentacctTests" / "ReferenceImages"
+SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+OTHER_COMMIT = "89abcdef0123456789abcdef0123456789abcdef"
+RENDERER_ID = "macos-test-build-xcode-test-build-arm64-2x"
+
+
+def run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=False, capture_output=True, text=True)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_failure(result: subprocess.CompletedProcess[str], message: str) -> None:
+    require(result.returncode != 0, message)
+
+
+def package_candidate(candidate: Path, images: Path) -> None:
+    candidate.mkdir()
+    shutil.copytree(images, candidate / "images")
+    result = run(
+        [
+            str(PACKAGER),
+            "--images",
+            str(candidate / "images"),
+            "--output",
+            str(candidate / "manifest.json"),
+            "--source-commit",
+            SOURCE_COMMIT,
+            "--renderer-id",
+            RENDERER_ID,
+            "--runner-image",
+            "macos26",
+            "--runner-image-version",
+            "test-image",
+        ]
+    )
+    require(result.returncode == 0, result.stderr)
+
+
+def validate(candidate: Path, **overrides: str) -> subprocess.CompletedProcess[str]:
+    values = {
+        "source_commit": SOURCE_COMMIT,
+        "renderer_id": RENDERER_ID,
+        **overrides,
+    }
+    return run(
+        [
+            str(VALIDATOR),
+            "--candidate",
+            str(candidate),
+            "--source-commit",
+            values["source_commit"],
+            "--renderer-id",
+            values["renderer_id"],
+        ]
+    )
+
+
+def main() -> None:
+    reference_directories = sorted(path for path in REFERENCE_ROOT.iterdir() if path.is_dir())
+    require(reference_directories, "expected at least one reference directory")
+
+    with tempfile.TemporaryDirectory(prefix="agentacct-candidate-intake-tests-") as temporary:
+        root = Path(temporary)
+        candidate = root / "candidate"
+        package_candidate(candidate, reference_directories[0])
+
+        valid = validate(candidate)
+        require(valid.returncode == 0, valid.stderr)
+        require("(4 images)" in valid.stdout, valid.stdout)
+
+        wrong_source = validate(candidate, source_commit=OTHER_COMMIT)
+        require_failure(wrong_source, "validator accepted the wrong expected source")
+        require("candidate source commit" in wrong_source.stderr, wrong_source.stderr)
+
+        wrong_renderer = validate(candidate, renderer_id="macos-other-renderer")
+        require_failure(wrong_renderer, "validator accepted the wrong expected renderer")
+        require("candidate renderer" in wrong_renderer.stderr, wrong_renderer.stderr)
+
+        tampered = root / "tampered"
+        shutil.copytree(candidate, tampered)
+        image = tampered / "images" / "dashboard-minimum-dark.png"
+        payload = bytearray(image.read_bytes())
+        payload[len(payload) // 2] ^= 1
+        image.write_bytes(payload)
+        tampered_result = validate(tampered)
+        require_failure(tampered_result, "validator accepted tampered image bytes")
+
+        duplicate_key = root / "duplicate-key"
+        shutil.copytree(candidate, duplicate_key)
+        manifest_path = duplicate_key / "manifest.json"
+        manifest_text = manifest_path.read_text(encoding="utf-8").rstrip()
+        manifest_path.write_text(
+            manifest_text[:-1] + ', "schema_version": 1}\n', encoding="utf-8"
+        )
+        duplicate_result = validate(duplicate_key)
+        require_failure(duplicate_result, "validator accepted a duplicate manifest key")
+        require("duplicate key" in duplicate_result.stderr, duplicate_result.stderr)
+
+        unknown_field = root / "unknown-field"
+        shutil.copytree(candidate, unknown_field)
+        unknown_manifest_path = unknown_field / "manifest.json"
+        unknown_manifest = json.loads(unknown_manifest_path.read_text(encoding="utf-8"))
+        unknown_manifest["untrusted"] = True
+        unknown_manifest_path.write_text(json.dumps(unknown_manifest), encoding="utf-8")
+        unknown_result = validate(unknown_field)
+        require_failure(unknown_result, "validator accepted an unknown manifest field")
+        require("fields mismatch" in unknown_result.stderr, unknown_result.stderr)
+
+        extra_root_file = root / "extra-root-file"
+        shutil.copytree(candidate, extra_root_file)
+        (extra_root_file / "notes.txt").write_text("unexpected", encoding="utf-8")
+        extra_result = validate(extra_root_file)
+        require_failure(extra_result, "validator accepted an extra root file")
+        require("root inventory mismatch" in extra_result.stderr, extra_result.stderr)
+
+        symlinked_manifest = root / "symlinked-manifest"
+        shutil.copytree(candidate, symlinked_manifest)
+        linked_manifest = symlinked_manifest / "manifest.json"
+        linked_manifest.unlink()
+        linked_manifest.symlink_to(candidate / "manifest.json")
+        symlink_result = validate(symlinked_manifest)
+        require_failure(symlink_result, "validator accepted a symlinked manifest")
+        require("regular file" in symlink_result.stderr, symlink_result.stderr)
+
+    print("dashboard reference candidate intake CLI tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
+++ b/apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Dependency-free CLI tests for downloaded reference candidate validation."""
+"""Dependency-free CLI tests for downloaded reference candidate intake."""
 
 from __future__ import annotations
 
@@ -7,10 +7,11 @@ import json
 import os
 from pathlib import Path
 import shutil
-import subprocess
 import struct
+import subprocess
 import sys
 import tempfile
+import unittest
 from unittest import mock
 import zlib
 
@@ -33,21 +34,6 @@ def run(command: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, check=False, capture_output=True, text=True)
 
 
-def require(condition: bool, message: str) -> None:
-    if not condition:
-        raise AssertionError(message)
-
-
-def require_failure(result: subprocess.CompletedProcess[str], message: str) -> None:
-    require(result.returncode != 0, message)
-
-
-def package_candidate(candidate: Path, images: Path) -> None:
-    candidate.mkdir()
-    shutil.copytree(images, candidate / "images")
-    write_manifest(candidate)
-
-
 def write_manifest(candidate: Path) -> None:
     result = run(
         [
@@ -66,7 +52,14 @@ def write_manifest(candidate: Path) -> None:
             "test-image",
         ]
     )
-    require(result.returncode == 0, result.stderr)
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+
+
+def package_candidate(candidate: Path, images: Path) -> None:
+    candidate.mkdir()
+    shutil.copytree(images, candidate / "images")
+    write_manifest(candidate)
 
 
 def validate(candidate: Path, **overrides: str) -> subprocess.CompletedProcess[str]:
@@ -116,9 +109,22 @@ def promote(
     return run(command)
 
 
+def read_manifest(candidate: Path) -> dict[str, object]:
+    return json.loads((candidate / "manifest.json").read_text(encoding="utf-8"))
+
+
+def replace_manifest(candidate: Path, manifest: dict[str, object]) -> None:
+    (candidate / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def directory_bytes(directory: Path) -> dict[str, bytes]:
+    return {path.name: path.read_bytes() for path in directory.iterdir()}
+
+
 def add_png_text_chunk(path: Path) -> None:
     payload = path.read_bytes()
-    require(payload[-8:-4] == b"IEND", "test PNG does not end in IEND")
+    if payload[-8:-4] != b"IEND":
+        raise AssertionError("test PNG does not end in IEND")
     chunk_type = b"tEXt"
     chunk_data = b"agentacct\x00reviewed-candidate"
     checksum = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
@@ -131,112 +137,215 @@ def add_png_text_chunk(path: Path) -> None:
     path.write_bytes(payload[:-12] + chunk + payload[-12:])
 
 
-def main() -> None:
-    reference_directories = sorted(path for path in REFERENCE_ROOT.iterdir() if path.is_dir())
-    require(reference_directories, "expected at least one reference directory")
+class CandidateIntakeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        reference_directories = sorted(
+            path for path in REFERENCE_ROOT.iterdir() if path.is_dir()
+        )
+        if not reference_directories:
+            raise AssertionError("expected at least one reference directory")
+        cls.reference_directory = reference_directories[0]
 
-    with tempfile.TemporaryDirectory(prefix="agentacct-candidate-intake-tests-") as temporary:
-        root = Path(temporary)
-        candidate = root / "candidate"
-        package_candidate(candidate, reference_directories[0])
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(
+            prefix="agentacct-candidate-intake-tests-"
+        )
+        self.root = Path(self.temporary.name)
+        self.candidate = self.root / "candidate"
+        package_candidate(self.candidate, self.reference_directory)
 
-        valid = validate(candidate)
-        require(valid.returncode == 0, valid.stderr)
-        require("(4 images)" in valid.stdout, valid.stdout)
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
 
-        wrong_source = validate(candidate, source_commit=OTHER_COMMIT)
-        require_failure(wrong_source, "validator accepted the wrong expected source")
-        require("candidate source commit" in wrong_source.stderr, wrong_source.stderr)
+    def copy_candidate(self, name: str) -> Path:
+        copied = self.root / name
+        shutil.copytree(self.candidate, copied)
+        return copied
 
-        wrong_renderer = validate(candidate, renderer_id="macos-other-renderer")
-        require_failure(wrong_renderer, "validator accepted the wrong expected renderer")
-        require("candidate renderer" in wrong_renderer.stderr, wrong_renderer.stderr)
+    def changed_candidate(self, name: str = "changed-candidate") -> Path:
+        candidate = self.copy_candidate(name)
+        add_png_text_chunk(candidate / "images" / "dashboard-minimum-dark.png")
+        write_manifest(candidate)
+        return candidate
 
-        tampered = root / "tampered"
-        shutil.copytree(candidate, tampered)
+    def references(self, name: str, *, populated: bool = True) -> tuple[Path, Path]:
+        references_root = self.root / name
+        references_root.mkdir()
+        destination = references_root / RENDERER_ID
+        if populated:
+            shutil.copytree(self.reference_directory, destination)
+        return references_root, destination
+
+    def assert_failed(
+        self,
+        result: subprocess.CompletedProcess[str],
+        expected_error: str,
+    ) -> None:
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn(expected_error, result.stderr)
+
+    def assert_clean_root(self, references_root: Path) -> None:
+        self.assertEqual(
+            sorted(path.name for path in references_root.iterdir()),
+            [RENDERER_ID],
+        )
+
+    def test_valid_candidate_matches_expected_identity(self) -> None:
+        result = validate(self.candidate)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("(4 images)", result.stdout)
+
+    def test_wrong_source_or_renderer_is_rejected(self) -> None:
+        wrong_source = validate(self.candidate, source_commit=OTHER_COMMIT)
+        self.assert_failed(wrong_source, "candidate source commit")
+
+        wrong_renderer = validate(self.candidate, renderer_id="macos-other-renderer")
+        self.assert_failed(wrong_renderer, "candidate renderer")
+
+    def test_tampered_image_bytes_are_rejected(self) -> None:
+        tampered = self.copy_candidate("tampered")
         image = tampered / "images" / "dashboard-minimum-dark.png"
         payload = bytearray(image.read_bytes())
         payload[len(payload) // 2] ^= 1
         image.write_bytes(payload)
-        tampered_result = validate(tampered)
-        require_failure(tampered_result, "validator accepted tampered image bytes")
 
-        duplicate_key = root / "duplicate-key"
-        shutil.copytree(candidate, duplicate_key)
+        self.assertNotEqual(validate(tampered).returncode, 0)
+
+    def test_manifest_json_contract_is_strict(self) -> None:
+        duplicate_key = self.copy_candidate("duplicate-key")
         manifest_path = duplicate_key / "manifest.json"
         manifest_text = manifest_path.read_text(encoding="utf-8").rstrip()
         manifest_path.write_text(
-            manifest_text[:-1] + ', "schema_version": 1}\n', encoding="utf-8"
+            manifest_text[:-1] + ', "schema_version": 1}\n',
+            encoding="utf-8",
         )
-        duplicate_result = validate(duplicate_key)
-        require_failure(duplicate_result, "validator accepted a duplicate manifest key")
-        require("duplicate key" in duplicate_result.stderr, duplicate_result.stderr)
+        self.assert_failed(validate(duplicate_key), "duplicate key")
 
-        oversized_manifest = root / "oversized-manifest"
-        shutil.copytree(candidate, oversized_manifest)
-        (oversized_manifest / "manifest.json").write_bytes(b" " * (64 * 1024 + 1))
-        oversized_result = validate(oversized_manifest)
-        require_failure(oversized_result, "validator accepted an oversized manifest")
-        require("manifest exceeds" in oversized_result.stderr, oversized_result.stderr)
+        oversized = self.copy_candidate("oversized-manifest")
+        (oversized / "manifest.json").write_bytes(b" " * (64 * 1024 + 1))
+        self.assert_failed(validate(oversized), "manifest exceeds")
 
-        unknown_field = root / "unknown-field"
-        shutil.copytree(candidate, unknown_field)
-        unknown_manifest_path = unknown_field / "manifest.json"
-        unknown_manifest = json.loads(unknown_manifest_path.read_text(encoding="utf-8"))
+        unknown_field = self.copy_candidate("unknown-field")
+        unknown_manifest = read_manifest(unknown_field)
         unknown_manifest["untrusted"] = True
-        unknown_manifest_path.write_text(json.dumps(unknown_manifest), encoding="utf-8")
-        unknown_result = validate(unknown_field)
-        require_failure(unknown_result, "validator accepted an unknown manifest field")
-        require("fields mismatch" in unknown_result.stderr, unknown_result.stderr)
+        replace_manifest(unknown_field, unknown_manifest)
+        self.assert_failed(validate(unknown_field), "fields mismatch")
 
-        extra_root_file = root / "extra-root-file"
-        shutil.copytree(candidate, extra_root_file)
+    def test_manifest_types_and_artifact_order_are_strict(self) -> None:
+        boolean_schema = self.copy_candidate("boolean-schema")
+        boolean_manifest = read_manifest(boolean_schema)
+        boolean_manifest["schema_version"] = True
+        replace_manifest(boolean_schema, boolean_manifest)
+        self.assert_failed(validate(boolean_schema), "schema_version must be integer 1")
+
+        boolean_width = self.copy_candidate("boolean-width")
+        width_manifest = read_manifest(boolean_width)
+        artifacts = width_manifest["artifacts"]
+        self.assertIsInstance(artifacts, list)
+        artifacts[0]["pixel_width"] = True
+        replace_manifest(boolean_width, width_manifest)
+        self.assert_failed(validate(boolean_width), "width is invalid")
+
+        reordered = self.copy_candidate("reordered-artifacts")
+        reordered_manifest = read_manifest(reordered)
+        reordered_artifacts = reordered_manifest["artifacts"]
+        self.assertIsInstance(reordered_artifacts, list)
+        reordered_artifacts[0], reordered_artifacts[1] = (
+            reordered_artifacts[1],
+            reordered_artifacts[0],
+        )
+        replace_manifest(reordered, reordered_manifest)
+        self.assert_failed(validate(reordered), "artifact 0 must describe")
+
+    def test_candidate_inventory_must_be_exact_and_regular(self) -> None:
+        extra_root_file = self.copy_candidate("extra-root-file")
         (extra_root_file / "notes.txt").write_text("unexpected", encoding="utf-8")
-        extra_result = validate(extra_root_file)
-        require_failure(extra_result, "validator accepted an extra root file")
-        require("root inventory mismatch" in extra_result.stderr, extra_result.stderr)
+        self.assert_failed(validate(extra_root_file), "root inventory mismatch")
 
-        symlinked_manifest = root / "symlinked-manifest"
-        shutil.copytree(candidate, symlinked_manifest)
+        symlinked_manifest = self.copy_candidate("symlinked-manifest")
         linked_manifest = symlinked_manifest / "manifest.json"
         linked_manifest.unlink()
-        linked_manifest.symlink_to(candidate / "manifest.json")
-        symlink_result = validate(symlinked_manifest)
-        require_failure(symlink_result, "validator accepted a symlinked manifest")
-        require("regular file" in symlink_result.stderr, symlink_result.stderr)
+        linked_manifest.symlink_to(self.candidate / "manifest.json")
+        self.assert_failed(validate(symlinked_manifest), "regular file")
 
-        references_root = root / "references"
-        references_root.mkdir()
-        destination = references_root / RENDERER_ID
-        shutil.copytree(reference_directories[0], destination)
+        symlinked_images = self.copy_candidate("symlinked-images")
+        shutil.rmtree(symlinked_images / "images")
+        (symlinked_images / "images").symlink_to(
+            self.candidate / "images",
+            target_is_directory=True,
+        )
+        self.assert_failed(validate(symlinked_images), "regular directory")
 
-        not_reviewed = promote(candidate, references_root, reviewed=False)
-        require_failure(not_reviewed, "promoter accepted a candidate without review confirmation")
-        require("--reviewed" in not_reviewed.stderr, not_reviewed.stderr)
+        linked_candidate = self.root / "linked-candidate"
+        linked_candidate.symlink_to(self.candidate, target_is_directory=True)
+        self.assert_failed(validate(linked_candidate), "candidate must be a regular directory")
 
-        unchanged = promote(candidate, references_root)
-        require(unchanged.returncode == 0, unchanged.stderr)
-        require("no files changed" in unchanged.stdout, unchanged.stdout)
+    def test_promotion_requires_review_and_detects_noop(self) -> None:
+        references_root, _ = self.references("references")
 
-        changed_candidate = root / "changed-candidate"
-        shutil.copytree(candidate, changed_candidate)
-        add_png_text_chunk(changed_candidate / "images" / "dashboard-minimum-dark.png")
-        write_manifest(changed_candidate)
+        self.assert_failed(
+            promote(self.candidate, references_root, reviewed=False),
+            "--reviewed",
+        )
+        unchanged = promote(self.candidate, references_root)
+        self.assertEqual(unchanged.returncode, 0, unchanged.stderr)
+        self.assertIn("no files changed", unchanged.stdout)
 
-        rollback_root = root / "rollback-references"
-        rollback_root.mkdir()
-        rollback_destination = rollback_root / RENDERER_ID
-        shutil.copytree(reference_directories[0], rollback_destination)
-        rollback_before = {
-            path.name: path.read_bytes() for path in rollback_destination.iterdir()
-        }
+    def test_promotion_can_create_a_new_renderer_directory(self) -> None:
+        references_root, destination = self.references(
+            "new-renderer-references",
+            populated=False,
+        )
+
+        result = promote(self.candidate, references_root)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            directory_bytes(destination),
+            directory_bytes(self.candidate / "images"),
+        )
+        self.assert_clean_root(references_root)
+
+    def test_changed_promotion_is_complete_and_idempotent(self) -> None:
+        references_root, destination = self.references("changed-references")
+        changed = self.changed_candidate()
+
+        result = promote(changed, references_root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Promoted four reviewed reference images", result.stdout)
+        self.assertEqual(directory_bytes(destination), directory_bytes(changed / "images"))
+        self.assert_clean_root(references_root)
+
+        repeated = promote(changed, references_root)
+        self.assertEqual(repeated.returncode, 0, repeated.stderr)
+        self.assertIn("no files changed", repeated.stdout)
+
+    def test_rejected_identity_does_not_mutate_references(self) -> None:
+        references_root, destination = self.references("identity-references")
+        before = directory_bytes(destination)
+
+        result = promote(
+            self.changed_candidate(),
+            references_root,
+            source_commit=OTHER_COMMIT,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(directory_bytes(destination), before)
+
+    def test_failed_directory_swap_restores_original_references(self) -> None:
+        references_root, destination = self.references("rollback-references")
+        before = directory_bytes(destination)
+        changed = self.changed_candidate()
         real_replace = os.replace
 
         def fail_staging_swap(source: object, destination_path: object) -> None:
             source_path = Path(source)
             if (
                 source_path.name.startswith(f".{RENDERER_ID}.candidate-")
-                and Path(destination_path) == rollback_destination
+                and Path(destination_path) == destination
             ):
                 raise OSError("simulated candidate swap failure")
             real_replace(source, destination_path)
@@ -245,41 +354,25 @@ def main() -> None:
             "dashboard_reference_candidate.os.replace",
             side_effect=fail_staging_swap,
         ):
-            try:
+            with self.assertRaisesRegex(OSError, "simulated candidate swap failure"):
                 dashboard_reference_candidate.promote_candidate_bundle(
-                    changed_candidate,
+                    changed,
                     SOURCE_COMMIT,
                     RENDERER_ID,
-                    rollback_root,
+                    references_root,
                 )
-            except OSError as error:
-                require("simulated candidate swap failure" in str(error), str(error))
-            else:
-                raise AssertionError("promotion swap failure did not propagate")
-        require(
-            {
-                path.name: path.read_bytes()
-                for path in rollback_destination.iterdir()
-            }
-            == rollback_before,
-            "failed directory swap did not restore the original references",
-        )
-        require(
-            [path.name for path in rollback_root.iterdir()] == [RENDERER_ID],
-            "failed directory swap left staging or backup directories behind",
-        )
 
-        sync_failure_root = root / "sync-failure-references"
-        sync_failure_root.mkdir()
-        sync_failure_destination = sync_failure_root / RENDERER_ID
-        shutil.copytree(reference_directories[0], sync_failure_destination)
-        sync_failure_before = {
-            path.name: path.read_bytes() for path in sync_failure_destination.iterdir()
-        }
+        self.assertEqual(directory_bytes(destination), before)
+        self.assert_clean_root(references_root)
+
+    def test_failed_directory_sync_restores_original_references(self) -> None:
+        references_root, destination = self.references("sync-failure-references")
+        before = directory_bytes(destination)
+        changed = self.changed_candidate()
         real_sync_directory = dashboard_reference_candidate._sync_directory
 
         def fail_reference_root_sync(path: Path) -> None:
-            if path == sync_failure_root:
+            if path == references_root:
                 raise OSError("simulated reference-root sync failure")
             real_sync_directory(path)
 
@@ -287,78 +380,35 @@ def main() -> None:
             "dashboard_reference_candidate._sync_directory",
             side_effect=fail_reference_root_sync,
         ):
-            try:
+            with self.assertRaisesRegex(OSError, "simulated reference-root sync failure"):
                 dashboard_reference_candidate.promote_candidate_bundle(
-                    changed_candidate,
+                    changed,
                     SOURCE_COMMIT,
                     RENDERER_ID,
-                    sync_failure_root,
+                    references_root,
                 )
-            except OSError as error:
-                require("simulated reference-root sync failure" in str(error), str(error))
-            else:
-                raise AssertionError("promotion sync failure did not propagate")
-        require(
-            {
-                path.name: path.read_bytes()
-                for path in sync_failure_destination.iterdir()
-            }
-            == sync_failure_before,
-            "failed reference-root sync did not restore the original references",
+
+        self.assertEqual(directory_bytes(destination), before)
+        self.assert_clean_root(references_root)
+
+    def test_destination_must_be_an_exact_regular_directory(self) -> None:
+        symlink_root, symlink_destination = self.references(
+            "symlink-references",
+            populated=False,
         )
-        require(
-            [path.name for path in sync_failure_root.iterdir()] == [RENDERER_ID],
-            "failed reference-root sync left staging or backup directories behind",
+        symlink_destination.symlink_to(self.reference_directory)
+        self.assert_failed(
+            promote(self.candidate, symlink_root),
+            "must not be a symlink",
         )
 
-        before_wrong_identity = {
-            path.name: path.read_bytes() for path in destination.iterdir()
-        }
-        rejected_promotion = promote(
-            changed_candidate,
-            references_root,
-            source_commit=OTHER_COMMIT,
-        )
-        require_failure(rejected_promotion, "promoter accepted the wrong source identity")
-        require(
-            {path.name: path.read_bytes() for path in destination.iterdir()}
-            == before_wrong_identity,
-            "failed promotion changed references",
-        )
-
-        promoted = promote(changed_candidate, references_root)
-        require(promoted.returncode == 0, promoted.stderr)
-        require("Promoted four reviewed reference images" in promoted.stdout, promoted.stdout)
-        require(
-            {path.name: path.read_bytes() for path in destination.iterdir()}
-            == {
-                path.name: path.read_bytes()
-                for path in (changed_candidate / "images").iterdir()
-            },
-            "promotion did not install the complete candidate set",
-        )
-
-        repeated = promote(changed_candidate, references_root)
-        require(repeated.returncode == 0, repeated.stderr)
-        require("no files changed" in repeated.stdout, repeated.stdout)
-
-        symlink_root = root / "symlink-references"
-        symlink_root.mkdir()
-        (symlink_root / RENDERER_ID).symlink_to(reference_directories[0])
-        symlink_destination = promote(candidate, symlink_root)
-        require_failure(symlink_destination, "promoter followed a destination symlink")
-        require("must not be a symlink" in symlink_destination.stderr, symlink_destination.stderr)
-
+        references_root, destination = self.references("extra-destination-references")
         (destination / "notes.txt").write_text("unexpected", encoding="utf-8")
-        unexpected_destination = promote(candidate, references_root)
-        require_failure(
-            unexpected_destination,
-            "promoter replaced a destination with unexpected files",
+        self.assert_failed(
+            promote(self.candidate, references_root),
+            "inventory mismatch",
         )
-        require("inventory mismatch" in unexpected_destination.stderr, unexpected_destination.stderr)
-
-    print("dashboard reference candidate intake CLI tests passed")
 
 
 if __name__ == "__main__":
-    main()
+    unittest.main()

--- a/apps/agentacct/Tests/visual-snapshots-cli-tests.sh
+++ b/apps/agentacct/Tests/visual-snapshots-cli-tests.sh
@@ -72,6 +72,13 @@ fail() {
   exit 1
 }
 
+declared_platform="$(AGENTACCT_FAKE_OS_BUILD=unexpected \
+  "$app_dir/Scripts/visual-snapshots" platform-id)"
+[[ "$declared_platform" == "$platform_id" ]] \
+  || fail "platform-id returned the wrong canonical platform: $declared_platform"
+[[ ! -s "$AGENTACCT_FAKE_SWIFT_LOG" ]] \
+  || fail "platform-id performed unnecessary test discovery"
+
 detected_platform="$("$app_dir/Scripts/visual-snapshots" check-environment)"
 [[ "$detected_platform" == "$platform_id" ]] \
   || fail "environment check returned the wrong platform id: $detected_platform"

--- a/tests/test_ci_resource_policy.py
+++ b/tests/test_ci_resource_policy.py
@@ -1,0 +1,60 @@
+"""Structural checks for bounded, current GitHub-hosted CI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+VISUAL_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "visual-reference-candidates.yml"
+
+
+def _workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _used_actions(path: Path) -> list[str]:
+    workflow = _workflow(path)
+    return [
+        step["uses"]
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if "uses" in step
+    ]
+
+
+def test_branch_ci_cancels_superseded_work_and_bounds_jobs() -> None:
+    workflow = _workflow(TESTS_WORKFLOW)
+    assert workflow["concurrency"] == {
+        "group": "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+        "cancel-in-progress": True,
+    }
+    assert workflow["jobs"]["pytest"]["timeout-minutes"] == 20
+    assert workflow["jobs"]["macos-app"]["timeout-minutes"] == 20
+
+
+def test_candidate_generation_is_manual_and_globally_serialized() -> None:
+    workflow = _workflow(VISUAL_WORKFLOW)
+    assert workflow["concurrency"] == {
+        "group": "visual-reference-candidates",
+        "cancel-in-progress": False,
+    }
+    assert workflow["jobs"]["preflight"]["timeout-minutes"] == 5
+    assert workflow["jobs"]["render"]["timeout-minutes"] == 20
+    assert workflow["jobs"]["verify"]["timeout-minutes"] == 5
+
+
+def test_touched_workflows_use_supported_hosted_action_majors() -> None:
+    actions = _used_actions(TESTS_WORKFLOW) + _used_actions(VISUAL_WORKFLOW)
+    expected_majors = {
+        "actions/checkout": "v7",
+        "actions/setup-python": "v7",
+        "actions/upload-artifact": "v7",
+        "actions/download-artifact": "v8",
+    }
+    for action in actions:
+        name, version = action.rsplit("@", 1)
+        assert version == expected_majors[name], action

--- a/tests/test_visual_reference_workflow.py
+++ b/tests/test_visual_reference_workflow.py
@@ -36,7 +36,7 @@ def test_visual_reference_workflow_is_manual_and_read_only() -> None:
 def test_visual_reference_workflow_uses_two_fresh_canonical_renderers() -> None:
     render = _workflow()["jobs"]["render"]
     assert render["runs-on"] == "macos-26"
-    assert render["strategy"]["fail-fast"] is False
+    assert render["strategy"]["fail-fast"] is True
     assert render["strategy"]["matrix"]["replica"] == ["a", "b"]
     assert render["env"] == {
         "DEVELOPER_DIR": "/Applications/Xcode_26.6.app/Contents/Developer",
@@ -51,15 +51,34 @@ def test_visual_reference_workflow_uses_two_fresh_canonical_renderers() -> None:
         "Run deterministic dashboard render tests"
     )
     combined = _combined_steps(render)
-    assert "^[0-9a-f]{40}$" in combined
     assert "visual-snapshots check-environment" in combined
     assert "DashboardSnapshotHarnessTests" in combined
     assert "swift build -c release" in combined
 
 
+def test_visual_reference_workflow_fails_cheap_before_allocating_macos() -> None:
+    jobs = _workflow()["jobs"]
+    preflight = jobs["preflight"]
+    assert preflight["runs-on"] == "ubuntu-latest"
+    assert preflight["timeout-minutes"] == 5
+    assert preflight["outputs"] == {
+        "source_commit": "${{ steps.source.outputs.commit }}"
+    }
+    assert jobs["render"]["needs"] == "preflight"
+
+    combined = _combined_steps(preflight)
+    assert "^[0-9a-f]{40}$" in combined
+    assert "git -C source rev-parse HEAD" in combined
+    assert 'echo "commit=$actual_commit" >> "$GITHUB_OUTPUT"' in combined
+
+
 def test_visual_reference_workflow_keeps_trusted_tools_outside_requested_source() -> None:
     render = _workflow()["jobs"]["render"]
-    checkout_steps = [step for step in render["steps"] if step.get("uses") == "actions/checkout@v4"]
+    checkout_steps = [
+        step
+        for step in render["steps"]
+        if step.get("uses", "").startswith("actions/checkout@")
+    ]
     assert len(checkout_steps) == 2
     assert checkout_steps[0]["with"] == {
         "ref": "${{ github.workflow_sha }}",
@@ -67,7 +86,7 @@ def test_visual_reference_workflow_keeps_trusted_tools_outside_requested_source(
         "persist-credentials": False,
     }
     assert checkout_steps[1]["with"] == {
-        "ref": "${{ inputs.ref }}",
+        "ref": "${{ needs.preflight.outputs.source_commit }}",
         "path": "source",
         "fetch-depth": 1,
         "persist-credentials": False,
@@ -105,7 +124,11 @@ def test_visual_reference_workflow_promotes_only_identical_replicas_to_artifact(
     assert "dashboard-reference-candidate-${{ inputs.ref }}-b" in combined
     assert "diff --recursive --brief --no-dereference replicas/a replicas/b" in combined
 
-    final_upload = next(step for step in verify["steps"] if step["name"] == "Upload verified candidate")
+    final_upload = next(
+        step
+        for step in verify["steps"]
+        if step["name"] == "Upload verified candidate"
+    )
     assert final_upload["with"]["name"] == "dashboard-reference-candidate-${{ inputs.ref }}"
     assert final_upload["with"]["path"] == "replicas/a"
     assert final_upload["with"]["retention-days"] == 14


### PR DESCRIPTION
## Why

Milestone 1 can generate a reproducible, traceable reference candidate without using a developer's Mac, but intake was still manual: contributors had to trust and copy downloaded files themselves. That left identity, schema, hash, inventory, and partial-replacement mistakes outside an enforced boundary.

## Central difference

Before this change, a hosted artifact ended at manual inspection and file copying. After it, the repository can independently declare the expected renderer, strictly validate the complete downloaded bundle, require explicit four-image review, and install exactly that validated set without rendering locally or mutating Git state.

## Design and safety

- `visual-snapshots platform-id` reports repository policy without consulting the developer's OS or running Swift tests.
- Downloaded manifests reject duplicate or unknown fields, invalid types and identities, oversized input, unexpected files, symlinks, malformed PNG structure, wrong dimensions, invalid hashes, and bytes that disagree with the manifest.
- Validation requires the caller's expected full source SHA and repository-declared renderer; the candidate cannot assert its own trust boundary.
- Promotion repeats validation, requires `--reviewed`, stages all four regular files on the destination filesystem, replaces the renderer directory as one set, and restores the original directory when the swap or its durability sync fails.
- Identical candidates are no-ops. The commands never render locally, stage, commit, push, or approve a visual change.
- The upstream single-run baseline artifact remains a review aid; only the manifest-bound, two-replica authoritative artifact is promotable.

## CI resource model

- Candidate generation remains manual-only and has no secrets or write permission.
- A five-minute Linux preflight rejects malformed or unreachable commits before any macOS capacity is allocated.
- Candidate runs are globally serialized. One active run may allocate exactly the two replicas required to prove reproducibility; only the newest additional request remains pending.
- Replica fail-fast avoids continuing work once no verified bundle can be produced. Every job has a timeout.
- Unverified replica artifacts expire after one day. Only a byte-identical verified bundle is retained for 14 days.
- Ordinary PR/branch CI cancels superseded runs for the same PR or branch.
- Touched workflows use the current supported hosted-action majors, eliminating the Node 20 deprecation fallback observed during review.

## Review map

1. `apps/agentacct/Scripts/dashboard_reference_candidate.py` — shared bounded parsing, manifest/image validation, staging, commit, and rollback.
2. `apps/agentacct/Scripts/validate-dashboard-reference-candidate` and `promote-dashboard-reference-candidate` — read-only validation and explicitly reviewed promotion boundaries.
3. `apps/agentacct/Scripts/visual-snapshots` — repository-declared renderer identity for noncanonical developer machines.
4. `apps/agentacct/Tests/dashboard-reference-candidate-intake-cli-tests.py` — 13 independent identity, tampering, schema, symlink, no-op, creation, replacement, and forced-rollback cases.
5. `.github/workflows/visual-reference-candidates.yml` and `.github/workflows/tests.yml` — bounded on-demand generation and superseded-run cancellation.
6. `tests/test_visual_reference_workflow.py`, `tests/test_ci_resource_policy.py`, and `apps/agentacct/Tests/README.md` — structural policy pins and operator runbook.

## Verification

- Candidate packaging, intake, and visual-snapshot CLI suites passed.
- Intake suite: 13 independent cases, including forced swap failure and parent-directory sync failure rollback.
- Workflow policy suite: 15 passed, including cheap preflight, serialization, timeouts, fail-fast, retention, and supported action-major pins.
- `swift test`: 34 tests, 0 failures, 1 intentional visual-CLI delegation skip.
- `swift build -c release` passed.
- actionlint 1.7.12 passed for both touched workflows.
- `git diff --check origin/main...HEAD` passed.
- [Exact-head PR CI](https://github.com/mikehasa/agentacct/actions/runs/33071165633) passed on macOS and Python 3.11, 3.12, and 3.13.
- [Authoritative exact-head candidate run](https://github.com/mikehasa/agentacct/actions/runs/33071172469) passed for `81bcb184fef30c8ddae2a3f7d9c68ea292cc79b9`: Linux preflight 5s; canonical macOS replicas 2m32s and 2m37s; independent Linux byte verification 10s; no workflow annotations.
- The downloaded manifest matched the exact source and renderer. All four PNGs were byte-identical to the reviewed references and the visually inspected candidate; reviewed promotion was a no-op.

## Scope

This is Milestone 2: safe candidate intake, explicit promotion, and bounded CI execution. It does not automate visual approval, write repository state from CI, change the canonical renderer, configure a Mac mini, or add scheduled renderer monitoring.
