### PR TITLE
Fix macOS owned-process identity after interpreter re-exec

### DIFF
--- a/src/agentacct/runner.py
+++ b/src/agentacct/runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import secrets
+import select
 import signal
 import subprocess
 import sys
@@ -26,11 +27,7 @@ import signal
 import sys
 
 gate = int(sys.argv[1])
-token = os.read(gate, 1)
-os.close(gate)
-if token != b"1":
-    raise SystemExit(126)
-
+ready = int(sys.argv[2])
 cancel_requested = False
 
 def on_term(_signum, _frame):
@@ -38,10 +35,17 @@ def on_term(_signum, _frame):
     cancel_requested = True
 
 signal.signal(signal.SIGTERM, on_term)
+os.write(ready, b"1")
+os.close(ready)
+token = os.read(gate, 1)
+os.close(gate)
+if token != b"1":
+    raise SystemExit(126)
+
 child = os.fork()
 if child == 0:
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
-    os.execvpe(sys.argv[2], sys.argv[2:], os.environ)
+    os.execvpe(sys.argv[3], sys.argv[3:], os.environ)
 while True:
     try:
         _, status = os.waitpid(child, 0)
@@ -222,29 +226,46 @@ def start_guarded_run(command: list[str], options: RunOptions | None = None) -> 
         }
     )
 
-    gate_read, gate_write = os.pipe()
+    gate_read = -1
+    gate_write = -1
+    ready_read = -1
+    ready_write = -1
     proc: subprocess.Popen[str] | None = None
     pgid: int | None = None
     process_birth_time: float | None = None
     process_executable: str | None = None
     process_cwd: str | None = None
     try:
+        gate_read, gate_write = os.pipe()
+        ready_read, ready_write = os.pipe()
         proc = subprocess.Popen(
-            [sys.executable, "-c", _RUNNER_SHIM, str(gate_read), *command],
+            [sys.executable, "-c", _RUNNER_SHIM, str(gate_read), str(ready_write), *command],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
             start_new_session=True,
-            pass_fds=(gate_read,),
+            pass_fds=(gate_read, ready_write),
             env=child_env,
             cwd=options.cwd,
         )
         os.close(gate_read)
         gate_read = -1
+        os.close(ready_write)
+        ready_write = -1
         pgid = os.getpgid(proc.pid)
         live_process = psutil.Process(proc.pid)
         process_birth_time = float(live_process.create_time())
+        process_executable = str(Path(live_process.exe()).resolve())
+        process_cwd = str(Path(live_process.cwd()).resolve())
+        readable, _, _ = select.select([ready_read], [], [], 5.0)
+        if not readable or os.read(ready_read, 1) != b"1":
+            raise RuntimeError("process launch readiness handshake failed")
+        os.close(ready_read)
+        ready_read = -1
+        # The child acknowledges only after the interpreter is executing the
+        # shim, so launchers that re-exec cannot leave a transient path behind.
+        live_process = psutil.Process(proc.pid)
         process_executable = str(Path(live_process.exe()).resolve())
         process_cwd = str(Path(live_process.cwd()).resolve())
         metadata = {
@@ -275,11 +296,12 @@ def start_guarded_run(command: list[str], options: RunOptions | None = None) -> 
         store.write_metadata(run_id, metadata)
         os.write(gate_write, b"1")
     except Exception:
-        if gate_read >= 0:
-            try:
-                os.close(gate_read)
-            except OSError:
-                pass
+        for descriptor in (gate_read, ready_read, ready_write):
+            if descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
         _abort_blocked_runner(
             proc,
             gate_write,

--- a/src/agentacct/supervisor.py
+++ b/src/agentacct/supervisor.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import os
 import secrets
+import select
 import shutil
 import signal
 import subprocess
@@ -47,11 +48,7 @@ import signal
 import sys
 
 gate = int(sys.argv[1])
-token = os.read(gate, 1)
-os.close(gate)
-if token != b"1":
-    raise SystemExit(126)
-
+ready = int(sys.argv[2])
 cancel_requested = False
 
 def on_term(_signum, _frame):
@@ -59,10 +56,17 @@ def on_term(_signum, _frame):
     cancel_requested = True
 
 signal.signal(signal.SIGTERM, on_term)
+os.write(ready, b"1")
+os.close(ready)
+token = os.read(gate, 1)
+os.close(gate)
+if token != b"1":
+    raise SystemExit(126)
+
 child = os.fork()
 if child == 0:
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
-    os.execv(sys.argv[2], sys.argv[2:])
+    os.execv(sys.argv[3], sys.argv[3:])
 
 while True:
     try:
@@ -546,6 +550,7 @@ class OwnedSupervisor:
         *,
         birth_time: float | None,
         pgid: int | None,
+        executable: str | None,
         cwd: Path,
         nonce: str,
     ) -> None:
@@ -568,9 +573,10 @@ class OwnedSupervisor:
         try:
             live = psutil.Process(process.pid)
             exact_match = (
-                abs(float(live.create_time()) - birth_time) <= 0.05
+                executable is not None
+                and abs(float(live.create_time()) - birth_time) <= 0.05
                 and os.getpgid(process.pid) == pgid
-                and str(Path(live.exe()).resolve()) == str(Path(sys.executable).resolve())
+                and str(Path(live.exe()).resolve()) == str(Path(executable).resolve())
                 and str(Path(live.cwd()).resolve()) == str(cwd)
                 and read_env_alias("AGENTACCT_OWNERSHIP_NONCE", live.environ()) == nonce
             )
@@ -667,6 +673,8 @@ class OwnedSupervisor:
         stderr_handle: Any | None = None
         handshake_read = -1
         handshake_write = -1
+        ready_read = -1
+        ready_write = -1
         nonce = secrets.token_urlsafe(32)
         try:
             self.runs.create_run_dir(attempt_id)
@@ -697,8 +705,9 @@ class OwnedSupervisor:
                 }
             )
             handshake_read, handshake_write = os.pipe()
