### PR TITLE
ci(app): add Milestone 3 renderer canary

### DIFF
--- a/.github/workflows/visual-renderer-canary.yml
+++ b/.github/workflows/visual-renderer-canary.yml
@@ -1,0 +1,36 @@
+name: visual renderer canary
+run-name: Visual renderer canary
+
+"on":
+  schedule:
+    # Avoid the start of the hour, when scheduled workflow delivery is busiest.
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: visual-renderer-canary
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check canonical visual renderer
+    runs-on: macos-26
+    timeout-minutes: 3
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+      TZ: UTC
+    defaults:
+      run:
+        working-directory: apps/agentacct
+    steps:
+      - name: Check out renderer definition
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Check canonical renderer
+        run: ./Scripts/visual-snapshots check-environment

--- a/apps/agentacct/Tests/README.md
+++ b/apps/agentacct/Tests/README.md
@@ -189,6 +189,45 @@ and baseline approval as separate review gates.
 | downloaded candidate validation | identity, schema, inventory, PNG, dimension, or hash evidence does not match |
 | candidate promotion | visual review was not confirmed or the existing reference destination is unsafe to replace |
 
+## Monitor hosted renderer availability
+
+The `visual renderer canary` workflow checks every Monday at 05:17 UTC whether
+GitHub's current `macos-26` image still matches the repository's canonical
+macOS, Xcode, architecture, and Xcode selection. Run the same check manually
+after a runner-image announcement or while investigating a candidate failure:
+
+```bash
+gh workflow run visual-renderer-canary.yml
+```
+
+This is availability monitoring, not candidate generation. Each run allocates
+one macOS runner for at most three minutes, checks out the renderer definition
+without persisted credentials, and invokes only `check-environment`. It does
+not discover or compile tests, build the app, render images, upload artifacts,
+read secrets, or write to the repository. Overlapping scheduled and manual
+runs cancel each other. Scheduled workflows run from the default branch, so a
+canary change takes effect only after its PR is merged.
+
+A canary failure means the hosted image drifted; it does not mean the reviewed
+pixels are wrong. Keep candidate generation paused and follow the explicit
+renderer migration procedure in [CI behavior](#ci-behavior). The failed run is
+the alert—this workflow deliberately does not create issues or other persistent
+repository writes.
+
+### Why a daily-use Mac mini is not a runner
+
+Do not register a developer's daily-use Mac mini as a self-hosted runner for
+this service. A separate user, process, container, or VM can isolate files and
+credentials, but it cannot guarantee zero effect on the interactive machine:
+CPU/GPU, unified memory, storage I/O, thermals, OS updates, and graphical login
+state remain shared. Hosted ephemeral macOS runners are therefore the service's
+isolation boundary and also remove developer macOS-version differences.
+
+If hosted macOS runners ever become unsuitable, the supported fallback is a
+dedicated Mac that is never used interactively, not stronger scheduling rules
+on a shared developer machine. Until then, keeping generation manual and the
+weekly canary identity-only is the smaller and more scalable design.
+
 ## Selecting tests
 
 The canonical identity is the specifier reported by `swift test list`. The CLI

--- a/tests/test_ci_resource_policy.py
+++ b/tests/test_ci_resource_policy.py
@@ -10,6 +10,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
 VISUAL_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "visual-reference-candidates.yml"
+CANARY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "visual-renderer-canary.yml"
 
 
 def _workflow(path: Path) -> dict:
@@ -48,7 +49,11 @@ def test_candidate_generation_is_manual_and_globally_serialized() -> None:
 
 
 def test_touched_workflows_use_supported_hosted_action_majors() -> None:
-    actions = _used_actions(TESTS_WORKFLOW) + _used_actions(VISUAL_WORKFLOW)
+    actions = (
+        _used_actions(TESTS_WORKFLOW)
+        + _used_actions(VISUAL_WORKFLOW)
+        + _used_actions(CANARY_WORKFLOW)
+    )
     expected_majors = {
         "actions/checkout": "v7",
         "actions/setup-python": "v7",

--- a/tests/test_visual_renderer_canary.py
+++ b/tests/test_visual_renderer_canary.py
@@ -1,0 +1,71 @@
+"""Structural resource and safety policy for the visual renderer canary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANARY_PATH = REPO_ROOT / ".github" / "workflows" / "visual-renderer-canary.yml"
+CANDIDATE_PATH = REPO_ROOT / ".github" / "workflows" / "visual-reference-candidates.yml"
+
+
+def _workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_canary_runs_weekly_or_manually_with_read_only_access() -> None:
+    workflow = _workflow(CANARY_PATH)
+    assert workflow["on"] == {
+        "schedule": [{"cron": "17 5 * * 1"}],
+        "workflow_dispatch": None,
+    }
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"] == {
+        "group": "visual-renderer-canary",
+        "cancel-in-progress": True,
+    }
+
+
+def test_canary_uses_one_short_canonical_runner() -> None:
+    canary = _workflow(CANARY_PATH)
+    candidate = _workflow(CANDIDATE_PATH)
+    assert set(canary["jobs"]) == {"check"}
+
+    check = canary["jobs"]["check"]
+    canonical_render = candidate["jobs"]["render"]
+    assert check["runs-on"] == canonical_render["runs-on"] == "macos-26"
+    assert check["env"] == canonical_render["env"]
+    assert check["timeout-minutes"] == 3
+
+
+def test_canary_only_checks_identity() -> None:
+    check = _workflow(CANARY_PATH)["jobs"]["check"]
+    assert check["defaults"] == {
+        "run": {"working-directory": "apps/agentacct"}
+    }
+    assert check["steps"] == [
+        {
+            "name": "Check out renderer definition",
+            "uses": "actions/checkout@v7",
+            "with": {"persist-credentials": False},
+        },
+        {
+            "name": "Check canonical renderer",
+            "run": "./Scripts/visual-snapshots check-environment",
+        },
+    ]
+
+    text = CANARY_PATH.read_text(encoding="utf-8")
+    for prohibited in (
+        "swift build",
+        "swift test",
+        "snapshot-dashboard",
+        "upload-artifact",
+        "download-artifact",
+        "secrets.",
+        "contents: write",
+    ):
+        assert prohibited not in text


### PR DESCRIPTION
## Summary

- add a weekly and manually dispatchable check that verifies GitHub's current `macos-26` image still matches the canonical visual renderer
- enforce the canary's trigger, permissions, single-runner budget, three-minute timeout, canonical environment, and identity-only execution in structural tests
- document the completed hosted reference-image service and explicitly reject a developer's daily-use Mac mini as an isolation boundary

## Why

Milestones 1 and 2 made authoritative image generation manual, hosted, independently replicated, validated, and explicitly promoted. The remaining operational risk is silent drift in GitHub's mutable macOS runner image. Detecting that drift weekly avoids discovering it only when a developer needs a candidate.

A daily-use Mac mini cannot honestly guarantee zero impact: accounts, processes, containers, and VMs still share CPU/GPU, unified memory, storage I/O, thermals, OS updates, and graphical login state. Ephemeral hosted runners provide the physical isolation the requirement needs without coupling output to developer hardware or macOS versions.

## Compute and safety model

- one `macos-26` runner per week, with optional manual dispatch
- three-minute hard timeout and one global concurrency group; overlapping runs cancel
- checkout plus `visual-snapshots check-environment` only
- no Swift discovery, compilation, app build, image render, artifact, secret, or repository write
- candidate generation remains manual, globally serialized, and dual-replica
- a failed check is the alert; the workflow does not create issues or other persistent writes

## Review map

1. `.github/workflows/visual-renderer-canary.yml` — the entire runtime and compute surface
2. `tests/test_visual_renderer_canary.py` — trigger, budget, environment, and prohibited-work contract
3. `tests/test_ci_resource_policy.py` — keeps the canary on supported hosted action versions
4. `apps/agentacct/Tests/README.md` — operation, drift response, and the Mac mini decision

## Verification

- [exact-head GitHub Actions run](https://github.com/mikehasa/agentacct/actions/runs/33073478778) — macOS app/visual verification and Python 3.11, 3.12, and 3.13 all passed at `36ff34a`
- `uv run --frozen --with pytest pytest -q tests/test_visual_renderer_canary.py tests/test_visual_reference_workflow.py tests/test_ci_resource_policy.py tests/test_publish_workflow.py` — 18 passed
- `actionlint` — all workflows passed
- `./Tests/visual-snapshots-cli-tests.sh` — passed
- `./Tests/dashboard-reference-candidate-intake-cli-tests.py` — 13 passed
- `./Tests/dashboard-reference-candidate-cli-tests.py` — passed
- `swift test` — 34 passed, 1 expected visual-baseline skip
- local full Python run — 2,635 passed; the 10 macOS/Python 3.14 failures reproduce exactly on the untouched `origin/main` tree and are outside this workflow/docs-only change; the PR's Linux 3.11–3.13 matrix is authoritative

The exact-head macOS job ran the same canonical `check-environment` command on the same runner/Xcode environment as the new canary. GitHub only enables a new scheduled or manually dispatched workflow after its definition reaches the default branch, so dispatching the standalone canary is the post-merge smoke check.

## Scope

This milestone does not change image generation, candidate validation/promotion, reviewed references, or product UI. It does not configure self-hosted hardware. Scheduled execution begins only after the workflow reaches the default branch; after merge, manually dispatch it once to verify the live hosted environment.
