### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ build/
 .hermes/
 *.local.md
 .gstack/
+# macOS Finder metadata — never useful in the repo, easy to commit by accident.
+.DS_Store
 # Event-store runtime artifacts if a stray run creates a store at the repo root
 # (the real store lives in .agent-sentinel/ or the XDG state dir) — never commit.
 /events.sqlite3*


### PR DESCRIPTION
Ignore `.DS_Store` repo-wide. macOS Finder drops these into any browsed directory, and one was sitting untracked under `apps/`; this keeps it from being committed by accident. No code or behavior change.