### PR TITLE
Keep large local stores responsive

### DIFF
--- a/apps/agentacct/Sources/agentacct/AgentacctApp.swift
+++ b/apps/agentacct/Sources/agentacct/AgentacctApp.swift
@@ -7,16 +7,16 @@ import SwiftUI
 // Python daemon; this process only renders what the API vouches for.
 
 struct AgentacctApp: App {
-    @StateObject private var glance = GlanceState()
-    @StateObject private var dashboard = DashboardStore()
-    @StateObject private var selection = AppSelection()
+    @State private var glance = GlanceState()
+    @State private var dashboard = DashboardStore()
+    @State private var selection = AppSelection()
 
     var body: some Scene {
         MenuBarExtra {
             MenuContent()
-                .environmentObject(glance)
-                .environmentObject(dashboard)
-                .environmentObject(selection)
+                .environment(glance)
+                .environment(dashboard)
+                .environment(selection)
         } label: {
             // The Stamped Tile mark as a template image, so the system tints
             // it for light/dark/tinted menu bars. The weekly-plan % lives in
@@ -29,9 +29,9 @@ struct AgentacctApp: App {
 
         Window("agentacct", id: "main") {
             MainWindow()
-                .environmentObject(glance)
-                .environmentObject(dashboard)
-                .environmentObject(selection)
+                .environment(glance)
+                .environment(dashboard)
+                .environment(selection)
         }
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 1040, height: 640)

--- a/apps/agentacct/Sources/agentacct/DashboardModel.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardModel.swift
@@ -67,8 +67,9 @@ struct AttributedWork: Decodable, Identifiable {
     let title: String?
     let joinStrategy: String?
     let joinConfidence: String?
+    private let fallbackId = UUID().uuidString
 
-    var id: String { workId ?? sectionId ?? UUID().uuidString }
+    var id: String { workId ?? sectionId ?? fallbackId }
 
     enum CodingKeys: String, CodingKey {
         case title
@@ -106,8 +107,9 @@ struct WorkItem: Decodable, Identifiable {
     let title: String?
     let latestStatus: String?
     let evidenceStatus: String?
+    private let fallbackId = UUID().uuidString
 
-    var id: String { workId ?? sectionId ?? UUID().uuidString }
+    var id: String { workId ?? sectionId ?? fallbackId }
 
     enum CodingKeys: String, CodingKey {
         case workId = "work_id"

--- a/apps/agentacct/Sources/agentacct/DashboardPane.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardPane.swift
@@ -210,9 +210,9 @@ func isActiveWorkStatus(_ status: String?) -> Bool {
 }
 
 struct DashboardPane: View {
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var glance: GlanceState
-    @EnvironmentObject var selection: AppSelection
+    @Environment(DashboardStore.self) var dashboard
+    @Environment(GlanceState.self) var glance
+    @Environment(AppSelection.self) var selection
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var presentedError: String? {

--- a/apps/agentacct/Sources/agentacct/DashboardSnapshotHarness.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardSnapshotHarness.swift
@@ -193,9 +193,9 @@ enum DashboardSnapshotRenderer {
             // A packaged app consistently offers setup here. Injecting that
             // state keeps SwiftPM and packaged-build snapshots identical.
             let view = MainWindow(canSetUpOverride: true)
-                .environmentObject(glance)
-                .environmentObject(dashboard)
-                .environmentObject(selection)
+                .environment(glance)
+                .environment(dashboard)
+                .environment(selection)
                 .frame(
                     width: configuration.width,
                     height: configuration.height,

--- a/apps/agentacct/Sources/agentacct/DashboardStore.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import SwiftUI
 
 /// Named state variants used only by deterministic offscreen review tooling.
@@ -20,42 +21,43 @@ enum SnapshotWorkStoreState {
 // store never re-derives a number.
 
 @MainActor
-final class DashboardStore: ObservableObject {
-    @Published private(set) var planClients: [V1PlanClient] = []
-    @Published private(set) var usage: UsageSummary?
-    @Published private(set) var receiptTasks: [ReceiptSummary] = []
-    @Published private(set) var totalReceiptTasks: Int?
-    @Published private(set) var receiptTasksTruncated: Bool?
-    @Published private(set) var receiptAttention: ReceiptAttentionPayload?
-    @Published private(set) var receipt: Receipt?
-    @Published private(set) var receiptListError: String?
-    @Published private(set) var receiptError: String?
+@Observable
+final class DashboardStore {
+    private(set) var planClients: [V1PlanClient] = []
+    private(set) var usage: UsageSummary?
+    private(set) var receiptTasks: [ReceiptSummary] = []
+    private(set) var totalReceiptTasks: Int?
+    private(set) var receiptTasksTruncated: Bool?
+    private(set) var receiptAttention: ReceiptAttentionPayload?
+    private(set) var receipt: Receipt?
+    private(set) var receiptListError: String?
+    private(set) var receiptError: String?
     /// Session deep views preloaded by key ("client::session"). Only the offscreen
     /// snapshot path fills this (the live app loads each drill row lazily via a
     /// SwiftUI `.task`, while deterministic rendering cannot wait on network
     /// work); a drill row reads it as a fallback so its steps render in a snapshot.
-    @Published private(set) var preloadedSessions: [String: V1SessionDetail] = [:]
-    @Published private(set) var errorText: String?
+    private(set) var preloadedSessions: [String: V1SessionDetail] = [:]
+    private(set) var errorText: String?
     /// Source/watcher health from /v1/ingestion (the Sources pane).
-    @Published private(set) var ingestion: V1IngestionSnapshot?
-    @Published private(set) var ingestionError: String?
-    @Published private(set) var isRefreshing = false
-    @Published private(set) var lastUpdated: Date?
+    private(set) var ingestion: V1IngestionSnapshot?
+    private(set) var ingestionError: String?
+    private(set) var isRefreshing = false
+    private(set) var lastUpdated: Date?
     /// Freshness of the independently published plan + recorded-usage pair.
     /// Receipt-list failures must not make a successful usage refresh look old.
-    @Published private(set) var usageLastUpdated: Date?
+    private(set) var usageLastUpdated: Date?
 
     /// The usage-pane range (7/30/90 trailing days). Defaults to 7 so the
     /// per-model plan breakdown lines up with the 7d headline out of the box
     /// (a 30-day accumulation reads as >100% of a weekly plan and confuses);
     /// the today/7d headline windows are fixed regardless of this.
-    @Published private(set) var usageDays = 7
+    private(set) var usageDays = 7
 
     /// Monotonic token so rapid range switches can't land out of order and a
     /// failed fetch can't leave the old data labeled with the new range.
-    private var usageDaysGeneration = 0
+    @ObservationIgnored private var usageDaysGeneration = 0
 
-    private let client = GlanceClient()
+    @ObservationIgnored private let client = GlanceClient()
 
     init() {}
 
@@ -315,14 +317,15 @@ struct DispositionResponse: Decodable {
 
 /// The menu bar → main window selection channel.
 @MainActor
-final class AppSelection: ObservableObject {
-    @Published var sessionId: String?
-    @Published var taskId: String?
-    @Published var pane: MainPane = .dashboard
+@Observable
+final class AppSelection {
+    var sessionId: String?
+    var taskId: String?
+    var pane: MainPane = .dashboard
     /// The Work surface's shared sort. Lives here (not in the table's @State)
     /// so opening a record — which unmounts the table — never resets it, and
     /// the record-mode rail stays on the same order as the table.
-    @Published var workSort: WorkSort = .latest
+    var workSort: WorkSort = .latest
 
     /// Dashboard actions replace stale deep links before changing panes. This
     /// keeps a previous Task or session from overriding the control the user

--- a/apps/agentacct/Sources/agentacct/GlanceState.swift
+++ b/apps/agentacct/Sources/agentacct/GlanceState.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import SwiftUI
 
 // The app's one state machine. Poll cadence is a fixed 30s in the skeleton
@@ -7,7 +8,8 @@ import SwiftUI
 // a daemon that is down or incompatible is an explicit, labeled UI state.
 
 @MainActor
-final class GlanceState: ObservableObject {
+@Observable
+final class GlanceState {
     enum Phase {
         case connecting
         case disconnected(String)
@@ -15,12 +17,12 @@ final class GlanceState: ObservableObject {
         case connected(GlanceSnapshot)
     }
 
-    @Published private(set) var phase: Phase = .connecting
-    @Published private(set) var lastUpdated: Date?
-    @Published private(set) var isRefreshing = false
+    private(set) var phase: Phase = .connecting
+    private(set) var lastUpdated: Date?
+    private(set) var isRefreshing = false
 
-    private let client = GlanceClient()
-    private var pollTask: Task<Void, Never>?
+    @ObservationIgnored private let client = GlanceClient()
+    @ObservationIgnored private var pollTask: Task<Void, Never>?
     private let pollIntervalSeconds: UInt64 = 30
 
     init() {

--- a/apps/agentacct/Sources/agentacct/MainWindow.swift
+++ b/apps/agentacct/Sources/agentacct/MainWindow.swift
@@ -9,9 +9,9 @@ import SwiftUI
 // their session drill-down), the merged UsagePane, and SourcesPane.
 
 struct MainWindow: View {
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var glance: GlanceState
-    @EnvironmentObject var selection: AppSelection
+    @Environment(DashboardStore.self) var dashboard
+    @Environment(GlanceState.self) var glance
+    @Environment(AppSelection.self) var selection
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var setup = SetupModel()
     @State private var showSetup = false
@@ -97,9 +97,9 @@ func refreshProgressVisible(isRefreshing: Bool, delayElapsed: Bool) -> Bool {
 }
 
 struct TopBar: View {
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var glance: GlanceState
-    @EnvironmentObject var selection: AppSelection
+    @Environment(DashboardStore.self) var dashboard
+    @Environment(GlanceState.self) var glance
+    @Environment(AppSelection.self) var selection
     /// Packaged build → show the "Set up recording" entry point.
     var canSetUp: Bool = false
     var onSetUp: () -> Void = {}

--- a/apps/agentacct/Sources/agentacct/MenuContent.swift
+++ b/apps/agentacct/Sources/agentacct/MenuContent.swift
@@ -5,9 +5,9 @@ import SwiftUI
 // answers the account question first, keeps usage and quota evidence distinct,
 // and sends deeper work to the main window.
 struct MenuContent: View {
-    @EnvironmentObject var state: GlanceState
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var selection: AppSelection
+    @Environment(GlanceState.self) var state
+    @Environment(DashboardStore.self) var dashboard
+    @Environment(AppSelection.self) var selection
     @Environment(\.openWindow) private var openWindow
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var showsRefreshProgress = false

--- a/apps/agentacct/Sources/agentacct/MenuSnapshotHarness.swift
+++ b/apps/agentacct/Sources/agentacct/MenuSnapshotHarness.swift
@@ -82,9 +82,9 @@ enum MenuSnapshotRenderer {
                 launchAtLoginInitialState: false,
                 snapshotBodyMaxHeight: configuration.density == .dense ? 420 : nil
             )
-            .environmentObject(glance)
-            .environmentObject(dashboard)
-            .environmentObject(selection)
+            .environment(glance)
+            .environment(dashboard)
+            .environment(selection)
             .background(Theme.canvas)
             .environment(\.colorScheme, configuration.colorScheme)
             .environment(\.locale, snapshotLocale)

--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -1021,7 +1021,7 @@ struct DispositionControls: View {
     let taskId: String
     var targetDigest: String? = nil
     var blockedEventId: String? = nil
-    @EnvironmentObject var dashboard: DashboardStore
+    @Environment(DashboardStore.self) var dashboard
     @State private var resolvePopoverShown = false
     @State private var note = ""
     @State private var busy = false
@@ -1303,11 +1303,13 @@ struct RecordChecksCard: View {
                         .font(Type.caption).foregroundStyle(Theme.muted)
                         .padding(.top, 2)
                 } else {
-                    ForEach(Array(checks.enumerated()), id: \.offset) { index, check in
-                        if index > 0 {
-                            Rectangle().fill(Theme.hairline).frame(height: 1)
+                    ScrollContentStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(checks.enumerated()), id: \.offset) { index, check in
+                            if index > 0 {
+                                Rectangle().fill(Theme.hairline).frame(height: 1)
+                            }
+                            RecordCheckRow(check: check, taskId: taskId)
                         }
-                        RecordCheckRow(check: check, taskId: taskId)
                     }
                 }
             }
@@ -1413,7 +1415,7 @@ private struct RecordCheckRow: View {
                 Text("recorded \(ago)").font(Type.dataSmall).foregroundStyle(Theme.muted)
             }
             if let files = check.files, !files.isEmpty {
-                VStack(alignment: .leading, spacing: 2) {
+                ScrollContentStack(alignment: .leading, spacing: 2) {
                     ForEach(Array(files.enumerated()), id: \.offset) { _, path in
                         Text(verbatim: path)
                             .font(Type.dataSmall).foregroundStyle(Theme.muted)
@@ -1476,7 +1478,7 @@ struct RecordGapsCard: View {
                     Text("Gaps (\(items.count)) — what could not be proven")
                         .font(Type.titleCard).foregroundStyle(Theme.ink)
                     Rectangle().fill(Theme.hairline).frame(height: 1).padding(.vertical, Space.m)
-                    VStack(alignment: .leading, spacing: Space.s) {
+                    ScrollContentStack(alignment: .leading, spacing: Space.s) {
                         ForEach(items) { item in
                             HStack(alignment: .firstTextBaseline, spacing: Space.s) {
                                 Text(item.dimension).font(Type.captionSemibold).foregroundStyle(Theme.muted)

--- a/apps/agentacct/Sources/agentacct/SnapshotRunner.swift
+++ b/apps/agentacct/Sources/agentacct/SnapshotRunner.swift
@@ -63,9 +63,9 @@ enum SnapshotRunner {
                         // content height (ImageRenderer centers an overflowing
                         // fixed frame, which would clip both ends).
                         let window = MainWindow()
-                            .environmentObject(glance)
-                            .environmentObject(dashboard)
-                            .environmentObject(selection)
+                            .environment(glance)
+                            .environment(dashboard)
+                            .environment(selection)
                             .frame(width: 1120, alignment: .top)
                             .environment(\.colorScheme, scheme)
                         try SnapshotImageWriter.render(
@@ -81,9 +81,9 @@ enum SnapshotRunner {
                     selection.pane = .work
                     selection.taskId = nil
                     let tableWindow = MainWindow()
-                        .environmentObject(glance)
-                        .environmentObject(dashboard)
-                        .environmentObject(selection)
+                        .environment(glance)
+                        .environment(dashboard)
+                        .environment(selection)
                         .frame(width: 1120, alignment: .top)
                         .environment(\.colorScheme, scheme)
                     try SnapshotImageWriter.render(
@@ -93,9 +93,9 @@ enum SnapshotRunner {
                     selection.taskId = recordTaskId
 
                     let menu = MenuContent()
-                        .environmentObject(glance)
-                        .environmentObject(dashboard)
-                        .environmentObject(selection)
+                        .environment(glance)
+                        .environment(dashboard)
+                        .environment(selection)
                         .background(Theme.canvas)
                         .frame(width: 360)
                         .environment(\.colorScheme, scheme)

--- a/apps/agentacct/Sources/agentacct/SourcesPane.swift
+++ b/apps/agentacct/Sources/agentacct/SourcesPane.swift
@@ -70,7 +70,7 @@ struct V1IngestionIssue: Decodable, Identifiable {
 // MARK: - Pane
 
 struct SourcesPane: View {
-    @EnvironmentObject var dashboard: DashboardStore
+    @Environment(DashboardStore.self) var dashboard
 
     var body: some View {
         ScrollBox {

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -1079,3 +1079,31 @@ struct ScrollBox<Content: View>: View {
         }
     }
 }
+
+/// Repeated content inside a ScrollBox: lazy in the live app, eager in the
+/// deterministic ImageRenderer path (which cannot lay out lazy containers).
+/// Keeping that renderer exception here prevents performance fixes from
+/// forking production and review markup at every large collection.
+struct ScrollContentStack<Content: View>: View {
+    let alignment: HorizontalAlignment
+    let spacing: CGFloat?
+    @ViewBuilder let content: () -> Content
+
+    init(
+        alignment: HorizontalAlignment = .center,
+        spacing: CGFloat? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.alignment = alignment
+        self.spacing = spacing
+        self.content = content
+    }
+
+    var body: some View {
+        if SnapshotMode.enabled {
+            VStack(alignment: alignment, spacing: spacing, content: content)
+        } else {
+            LazyVStack(alignment: alignment, spacing: spacing, content: content)
+        }
+    }
+}

--- a/apps/agentacct/Sources/agentacct/UsagePane.swift
+++ b/apps/agentacct/Sources/agentacct/UsagePane.swift
@@ -4,8 +4,8 @@ import SwiftUI
 // recorded usage second. The two lanes share client rows but never a denominator,
 // freshness claim, error state, or range control.
 struct UsagePane: View {
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var glance: GlanceState
+    @Environment(DashboardStore.self) var dashboard
+    @Environment(GlanceState.self) var glance
     @State private var showStale = false
     @State private var showAbout = false
 
@@ -401,8 +401,10 @@ private struct UsagePlanClientDetail: View {
             }
             if !presentation.modelRows.isEmpty {
                 CapsLabel(text: presentation.modelHeading)
-                ForEach(Array(presentation.modelRows.enumerated()), id: \.offset) { _, row in
-                    Text(row).font(Type.caption).foregroundStyle(Theme.muted)
+                ScrollContentStack(alignment: .leading, spacing: Space.s) {
+                    ForEach(Array(presentation.modelRows.enumerated()), id: \.offset) { _, row in
+                        Text(row).font(Type.caption).foregroundStyle(Theme.muted)
+                    }
                 }
             }
         }
@@ -823,11 +825,7 @@ struct UsageBreakdownTable: View {
                         .padding(Space.xl)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else {
-                    if SnapshotMode.enabled {
-                        VStack(spacing: 0) { populatedRows }
-                    } else {
-                        LazyVStack(spacing: 0) { populatedRows }
-                    }
+                    ScrollContentStack(spacing: 0) { populatedRows }
                 }
             }
         }

--- a/apps/agentacct/Sources/agentacct/UsageSnapshotHarness.swift
+++ b/apps/agentacct/Sources/agentacct/UsageSnapshotHarness.swift
@@ -76,9 +76,9 @@ enum UsageSnapshotRenderer {
             let selection = AppSelection()
             selection.pane = .usage
             let view = MainWindow(canSetUpOverride: true)
-                .environmentObject(glance)
-                .environmentObject(dashboard)
-                .environmentObject(selection)
+                .environment(glance)
+                .environment(dashboard)
+                .environment(selection)
                 .frame(width: configuration.width, height: configuration.height, alignment: .top)
                 .clipped()
                 .environment(\.colorScheme, configuration.colorScheme)

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -137,8 +137,9 @@ struct V1Step: Decodable, Identifiable {
     let evidenceGradeReason: String?
     let models: [V1ModelLane]?
     let checks: [V1Check]?
+    private let fallbackId = UUID().uuidString
 
-    var id: String { workId ?? sectionId ?? UUID().uuidString }
+    var id: String { workId ?? sectionId ?? fallbackId }
 
     enum CodingKeys: String, CodingKey {
         case title, kind, phase, summary, files, blocker, usage, models, checks
@@ -215,8 +216,9 @@ struct V1Check: Decodable, Identifiable {
     let artifactPath: String?
     let artifactUrl: String?
     let commandRedacted: Bool?
+    private let fallbackId = UUID().uuidString
 
-    var id: String { eventId ?? UUID().uuidString }
+    var id: String { eventId ?? fallbackId }
 
     /// How independent of the agent this check is — the honest counter to a
     /// check whose free-text summary claims "CI green" while its source is only
@@ -261,8 +263,9 @@ struct V1Descendant: Decodable, Identifiable {
     /// type (Explore / Plan / workflow-subagent / …) and its Task prompt.
     let agentType: String?
     let task: String?
+    private let fallbackId = UUID().uuidString
 
-    var id: String { "\(client ?? "?")::\(clientSessionId ?? UUID().uuidString)" }
+    var id: String { "\(client ?? "?")::\(clientSessionId ?? fallbackId)" }
 
     /// The best human label: Task prompt first line > recorded title >
     /// agent type > short id.

--- a/apps/agentacct/Sources/agentacct/WorkPane.swift
+++ b/apps/agentacct/Sources/agentacct/WorkPane.swift
@@ -242,8 +242,8 @@ struct DecisionLegendButton: View {
 }
 
 struct WorkPane: View {
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var selection: AppSelection
+    @Environment(DashboardStore.self) var dashboard
+    @Environment(AppSelection.self) var selection
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var unresolvedSessionId: String?
     @State private var query = ""
@@ -612,9 +612,34 @@ private struct WorkUnresolvedSessionPage: View {
 
 // MARK: - Work receipts table
 
+struct WorkTaskPresentation {
+    let groupCounts: [WorkGroup: Int]
+    let visibleTasks: [ReceiptSummary]
+
+    init(tasks: [ReceiptSummary], group: WorkGroup?, query: String, sort: WorkSort) {
+        groupCounts = Dictionary(grouping: tasks) {
+            WorkGroup.forKey($0.decisionStatus.key)
+        }.mapValues(\.count)
+
+        var visible = tasks
+        if let group {
+            visible = visible.filter { WorkGroup.forKey($0.decisionStatus.key) == group }
+        }
+        if !query.isEmpty {
+            let needle = query.lowercased()
+            visible = visible.filter {
+                ($0.title ?? "").lowercased().contains(needle)
+                    || $0.taskId.lowercased().contains(needle)
+                    || ($0.primaryRoot?.client ?? "").lowercased().contains(needle)
+            }
+        }
+        visibleTasks = sortedReceipts(visible, by: sort)
+    }
+}
+
 private struct WorkTablePage: View {
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var selection: AppSelection
+    @Environment(DashboardStore.self) var dashboard
+    @Environment(AppSelection.self) var selection
     @Binding var query: String
     @Binding var group: WorkGroup?
     let focusedTarget: FocusState<WorkFocusTarget?>.Binding
@@ -622,35 +647,20 @@ private struct WorkTablePage: View {
 
     private var sort: WorkSort { selection.workSort }
 
-    private var groupCounts: [WorkGroup: Int] {
-        Dictionary(grouping: dashboard.receiptTasks) { WorkGroup.forKey($0.decisionStatus.key) }
-            .mapValues(\.count)
-    }
-
-    private var visibleTasks: [ReceiptSummary] {
-        var rows = dashboard.receiptTasks
-        if let group {
-            rows = rows.filter { WorkGroup.forKey($0.decisionStatus.key) == group }
-        }
-        if !query.isEmpty {
-            let needle = query.lowercased()
-            rows = rows.filter {
-                ($0.title ?? "").lowercased().contains(needle)
-                    || $0.taskId.lowercased().contains(needle)
-                    || ($0.primaryRoot?.client ?? "").lowercased().contains(needle)
-            }
-        }
-        return sortedReceipts(rows, by: sort)
-    }
-
     var body: some View {
+        let presentation = WorkTaskPresentation(
+            tasks: dashboard.receiptTasks,
+            group: group,
+            query: query,
+            sort: sort
+        )
         ScrollBox {
             VStack(alignment: .leading, spacing: 0) {
                 header
-                tabs.padding(.top, Space.xl)
+                tabs(groupCounts: presentation.groupCounts).padding(.top, Space.xl)
                 filterRow.padding(.top, Space.m)
-                tableCard.padding(.top, Space.l)
-                footer.padding(.top, Space.m)
+                tableCard(visibleTasks: presentation.visibleTasks).padding(.top, Space.l)
+                footer(visibleTasks: presentation.visibleTasks).padding(.top, Space.m)
                 legend.padding(.top, Space.l)
             }
             .padding(Space.gutter)
@@ -661,7 +671,7 @@ private struct WorkTablePage: View {
             guard case .task(let taskId) = focusedTarget.wrappedValue else { return }
             focusedTarget.wrappedValue = workFocusTarget(
                 lastOpenedTaskId: taskId,
-                visibleTaskIds: Set(visibleTasks.map(\.taskId))
+                visibleTaskIds: Set(presentation.visibleTasks.map(\.taskId))
             )
         }
     }
@@ -688,7 +698,7 @@ private struct WorkTablePage: View {
         }
     }
 
-    private var tabs: some View {
+    private func tabs(groupCounts: [WorkGroup: Int]) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: Space.xl) {
                 let truncated = (dashboard.totalReceiptTasks ?? 0) > dashboard.receiptTasks.count
@@ -733,7 +743,8 @@ private struct WorkTablePage: View {
     }
 
     private var filterRow: some View {
-        HStack(spacing: Space.m) {
+        @Bindable var selection = selection
+        return HStack(spacing: Space.m) {
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 11)).foregroundStyle(Theme.muted)
@@ -767,7 +778,7 @@ private struct WorkTablePage: View {
         }
     }
 
-    private var tableCard: some View {
+    private func tableCard(visibleTasks: [ReceiptSummary]) -> some View {
         Card(padding: 0) {
             VStack(spacing: 0) {
                 columnHeader
@@ -788,13 +799,15 @@ private struct WorkTablePage: View {
                     // Offscreen full-content renders cap the rows and name the
                     // overflow; the live app scrolls the full set.
                     let rows = SnapshotMode.enabled ? Array(visibleTasks.prefix(9)) : visibleTasks
-                    ForEach(Array(rows.enumerated()), id: \.element.id) { index, task in
-                        if index > 0 {
-                            Rectangle().fill(Theme.hairline).frame(height: 1)
-                                .padding(.horizontal, Space.xl)
-                        }
-                        WorkTableRow(task: task, focusedTarget: focusedTarget) {
-                            openTask(task.taskId)
+                    ScrollContentStack(spacing: 0) {
+                        ForEach(rows) { task in
+                            if task.id != rows.first?.id {
+                                Rectangle().fill(Theme.hairline).frame(height: 1)
+                                    .padding(.horizontal, Space.xl)
+                            }
+                            WorkTableRow(task: task, focusedTarget: focusedTarget) {
+                                openTask(task.taskId)
+                            }
                         }
                     }
                     if SnapshotMode.enabled, visibleTasks.count > rows.count {
@@ -826,7 +839,7 @@ private struct WorkTablePage: View {
         .frame(height: Metrics.rowHeader)
     }
 
-    private var footer: some View {
+    private func footer(visibleTasks: [ReceiptSummary]) -> some View {
         Text("\(visibleTasks.count) of \(dashboard.totalReceiptTasks ?? dashboard.receiptTasks.count) receipts · \(sort.footerText)")
             .font(Type.dataSmall).foregroundStyle(Theme.muted)
     }
@@ -992,8 +1005,8 @@ private struct WorkTableRow: View {
 /// The 204pt receipt rail beside an open record: every receipt, current one
 /// washed + accent-barred, each row carrying its decision word and cost.
 private struct WorkRail: View {
-    @EnvironmentObject var dashboard: DashboardStore
-    @EnvironmentObject var selection: AppSelection
+    @Environment(DashboardStore.self) var dashboard
+    @Environment(AppSelection.self) var selection
     let openTask: (String) -> Void
 
     /// Offscreen full-content renders would let a long rail stretch (and then
@@ -1006,6 +1019,7 @@ private struct WorkRail: View {
     }
 
     var body: some View {
+        @Bindable var selection = selection
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .top, spacing: Space.s) {
                 VStack(alignment: .leading, spacing: 3) {
@@ -1052,7 +1066,7 @@ private struct WorkRail: View {
             .padding(.horizontal, Space.l)
             .padding(.vertical, Space.l)
             ScrollBox {
-                VStack(spacing: 0) {
+                ScrollContentStack(spacing: 0) {
                     ForEach(railTasks) { task in
                         WorkRailRow(task: task, selected: task.taskId == selection.taskId) {
                             openTask(task.taskId)
@@ -1358,11 +1372,13 @@ struct WorkRecordPage: View {
                                 }
                             }
                         }
-                        ForEach(group.members) { member in
-                            SessionDrillRow(
-                                member: member,
-                                initiallyExpanded: group.role == "primary" && member.role == "root"
-                            )
+                        ScrollContentStack(alignment: .leading, spacing: 5) {
+                            ForEach(group.members) { member in
+                                SessionDrillRow(
+                                    member: member,
+                                    initiallyExpanded: group.role == "primary" && member.role == "root"
+                                )
+                            }
                         }
                     }
                 }
@@ -1427,7 +1443,7 @@ private struct WorkRecordSplitLayout: Layout {
 private struct SessionDrillRow: View {
     let member: ReceiptSessionMember
     let initiallyExpanded: Bool
-    @EnvironmentObject var dashboard: DashboardStore
+    @Environment(DashboardStore.self) var dashboard
     @State private var expanded: Bool
     @State private var detail: V1SessionDetail?
     @State private var loading = false
@@ -1521,8 +1537,10 @@ private struct SessionDrillRow: View {
                             + detail.steps.filter { ($0.checks?.isEmpty ?? true) }.prefix(1).map(\.id)
                           )
                         : []
-                    ForEach(detail.steps) { step in
-                        StepCard(step: step, initiallyExpanded: opened.contains(step.id))
+                    ScrollContentStack(alignment: .leading, spacing: 6) {
+                        ForEach(detail.steps) { step in
+                            StepCard(step: step, initiallyExpanded: opened.contains(step.id))
+                        }
                     }
                 }
                 // The Task's subagents are already listed once, flat and

--- a/apps/agentacct/Sources/agentacct/WorkSnapshotHarness.swift
+++ b/apps/agentacct/Sources/agentacct/WorkSnapshotHarness.swift
@@ -112,9 +112,9 @@ enum WorkSnapshotRenderer {
             selection.taskId = configuration.state.selectsReceipt ? work.receipt.taskId : nil
 
             let view = MainWindow(canSetUpOverride: true)
-                .environmentObject(glance)
-                .environmentObject(dashboard)
-                .environmentObject(selection)
+                .environment(glance)
+                .environment(dashboard)
+                .environment(selection)
                 .frame(
                     width: configuration.width,
                     height: configuration.height,

--- a/apps/agentacct/Tests/agentacctTests/LargeDataPerformanceTests.swift
+++ b/apps/agentacct/Tests/agentacctTests/LargeDataPerformanceTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Observation
+import XCTest
+@testable import agentacct
+
+final class LargeDataPerformanceTests: XCTestCase {
+    private final class ChangeFlag: @unchecked Sendable {
+        var count = 0
+    }
+
+    func testLegacyRowsKeepStableFallbackIdentityAcrossDiffPasses() throws {
+        let step = try decode(V1Step.self, from: #"{"title":"legacy step"}"#)
+        let check = try decode(V1Check.self, from: #"{"summary":"legacy check"}"#)
+        let descendant = try decode(V1Descendant.self, from: #"{"client":"codex"}"#)
+        let work = try decode(WorkItem.self, from: #"{"title":"legacy work"}"#)
+        let attributed = try decode(AttributedWork.self, from: #"{"title":"legacy attribution"}"#)
+
+        for identifier in [step.id, check.id, descendant.id, work.id, attributed.id] {
+            XCTAssertFalse(identifier.isEmpty)
+        }
+        XCTAssertEqual(step.id, step.id)
+        XCTAssertEqual(check.id, check.id)
+        XCTAssertEqual(descendant.id, descendant.id)
+        XCTAssertEqual(work.id, work.id)
+        XCTAssertEqual(attributed.id, attributed.id)
+    }
+
+    @MainActor
+    func testHighChurnStoresAdoptFineGrainedObservation() {
+        requireObservable(DashboardStore.self)
+        requireObservable(GlanceState.self)
+        requireObservable(AppSelection.self)
+
+        let selection = AppSelection()
+        let invalidations = ChangeFlag()
+        withObservationTracking {
+            _ = selection.pane
+        } onChange: {
+            invalidations.count += 1
+        }
+
+        selection.workSort = .cost
+        XCTAssertEqual(invalidations.count, 0, "an unrelated sort change must not invalidate pane readers")
+        selection.pane = .work
+        XCTAssertEqual(invalidations.count, 1)
+    }
+
+    func testLargeWorkProjectionFiltersCountsAndSortsOnce() throws {
+        let tasksJSON = (0..<1_000).reversed().map { index in
+            let status = index.isMultiple(of: 10) ? "blocked" : "verified"
+            let title = index.isMultiple(of: 125) ? "Needle task \(index)" : "Task \(index)"
+            return """
+            {
+              "task_id":"task-\(index)",
+              "title":"\(title)",
+              "decision_status":{"key":"\(status)"},
+              "evidence_strength":{"key":"none"},
+              "cost":{},
+              "last_activity_at":\(index)
+            }
+            """
+        }.joined(separator: ",")
+        let tasks = try decode([ReceiptSummary].self, from: "[\(tasksJSON)]")
+
+        let presentation = WorkTaskPresentation(
+            tasks: tasks,
+            group: nil,
+            query: "needle",
+            sort: .latest
+        )
+
+        XCTAssertEqual(presentation.groupCounts[.attention], 100)
+        XCTAssertEqual(presentation.groupCounts[.verified], 900)
+        XCTAssertEqual(presentation.visibleTasks.count, 8)
+        XCTAssertEqual(presentation.visibleTasks.map(\.taskId), [
+            "task-875", "task-750", "task-625", "task-500",
+            "task-375", "task-250", "task-125", "task-0",
+        ])
+    }
+
+    private func requireObservable<T: Observable>(_ type: T.Type) {}
+
+    private func decode<T: Decodable>(_ type: T.Type, from json: String) throws -> T {
+        try JSONDecoder().decode(type, from: Data(json.utf8))
+    }
+}

--- a/apps/agentacct/Tests/agentacctTests/MenuSnapshotHarnessTests.swift
+++ b/apps/agentacct/Tests/agentacctTests/MenuSnapshotHarnessTests.swift
@@ -111,9 +111,9 @@ final class MenuSnapshotHarnessTests: XCTestCase {
             lastUpdatedTextOverride: "just now",
             launchAtLoginInitialState: false
         )
-        .environmentObject(glance)
-        .environmentObject(dashboard)
-        .environmentObject(selection)
+        .environment(glance)
+        .environment(dashboard)
+        .environment(selection)
 
         let hostingView = NSHostingView(rootView: CompressedMenuHost { view })
         let fittingSize = hostingView.fittingSize

--- a/benchmarks/dashboard_refresh.py
+++ b/benchmarks/dashboard_refresh.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Reproducible large-ledger benchmark for the native app refresh fan-out."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from agentacct.api import create_local_api_app
+from agentacct.event_log import RawEventLog, serialize_event
+
+ROUTES = (
+    "/v1/glance",
+    "/v1/tasks?limit=50",
+    "/v1/plan?days=7",
+    "/usage/summary?days=7",
+)
+
+
+def _seed(store: Path, event_count: int) -> None:
+    store.mkdir(parents=True)
+    log = RawEventLog(store / "events.sqlite3")
+    log.replace_all(
+        serialize_event(
+            {
+                "event_id": f"evt_benchmark_{index}",
+                "event_type": "note",
+                "created_at": float(index),
+                "metadata": {"client": "benchmark"},
+            }
+        )
+        for index in range(event_count)
+    )
+    (store / "events.authoritative").write_text("1\n", encoding="utf-8")
+
+
+def _refresh(client: TestClient, token: str) -> int:
+    headers = {"Authorization": f"Bearer {token}"}
+    downloaded = 0
+    for route in ROUTES:
+        response = client.get(route, headers=headers if route.startswith("/v1/") else None)
+        response.raise_for_status()
+        downloaded += len(response.content)
+    return downloaded
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--events", type=int, default=50_000)
+    parser.add_argument("--rounds", type=int, default=5)
+    args = parser.parse_args()
+    if args.events < 1 or args.rounds < 1:
+        parser.error("--events and --rounds must be positive")
+
+    os.environ["AGENTACCT_EVIDENCE_V2"] = "0"
+    token = "benchmark-token"
+    with tempfile.TemporaryDirectory(prefix="agentacct-dashboard-benchmark-") as directory:
+        store = Path(directory) / "store"
+        _seed(store, args.events)
+        app = create_local_api_app(
+            store_dir=store,
+            v1_auth_token=token,
+            extra_allowed_hosts=("testserver",),
+        )
+        with TestClient(app) as client:
+            started = time.perf_counter()
+            downloaded = _refresh(client, token)
+            cold = time.perf_counter() - started
+
+            warm_samples = []
+            for _ in range(args.rounds):
+                started = time.perf_counter()
+                _refresh(client, token)
+                warm_samples.append(time.perf_counter() - started)
+
+    print(
+        json.dumps(
+            {
+                "schema": "agentacct.dashboard-refresh-benchmark.v1",
+                "events": args.events,
+                "routes": list(ROUTES),
+                "downloaded_bytes": downloaded,
+                "cold_seconds": round(cold, 6),
+                "warm_seconds": [round(value, 6) for value in warm_samples],
+                "warm_median_seconds": round(statistics.median(warm_samples), 6),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -3,10 +3,10 @@ import hashlib
 import hmac
 import html
 import json
-import threading
 import math
 import os
 import secrets
+import threading
 import time
 # ``field`` is aliased: several helpers below use ``field`` as a loop variable.
 from dataclasses import dataclass, replace
@@ -2673,6 +2673,27 @@ def create_local_api_app(
     install_localhost_guard(app, extra_allowed_hosts=extra_allowed_hosts)
 
     service = SentinelService(store_dir)
+    # One parsed event snapshot + one content fingerprint per durable ledger
+    # revision. The native app refreshes glance, tasks, plan, ingestion, and
+    # usage together; without this boundary every route independently loaded,
+    # decoded, and hashed the complete ledger before its own cache could answer.
+    dashboard_event_snapshot_lock = threading.Lock()
+    dashboard_event_snapshot_cache: dict[str, Any] = {}
+
+    def _dashboard_events() -> tuple[list[dict[str, Any]], int]:
+        snapshot = service.all_events_snapshot()
+        cached = dashboard_event_snapshot_cache.get("value")
+        if cached is not None and cached[0] is snapshot:
+            return list(snapshot.events), cached[1]
+        with dashboard_event_snapshot_lock:
+            cached = dashboard_event_snapshot_cache.get("value")
+            if cached is not None and cached[0] is snapshot:
+                return list(snapshot.events), cached[1]
+            loaded = list(snapshot.events)
+            fingerprint = events_fingerprint(loaded)
+            dashboard_event_snapshot_cache["value"] = (snapshot, fingerprint)
+            return loaded, fingerprint
+
     cost_ledger = CostLedger(store_dir)
     ingestion_health = IngestionHealthStore(store_dir)
     continuation_store = ContinuationTaskStore(store_dir)
@@ -2745,10 +2766,11 @@ def create_local_api_app(
     ) -> dict[str, Any]:
         """The derived ledger, fingerprint + TTL cached (see WorkLedgerCache).
 
-        Every ledger-backed route shares one cache: a poll that finds no event
-        change pays one store read + an O(n) hash, never the multi-second
-        rebuild. ``events``/``fingerprint`` may be passed pre-computed by a
-        route that already loaded them (avoids a second store read/hash).
+        Every ledger-backed route shares one cache. Native app routes pass the
+        revisioned event snapshot and its one precomputed fingerprint, so an
+        unchanged poll skips both ledger decoding and O(n) hashing as well as
+        the multi-second rebuild. Other callers may still pass their own
+        ``events``/``fingerprint`` pair to avoid duplicate work.
         """
 
         if events is None:
@@ -2917,14 +2939,19 @@ def create_local_api_app(
         """The glance snapshot (usage · cost · plan · recent sessions).
 
         Fingerprint + TTL cached: a poll that finds no event change skips the
-        aggregation REBUILD (the expensive part) — each poll still reads the
-        event list once to compute the change key, so per-request cost is one
-        store read + an O(n) hash, never a re-aggregation (see
-        :mod:`agentacct.glance` for the schema contract)."""
+        aggregation rebuild. The fingerprint comes from the native API's
+        revisioned shared snapshot, so unchanged sibling requests do not read,
+        parse, or hash the full ledger again (see :mod:`agentacct.glance` for
+        the schema contract)."""
 
         _require_v1_token(request)
-        events = service.list_all_events()
-        return glance_cache.snapshot(events, store_dir=store_dir, version=_dashboard_importer_version())
+        events, fingerprint = _dashboard_events()
+        return glance_cache.snapshot(
+            events,
+            store_dir=store_dir,
+            version=_dashboard_importer_version(),
+            fingerprint=fingerprint,
+        )
 
     v1_sessions_cache = V1SessionsCache()
 
@@ -2946,8 +2973,7 @@ def create_local_api_app(
         """
 
         _require_v1_token(request)
-        events = service.list_all_events()
-        fingerprint = events_fingerprint(events)
+        events, fingerprint = _dashboard_events()
         view = v1_sessions_cache.view(
             fingerprint,
             lambda: build_v1_sessions_view(
@@ -2970,8 +2996,7 @@ def create_local_api_app(
         never an empty fabrication."""
 
         _require_v1_token(request)
-        events = service.list_all_events()
-        fingerprint = events_fingerprint(events)
+        events, fingerprint = _dashboard_events()
         ledger = _derived_work_ledger(events, fingerprint=fingerprint)
         view = v1_sessions_cache.view(
             fingerprint,
@@ -2998,8 +3023,7 @@ def create_local_api_app(
         — a different quantity, deliberately not duplicated here."""
 
         _require_v1_token(request)
-        events = service.list_all_events()
-        fingerprint = events_fingerprint(events)
+        events, fingerprint = _dashboard_events()
         moment = time.time()
         cached = v1_plan_cache.get(days)
         if cached is not None and cached[0] == fingerprint and (moment - cached[1]) < 30.0:
@@ -3028,8 +3052,7 @@ def create_local_api_app(
         # so those fingerprint-invisible inputs (cost/run-report/mechanical-obs
         # imports) can lag up to ~60s here — the SAME staleness class and the
         # SAME reused-ledger profile the sessions lane already accepts.
-        events = service.list_all_events()
-        fingerprint = events_fingerprint(events)
+        events, fingerprint = _dashboard_events()
         cached = v1_receipt_projection_cache.get("projection")
         if cached is not None and cached[0] == fingerprint and (time.time() - cached[1]) < 30.0:
             return cached[2]
@@ -3926,7 +3949,8 @@ def create_local_api_app(
             raise HTTPException(status_code=422, detail=f"unknown days filter: {days}")
         if granularity not in {"auto", *USAGE_CUBE_GRANULARITY_CHOICES}:
             raise HTTPException(status_code=422, detail=f"unknown granularity: {granularity}")
-        usage_view = _build_usage_view([], service.list_all_events())
+        events, _ = _dashboard_events()
+        usage_view = _build_usage_view([], events)
         records = usage_view.saved_records
         cube_records = [*records, *usage_view.excluded_saved_records]
         effective_granularity = resolve_granularity(days, granularity)

--- a/src/agentacct/event_log.py
+++ b/src/agentacct/event_log.py
@@ -79,6 +79,30 @@ CREATE TABLE IF NOT EXISTS event_lines (
 );
 CREATE INDEX IF NOT EXISTS idx_event_lines_run ON event_lines(run_id);
 CREATE INDEX IF NOT EXISTS idx_event_lines_event_id ON event_lines(event_id);
+-- A constant-time, cross-process cache key for the parsed ledger. Triggers
+-- live in SQLite rather than only in RawEventLog's Python write methods so an
+-- older agentacct process or a direct repair transaction cannot leave a live
+-- daemon serving a stale in-memory snapshot.
+CREATE TABLE IF NOT EXISTS event_log_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    revision INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO event_log_state(singleton, revision) VALUES (1, 0);
+CREATE TRIGGER IF NOT EXISTS event_lines_revision_insert
+AFTER INSERT ON event_lines
+BEGIN
+    UPDATE event_log_state SET revision = revision + 1 WHERE singleton = 1;
+END;
+CREATE TRIGGER IF NOT EXISTS event_lines_revision_update
+AFTER UPDATE ON event_lines
+BEGIN
+    UPDATE event_log_state SET revision = revision + 1 WHERE singleton = 1;
+END;
+CREATE TRIGGER IF NOT EXISTS event_lines_revision_delete
+AFTER DELETE ON event_lines
+BEGIN
+    UPDATE event_log_state SET revision = revision + 1 WHERE singleton = 1;
+END;
 -- Durable record of every flat-file line already drained into the log during a
 -- rolling upgrade (see absorb_new_events). Its keys OUTLIVE a log rewrite that
 -- removes the row, which is what stops a deliberately-removed event from being
@@ -200,6 +224,17 @@ class RawEventLog:
     def count(self) -> int:
         with self._connect() as connection:
             return int(connection.execute("SELECT COUNT(*) FROM event_lines").fetchone()[0])
+
+    def revision(self) -> int:
+        """Return the persistent mutation revision without scanning event rows."""
+
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT revision FROM event_log_state WHERE singleton = 1"
+            ).fetchone()
+        if row is None:  # Defensive: _SCHEMA always creates the singleton.
+            raise sqlite3.DatabaseError("event log revision row is missing")
+        return int(row[0])
 
     def read_lines(self) -> list[str]:
         with self._connect() as connection:

--- a/src/agentacct/glance.py
+++ b/src/agentacct/glance.py
@@ -10,8 +10,9 @@ show "usage · cost · plan · active sessions" at a glance. Design contract:
   number another surface would not show.
 * **Cheap under polling** — the payload is rebuilt when the event list changes
   (``events_fingerprint``) or when the cached build is older than the cache
-  TTL; a poll that hits the cache skips the aggregation rebuild (each poll
-  still loads the event list once to compute the change key). The TTL exists
+  TTL; a poll that hits the cache skips the aggregation rebuild. The native API
+  supplies a fingerprint from its revisioned shared event snapshot, so sibling
+  refresh routes neither reload nor re-hash an unchanged ledger. The TTL exists
   because the payload is calendar/time-dependent (the "today" window, the
   recency cutoff, ``limits[].stale``) — an unchanged event list must still
   refresh across midnight. The expensive work-ledger build is deliberately NOT
@@ -811,9 +812,10 @@ class GlanceCache:
         store_dir: Path | str,
         version: str,
         now: float | None = None,
+        fingerprint: int | None = None,
     ) -> dict[str, Any]:
         moment = time.time() if now is None else float(now)
-        fingerprint = events_fingerprint(events)
+        fingerprint = events_fingerprint(events) if fingerprint is None else fingerprint
         cached = self._cached
         if self._fresh(cached, fingerprint, moment):
             return cached[2]  # type: ignore[index]

--- a/src/agentacct/service.py
+++ b/src/agentacct/service.py
@@ -12,7 +12,9 @@ import time
 import uuid
 from collections import Counter
 from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
 from pathlib import Path
+from threading import Lock
 from typing import Any, Callable, Iterator, Mapping
 
 from .confidence import normalize_cost_confidence, normalize_usage_confidence
@@ -103,6 +105,20 @@ class SessionObservationConflict(ValueError):
     def __init__(self, reason: str, message: str) -> None:
         super().__init__(message)
         self.reason = reason
+
+
+@dataclass(frozen=True)
+class EventSnapshot:
+    """One immutable-by-contract parsed view of a ledger revision.
+
+    The tuple prevents callers from reordering the shared collection. Event
+    mappings remain ordinary dictionaries for compatibility with the existing
+    reducers; snapshot consumers are read-only and receive a new snapshot as
+    soon as the persistent change token moves.
+    """
+
+    change_token: tuple[str, object]
+    events: tuple[dict[str, Any], ...]
 
 
 def _session_observation_conflict_reason(diagnostics: Mapping[str, int]) -> str:
@@ -960,6 +976,8 @@ class SentinelService:
         self.event_log: RawEventLog | None = None
         self._event_log_synced_signature: tuple[int, int] | None = None
         self._is_authoritative = False
+        self._event_snapshot_lock = Lock()
+        self._event_snapshot: EventSnapshot | None = None
         self._init_event_log()
 
     def _authoritative_intended(self) -> bool:
@@ -2669,6 +2687,44 @@ class SentinelService:
         # proven flat file until the read cutover.
         self._sync_event_log()
         return self._read_events_file_order(run_id=run_id)
+
+    def all_events_snapshot(self) -> EventSnapshot:
+        """Return a single-flight parsed snapshot for read-only projections.
+
+        Dashboard polling used to read and JSON-decode the complete ledger once
+        per endpoint before any higher-level cache could answer. The SQLite
+        revision makes the unchanged path constant-time; the lock coalesces a
+        cold fan-out so concurrent glance/plan/tasks requests parse exactly
+        once. Legacy flat-file mode retains its existing mtime+size change key.
+        """
+
+        self._sync_event_log()
+        token = self._event_snapshot_change_token()
+        cached = self._event_snapshot
+        if cached is not None and cached.change_token == token:
+            return cached
+
+        with self._event_snapshot_lock:
+            # A concurrent writer or rolling-upgrade absorb may have moved the
+            # ledger while this reader waited. Re-sync and re-key under the
+            # single-flight lock before deciding whether to rebuild.
+            self._sync_event_log()
+            token = self._event_snapshot_change_token()
+            cached = self._event_snapshot
+            if cached is not None and cached.change_token == token:
+                return cached
+            snapshot = EventSnapshot(
+                change_token=token,
+                events=tuple(self._read_events_file_order()),
+            )
+            self._event_snapshot = snapshot
+            return snapshot
+
+    def _event_snapshot_change_token(self) -> tuple[str, object]:
+        if self._authoritative():
+            assert self.event_log is not None  # _authoritative fails loud otherwise.
+            return ("sqlite", self.event_log.revision())
+        return ("flat-file", self._events_file_signature())
 
     def reconcile_evidence_refreshable_usage_snapshot(
         self,

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import sqlite3
 from pathlib import Path
 
 from agentacct.event_log import RawEventLog, serialize_event
@@ -28,6 +28,35 @@ def test_append_and_read_preserve_order_and_content(tmp_path: Path) -> None:
     assert log.read_events(run_id="r1") == [events[1]]
     # Verbatim lines match the canonical serialization exactly.
     assert log.read_lines() == [serialize_event(event) for event in events]
+
+
+def test_revision_tracks_every_sql_mutation_including_external_writers(tmp_path: Path) -> None:
+    """The read cache key must change without scanning or parsing the ledger.
+
+    Triggers are deliberately tested through a separate raw SQLite connection:
+    another agentacct process (including an older one) must invalidate a live
+    daemon's snapshot just as reliably as writes through ``RawEventLog``.
+    """
+
+    database = tmp_path / "events.sqlite3"
+    log = RawEventLog(database)
+    initial = log.revision()
+
+    log.append_event(_event("e1"))
+    appended = log.revision()
+    assert appended > initial
+
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE event_lines SET line = ? WHERE event_id = ?",
+            (serialize_event(_event("e1", note="external rewrite")), "e1"),
+        )
+    rewritten = log.revision()
+    assert rewritten > appended
+
+    with sqlite3.connect(database) as connection:
+        connection.execute("DELETE FROM event_lines WHERE event_id = ?", ("e1",))
+    assert log.revision() > rewritten
 
 
 def test_reconcile_from_file_backfills_an_empty_log(tmp_path: Path) -> None:

--- a/tests/test_event_log_service.py
+++ b/tests/test_event_log_service.py
@@ -8,6 +8,9 @@ whole-file rewrite), not just the RawEventLog unit.
 from __future__ import annotations
 
 import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -115,6 +118,68 @@ def test_authoritative_mode_writes_to_the_log_and_survives_file_deletion(
     assert not _events_file(store_root).exists()
     assert len(service.list_all_events()) == 3
     assert service.verify_event_log_parity()["authoritative"] is True
+
+
+def test_event_snapshot_reuses_parsed_rows_and_invalidates_cross_process(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "1")
+    store_root = tmp_path / "store"
+    service = SentinelService(store_root)
+    service.record_event(_note("first"))
+
+    reads = 0
+    original = service._read_events_file_order
+
+    def counted_read(*, run_id=None):
+        nonlocal reads
+        reads += 1
+        return original(run_id=run_id)
+
+    monkeypatch.setattr(service, "_read_events_file_order", counted_read)
+    first = service.all_events_snapshot()
+    second = service.all_events_snapshot()
+
+    assert first is second
+    assert reads == 1
+    assert len(first.events) == 1
+
+    # A separate service simulates another MCP/CLI process writing the same
+    # authoritative store. The persistent SQLite revision must invalidate the
+    # first process without a restart or a full-ledger probe.
+    writer = SentinelService(store_root)
+    writer.record_event(_note("second"))
+
+    refreshed = service.all_events_snapshot()
+    assert refreshed is not first
+    assert reads == 2
+    assert len(refreshed.events) == 2
+
+
+def test_event_snapshot_single_flights_concurrent_cold_read(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTACCT_EVENT_LOG_AUTHORITATIVE", "1")
+    service = SentinelService(tmp_path / "store")
+    for index in range(25):
+        service.record_event(_note(f"event-{index}"))
+
+    reads = 0
+    reads_lock = threading.Lock()
+    original = service._read_events_file_order
+
+    def slow_read(*, run_id=None):
+        nonlocal reads
+        with reads_lock:
+            reads += 1
+        time.sleep(0.03)
+        return original(run_id=run_id)
+
+    monkeypatch.setattr(service, "_read_events_file_order", slow_read)
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        snapshots = list(executor.map(lambda _: service.all_events_snapshot(), range(8)))
+
+    assert reads == 1
+    assert all(snapshot is snapshots[0] for snapshot in snapshots)
+    assert len(snapshots[0].events) == 25
 
 
 def test_authoritative_mode_rewrite_operates_on_the_log(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_glance_api.py
+++ b/tests/test_glance_api.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 
+import agentacct.api as api_module
 import agentacct.glance as glance_module
 from agentacct.api import create_local_api_app
 from agentacct.cli import app as cli_app
@@ -244,6 +245,38 @@ def test_v1_routes_require_the_exact_bearer_token(tmp_path):
     assert body["glance_schema"] == GLANCE_SCHEMA_VERSION
     assert body["pid"] == os.getpid()
     assert isinstance(body["version"], str) and body["version"]
+
+
+def test_native_refresh_fanout_hashes_one_shared_ledger_snapshot(tmp_path, monkeypatch):
+    service = SentinelService(tmp_path)
+    service.record_event({"event_type": "note", "metadata": {"client": "codex"}})
+
+    fingerprints = 0
+    original = api_module.events_fingerprint
+
+    def counted_fingerprint(events):
+        nonlocal fingerprints
+        fingerprints += 1
+        return original(events)
+
+    monkeypatch.setattr(api_module, "events_fingerprint", counted_fingerprint)
+    client = TestClient(create_local_api_app(store_dir=tmp_path, v1_auth_token=TOKEN))
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+
+    assert client.get("/v1/glance", headers=headers).status_code == 200
+    assert client.get("/v1/plan?days=7", headers=headers).status_code == 200
+    assert client.get("/usage/summary?days=7").status_code == 200
+    assert client.get("/v1/glance", headers=headers).status_code == 200
+
+    assert fingerprints == 1
+
+    # A writer in another process moves the durable revision. The next request
+    # must observe that revision and compute exactly one new shared fingerprint.
+    SentinelService(tmp_path).record_event(
+        {"event_type": "note", "metadata": {"client": "claude-code"}}
+    )
+    assert client.get("/v1/glance", headers=headers).status_code == 200
+    assert fingerprints == 2
 
 
 def test_localhost_guard_still_covers_v1(tmp_path):


### PR DESCRIPTION
## Summary

- Cache one parsed event snapshot per durable ledger revision, then share one content fingerprint across the native app's glance, tasks, plan, session, and usage refresh fan-out.
- Invalidate safely across processes with SQLite mutation triggers and coalesce concurrent cold reads with a single-flight lock; legacy flat-file stores retain their existing file-signature path.
- Move the macOS app to property-granular Observation, stabilize fallback row identities, compute the Work projection once per render, and lazily construct large scroll collections while preserving eager deterministic snapshots.
- Add cross-process/concurrency regressions, 1,000-row Swift coverage, and a reproducible 50,000-event benchmark.

## Why this design

The live store audit found three compounding costs: every dashboard endpoint decoded and hashed the complete ledger before its higher cache could answer; broad `ObservableObject` publication invalidated unrelated panes; and several high-volume collections were built eagerly with unstable legacy fallback IDs.

This follows Apple's SwiftUI guidance around explicit dependencies, stable identity, property-level Observation, and lazy stacks. It also keeps the change bounded: response schemas, endpoint limits, data ownership, and visual markup stay unchanged.

Safety properties:

- The ledger cache key lives in SQLite and is advanced by INSERT, UPDATE, and DELETE triggers, so older processes and direct repair transactions cannot leave a long-running daemon stale.
- Snapshot rebuilds are single-flight, and cross-process mutation is covered by tests.
- Existing mutable `list_all_events()` behavior remains available to write/control lanes; only read-only dashboard projections use the shared snapshot.
- SnapshotMode stays eager because ImageRenderer cannot authoritatively lay out lazy content; all reviewed pixel references still match.
- The app still performs one full ledger parse after each real revision. Persisted rollups or database-native projections would be the next step for multi-million-event stores, not part of this focused fix.

## Performance evidence

Local comparative benchmark, 50,000 synthetic events, seven warm rounds, four native refresh routes:

| Revision | Cold refresh | Warm median |
| --- | ---: | ---: |
| `origin/main` (`89c34f8`) | 1.055886s | 0.568988s |
| this branch | 0.674708s | 0.024044s |

That is a 95.8% warm-time reduction (23.7x faster) and a 36.1% cold-time reduction. The comparative runs used the same routes and returned the same 6,711 aggregate response bytes. This is a local TestClient benchmark of the refresh boundary, not a claim about every end-to-end UI frame.

Reproduce:

```bash
PYTHONPATH=src .venv/bin/python benchmarks/dashboard_refresh.py --events 50000 --rounds 7
```

## Review order

1. `src/agentacct/event_log.py` and `src/agentacct/service.py` — revision contract and parsed snapshot.
2. `src/agentacct/api.py` and `src/agentacct/glance.py` — shared native refresh boundary.
3. `DashboardStore.swift`, `GlanceState.swift`, `Theme.swift`, and `WorkPane.swift` — granular observation, stable/lazy rendering, and one-pass projection.
4. `LargeDataPerformanceTests.swift`, Python regression tests, and `benchmarks/dashboard_refresh.py` — invariants and measured result.

## Test plan

- [x] Focused Python/API regressions: 137 passed (one upstream Starlette TestClient deprecation warning).
- [x] Swift suite: 122 tests, 6 visual-only skips, 0 failures.
- [x] Canonical visual references: all six suites match on `macos-26.6-25G72-xcode-26.6-17F113-arm64-2x`.
- [x] `swift build -c release` and `./Scripts/build-app.sh`.
- [x] Visual snapshot CLI, dashboard candidate packaging/intake, and app bundle identity suites.
- [x] 50,000-event benchmark after implementation.
- [ ] Full local `pytest -q`: 2,644 passed and 10 macOS process-ownership tests failed. The exact same 10 selectors fail 10/10 in a detached, untouched `origin/main` worktree with `process identity no longer matches`; none touch this diff. Linux CI remains the authoritative matrix for Python 3.11-3.13.
- [x] Secret review: no credentials or captured user data added; fixtures are synthetic.
- [x] No paid provider/API calls were run.

The packaged current-build app and a disposable daemon also launched successfully. Exact-window automation was not claimed because macOS could not disambiguate it from the already-running installed app sharing the same product identity; canonical pixel verification above is complete.

## Safety checklist

- [x] Preserves local-first behavior
- [x] Does not store API keys or secrets
- [x] Does not expose localhost services publicly by default
- [x] Does not control processes agentacct did not start
- [x] Provider/API forwarding remains opt-in and budget-gated
- [x] JSON output paths remain machine-readable when `--json` is used

## Docs

- [x] No public contract changed; code comments, tests, and the benchmark document the internal performance boundary.
- [x] Public docs avoid private strategy, private roadmap, and overbroad support claims.
