### PR TITLE
Fix collapsed menu popover height

### DIFF
--- a/apps/agentacct/Sources/agentacct/MenuContent.swift
+++ b/apps/agentacct/Sources/agentacct/MenuContent.swift
@@ -73,6 +73,9 @@ struct MenuContent: View {
             }
             .scrollBounceBehavior(.basedOnSize)
             .frame(maxHeight: 420)
+            // MenuBarExtra can propose only the footer's height. Preserve the
+            // capped scroll body's ideal height instead of accepting zero.
+            .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/apps/agentacct/Tests/agentacctTests/MenuSnapshotHarnessTests.swift
+++ b/apps/agentacct/Tests/agentacctTests/MenuSnapshotHarnessTests.swift
@@ -1,8 +1,32 @@
 import AppKit
+import SwiftUI
 import XCTest
 @testable import agentacct
 
 final class MenuSnapshotHarnessTests: XCTestCase {
+    private struct CompressedMenuHost: Layout {
+        func sizeThatFits(
+            proposal: ProposedViewSize,
+            subviews: Subviews,
+            cache: inout ()
+        ) -> CGSize {
+            subviews[0].sizeThatFits(ProposedViewSize(width: 360, height: 44))
+        }
+
+        func placeSubviews(
+            in bounds: CGRect,
+            proposal: ProposedViewSize,
+            subviews: Subviews,
+            cache: inout ()
+        ) {
+            subviews[0].place(
+                at: bounds.origin,
+                anchor: .topLeading,
+                proposal: ProposedViewSize(width: 360, height: 44)
+            )
+        }
+    }
+
     private struct ExpectedArtifact {
         let filename: String
         let pixelsWide: Int
@@ -69,6 +93,42 @@ final class MenuSnapshotHarnessTests: XCTestCase {
         XCTAssertGreaterThan(appearanceDifference.changedPixelFraction, 0.05)
         XCTAssertFalse(SnapshotMode.enabled)
         XCTAssertNil(SnapshotScheme.override)
+    }
+
+    @MainActor
+    func testLiveConnectedMenuProvidesAUsableIntrinsicHeight() throws {
+        let fixture = try DashboardSnapshotFixture.load(from: fixtureURL())
+        let glance = GlanceState(preloaded: GlanceSnapshot(
+            glance: fixture.glance,
+            daemonVersion: fixture.daemonVersion
+        ))
+        let dashboard = DashboardStore(preloaded: fixture)
+        let selection = AppSelection()
+
+        SnapshotMode.enabled = false
+        let view = MenuContent(
+            buildIdentity: MenuSnapshotRenderer.reviewBuildIdentity,
+            lastUpdatedTextOverride: "just now",
+            launchAtLoginInitialState: false
+        )
+        .environmentObject(glance)
+        .environmentObject(dashboard)
+        .environmentObject(selection)
+
+        let hostingView = NSHostingView(rootView: CompressedMenuHost { view })
+        let fittingSize = hostingView.fittingSize
+
+        XCTAssertEqual(fittingSize.width, 360, accuracy: 0.5)
+        XCTAssertGreaterThanOrEqual(
+            fittingSize.height,
+            440,
+            "the live MenuBarExtra must reserve room for its content above the persistent footer"
+        )
+        XCTAssertLessThanOrEqual(
+            fittingSize.height,
+            465,
+            "the connected menu must remain capped to a glanceable popover height"
+        )
     }
 
     func testFixtureExercisesPopulatedUsageWindows() throws {


### PR DESCRIPTION
## Why

Follow-up to #147. The redesigned popover could open at only 45 points tall: the divider and footer remained visible while the connected content disappeared.

The earlier verification did not exercise this failure path. `MenuSnapshotRenderer` enables `SnapshotMode`, which replaces the live `ScrollView` with a plain, explicitly sized snapshot body. That correctly verifies deterministic pixels, but it bypasses the live `MenuBarExtra` sizing negotiation. Under the 44-point proposal observed from the native host, the live scroll body accepted zero height; adding the 1-point divider produced the exact 45-point failure.

## Central difference

Before: the scroll body honored a footer-only height proposal and collapsed to zero.

After: the scroll body keeps its vertical ideal size after applying the existing 420-point cap, so it resists compression while preserving the intended bounded scrolling behavior.

## Design and safety

- Applies vertical-only `fixedSize` after `.frame(maxHeight: 420)`: the body resists the bad host proposal but cannot grow beyond the existing cap.
- Leaves horizontal negotiation, snapshot-only rendering, disconnected states, content hierarchy, and visual references unchanged.
- Adds a live-path `NSHostingView` regression that deliberately proposes `360 × 44`, matching the native failure boundary.
- The test requires a usable total height of at least 440 points and at most 465 points, proving both content visibility and the glanceable cap.

## Red/green proof

On untouched `origin/main@311c3d9` with only the regression test added:

- package-qualified test executed exactly once;
- failed with `fittingSize.height == 45.0`;
- expected `>= 440.0`.

On this PR head, the same test executes exactly once and passes.

## Verification

- `swift test --filter 'agentacctTests.MenuSnapshotHarnessTests/testLiveConnectedMenuProvidesAUsableIntrinsicHeight'` — 1 passed, 0 failures.
- `swift test --filter 'MenuPresentationTests|MenuSnapshotHarnessTests|ThemeContrastTests'` — 13 passed, 0 failures.
- `swift test` — 79 executed, 5 intentional visual-mode skips, 0 failures.
- `./Scripts/visual-snapshots verify MenuVisualRegressionTests` — passed; all four canonical menu references match.
- `swift build -c release` — passed.
- `git diff --check origin/main` — passed.
- Installed `/Applications/agentacct.app` executable is byte-identical to the verified worktree release executable.
- Native exact-PID smoke — passed at `360 × 440`; the broken build measured `360 × 45`.
- GitHub Actions on `8db38d9` — macOS app/UI plus pytest 3.11, 3.12, and 3.13 all passed.

The deterministic regression covers the exact live layout contract that #147 omitted. The installed byte-identical branch build was also observed by exact PID: its native popover measured `360 × 440`, not the broken `360 × 45` footer-only window. Computer Use still cannot automate the menu-bar click, so the native smoke used a user-opened menu plus read-only `CGWindowListCopyWindowInfo` measurement.

## Review order

1. `MenuSnapshotHarnessTests.swift` — see the compressed-host reproducer and its lower/upper height contract.
2. `MenuContent.swift` — verify the single modifier is ordered after the existing 420-point cap.

## Scope

Two files only. No reference-image changes, data-model changes, dependencies, migrations, or unrelated cleanup.