+            ready_read, ready_write = os.pipe()
         except Exception as exc:
-            for descriptor in (handshake_read, handshake_write):
+            for descriptor in (handshake_read, handshake_write, ready_read, ready_write):
                 if descriptor >= 0:
                     try:
                         os.close(descriptor)
@@ -718,41 +727,61 @@ class OwnedSupervisor:
         process: subprocess.Popen[bytes] | None = None
         birth_time: float | None = None
         pgid: int | None = None
+        executable: str | None = None
         try:
             self._assert_preflight_identities(manifest_payload)
             process = subprocess.Popen(
-                [sys.executable, "-c", _LAUNCH_SHIM, str(handshake_read), *command],
+                [
+                    sys.executable,
+                    "-c",
+                    _LAUNCH_SHIM,
+                    str(handshake_read),
+                    str(ready_write),
+                    *command,
+                ],
                 cwd=root,
                 env=child_env,
                 stdout=stdout_handle,
                 stderr=stderr_handle,
                 start_new_session=True,
-                pass_fds=(handshake_read,),
+                pass_fds=(handshake_read, ready_write),
             )
             os.close(handshake_read)
             handshake_read = -1
+            os.close(ready_write)
+            ready_write = -1
             live = psutil.Process(process.pid)
             birth_time = float(live.create_time())
             pgid = os.getpgid(process.pid)
+            executable = str(Path(live.exe()).resolve())
+            readable, _, _ = select.select([ready_read], [], [], 5.0)
+            if not readable or os.read(ready_read, 1) != b"1":
+                raise SupervisorError("process launch readiness handshake failed")
+            os.close(ready_read)
+            ready_read = -1
             # The shim remains the stable process-group leader.  This keeps the
             # ownership proof valid for direct shebang scripts and throughout
             # cancellation even when the target leader exits before children.
-            executable = str(Path(sys.executable).resolve())
+            # It acknowledges only after any interpreter-launcher re-exec.
+            live = psutil.Process(process.pid)
+            executable = str(Path(live.exe()).resolve())
             process_cwd = str(Path(live.cwd()).resolve())
             if read_env_alias("AGENTACCT_OWNERSHIP_NONCE", live.environ()) != nonce:
                 raise SupervisorError("process launch nonce handshake failed")
             self._assert_preflight_identities(manifest_payload)
         except Exception as exc:
