### PR TITLE
ci: shorten Python and macOS test runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e . pytest
+          python -m pip install -e . pytest pytest-xdist
       - name: Run tests
-        run: pytest -q
+        run: pytest -q -n 4 --dist loadfile
 
   macos-app:
     name: macOS app and UI snapshots
@@ -62,7 +62,7 @@ jobs:
       - name: Test dashboard reference candidate intake
         run: ./Tests/dashboard-reference-candidate-intake-cli-tests.py
       - name: Run Swift tests
-        run: swift test
+        run: swift test -c release
       - name: Test app bundle identity
         run: ./Tests/build-app-identity-tests.sh
       - name: Detect canonical visual renderer

--- a/apps/agentacct/Scripts/visual-snapshots
+++ b/apps/agentacct/Scripts/visual-snapshots
@@ -79,7 +79,7 @@ check_environment() {
 
 discover_visual_tests() {
   discovered_file="$(mktemp "${TMPDIR:-/tmp}/agentacct-visual-tests.XXXXXX")"
-  "$swift_bin" test list \
+  "$swift_bin" test -c release list \
     | awk -F/ '$1 ~ /VisualRegressionTests$/ { print }' \
     | sort -u > "$discovered_file"
 }
@@ -183,16 +183,21 @@ filter_for_selector() {
 
 run_selected() {
   local mode="$1"
-  local selector filter
+  local selector filter combined_filter=""
   while IFS= read -r selector; do
     filter="$(filter_for_selector "$selector")"
     echo "$mode $selector"
-    AGENTACCT_SNAPSHOT_MODE="$mode" \
-      AGENTACCT_VERIFY_VISUAL_BASELINES=1 \
-      AGENTACCT_SNAPSHOT_PLATFORM_ID="$platform_id" \
-      AGENTACCT_SNAPSHOT_ARTIFACT_DIR="$failure_dir" \
-      "$swift_bin" test --filter "$filter"
+    if [[ -n "$combined_filter" ]]; then
+      combined_filter+="|"
+    fi
+    combined_filter+="$filter"
   done < "$selected_file"
+
+  AGENTACCT_SNAPSHOT_MODE="$mode" \
+    AGENTACCT_VERIFY_VISUAL_BASELINES=1 \
+    AGENTACCT_SNAPSHOT_PLATFORM_ID="$platform_id" \
+    AGENTACCT_SNAPSHOT_ARTIFACT_DIR="$failure_dir" \
+    "$swift_bin" test -c release --filter "$combined_filter"
 }
 
 [[ $# -ge 1 ]] || usage

--- a/apps/agentacct/Tests/README.md
+++ b/apps/agentacct/Tests/README.md
@@ -10,7 +10,7 @@ connecting an account, or creating another snapshot system.
 Run the ordinary deterministic and unit checks during development:
 
 ```bash
-swift test
+swift test -c release
 ```
 
 Discover the available visual regression suites:
@@ -553,8 +553,9 @@ rendering the app.
 Each `*VisualRegressionTests` suite compares its complete surface matrix with
 reviewed PNGs. The CLI supplies `AGENTACCT_VERIFY_VISUAL_BASELINES=1`,
 `AGENTACCT_SNAPSHOT_MODE`, the exact platform ID, and the failure directory.
-Ordinary `swift test` runs compile the visual suites but skip their baseline
-comparison, so semantic tests remain useful on non-canonical developer
+Both the CLI and ordinary `swift test -c release` runs use the production
+optimization level. Ordinary runs compile the visual suites but skip their
+baseline comparison, so semantic tests remain useful on non-canonical developer
 machines. Always use the CLI when the intent is to verify visual references.
 
 ### Dashboard interaction coverage
@@ -581,7 +582,7 @@ duplicate them with brittle view-tree tests in the meantime.
 3. Have a human review the finished render before recording.
 4. Run `./Scripts/visual-snapshots record <same-target>`.
 5. Review every changed PNG in Git, including images that seem unchanged.
-6. Run verify, `swift test`, and `swift build -c release` again.
+6. Run verify, `swift test -c release`, and `swift build -c release` again.
 7. Commit the UI code and reviewed references together.
 
 Never record automatically after failure. That converts an unexpected

--- a/apps/agentacct/Tests/visual-snapshots-cli-tests.sh
+++ b/apps/agentacct/Tests/visual-snapshots-cli-tests.sh
@@ -11,7 +11,7 @@ touch "$test_dir/TestFiles/DashboardVisualRegressionTests.swift"
 cat > "$test_dir/bin/swift" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "$1" == "test" && "$2" == "list" ]]; then
+if [[ "$1" == "test" && "$2" == "-c" && "$3" == "release" && "$4" == "list" ]]; then
   if [[ "${AGENTACCT_FAKE_NO_VISUAL_TESTS:-}" == "1" ]]; then
     echo 'agentacctTests.UnitTests/testUnrelatedBehavior'
     exit 0
@@ -24,12 +24,13 @@ TESTS
   if [[ "${AGENTACCT_FAKE_AMBIGUOUS_SUITE:-}" == "1" ]]; then
     echo 'otherTests.DashboardVisualRegressionTests/testAnotherDashboard'
   fi
-elif [[ "$1" == "test" && "$2" == "--filter" ]]; then
-  printf '%s|%s|%s|%s\n' \
+elif [[ "$1" == "test" && "$2" == "-c" && "$3" == "release" && "$4" == "--filter" ]]; then
+  printf '%s|%s|%s|%s|%s\n' \
     "${AGENTACCT_SNAPSHOT_MODE:-}" \
     "${AGENTACCT_VERIFY_VISUAL_BASELINES:-}" \
     "${AGENTACCT_SNAPSHOT_PLATFORM_ID:-}" \
-    "$3" >> "$AGENTACCT_FAKE_SWIFT_LOG"
+    "$3" \
+    "$5" >> "$AGENTACCT_FAKE_SWIFT_LOG"
 else
   echo "unexpected fake swift invocation: $*" >&2
   exit 1
@@ -130,17 +131,25 @@ non_overlapping="$("$app_dir/Scripts/visual-snapshots" list \
 
 "$app_dir/Scripts/visual-snapshots" verify \
   'SettingsVisualRegressionTests/testCompactDark' >/dev/null
-expected_verify="verify|1|$platform_id|"
+expected_verify="verify|1|$platform_id|release|"
 expected_verify+='^agentacctTests\.SettingsVisualRegressionTests\/testCompactDark$'
 [[ "$(cat "$AGENTACCT_FAKE_SWIFT_LOG")" == "$expected_verify" ]] \
   || fail "verify did not use the exact discovered test selector"
 
 : > "$AGENTACCT_FAKE_SWIFT_LOG"
+"$app_dir/Scripts/visual-snapshots" verify >/dev/null
+expected_all="verify|1|$platform_id|release|"
+expected_all+='^agentacctTests\.DashboardVisualRegressionTests/|'
+expected_all+='^agentacctTests\.SettingsVisualRegressionTests/'
+[[ "$(cat "$AGENTACCT_FAKE_SWIFT_LOG")" == "$expected_all" ]] \
+  || fail "verify did not combine all selected suites into one release test process"
+
+: > "$AGENTACCT_FAKE_SWIFT_LOG"
 CI=false "$app_dir/Scripts/visual-snapshots" record \
   "$test_dir/TestFiles/DashboardVisualRegressionTests.swift" >/dev/null
-expected_record="record|1|$platform_id|^agentacctTests\\.DashboardVisualRegressionTests/"
+expected_record="record|1|$platform_id|release|^agentacctTests\\.DashboardVisualRegressionTests/"
 expected_record+=$'\n'
-expected_record+="verify|1|$platform_id|^agentacctTests\\.DashboardVisualRegressionTests/"
+expected_record+="verify|1|$platform_id|release|^agentacctTests\\.DashboardVisualRegressionTests/"
 [[ "$(cat "$AGENTACCT_FAKE_SWIFT_LOG")" == "$expected_record" ]] \
   || fail "record did not replace and then verify the selected suite"
 

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -371,7 +371,7 @@ def test_cli_install_autostart_dry_run_writes_and_loads_nothing(
     expected = home / ".config" / "systemd" / "user" / SYSTEMD_SERVICE_FILENAME
     assert not expected.exists()
     assert called == []
-    assert "start --foreground" in result.output
+    assert "start --foreground" in " ".join(result.output.split())
 
 
 # --- foreground supervisor loop ---------------------------------------------

--- a/tests/test_ci_resource_policy.py
+++ b/tests/test_ci_resource_policy.py
@@ -27,6 +27,14 @@ def _used_actions(path: Path) -> list[str]:
     ]
 
 
+def _named_step(workflow: dict, job_name: str, step_name: str) -> dict:
+    return next(
+        step
+        for step in workflow["jobs"][job_name]["steps"]
+        if step.get("name") == step_name
+    )
+
+
 def test_branch_ci_cancels_superseded_work_and_bounds_jobs() -> None:
     workflow = _workflow(TESTS_WORKFLOW)
     assert workflow["concurrency"] == {
@@ -35,6 +43,19 @@ def test_branch_ci_cancels_superseded_work_and_bounds_jobs() -> None:
     }
     assert workflow["jobs"]["pytest"]["timeout-minutes"] == 20
     assert workflow["jobs"]["macos-app"]["timeout-minutes"] == 20
+
+
+def test_branch_ci_uses_bounded_parallel_python_and_release_swift_tests() -> None:
+    workflow = _workflow(TESTS_WORKFLOW)
+
+    install = _named_step(workflow, "pytest", "Install package")["run"]
+    assert "python -m pip install -e . pytest pytest-xdist" in install
+    assert _named_step(workflow, "pytest", "Run tests")["run"] == (
+        "pytest -q -n 4 --dist loadfile"
+    )
+    assert _named_step(workflow, "macos-app", "Run Swift tests")["run"] == (
+        "swift test -c release"
+    )
 
 
 def test_candidate_generation_is_manual_and_globally_serialized() -> None:

--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -247,7 +247,11 @@ def test_cursor_accepts_consistent_seconds_and_milliseconds(tmp_path: Path) -> N
         (0, None),
         (-1, None),
         (10**30, None),
-        (int((time.time() + 2 * 24 * 60 * 60) * 1_000), None),
+        pytest.param(
+            int((time.time() + 2 * 24 * 60 * 60) * 1_000),
+            None,
+            id="future-created-at-milliseconds",
+        ),
         (1_750_000_100_000, 1_750_000_000_000),
         (1_750_000_000, 1_750_000_001_000),
     ],


### PR DESCRIPTION
## Why

The required test workflow is dominated by serial Python execution and debug-mode AppKit rendering. Across six recent successful `main` runs, the macOS job had a 7m39s median duration; its Swift step alone had a 4m59s median.

This keeps the same coverage but makes the work cheaper:

- run every Python version with four bounded pytest workers using file-level distribution;
- run ordinary Swift tests with release optimization;
- discover and execute canonical visual suites in release mode and combine selected suites into one Swift test process.

## Measured impact

### GitHub Actions

| Workload | Recent `main` | PR #181 | Improvement |
| --- | ---: | ---: | ---: |
| macOS job | 7m39s median | 5m45s | about 25% |
| Swift test step | 4m59s median | 2m39s | about 47% |
| Python jobs | generally 3m13s–4m07s | 1m42s–1m59s | about 40–57% |

All four required jobs passed in [the first hosted run](https://github.com/mikehasa/agentacct/actions/runs/33484193203). App identity now dominates the macOS job at 2m26s and is the clearest follow-up target. Hosted canonical visual verification was skipped because the runner does not match the pinned renderer, as on recent `main` runs.

### Local isolation benchmarks

| Workload | Before | This branch | Improvement |
| --- | ---: | ---: | ---: |
| Full Python suite | 2,661 tests in 135.97s | 2,662 tests in 35–38s | 72–74% |
| Full Swift suite | 182 tests in 267.87s debug | 40.00s cold build + 28.73s tests | about 74% |
| Work deterministic renderer | 209.86s | 21.31s | about 90% |
| Six-suite visual test process | 245.27s debug | 15.45s release | about 94% |

The extra Python test is the new workflow-policy regression. The local visual figure is canonical-renderer evidence; the hosted run cannot prove it while that step is skipped.

## Design and safety

- `-n 4` is intentionally bounded instead of using host-dependent `auto` worker counts.
- `--dist loadfile` keeps each test module on one worker and limits shared-state exposure.
- A time-derived parametrization now has a stable collection ID across workers.
- A CLI assertion normalizes terminal wrapping without weakening the command-content check.
- Visual target resolution, exact filters, canonical-renderer checks, CI recording denial, and record-then-verify behavior remain covered.
- No tests, Python versions, visual suites, or safety checks are removed.

## Pre-existing visual reference gap

On the exact canonical local renderer, both untouched base `7f43eec` and this branch fail only `usage-weekly-reference-light` and `usage-weekly-reference-dark`, with identical pixel statistics:

- light: 0.0362% changed, maximum channel delta 218;
- dark: 0.0353% changed, maximum channel delta 229.

Release and debug produce byte-identical actual Usage PNGs. The other five visual suites pass. This PR therefore does not rewrite or claim approval of those pre-existing reviewed references.

## Review map

1. `.github/workflows/tests.yml` and `tests/test_ci_resource_policy.py`: bounded Python workers and release Swift policy.
2. `tests/test_cursor_adapter.py` and `tests/test_autostart.py`: the two xdist determinism fixes.
3. `apps/agentacct/Scripts/visual-snapshots` and its CLI test: release configuration and one combined test process without relaxing safeguards.
4. `apps/agentacct/Tests/README.md`: contributor commands and intentional baseline workflow.

## Test plan

- [x] GitHub Actions — all four required jobs passed
- [x] `.venv-ci-final/bin/python -m pytest -q -n 4 --dist loadfile` — 2,662 passed in 38.03s
- [x] Two additional full xdist runs — 2,662 passed in 35.06s and 35.01s
- [x] `swift test -c release` — 182 passed, 6 expected visual-wrapper skips, 0 failures
- [x] `./Tests/visual-snapshots-cli-tests.sh`
- [x] `./Tests/build-app-identity-tests.sh` in a disposable clean committed clone
- [x] `bash -n` for both changed shell scripts
- [x] `git diff --check`
- [x] Diff secret-pattern scan; no credentials found
- [x] No paid provider or API calls were run

## Safety checklist

- [x] Preserves local-first behavior
- [x] Does not store API keys or secrets
- [x] Does not expose localhost services publicly by default
- [x] Does not control processes agentacct did not start
- [x] Provider/API forwarding remains opt-in and budget-gated
- [x] JSON output paths remain machine-readable when `--json` is used

## Docs

- [x] Updated the contributor visual-testing guide
- [x] Public docs avoid private strategy, private roadmap, and overbroad support claims
