### PR TITLE
Fix post-push UI and receipt-honesty bugs found in review

### DIFF
--- a/apps/agentacct/Sources/agentacct/DashboardModel.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardModel.swift
@@ -31,10 +31,13 @@ struct SessionUsage: Decodable {
     }
 
     /// Per-session cost honesty: an estimate renders as an estimate, an
-    /// unpriced session renders as an em-dash — never $0.00.
+    /// unpriced session renders as an em-dash — never $0.00. A reported OR billed
+    /// figure is exact; matches Fmt.costDisplay / receiptCostDisplay so the same
+    /// cost never reads exact at the task level and estimated at the step level.
     var costText: String {
         guard let cost = estimatedCostUsd else { return "—" }
-        return Fmt.dollars(cost, prefix: costConfidence == "client_reported" ? "$" : "≈$")
+        let reported = costConfidence == "client_reported" || costConfidence == "provider_billed"
+        return Fmt.dollars(cost, prefix: reported ? "$" : "≈$")
     }
 }
 

--- a/apps/agentacct/Sources/agentacct/DashboardPane.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardPane.swift
@@ -100,9 +100,13 @@ struct DashboardWorkItem: Identifiable {
     private static func compactCost(_ cost: ReceiptCost) -> String {
         guard let value = cost.estimatedCostUsd else { return "—" }
         let prefix: String
+        // A complete reported OR billed figure is exact ("$"); everything else
+        // is an estimate. Matches Fmt.costDisplay and receiptCostDisplay so the
+        // same cost never reads exact on Usage and estimated on the Dashboard.
+        let reported = cost.costConfidence == "client_reported" || cost.costConfidence == "provider_billed"
         if cost.costComplete == false {
             prefix = "~$"
-        } else if cost.costComplete == true && cost.costConfidence == "client_reported" {
+        } else if cost.costComplete == true && reported {
             prefix = "$"
         } else {
             prefix = "≈$"

--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -44,11 +44,15 @@ func receiptSourceTint(_ source: String) -> Color {
 }
 
 /// The app-wide cost prefix grammar, applied wherever a receipt cost renders:
-/// bare `$` only for a complete client-reported figure, `~$` for a knowingly
-/// partial one, `≈$` for every other estimate. One prefix per basis — the
-/// same number never appears with and without its estimate marker.
+/// bare `$` only for a complete figure whose confidence is reported OR billed,
+/// `~$` for a knowingly partial one, `≈$` for every other estimate. One prefix
+/// per basis — the same number never appears with and without its estimate
+/// marker, and the same figure never reads exact on one pane and estimated on
+/// another. Mirrors `Fmt.costDisplay`'s `reported` set (the single source of
+/// truth for the grammar).
 func receiptCostDisplay(_ usd: Double, complete: Bool?, confidence: String?) -> String {
-    if complete == true && confidence == "client_reported" { return Fmt.dollars(usd) }
+    let reported = confidence == "client_reported" || confidence == "provider_billed"
+    if complete == true && reported { return Fmt.dollars(usd) }
     if complete == false { return Fmt.dollars(usd, prefix: "~$") }
     return Fmt.dollars(usd, prefix: "≈$")
 }
@@ -1091,7 +1095,6 @@ struct DispositionControls: View {
                 .textFieldStyle(.roundedBorder)
                 .workFont(.body)
                 .lineLimit(2...4)
-                .frame(width: 300)
             HStack {
                 Spacer()
                 Button {
@@ -1107,6 +1110,12 @@ struct DispositionControls: View {
             }
         }
         .padding(Space.l)
+        // Pin the popover width. Without a definite width the two
+        // .fixedSize(vertical:) Text rows wrap into a tall tower during the
+        // popover's width negotiation (measured 949pt), ballooning the sheet;
+        // a fixed width holds it at a stable ~130pt. Mirrors the status legend
+        // popover, which pins .frame(width: 440) for the same reason.
+        .frame(width: 340)
     }
 
     private func post(_ action: String, note: String?) {
@@ -1141,14 +1150,21 @@ struct BlockerCallout: View {
     let blocker: ReceiptBlocker
     let taskId: String
 
+    // A blocker the user resolved must not keep wearing the coral "blocked"
+    // tone — in this app coral means "needs you". It still shows here (so the
+    // resolve is auditable and reopenable), but in a calm, neutral treatment.
+    private var isResolved: Bool {
+        (blocker.disposition?.state ?? "open") == "resolved"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
-                Image(systemName: "hand.raised")
+                Image(systemName: isResolved ? "checkmark.circle" : "hand.raised")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(Theme.coral)
+                    .foregroundStyle(isResolved ? Theme.muted : Theme.coral)
                     .accessibilityHidden(true)
-                Text(blocker.stepTitle ?? "Blocked step")
+                Text(blocker.stepTitle ?? (isResolved ? "Resolved blocker" : "Blocked step"))
                     .workFont(.rowLabel).foregroundStyle(Theme.ink)
                     .lineLimit(2)
                 Spacer(minLength: Space.s)
@@ -1208,7 +1224,10 @@ struct BlockerCallout: View {
         }
         .padding(Space.l)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.tintCoral, in: RoundedRectangle(cornerRadius: Metrics.radius))
+        .background(
+            isResolved ? Theme.tintNeutral : Theme.tintCoral,
+            in: RoundedRectangle(cornerRadius: Metrics.radius)
+        )
         .accessibilityIdentifier("receipt.blocker")
     }
 }

--- a/apps/agentacct/Sources/agentacct/UsagePane.swift
+++ b/apps/agentacct/Sources/agentacct/UsagePane.swift
@@ -19,7 +19,10 @@ struct UsagePane: View {
             }
             .padding(Space.gutter)
             .frame(maxWidth: 1172 + Space.gutter * 2, alignment: .leading)
-            .frame(maxWidth: .infinity, alignment: .center)
+            // Left-align the capped content column to match Work and Sources
+            // (WorkPane .leading, SourcesPane .leading). Centering here made the
+            // whole pane slide sideways on wide windows when switching tabs.
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/apps/agentacct/Sources/agentacct/WorkPane.swift
+++ b/apps/agentacct/Sources/agentacct/WorkPane.swift
@@ -260,7 +260,10 @@ struct WorkReceiptRowPresentation {
         title = selectedDetail?.title ?? task.title ?? task.taskId
         decisionKey = decision.key
         decisionLabel = decision.label ?? decision.key
-        decisionHelp = decision.blocker?.text ?? decision.statement ?? ""
+        // A resolved blocker is surfaced (so it can be reopened) but must not
+        // colour the row or the badge tooltip as if the task still needs you.
+        let blockerIsStanding = (decision.blocker?.disposition?.state ?? "open") != "resolved"
+        decisionHelp = (blockerIsStanding ? decision.blocker?.text : nil) ?? decision.statement ?? ""
         evidence = resolvedEvidence
         handedOff = selectedDetail?.axes.handoff?.handedOff ?? (task.handedOff == true)
         let coveragePresentation = ReceiptCoveragePresentation(evidence: resolvedEvidence)
@@ -289,7 +292,9 @@ struct WorkReceiptRowPresentation {
             costText = compact == "—" ? "cost unknown" : compact
         }
         updatedText = agoText(task.lastActivityAt) ?? "no activity"
-        if let blocker = decision.blocker?.text, !blocker.isEmpty {
+        // Only a STANDING blocker states the (coral) attention reason; a resolved
+        // one is surfaced for reopen but must not read as needing attention.
+        if let blocker = decision.blocker?.text, !blocker.isEmpty, blockerIsStanding {
             attentionReason = blocker
         } else if let checksFailed, checksFailed > 0 {
             attentionReason = "\(checksFailed) failed check run\(checksFailed == 1 ? "" : "s")"

--- a/src/agentacct/client_usage.py
+++ b/src/agentacct/client_usage.py
@@ -2126,15 +2126,33 @@ def _discover_claude_code_usage_from_home(
     workflow_journal_fingerprints: dict[Path, _ClaudeFileFingerprint] = {}
     transcript_paths: list[Path] = []
     traversal_fingerprints: dict[Path, _ClaudeFileFingerprint] = {}
+    skipped_journal_codes: list[str] = []
     for candidate in candidate_files:
         path = candidate.path
         traversal_fingerprints[path] = candidate.fingerprint
         if _is_claude_workflow_journal(path, projects_root):
-            observed_fingerprint = _validate_claude_workflow_journal(
-                path,
-                projects_root=projects_root,
-                projects_root_fd=projects_root_fd,
-            )
+            try:
+                observed_fingerprint = _validate_claude_workflow_journal(
+                    path,
+                    projects_root=projects_root,
+                    projects_root_fd=projects_root_fd,
+                )
+            except _ClientUsageDiscoveryReadError as exc:
+                # A workflow journal that fails validation — an unknown row shape
+                # (schema drift) or a file past the scan caps (truncated) — is
+                # non-transcript metadata that carries no token usage. Skip just
+                # this file and record the diagnostic; NEVER abort the whole
+                # home. This is the exact #53 invariant every transcript path
+                # below already upholds — and this journal path was the one place
+                # that still raised, so a single new row type the Workflow tool
+                # started writing (or one oversized journal) silently froze ALL
+                # claude-code usage import for the home. A changed-during-scan
+                # (fingerprint race) and an unsafe path are OSErrors, not
+                # _ClientUsageDiscoveryReadError, so they still propagate.
+                skipped_journal_codes.append(
+                    getattr(exc, "code", None) or "claude_workflow_journal_skipped"
+                )
+                continue
             if (
                 candidate.fingerprint is None
                 or observed_fingerprint != candidate.fingerprint
@@ -2154,6 +2172,11 @@ def _discover_claude_code_usage_from_home(
         error_count += 1
         if code not in error_codes:
             error_codes.append(code)
+
+    # A journal we could not validate is a recorded error, not a reason to zero
+    # the home (see the try/except above).
+    for _journal_code in skipped_journal_codes:
+        record_error(_journal_code)
 
     # A descendant directory symlink is never followed (no-follow policy), but
     # it no longer aborts the whole home. Surface each skipped link as an unsafe

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -445,8 +445,25 @@ def _evidence_strength(
     }
     unattributed_checks = len(task_passing_ids - linked)
 
-    passed = sum(1 for check in checks if _text(check.get("result")).lower() == "passed")
-    failed = sum(1 for check in checks if _text(check.get("result")).lower() in {"failed", "error"})
+    # Count passes/failures over the FRONTIER only. A run that a later run of the
+    # same check superseded (a fail that a re-run then passed) stays in
+    # checks_total and stays visible in the history group, but it must not read
+    # as a current failure in the header tally — otherwise "N failed" overstates
+    # failures the frontier already cleared, contradicting the row that is marked
+    # "superseded by a later passing run". The decision_status lane already
+    # excludes superseded checks the same way.
+    passed = sum(
+        1
+        for check in checks
+        if not check.get("superseded")
+        and _text(check.get("result")).lower() == "passed"
+    )
+    failed = sum(
+        1
+        for check in checks
+        if not check.get("superseded")
+        and _text(check.get("result")).lower() in {"failed", "error"}
+    )
 
     # Coarse key kept ONLY for colour + list sort/filter. It is an ordinal, not a
     # headline: undefined < unchecked < self_checked < independently < externally.
@@ -601,8 +618,10 @@ def _decision_status(
     # The newest blocker's own words (agent-recorded text, next step, when, and
     # how many successful steps were recorded AFTER it) — computed by the
     # outcome reducer, passed through verbatim so every surface can finally SAY
-    # why a Task is blocked instead of only that it is. None off the
-    # blocked/failed keys.
+    # why a Task is blocked instead of only that it is. Present on the
+    # blocked/failed keys and on ``blocker_resolved_by_user`` (which carries a
+    # resolved blocker so its callout stays reachable for reopen); None
+    # otherwise.
     blocker = canonical.get("blocker") if isinstance(canonical.get("blocker"), Mapping) else None
 
     return {

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -549,7 +549,17 @@ def reduce_task_outcome(
         # agent's own words); only when no blocked step has text does the newest
         # blocked step itself stand in (e.g. a bare ``failed``).
         texted = [item for item in blocked_items if _text(item.get("blocker"))]
-        newest = max(texted or blocked_items, key=_item_time)
+        # Prefer a blocker the user can actually DISPOSE: one that carries both
+        # the agent's text AND a current_blocked_event_id (the write handle a
+        # disposition needs). Blocker text can ride a NON-blocked event — e.g. a
+        # checkpoint noting "waiting on X" — which never receives a blocked event
+        # id; surfacing that one would show a blocker whose Resolve/Reopen
+        # control cannot post, while the actually-disposable blocked step stays
+        # hidden. Fall back to any texted blocker, then to any blocked item.
+        texted_disposable = [
+            item for item in texted if _text(item.get("current_blocked_event_id"))
+        ]
+        newest = max(texted_disposable or texted or blocked_items, key=_item_time)
         newest_at = _item_time(newest)
         # Staleness, stated as a fact, never a re-grade: ``blocked`` is sticky by
         # design (an explicit blocker is the user-action contract), but a count
@@ -726,12 +736,61 @@ def reduce_task_outcome(
             for item, status in zip(items, statuses)
         )
         if non_success_all_dismissed:
+            # Keep the resolved blocker's callout REACHABLE so the user can
+            # reopen it in-app. The backend supports resolved->open for blockers,
+            # but the only host of the blocker's disposition controls is this
+            # callout — dropping the blocker entirely made "Reopen" unreachable
+            # (findings stay reopenable because their failing check row persists;
+            # a resolved blocker had no such surface). Surface the newest resolved
+            # blocker that carries text, with its disposition and reopen handle.
+            # The decision word stays ``blocker_resolved_by_user`` — this never
+            # re-blocks the Task; the callout renders in a resolved (calm) tone.
+            resolved_texted = [
+                item
+                for item, status in zip(items, statuses)
+                if _blocker_resolved_by_user(item) and _text(item.get("blocker"))
+            ]
+            resolved_blocker = None
+            if resolved_texted:
+                newest_resolved = max(
+                    resolved_texted,
+                    key=lambda item: _number(
+                        item.get("updated_at") or item.get("started_at")
+                    ),
+                )
+                resolved_blocker = {
+                    "step_title": _text(newest_resolved.get("title")) or None,
+                    "section_id": _text(newest_resolved.get("section_id")) or None,
+                    "text": _text(newest_resolved.get("blocker")) or None,
+                    "next_step": _text(newest_resolved.get("next_step")) or None,
+                    "updated_at": _number(
+                        newest_resolved.get("updated_at")
+                        or newest_resolved.get("started_at")
+                    )
+                    or None,
+                    "blocked_step_count": len(resolved_texted),
+                    # A resolved blocker was not "moved on past" — the later-steps
+                    # nudge is only meaningful for a standing blocker.
+                    "later_completed_steps": 0,
+                    "blocked_event_id": _text(
+                        newest_resolved.get("current_blocked_event_id")
+                    )
+                    or None,
+                    "disposition_revision": _integer(
+                        newest_resolved.get("blocker_target_revision")
+                    ),
+                    "disposition": (
+                        dict(newest_resolved["blocker_disposition"])
+                        if isinstance(newest_resolved.get("blocker_disposition"), Mapping)
+                        else None
+                    ),
+                }
             return {
                 "key": "blocker_resolved_by_user",
                 "finding": None,
                 "verification": None,
                 "latest_checks": checks,
-                "blocker": None,
+                "blocker": resolved_blocker,
                 "max_work_updated_at": max_work_updated_at,
                 "open_step_count": open_step_count,
                 "handoff_current": handoff_current,

--- a/tests/test_client_usage.py
+++ b/tests/test_client_usage.py
@@ -3139,7 +3139,14 @@ def test_claude_workflow_journal_failed_row_is_ignored(tmp_path):
     assert diagnostic["error_codes"] == []
 
 
-def test_claude_workflow_journal_schema_drift_fails_closed(tmp_path):
+def test_claude_workflow_journal_schema_drift_is_quarantined_not_frozen(tmp_path):
+    # A workflow journal with an unknown row shape is non-transcript metadata.
+    # It is skipped and flagged, but it must NOT freeze the whole home: the real
+    # session's usage still imports. Regression (the #169 recurrence): the
+    # journal validator raised _ClientUsageDiscoveryReadError inside the
+    # candidate loop with no try/except, so a single unknown row type the
+    # Workflow tool began writing zeroed ALL claude-code usage for the home —
+    # violating the very #53 invariant every transcript path already upholds.
     claude_home = _make_claude_home(tmp_path)
     project = claude_home / "projects" / "-tmp-project"
     journal = (
@@ -3172,11 +3179,56 @@ def test_claude_workflow_journal_schema_drift_fails_closed(tmp_path):
         limit_sessions=10,
     )
 
-    assert result.events == []
-    assert result.diagnostics["claude-code"]["discovered"] == 2
-    assert result.diagnostics["claude-code"]["error_codes"] == [
-        "claude_workflow_journal_schema_drift"
+    # The real session imports; the drift journal is quarantined, not fatal.
+    assert [event.client_session_id for event in result.events] == ["claude-session"]
+    diagnostic = result.diagnostics["claude-code"]
+    assert diagnostic["discovered"] == 2
+    # The drift journal never validated, so it is a recorded error rather than a
+    # counted "ignored non-transcript" file.
+    assert diagnostic["ignored_non_transcript_files"] == 0
+    assert diagnostic["error_codes"] == ["claude_workflow_journal_schema_drift"]
+    assert result.events[0].source_parse_complete is True
+
+
+def test_claude_workflow_journal_oversize_is_quarantined_not_frozen(tmp_path):
+    # A perfectly well-formed journal that merely exceeds the scan caps (here:
+    # more than _CLAUDE_WORKFLOW_JOURNAL_MAX_LINES rows) trips the "truncated"
+    # guard. Like schema drift, that must skip only the journal and still import
+    # the real session — size alone must never freeze the whole home.
+    claude_home = _make_claude_home(tmp_path)
+    project = claude_home / "projects" / "-tmp-project"
+    journal = (
+        project
+        / "claude-session"
+        / "subagents"
+        / "workflows"
+        / "wf_big"
+        / "journal.jsonl"
+    )
+    journal.parent.mkdir(parents=True)
+    row_count = client_usage_module._CLAUDE_WORKFLOW_JOURNAL_MAX_LINES + 1
+    journal.write_text(
+        "".join(
+            json.dumps({"agentId": f"agent-{i}", "key": "state", "type": "started"})
+            + "\n"
+            for i in range(row_count)
+        ),
+        encoding="utf-8",
+    )
+
+    result = discover_client_usage_with_diagnostics(
+        client="claude-code",
+        claude_home=claude_home,
+        limit_sessions=10,
+    )
+
+    assert [event.client_session_id for event in result.events] == ["claude-session"]
+    diagnostic = result.diagnostics["claude-code"]
+    assert diagnostic["ignored_non_transcript_files"] == 0
+    assert diagnostic["error_codes"] == [
+        "claude_workflow_journal_validation_truncated"
     ]
+    assert result.events[0].source_parse_complete is True
 
 
 def test_claude_workflow_journal_mutation_after_validation_fails_closed(

--- a/tests/test_disposition_v1.py
+++ b/tests/test_disposition_v1.py
@@ -166,7 +166,17 @@ def test_blocker_resolve_end_to_end_moves_the_task_off_blocked(tmp_path: Path) -
     assert decision["label"] == "Blocker resolved"
     assert decision["asserted_by"] == "human"
     assert "not a completion claim" in decision["statement"]
-    assert decision["blocker"] is None
+    # The resolved blocker stays SURFACED so the user can REOPEN it in-app — the
+    # callout is the only host of the blocker's disposition controls, and the
+    # backend supports resolved->open. It carries the reopen handle (blocked
+    # event id + current revision) and the resolved disposition; the decision
+    # word is still blocker_resolved_by_user, so the Task is not re-blocked.
+    resolved_blocker = decision["blocker"]
+    assert resolved_blocker is not None
+    assert resolved_blocker["blocked_event_id"] == blocked_id
+    assert resolved_blocker["disposition_revision"] == 1
+    assert resolved_blocker["disposition"]["state"] == "resolved"
+    assert resolved_blocker["disposition"]["note"] == "approved and shipped by hand"
 
     # Stale revision now conflicts (409), never silently overwrites.
     stale = client.post(

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -245,6 +245,61 @@ def test_passing_hook_check_is_independently_checked() -> None:
     assert receipt["dimensions"]["evidence"]["checks"][0]["source"] == "hook"
 
 
+def test_superseded_failure_is_not_counted_in_the_check_tally() -> None:
+    # A failing check that a later, distinct passing check superseded stays in
+    # checks_total and stays visible as a (history) row, but must NOT read as a
+    # current failure in the header tally — otherwise "N failed" overstates
+    # failures the frontier already cleared, contradicting the row that is
+    # marked "superseded by a later passing run".
+    superseded_fail = {
+        "event_id": "evt_fail",
+        "result": "failed",
+        "name": "lint",
+        "evidence_type": "lint",
+        "created_at": 100.0,
+        "exit_code": 1,
+        "source_type": "client_hook",
+        "source": "claude-code",
+        "check_identity": "check:lint-old",
+        "check_identity_stable": True,
+        "supersession_state": "superseded",
+        "superseded_by_event_id": "evt_pass",
+    }
+    superseding_pass = {
+        "event_id": "evt_pass",
+        "result": "passed",
+        "name": "lint",
+        "evidence_type": "lint",
+        "created_at": 200.0,
+        "exit_code": 0,
+        "source_type": "client_hook",
+        "source": "claude-code",
+        "check_identity": "check:lint-new",
+        "check_identity_stable": True,
+    }
+    task = _task(
+        [
+            {
+                "work_id": "w",
+                "latest_status": "completed",
+                "updated_at": 100.0,
+                "current_check_events": [superseded_fail, superseding_pass],
+            }
+        ],
+        task_checks=[superseded_fail, superseding_pass],
+    )
+    receipt = _receipt(task)
+    evidence = receipt["axes"]["evidence_strength"]
+    # Both runs are still counted in the total…
+    assert evidence["checks_total"] == 2
+    # …but the superseded failure no longer inflates the failed tally.
+    assert evidence["checks_passed"] == 1
+    assert evidence["checks_failed"] == 0
+    # The superseded failure is still present as a row so the history stays auditable.
+    rows = receipt["dimensions"]["evidence"]["checks"]
+    assert [row for row in rows if row.get("superseded")] != []
+
+
 def test_agent_reported_check_is_self_checked_not_independent() -> None:
     # An mcp_agent_reported passing check is the agent's own word — it is
     # 'self_checked', never promoted to independent verification, no matter what


### PR DESCRIPTION
A wholistic bug review after the pre-demo push. Three UI bugs reported from the app, plus four more found by a diff review of the last few days' changes. Each fix is described with the concrete wrong behavior it removes.

## UI

- **Oversized resolve popover.** The "Resolve blocker/finding" sheet had no fixed width, so during the popover's width negotiation the two `.fixedSize(vertical:)` Text rows wrapped into a ~949pt tower and ballooned the sheet into a giant empty box. Pinned the width (`.frame(width: 340)`), matching the status-legend popover. Root cause of it shipping: `DispositionControls` renders only when `!SnapshotMode.enabled`, so the popover is excluded from the snapshot suite.
- **Usage pane slides sideways.** `UsagePane` centered its capped content column (`.center`) while Work and Sources left-align (`.leading`), so on any window wider than the 1228pt cap the whole pane jumped horizontally on tab switch. Left-aligned to match.
- **Cost prefix contradiction.** A complete `provider_billed` figure rendered exact `$` via `Fmt.costDisplay` but estimate `≈$` via `receiptCostDisplay`, `compactCost`, and `SessionUsage.costText` — the same cost read exact on one surface and estimated on another. Aligned all of them to the documented app-wide grammar (reported **or** billed → exact).

## Ingestion / receipt honesty

- **Usage-ingestion freeze (blast radius).** The workflow-journal validator raised inside the discovery candidate loop with no `try/except`, so one journal with an unknown row shape **or** a size past the scan caps aborted the *entire* claude-code home's usage import (this is the #169 recurrence). It now quarantines the single file (records the diagnostic, skips it) and imports everything else — the same issue-#53 invariant every transcript path already follows.
- **Superseded checks in the tally.** The receipt "check runs · N failed" header counted a failure that a later run had superseded, even though the row itself is marked "superseded by a later passing run." Passes/failures are now counted over the frontier (superseded excluded); the run stays in the total and in the history group.
- **Resolved blockers couldn't be reopened in-app.** Resolving a blocker dropped it from the projection, so the only host of the blocker's disposition controls (`BlockerCallout`) disappeared and the backend-supported resolved→open reopen was unreachable. The resolved blocker now stays surfaced with its reopen handle, in a calm neutral tone (not coral); the decision word stays `blocker_resolved_by_user` and the list row does not read as needing attention.
- **Blocker selection.** The surfaced blocker is now the newest one that carries both text **and** a blocked-event id, so it is one the user can actually dispose (blocker text can ride a non-blocked checkpoint event that has no write handle).

## Tests

Updated the locked journal fail-closed, disposition end-to-end, and receipt tests to the new intended behavior, and added regression coverage (journal schema-drift + oversize quarantine; superseded tally; resolved-blocker reopen handle). Full Python suite (2660) and macOS app tests pass; `swift build` clean. A separate adversarial diff review found one incomplete cost surface (`SessionUsage.costText`), now fixed.

## Follow-up (not in this PR)

`V1Model.costText` renders any non-partial cost as exact `$` with no confidence check, so a non-partial *estimate* reads as exact there. Pre-existing and a different class from the `provider_billed` grammar fix above — flagged for a separate change.