-            if handshake_read >= 0:
-                try:
-                    os.close(handshake_read)
-                except OSError:
-                    pass
+            for descriptor in (handshake_read, ready_read, ready_write):
+                if descriptor >= 0:
+                    try:
+                        os.close(descriptor)
+                    except OSError:
+                        pass
             self._abort_blocked_process(
                 process,
                 handshake_write,
                 birth_time=birth_time,
                 pgid=pgid,
+                executable=executable,
                 cwd=root,
                 nonce=nonce,
             )
@@ -762,7 +791,7 @@ class OwnedSupervisor:
             self._record_launch_failure(attempt_id, idempotency_key, f"launch failed: {type(exc).__name__}")
             raise SupervisorError("agentacct-owned process launch failed") from exc
 
-        assert process is not None and birth_time is not None and pgid is not None
+        assert process is not None and birth_time is not None and pgid is not None and executable is not None
         started_at = time.time()
         metadata = {
             "run_id": attempt_id,
@@ -835,6 +864,7 @@ class OwnedSupervisor:
                 handshake_write,
                 birth_time=birth_time,
                 pgid=pgid,
+                executable=executable,
                 cwd=root,
                 nonce=nonce,
             )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -7,10 +8,10 @@ import time
 from pathlib import Path
 
 import psutil
-
-from agentacct.runner import RunOptions, RunStatus, start_guarded_run
 import pytest
 
+import agentacct.runner as runner_module
+from agentacct.runner import RunOptions, RunStatus, start_guarded_run
 from agentacct.storage import RunStore
 
 
@@ -104,6 +105,43 @@ def test_timeout_pauses_only_owned_dummy_process(tmp_path):
         assert verified["process_executable"] == str(Path(proc.exe()).resolve())
         assert verified["process_cwd"] == str(Path(proc.cwd()).resolve())
         assert verified["ownership_nonce"]
+    finally:
+        os.killpg(metadata["process_group_id"], signal.SIGKILL)
+
+
+def test_runner_waits_for_the_live_shim_before_recording_its_executable(tmp_path, monkeypatch):
+    real_python = sys.executable
+    launcher = tmp_path / "python-launcher"
+    launcher.write_text(
+        f"#!/bin/sh\nsleep 0.5\nexec {shlex.quote(real_python)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    launcher.chmod(0o700)
+    dummy = write_dummy(
+        tmp_path / "loop.py",
+        "import time\nprint('started', flush=True)\nwhile True:\n    time.sleep(0.2)\n",
+    )
+    store = RunStore(tmp_path / "state")
+    monkeypatch.setattr(runner_module.sys, "executable", str(launcher))
+
+    result = start_guarded_run(
+        [real_python, str(dummy)],
+        RunOptions(
+            store_dir=store.root,
+            max_runtime_seconds=0.25,
+            on_timeout="pause",
+            poll_interval=0.05,
+        ),
+    )
+
+    metadata = store.read_metadata(result.run_id)
+    try:
+        live_executable = psutil.Process(metadata["pid"]).exe()
+        assert metadata["process_executable"] == str(Path(live_executable).resolve())
+        assert (
+            store.verify_owned_process(result.run_id)["process_executable"]
+            == metadata["process_executable"]
+        )
     finally:
         os.killpg(metadata["process_group_id"], signal.SIGKILL)
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import signal
 import stat
 import sys
@@ -13,6 +14,7 @@ from pathlib import Path
 import psutil
 import pytest
 
+import agentacct.supervisor as supervisor_module
 from agentacct.control_plane import ControlStore
 from agentacct.storage import OWNERSHIP_SCHEMA_VERSION, RunStore
 from agentacct.supervisor import OwnedSupervisor, SupervisorAlreadyRunning, SupervisorError
@@ -336,12 +338,48 @@ def test_direct_shebang_agent_keeps_verifiable_shim_identity(tmp_path):
             assert time.time() < deadline
             time.sleep(0.02)
         metadata = RunStore(state).verify_owned_process(attempt.attempt_id)
-        assert metadata["process_executable"] == str(Path(sys.executable).resolve())
+        live_executable = psutil.Process(metadata["pid"]).exe()
+        assert metadata["process_executable"] == str(Path(live_executable).resolve())
         assert supervisor.cancel_attempt(
             attempt.attempt_id,
             idempotency_key="cancel:shebang",
         ).execution_state == "cancelled"
     finally:
+        supervisor.close()
+
+
+def test_supervisor_waits_for_the_live_shim_before_recording_its_executable(tmp_path, monkeypatch):
+    state, _control, attempt = _attempt(
+        tmp_path,
+        "import time\nprint('READY', flush=True)\nwhile True:\n    time.sleep(0.1)\n",
+    )
+    real_python = sys.executable
+    launcher = tmp_path / "python-launcher"
+    launcher.write_text(
+        f"#!/bin/sh\nsleep 0.5\nexec {shlex.quote(real_python)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    launcher.chmod(0o700)
+    monkeypatch.setattr(supervisor_module.sys, "executable", str(launcher))
+    supervisor = OwnedSupervisor(state, cancel_grace_seconds=0.05)
+    launched = supervisor.launch_attempt(attempt.attempt_id, idempotency_key="launch:delayed-exec")
+
+    try:
+        deadline = time.time() + 3
+        while "READY" not in launched.run_dir.joinpath("stdout.log").read_text(errors="replace"):
+            assert time.time() < deadline
+            time.sleep(0.02)
+        metadata = RunStore(state).verify_owned_process(attempt.attempt_id)
+        live_executable = psutil.Process(metadata["pid"]).exe()
+        assert metadata["process_executable"] == str(Path(live_executable).resolve())
+        assert supervisor.cancel_attempt(
+            attempt.attempt_id,
+            idempotency_key="cancel:delayed-exec",
+        ).execution_state == "cancelled"
+    finally:
+        metadata = RunStore(state).read_metadata(attempt.attempt_id)
+        if psutil.pid_exists(metadata["pid"]):
+            os.killpg(metadata["process_group_id"], signal.SIGKILL)
         supervisor.close()
 
 


### PR DESCRIPTION
## Why

On Homebrew macOS, the Python launcher path can re-exec into the framework `Python.app` executable after `Popen` returns. The control supervisor recorded the requested or transient launcher path, while later ownership verification compared it with the executable actually running. The intentional fail-closed check then rejected agentacct's own process, breaking cancellation, timeout handling, and reconciliation and potentially leaving an owned attempt running.

Pre-fix public-boundary reproduction:

```text
Control request failed: process identity no longer matches; refusing to control it
```

## Central difference

Before, executable identity was sampled before the Python shim proved it was running; now the shim acknowledges readiness after any interpreter re-exec, and only then does the parent capture and commit the live executable identity.

## Design and safety

- The existing launch gate remains authoritative: the target command is still blocked until ownership metadata and the running transition are durably committed.
- A separate one-byte readiness pipe proves that the stable shim is executing before `process_executable` is sampled.
- Readiness is bounded to five seconds; a missing or malformed acknowledgement fails the launch.
- Failed-launch cleanup uses the executable sampled from the live bootstrap rather than assuming `sys.executable`, while retaining PID, birth-time, PGID, cwd, and nonce checks.
- No ownership checks are weakened, no stored schema changes, and no migration is introduced. Existing attempts recorded with a mismatched path remain fail-closed; newly launched attempts receive the corrected proof.

## Review map

1. `src/agentacct/supervisor.py`: adds the child-ready handshake to control-plane launches and reuses the sampled live executable for exact abort cleanup.
2. `src/agentacct/runner.py`: applies the same readiness boundary to guarded runs and timeout/error controls.
3. `tests/test_supervisor.py`: simulates a launcher that delays and then `exec`s Python, proving cancellation uses the post-exec identity; direct-shebang coverage now asserts the live executable.
4. `tests/test_runner.py`: applies the same delayed-exec regression to timeout/pause behavior.

## Verification

- Red before fix: `test_cancel_controls_only_the_exact_owned_attempt` failed with `process identity no longer matches`.
- Green after fix: the same CLI-boundary test passes on Homebrew Python 3.12.
- Process-control matrix, Python 3.12: **73 passed**.
- Process-control matrix, Python 3.14: **73 passed**.
- Final full Python suite: **2,652 passed**, one existing Starlette/httpx deprecation warning.
- GitHub CI: Python 3.11, 3.12, 3.13, and the macOS app/UI job passed. Canonical pixel comparison was skipped by workflow on the noncanonical hosted renderer; Swift tests, bundle identity, release build, and review-matrix rendering passed.
- `python -m compileall -q src/agentacct`: passed.
- `git diff --check origin/main...HEAD`: passed.
