### PR TITLE
feat: honest inactive/stale task-status state

### DIFF
--- a/apps/agentacct/Sources/agentacct/DashboardPane.swift
+++ b/apps/agentacct/Sources/agentacct/DashboardPane.swift
@@ -64,6 +64,7 @@ struct DashboardWorkItem: Identifiable {
         case "blocked": return "Blocked"
         case "in_progress": return "In progress"
         case "handed_off": return "Handed off"
+        case "inactive": return "Inactive"
         default: return key.replacingOccurrences(of: "_", with: " ").capitalized
         }
     }

--- a/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
+++ b/apps/agentacct/Sources/agentacct/ReceiptsPane.swift
@@ -82,6 +82,28 @@ func assertedByLabel(_ raw: String?) -> String? {
     }
 }
 
+/// Builds the verbatim Outcome-row text for the Receipt DETAIL: the daemon's
+/// decision word + who asserted it, the honest statement quoted beneath, and —
+/// only when the daemon attached them (the `inactive`/`mostly_done` keys) — one
+/// factual sub-line naming when the Task went quiet and when a newer session
+/// started. The app is a pure renderer: it never derives the honesty logic, it
+/// only shows the timestamps the daemon already decided to attach. `quietSince`
+/// absent means "no quiet fact", never a completion signal.
+func receiptOutcomeSummary(_ dim: ReceiptOutcomeDim) -> String {
+    var line = "\(dim.decisionStatus ?? "unknown") · \(assertedByLabel(dim.assertedBy) ?? "unattested")"
+    if let statement = dim.statement, !statement.isEmpty {
+        line += "\n“\(statement)”"
+    }
+    if let quietSince = dim.quietSince, let quietAgo = agoText(quietSince) {
+        var sub = "Quiet since \(quietAgo)"
+        if let newer = dim.newerSessionStartedAt, let newerAgo = agoText(newer) {
+            sub += " · a newer session started \(newerAgo)"
+        }
+        line += "\n\(sub)"
+    }
+    return line
+}
+
 /// Renders only check tallies that the receipt actually carries. A missing
 /// total is named explicitly so an older or partial payload never reads as a
 /// measured zero.
@@ -1014,12 +1036,7 @@ struct RecordDimensionsCard: View {
     }
 
     private var outcomeSummary: String {
-        let dim = receipt.dimensions.outcome
-        var line = "\(dim.decisionStatus ?? "unknown") · \(assertedByLabel(dim.assertedBy) ?? "unattested")"
-        if let statement = dim.statement, !statement.isEmpty {
-            line += "\n“\(statement)”"
-        }
-        return line
+        receiptOutcomeSummary(receipt.dimensions.outcome)
     }
 }
 

--- a/apps/agentacct/Sources/agentacct/Theme.swift
+++ b/apps/agentacct/Sources/agentacct/Theme.swift
@@ -654,6 +654,13 @@ enum DecisionTintClass {
              "finding_resolved_by_user", "blocker_resolved_by_user":
             return .claimed
         case "ended_open": return .inferredStop
+        // Inactive is agentacct's own inference (asserted_by='inferred'), weaker
+        // than any claim. It must NOT read done-ish like the claimed family, must
+        // NOT alarm like a finding, and must NOT be green. A quiet neutral badge
+        // carries the honest "not a completion, not a stated stop" meaning the
+        // Inactive label already states — matching the daemon's calm, non-green
+        // treatment. (Explicit, so it never drifts into the unknown default.)
+        case "inactive": return .neutral
         case "verified": return .verified
         default: return .neutral
         }

--- a/apps/agentacct/Sources/agentacct/V1Model.swift
+++ b/apps/agentacct/Sources/agentacct/V1Model.swift
@@ -1450,12 +1450,21 @@ struct ReceiptOutcomeDim: Decodable {
     let assertedBy: String?
     let provenance: [String]?
     let gaps: [String]?
+    // Facts the daemon attaches only when the decision is `inactive`/`mostly_done`:
+    // when this Task last recorded an event, and the start of the newer session
+    // the daemon keyed its "went quiet elsewhere" inference off. Epoch seconds,
+    // matching every other timestamp field in the app. Present-but-None on every
+    // other decision key; older payloads omit them entirely (additive, tolerated).
+    let quietSince: Double?
+    let newerSessionStartedAt: Double?
 
     enum CodingKeys: String, CodingKey {
         case decisionStatus = "decision_status"
         case statement
         case assertedBy = "asserted_by"
         case provenance, gaps
+        case quietSince = "quiet_since"
+        case newerSessionStartedAt = "newer_session_started_at"
     }
 }
 

--- a/apps/agentacct/Sources/agentacct/WorkPane.swift
+++ b/apps/agentacct/Sources/agentacct/WorkPane.swift
@@ -68,8 +68,9 @@ enum WorkGroup: String, CaseIterable, Identifiable {
 
     /// Buckets never upgrade a claim: "Verified" holds only the machine-
     /// asserted key; agent claims of done-ness group under their own word
-    /// ("Reported"); ambient activity stays "Observed". "Stopped" holds both
-    /// stop shapes — the deliberate handoff and the inferred ended-open —
+    /// ("Reported"); ambient activity stays "Observed". "Stopped" holds the
+    /// stop shapes — the deliberate handoff, the inferred ended-open, and the
+    /// inferred inactive (open, nothing finished, work moved on elsewhere) —
     /// each row still wearing its own decision word.
     static func forKey(_ key: String?) -> WorkGroup {
         switch key {
@@ -80,7 +81,7 @@ enum WorkGroup: String, CaseIterable, Identifiable {
             return .reported
         case "in_progress", "started", "checkpoint": return .inProgress
         case "observed": return .observed
-        case "handed_off", "ended_open": return .stopped
+        case "handed_off", "ended_open", "inactive": return .stopped
         default: return .other
         }
     }
@@ -448,6 +449,8 @@ enum DecisionLegend {
               definition: "A check failed, but a later run of the same check passed."),
         .init(key: "ended_open", label: "Ended open",
               definition: "The session ended with steps still open; the stop is inferred, not stated."),
+        .init(key: "inactive", label: "Inactive",
+              definition: "Open with nothing finished; work has since continued elsewhere — agentacct inferred it went quiet, it never said done."),
         .init(key: "observed", label: "Observed",
               definition: "Activity was recorded; no outcome was ever stated."),
     ]

--- a/apps/agentacct/Tests/agentacctTests/InactiveDecisionStateTests.swift
+++ b/apps/agentacct/Tests/agentacctTests/InactiveDecisionStateTests.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import XCTest
+@testable import agentacct
+
+/// APP-side rendering of the daemon's honest `inactive` task-status state.
+///
+/// The daemon is the single source of the decision word: an open Task with
+/// nothing recorded finished, where the store demonstrably moved on elsewhere,
+/// reads `decision_status.key == "inactive"`, `asserted_by == "inferred"`,
+/// `label == "Inactive"`, and a non-completion statement. These tests pin that
+/// the app RENDERS that word truthfully and never re-derives the honesty logic:
+/// inactive is quiet (its own Stopped bucket, a neutral non-green tint), it is
+/// never treated as attention, and it never reads done-ish or verified.
+final class InactiveDecisionStateTests: XCTestCase {
+    private func decode<Value: Decodable>(_ type: Value.Type, from json: String) throws -> Value {
+        try JSONDecoder().decode(type, from: Data(json.utf8))
+    }
+
+    /// A daemon-shaped `/v1/tasks` row for an inactive Task: the label and
+    /// statement ride the payload exactly as the daemon emits them.
+    private func inactiveSummary(
+        label: String? = "Inactive",
+        checksFailed: Int? = nil
+    ) throws -> ReceiptSummary {
+        let labelField = label.map { ",\"label\":\"\($0)\"" } ?? ""
+        let failedField = checksFailed.map { ",\"checks_failed\":\($0)" } ?? ""
+        return try decode(
+            ReceiptSummary.self,
+            from: """
+            {
+              "task_id": "went-quiet",
+              "title": "Refactor the importer",
+              "decision_status": {
+                "key": "inactive"\(labelField),
+                "statement": "This Task has open steps, nothing recorded as finished, and work has since continued elsewhere in the store — agentacct inferred it went quiet. Not a completion, and not a stated stop.",
+                "asserted_by": "inferred"
+              },
+              "evidence_strength": { "key": "unchecked"\(failedField) },
+              "cost": {}
+            }
+            """
+        )
+    }
+
+    // MARK: - Lifecycle bucket
+
+    func testInactiveKeyFoldsIntoStoppedBucket() {
+        XCTAssertEqual(WorkGroup.forKey("inactive"), .stopped)
+    }
+
+    func testInactiveTaskGroupsAsStoppedNotAttention() throws {
+        let summary = try inactiveSummary()
+        // A pure renderer: the quiet inferred state sits beside ended_open in
+        // Stopped, never promoted to the review queue.
+        XCTAssertEqual(WorkGroup.forTask(summary), .stopped)
+    }
+
+    // MARK: - Attention exclusion
+
+    func testInactiveNeverEntersAttention() {
+        XCTAssertFalse(workReceiptNeedsAttention(decisionKey: "inactive", checksFailed: nil))
+        XCTAssertFalse(workReceiptNeedsAttention(decisionKey: "inactive", checksFailed: 0))
+    }
+
+    // MARK: - Tint (quiet, never green, never done-ish)
+
+    func testInactiveTintIsNeutralAndNeverGreenOrClaimed() {
+        let tint = DecisionTintClass.forKey("inactive")
+        XCTAssertEqual(tint, .neutral)
+        // Never machine-verified green, never the done-ish claimed cobalt.
+        XCTAssertNotEqual(tint, .verified)
+        XCTAssertNotEqual(tint, .claimed)
+        // The rendered decision colour must not be the verified green.
+        XCTAssertNotEqual(receiptDecisionTint("inactive"), Theme.green)
+    }
+
+    // MARK: - Legend
+
+    func testDecisionLegendCarriesInactiveAsAnInferredNonCompletion() throws {
+        let entry = try XCTUnwrap(
+            DecisionLegend.entries.first { $0.key == "inactive" },
+            "The status legend must define the inactive word."
+        )
+        XCTAssertEqual(entry.label, "Inactive")
+        // The definition states an inference, not a completion.
+        XCTAssertTrue(entry.definition.lowercased().contains("inferred"))
+        XCTAssertFalse(entry.definition.lowercased().contains("verified"))
+        XCTAssertFalse(entry.definition.lowercased().contains("finished successfully"))
+    }
+
+    // MARK: - Dashboard label
+
+    func testDashboardOutcomeUsesDaemonLabelForInactive() throws {
+        let item = DashboardWorkItem(task: try inactiveSummary())
+        XCTAssertEqual(item.outcomeKey, "inactive")
+        XCTAssertEqual(item.outcome, "Inactive")
+    }
+
+    func testDashboardOutcomeFallbackCapitalizesInactiveWhenDaemonOmitsLabel() throws {
+        // Older daemon payload with no explicit label — the fallback still reads
+        // "Inactive", never the raw key.
+        let item = DashboardWorkItem(task: try inactiveSummary(label: nil))
+        XCTAssertEqual(item.outcomeKey, "inactive")
+        XCTAssertEqual(item.outcome, "Inactive")
+    }
+
+    // MARK: - Work row presentation
+
+    func testWorkRowRendersDaemonInactiveWordWithNoAttentionReason() throws {
+        let presentation = WorkReceiptRowPresentation(task: try inactiveSummary())
+        XCTAssertEqual(presentation.decisionKey, "inactive")
+        XCTAssertEqual(presentation.decisionLabel, "Inactive")
+        XCTAssertFalse(presentation.decisionHelp.isEmpty)
+        // Quiet: an inactive Task states no coral attention reason.
+        XCTAssertNil(presentation.attentionReason)
+        XCTAssertFalse(presentation.handedOff)
+    }
+}

--- a/apps/agentacct/Tests/agentacctTests/ReceiptOutcomeSublineTests.swift
+++ b/apps/agentacct/Tests/agentacctTests/ReceiptOutcomeSublineTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import agentacct
+
+/// The Receipt DETAIL Outcome row shows one factual sub-line — "Quiet since …
+/// · a newer session started …" — but ONLY when the daemon attached
+/// `quiet_since` / `newer_session_started_at` (the `inactive`/`mostly_done`
+/// keys). The app is a pure renderer here: it formats the timestamps the daemon
+/// already decided to attach and never derives the honesty logic itself.
+final class ReceiptOutcomeSublineTests: XCTestCase {
+    private func decodeOutcome(_ json: String) throws -> ReceiptOutcomeDim {
+        try JSONDecoder().decode(ReceiptOutcomeDim.self, from: Data(json.utf8))
+    }
+
+    /// Pin the relative clock so `agoText` renders deterministically, then
+    /// restore it — matching how the snapshot renderer freezes the clock.
+    private func withFixedClock(_ now: Date, _ body: () throws -> Void) rethrows {
+        SnapshotMode.setFixtureDate(now)
+        defer { SnapshotMode.setFixtureDate(nil) }
+        try body()
+    }
+
+    func testSublinePresentWhenQuietFieldsSet() throws {
+        // now = quiet_since + 3h; newer session started 2h ago.
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let quietSince = now.timeIntervalSince1970 - 3 * 3600
+        let newerStart = now.timeIntervalSince1970 - 2 * 3600
+        let dim = try decodeOutcome(
+            """
+            {
+              "decision_status": "inactive",
+              "statement": "This Task has open steps and work has since continued elsewhere.",
+              "asserted_by": "inferred",
+              "quiet_since": \(quietSince),
+              "newer_session_started_at": \(newerStart)
+            }
+            """
+        )
+        withFixedClock(now) {
+            let summary = receiptOutcomeSummary(dim)
+            // The decision word + statement still lead the block.
+            XCTAssertTrue(summary.contains("inactive · state inferred"))
+            XCTAssertTrue(summary.contains("This Task has open steps"))
+            // The factual sub-line renders both timestamps, relative + app idiom.
+            XCTAssertTrue(
+                summary.contains("Quiet since 3h ago · a newer session started 2h ago"),
+                "Expected the quiet sub-line, got: \(summary)"
+            )
+        }
+    }
+
+    func testSublineAbsentWhenQuietFieldsMissing() throws {
+        let dim = try decodeOutcome(
+            """
+            {
+              "decision_status": "verified",
+              "statement": "Task finished; checks passed.",
+              "asserted_by": "machine"
+            }
+            """
+        )
+        withFixedClock(Date(timeIntervalSince1970: 1_000_000)) {
+            let summary = receiptOutcomeSummary(dim)
+            XCTAssertTrue(summary.contains("verified · machine checked"))
+            XCTAssertFalse(
+                summary.contains("Quiet since"),
+                "No quiet fields means no sub-line, got: \(summary)"
+            )
+        }
+    }
+
+    func testSublineAbsentWhenQuietFieldsPresentButNull() throws {
+        // The daemon emits present-but-None off the went-quiet keys.
+        let dim = try decodeOutcome(
+            """
+            {
+              "decision_status": "in_progress",
+              "statement": "Still working.",
+              "asserted_by": "inferred",
+              "quiet_since": null,
+              "newer_session_started_at": null
+            }
+            """
+        )
+        withFixedClock(Date(timeIntervalSince1970: 1_000_000)) {
+            let summary = receiptOutcomeSummary(dim)
+            XCTAssertFalse(summary.contains("Quiet since"), "Null fields must not render, got: \(summary)")
+        }
+    }
+
+    func testSublineOmitsNewerSessionClauseWhenOnlyQuietSincePresent() throws {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let quietSince = now.timeIntervalSince1970 - 24 * 3600
+        let dim = try decodeOutcome(
+            """
+            {
+              "decision_status": "mostly_done",
+              "statement": "A step finished; work moved on elsewhere.",
+              "asserted_by": "inferred",
+              "quiet_since": \(quietSince)
+            }
+            """
+        )
+        withFixedClock(now) {
+            let summary = receiptOutcomeSummary(dim)
+            XCTAssertTrue(summary.contains("Quiet since 1d ago"), "got: \(summary)")
+            XCTAssertFalse(summary.contains("a newer session started"), "got: \(summary)")
+        }
+    }
+}

--- a/src/agentacct/api.py
+++ b/src/agentacct/api.py
@@ -106,6 +106,7 @@ from .receipt import (
     build_receipt,
     build_receipt_summary,
     latest_store_activity,
+    session_start_index,
 )
 from .usage_cube import (
     KNOWN_USAGE_CLIENTS,
@@ -1214,6 +1215,7 @@ def _dashboard_receipt_attention(
     tasks: Sequence[Mapping[str, Any]],
     *,
     latest_store_activity_at: float | None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> dict[str, Any]:
     """Exact all-store attention count plus a bounded Dashboard preview.
 
@@ -1229,6 +1231,7 @@ def _dashboard_receipt_attention(
             public_task_id=str(task.get("public_task_id")),
             title=_task_title(task),
             latest_store_activity_at=latest_store_activity_at,
+            session_starts=session_starts,
         )
         priority = _receipt_attention_priority(row)
         if priority is None:
@@ -3086,6 +3089,7 @@ def create_local_api_app(
             projection["_dashboard_receipt_attention"] = _dashboard_receipt_attention(
                 attention_tasks,
                 latest_store_activity_at=latest_store_activity(attention_tasks),
+                session_starts=session_start_index(attention_tasks),
             )
             v1_receipt_projection_cache["projection"] = (fingerprint, time.time(), projection)
             return projection
@@ -3102,6 +3106,7 @@ def create_local_api_app(
     ) -> tuple[
         list[tuple[int, float, str, Mapping[str, Any], dict[str, Any]]],
         float | None,
+        dict[str, float],
         dict[str, int],
         str,
     ]:
@@ -3135,7 +3140,7 @@ def create_local_api_app(
                 return cached[2]
 
             if cached is not None and cached[1] == attention_fingerprint:
-                cached_candidates, _, cached_counts, _ = cached[2]
+                cached_candidates, _, _, cached_counts, _ = cached[2]
                 tasks_by_id = {
                     str(task.get("public_task_id")): task
                     for task in tasks
@@ -3148,6 +3153,7 @@ def create_local_api_app(
                 result = (
                     candidates,
                     latest_store_activity(tasks),
+                    session_start_index(tasks),
                     cached_counts,
                     attention_fingerprint,
                 )
@@ -3159,6 +3165,7 @@ def create_local_api_app(
                 return result
 
             latest = latest_store_activity(tasks)
+            starts = session_start_index(tasks)
             candidates: list[
                 tuple[int, float, str, Mapping[str, Any], dict[str, Any]]
             ] = []
@@ -3167,6 +3174,7 @@ def create_local_api_app(
                 classified = build_attention_reason(
                     task,
                     latest_store_activity_at=latest,
+                    session_starts=starts,
                 )
                 if classified is None:
                     continue
@@ -3183,7 +3191,7 @@ def create_local_api_app(
                     )
                 )
             candidates.sort(key=lambda candidate: candidate[:3])
-            result = (candidates, latest, counts, attention_fingerprint)
+            result = (candidates, latest, starts, counts, attention_fingerprint)
             # The parent projection is rebuilt on a short TTL even when its
             # attention inputs are unchanged. Preserve the reduced/sorted index
             # across those rebuilds by hashing exactly the task state that can
@@ -3214,6 +3222,7 @@ def create_local_api_app(
         projection = _v1_task_projection()
         tasks = _visible_tasks(projection)
         latest = latest_store_activity(tasks)
+        starts = session_start_index(tasks)
         tasks.sort(key=lambda task: float(task.get("last_activity_at") or 0.0), reverse=True)
         total = len(tasks)
         window = tasks[offset : offset + limit]
@@ -3223,6 +3232,7 @@ def create_local_api_app(
                 public_task_id=str(task.get("public_task_id")),
                 title=_task_title(task),
                 latest_store_activity_at=latest,
+                session_starts=starts,
             )
             for task in window
         ]
@@ -3256,7 +3266,7 @@ def create_local_api_app(
 
         _require_v1_token(request)
         projection = _v1_task_projection()
-        candidates, latest, counts, snapshot = _v1_attention_candidates(projection)
+        candidates, latest, starts, counts, snapshot = _v1_attention_candidates(projection)
         selected = candidates[offset : offset + limit]
         items = []
         for _, _, task_id, task, reason in selected:
@@ -3265,6 +3275,7 @@ def create_local_api_app(
                 public_task_id=task_id,
                 title=_task_title(task),
                 latest_store_activity_at=latest,
+                session_starts=starts,
             )
             row["attention"] = reason
             items.append(row)
@@ -3301,6 +3312,7 @@ def create_local_api_app(
             public_task_id=str(selected.get("public_task_id")),
             title=_task_title(selected),
             latest_store_activity_at=latest_store_activity(tasks),
+            session_starts=session_start_index(tasks),
         )
 
     @app.post("/v1/disposition")

--- a/src/agentacct/cli.py
+++ b/src/agentacct/cli.py
@@ -9625,6 +9625,7 @@ def receipts(
         build_receipt_summary,
         evidence_coverage_headline,
         latest_store_activity,
+        session_start_index,
     )
 
     resolved = _resolve_cli_store_dir(store_dir).path
@@ -9635,6 +9636,7 @@ def receipts(
         if isinstance(task, dict) and str(task.get("public_task_id") or "")
     ]
     latest = latest_store_activity(tasks)
+    starts = session_start_index(tasks)
     tasks.sort(key=lambda task: float(task.get("last_activity_at") or 0.0), reverse=True)
     rows = [
         build_receipt_summary(
@@ -9642,6 +9644,7 @@ def receipts(
             public_task_id=str(task.get("public_task_id")),
             title=_task_title(task),
             latest_store_activity_at=latest,
+            session_starts=starts,
         )
         for task in tasks[:limit]
     ]
@@ -9684,7 +9687,7 @@ def receipt(
     axes (decision status × evidence strength), per-field provenance, and gaps."""
 
     from .api import build_store_task_projection, _task_title
-    from .receipt import build_receipt, latest_store_activity
+    from .receipt import build_receipt, latest_store_activity, session_start_index
 
     resolved = _resolve_cli_store_dir(store_dir).path
     projection = build_store_task_projection(resolved)
@@ -9698,6 +9701,7 @@ def receipt(
         public_task_id=str(task.get("public_task_id")),
         title=_task_title(task),
         latest_store_activity_at=latest_store_activity(all_tasks),
+        session_starts=session_start_index(all_tasks),
     )
     if json_output:
         console.print_json(data=receipt_payload)

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -53,6 +53,7 @@ from .task_outcome import (
     step_evidence_grade,
     step_verification_counts,
     task_newest_event_at,
+    task_session_starts,
 )
 
 
@@ -593,10 +594,15 @@ def _decision_status(
     task: Mapping[str, Any],
     *,
     latest_store_activity_at: float | None,
+    session_starts: Mapping[str, float] | None = None,
     canonical: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     if canonical is None:
-        canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
+        canonical = reduce_task_outcome(
+            task,
+            latest_store_activity_at=latest_store_activity_at,
+            session_starts=session_starts,
+        )
     key = _text(canonical.get("key")) or "observed"
 
     # Refine ``failed`` out of ``blocked`` at the Receipt layer without changing
@@ -925,6 +931,7 @@ def _outcome_dimension(
     verification: Mapping[str, Any],
     decision_brief: Mapping[str, Any],
     checks: list[Mapping[str, Any]],
+    canonical: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     asserted_by = _text(decision.get("asserted_by")) or "none"
     gaps: list[str] = []
@@ -933,7 +940,7 @@ def _outcome_dimension(
     # as a gap, never a settled result.
     if decision.get("key") in {"in_progress", "observed", "unknown", "inactive"}:
         gaps.append("No terminal outcome has been recorded for this Task yet.")
-    return {
+    dimension: dict[str, Any] = {
         "decision_status": decision.get("key"),
         "statement": decision.get("statement"),
         "asserted_by": asserted_by,
@@ -947,6 +954,20 @@ def _outcome_dimension(
         "provenance": [_asserted_by_source(asserted_by, checks)],
         "gaps": gaps,
     }
+    # Detail-line facts (#3), surfaced ONLY when the Task went quiet
+    # (inactive / mostly_done): ``quiet_since`` = this Task's newest event (when it
+    # fell silent), ``newer_session_started_at`` = the newer session's start the
+    # went-quiet predicate keyed off. Null on every other outcome. These are
+    # factual timestamps, never a completion claim — the app renders a "quiet since
+    # …" sub-line from them, nothing more.
+    source = canonical if isinstance(canonical, Mapping) else {}
+    if decision.get("key") in {"inactive", "mostly_done"}:
+        dimension["quiet_since"] = source.get("quiet_since")
+        dimension["newer_session_started_at"] = source.get("newer_session_started_at")
+    else:
+        dimension["quiet_since"] = None
+        dimension["newer_session_started_at"] = None
+    return dimension
 
 
 # --- Roll-ups (dimensions 7 & 8) ---------------------------------------------
@@ -1076,6 +1097,7 @@ def build_receipt(
     control: Mapping[str, Any] | None = None,
     timeline_limit: int = 50,
     latest_store_activity_at: float | None = None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> dict[str, Any]:
     """Project one enriched Task into a canonical ``agentacct.receipt.v1``.
 
@@ -1094,13 +1116,21 @@ def build_receipt(
         control=control,
         timeline_limit=timeline_limit,
         latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
     )
     verification = step_verification_counts(task)
     checks = _project_checks(task)
     evidence_strength = _evidence_strength(task, checks, verification)
-    canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
+    canonical = reduce_task_outcome(
+        task,
+        latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
+    )
     decision = _decision_status(
-        task, latest_store_activity_at=latest_store_activity_at, canonical=canonical
+        task,
+        latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
+        canonical=canonical,
     )
     handoff = _handoff_marker(canonical)
     decision_brief = _mapping(intelligence.get("decision_brief"))
@@ -1111,7 +1141,9 @@ def build_receipt(
         "actions": _actions_dimension(task),
         "cost": _cost_dimension(task),
         "evidence": _evidence_dimension(checks, evidence_strength),
-        "outcome": _outcome_dimension(decision, verification, decision_brief, checks),
+        "outcome": _outcome_dimension(
+            decision, verification, decision_brief, checks, canonical
+        ),
     }
     coverage = intelligence.get("coverage") if isinstance(intelligence.get("coverage"), list) else []
     # Roll both meta-dimensions up over ONLY the six content dimensions, before
@@ -1162,6 +1194,7 @@ def build_receipt_summary(
     public_task_id: str,
     title: str,
     latest_store_activity_at: float | None = None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> dict[str, Any]:
     """A compact Receipt row for a task LIST — the two axes plus cost/activity.
 
@@ -1173,9 +1206,16 @@ def build_receipt_summary(
     verification = step_verification_counts(task)
     checks = _project_checks(task)
     evidence_strength = _evidence_strength(task, checks, verification)
-    canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
+    canonical = reduce_task_outcome(
+        task,
+        latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
+    )
     decision = _decision_status(
-        task, latest_store_activity_at=latest_store_activity_at, canonical=canonical
+        task,
+        latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
+        canonical=canonical,
     )
     usage = _mapping(task.get("usage"))
     return {
@@ -1234,6 +1274,7 @@ def build_attention_reason(
     task: Mapping[str, Any],
     *,
     latest_store_activity_at: float | None = None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> tuple[int, dict[str, Any]] | None:
     """Return the operational attention class and its truthful leading reason.
 
@@ -1247,7 +1288,11 @@ def build_attention_reason(
 
     from .finding_disposition import finding_target_digest
 
-    canonical = reduce_task_outcome(task, latest_store_activity_at=latest_store_activity_at)
+    canonical = reduce_task_outcome(
+        task,
+        latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
+    )
     episodes = task.get("finding_episodes") if isinstance(task.get("finding_episodes"), list) else []
     disposition_by_digest = {
         str(episode.get("target_digest")): _text(episode.get("disposition_state")) or "open"
@@ -1324,6 +1369,7 @@ def build_attention_reason(
     decision = _decision_status(
         task,
         latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
         canonical=canonical,
     )
     key = _text(decision.get("key"))
@@ -1357,6 +1403,28 @@ def latest_store_activity(tasks: list[Mapping[str, Any]]) -> float | None:
     return newest or None
 
 
+def session_start_index(tasks: list[Mapping[str, Any]]) -> dict[str, float]:
+    """Each session's START (earliest event timestamp) across the whole store.
+
+    The sibling of ``latest_store_activity``: computed once by the caller that
+    already holds every Task and threaded into ``reduce_task_outcome`` /
+    ``build_receipt*`` as ``session_starts``. It maps ``client_session_id`` to the
+    MINIMUM of that session's earliest event timestamp seen in any Task (a session
+    may contribute work items / checks to more than one Task projection). Sessions'
+    ``last_activity_at`` is a latest, not a start, so it is never used — see
+    ``task_session_starts``. The went-quiet predicate uses this to require a
+    genuinely NEWER session before it downgrades a Task."""
+
+    starts: dict[str, float] = {}
+    for task in tasks:
+        if not isinstance(task, Mapping):
+            continue
+        for session_id, start in task_session_starts(task).items():
+            if session_id not in starts or start < starts[session_id]:
+                starts[session_id] = start
+    return starts
+
+
 __all__ = [
     "V1_ATTENTION_SCHEMA_VERSION",
     "RECEIPT_SCHEMA_VERSION",
@@ -1368,4 +1436,5 @@ __all__ = [
     "evidence_coverage_headline",
     "evidence_coverage_ledger",
     "latest_store_activity",
+    "session_start_index",
 ]

--- a/src/agentacct/receipt.py
+++ b/src/agentacct/receipt.py
@@ -115,6 +115,10 @@ _DECISION_ASSERTED_BY: dict[str, str] = {
     # Inferred by agentacct from an ambient SessionEnd event — the weakest
     # provenance, deliberately NOT agent_report (the agent never said this).
     "ended_open": "inferred",
+    # Inferred by agentacct from the store moving on elsewhere while this Task's
+    # open steps recorded nothing finished — the same weakest provenance as
+    # ended_open (agentacct's own inference), never a completion or a stated stop.
+    "inactive": "inferred",
     "in_progress": "agent_report",
     "observed": "none",
     "unknown": "none",
@@ -144,6 +148,10 @@ _DECISION_STATEMENTS: dict[str, str] = {
         "The session ended with this step still open; agentacct inferred a stop from the session-end "
         "event — not a recorded completion or a deliberate handoff."
     ),
+    "inactive": (
+        "This Task has open steps, nothing recorded as finished, and work has since continued elsewhere "
+        "in the store — agentacct inferred it went quiet. Not a completion, and not a stated stop."
+    ),
     "mostly_done": "Recorded steps completed while one or more were left open; not a claim the Task is finished.",
     "in_progress": "This Task is still in progress.",
     "observed": "agentacct observed this Task but no outcome was recorded.",
@@ -154,6 +162,9 @@ _DECISION_STATEMENTS: dict[str, str] = {
 _DECISION_LABELS: dict[str, str] = {
     "finding_resolved_by_user": "Finding resolved",
     "blocker_resolved_by_user": "Blocker resolved",
+    # Mechanical Title Case already yields "Inactive"; pinned so every surface
+    # reads the daemon's one word and the label never drifts.
+    "inactive": "Inactive",
 }
 
 _SUCCESS_STATUSES = {"completed", "passed", "resolved"}
@@ -917,7 +928,10 @@ def _outcome_dimension(
 ) -> dict[str, Any]:
     asserted_by = _text(decision.get("asserted_by")) or "none"
     gaps: list[str] = []
-    if decision.get("key") in {"in_progress", "observed", "unknown"}:
+    # ``inactive`` joins the non-terminal set: agentacct inferred the Task went
+    # quiet, but nothing finished — so it still owes a terminal outcome and reads
+    # as a gap, never a settled result.
+    if decision.get("key") in {"in_progress", "observed", "unknown", "inactive"}:
         gaps.append("No terminal outcome has been recorded for this Task yet.")
     return {
         "decision_status": decision.get("key"),

--- a/src/agentacct/task_intelligence.py
+++ b/src/agentacct/task_intelligence.py
@@ -129,6 +129,7 @@ def _state_axes(
             "resolved",
             "handed_off",
             "ended_open",
+            "inactive",
             "mostly_done",
         }
         else "unknown"
@@ -182,6 +183,7 @@ def _decision_brief(
         "reported": "The agent reported completing work; no check verifies the completion claim itself.",
         "handed_off": "The work was cleanly handed off (continued elsewhere or in a new session); this is a deliberate stop, not a completed or verified outcome.",
         "ended_open": "The session ended with a step still open; agentacct inferred a stop from the session-end event — this is not a recorded completion or a deliberate handoff.",
+        "inactive": "This Task has open steps, nothing recorded as finished, and work has since continued elsewhere in the store; agentacct inferred it went quiet — this is not a completion and not a stated stop.",
         "mostly_done": "Recorded steps completed while one or more were left open without a terminal record; this is not a claim the Task is finished.",
         "unknown": "agentacct observed this Task but no outcome was recorded.",
     }[outcome]

--- a/src/agentacct/task_intelligence.py
+++ b/src/agentacct/task_intelligence.py
@@ -87,6 +87,7 @@ def _state_axes(
     control: Mapping[str, Any] | None,
     *,
     latest_store_activity_at: float | None = None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> dict[str, dict[str, str]]:
     items = _items(task)
     attempt = _latest_attempt(control)
@@ -111,7 +112,9 @@ def _state_axes(
 
     canonical_outcome = str(
         reduce_task_outcome(
-            task, latest_store_activity_at=latest_store_activity_at
+            task,
+            latest_store_activity_at=latest_store_activity_at,
+            session_starts=session_starts,
         ).get("key")
         or "observed"
     )
@@ -158,9 +161,12 @@ def _decision_brief(
     axes: Mapping[str, Mapping[str, str]],
     *,
     latest_store_activity_at: float | None = None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> dict[str, Any]:
     canonical = reduce_task_outcome(
-        task, latest_store_activity_at=latest_store_activity_at
+        task,
+        latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
     )
     finding = canonical.get("finding") if isinstance(canonical.get("finding"), Mapping) else None
     verification = (
@@ -464,10 +470,16 @@ def build_task_intelligence(
     control: Mapping[str, Any] | None = None,
     timeline_limit: int = 50,
     latest_store_activity_at: float | None = None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> dict[str, Any]:
     if timeline_limit < 1 or timeline_limit > 200:
         raise ValueError("timeline_limit must be between 1 and 200")
-    axes = _state_axes(task, control, latest_store_activity_at=latest_store_activity_at)
+    axes = _state_axes(
+        task,
+        control,
+        latest_store_activity_at=latest_store_activity_at,
+        session_starts=session_starts,
+    )
     timeline, total = _timeline(task, control, limit=timeline_limit)
     usage = task.get("usage") if isinstance(task.get("usage"), Mapping) else {}
     return {
@@ -476,7 +488,10 @@ def build_task_intelligence(
         "title": title,
         "states": axes,
         "decision_brief": _decision_brief(
-            task, axes, latest_store_activity_at=latest_store_activity_at
+            task,
+            axes,
+            latest_store_activity_at=latest_store_activity_at,
+            session_starts=session_starts,
         ),
         # DECISION 3b: partial verification, not all-or-nothing. Surfaces can say
         # "N of M steps verified" instead of one verified/grey flag for the Task.

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -31,6 +31,12 @@ _HANDED_OFF_STATUS = "handed_off"
 # against a DETERMINISTIC store timestamp, never the wall clock, so the state
 # cannot flip between two reads at a time boundary. It only ever downgrades "in
 # progress" to an equally honest partial state; it never infers completion.
+#
+# This is the SINGLE knob for "the store went quiet on this Task": it governs BOTH
+# ``mostly_done`` (open steps + at least one completed step) AND ``inactive`` (open
+# steps + NOTHING finished). Both split on the exact same predicate
+# (``task_went_quiet_elsewhere``), so the two states share one boundary and can
+# never disagree about the middle zone. Owner's 24–48h range is this one line.
 _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS = 24 * 60 * 60
 
 # --- Per-step evidence grade (M2) --------------------------------------------
@@ -432,6 +438,38 @@ def task_newest_event_at(task: Mapping[str, Any]) -> float:
     return max(candidates, default=0.0)
 
 
+def task_went_quiet_elsewhere(
+    task: Mapping[str, Any], latest_store_activity_at: float | None
+) -> bool:
+    """Did the store DEMONSTRABLY keep working elsewhere long after this Task froze?
+
+    The ONE deterministic predicate behind both the ``mostly_done`` split (open
+    steps + a completed step) and the ``inactive`` split (open steps + nothing
+    finished). Keeping it a single named helper is deliberate: it guarantees the
+    two states can never drift onto different boundaries and open an inconsistent
+    middle zone.
+
+    True only when the store's own latest activity postdates this Task's newest
+    event by more than ``_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS``. It is compared
+    against a DETERMINISTIC store timestamp (``latest_store_activity_at``), never
+    the wall clock, so the answer cannot flip between two reads at a time
+    boundary. Every edge case resolves toward NOT firing, so silence / skew can
+    only ever KEEP a Task active, never falsely retire it:
+
+      * ``latest_store_activity_at is None`` (single-Task read / not plumbed) -> False.
+      * this Task's newest event is missing or zero -> False.
+      * this Task IS the store's latest activity (equal to the global max) -> the
+        strict ``>`` is False, so a live/frontier Task never trips its own rule.
+    """
+
+    if latest_store_activity_at is None:
+        return False
+    newest = task_newest_event_at(task)
+    if newest <= 0.0:
+        return False
+    return latest_store_activity_at > newest + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+
+
 def reduce_task_outcome(
     task: Mapping[str, Any], *, latest_store_activity_at: float | None = None
 ) -> dict[str, Any]:
@@ -673,6 +711,11 @@ def reduce_task_outcome(
             "handoff_current": handoff_current,
             **step_counts,
         }
+    # ``went_quiet`` rides the returned dict so surfaces can render a factual
+    # "quiet since <task_newest_event_at>" sub-line without re-deriving it. It is
+    # only meaningful on the open-step branch (mostly_done / inactive); every
+    # other terminal/non-open key leaves it at the honest default of False.
+    went_quiet = False
     if statuses and any(status == _RESOLVED_STATUS for status in statuses) and all(
         status in _SUCCESS_STATUSES or status == _RESOLVED_STATUS
         for status in statuses
@@ -700,27 +743,31 @@ def reduce_task_outcome(
         # receipt). Never fabricates ``completed``.
         key = "ended_open"
     elif open_step_count:
-        # DECISION 3a: one un-closed step must not drag a mostly-finished Task to
-        # plain "in progress" — but silence is NOT evidence of abandonment. The
-        # open step stays open in the DATA; we only summarise the Task honestly.
-        # A frozen open Task flips to "mostly done" ONLY when at least one step
-        # actually completed AND the user demonstrably kept working ELSEWHERE in
-        # the store afterward: the store's latest activity postdates this Task's
-        # newest event by more than ``_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS``. If
-        # nothing later happened anywhere (the user was merely away), or this Task
-        # IS the store's latest activity, it stays "in progress" no matter how old
-        # — we never infer abandonment from absence. Fully deterministic from
+        # DECISION 3a / inactive: one un-closed step must not drag a Task to plain
+        # "in progress" when the store has DEMONSTRABLY moved on elsewhere — but
+        # silence is NOT evidence of abandonment. The open step stays open in the
+        # DATA; we only summarise the Task honestly. Both downgrades split on the
+        # ONE deterministic ``task_went_quiet_elsewhere`` predicate (the store's
+        # latest activity postdates this Task's newest event by more than
+        # ``_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS``), so they share one boundary:
+        #   * quiet AND a completed step -> ``mostly_done`` (some work landed).
+        #   * quiet AND nothing finished  -> ``inactive`` (open, nothing proven,
+        #     work continued elsewhere — agentacct INFERRED it went quiet; a
+        #     downgrade of a possibly-misleading "In progress", never a completion
+        #     or verification claim, provenance ``inferred``).
+        #   * otherwise                   -> ``in_progress``.
+        # If nothing later happened anywhere (the user was merely away), or this
+        # Task IS the store's latest activity, it stays "in progress" no matter how
+        # old — we never infer abandonment from absence. Fully deterministic from
         # stored data (no wall clock), so the state cannot flip between reads.
         has_completed_step = any(status in _SUCCESS_STATUSES for status in statuses)
-        this_task_newest_event_at = task_newest_event_at(task)
-        left_behind = (
-            has_completed_step
-            and latest_store_activity_at is not None
-            and this_task_newest_event_at > 0.0
-            and latest_store_activity_at
-            > this_task_newest_event_at + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
-        )
-        key = "mostly_done" if left_behind else "in_progress"
+        went_quiet = task_went_quiet_elsewhere(task, latest_store_activity_at)
+        if went_quiet and has_completed_step:
+            key = "mostly_done"
+        elif went_quiet:
+            key = "inactive"
+        else:
+            key = "in_progress"
     elif not items:
         key = "observed"
     else:
@@ -832,6 +879,9 @@ def reduce_task_outcome(
         "max_work_updated_at": max_work_updated_at,
         "open_step_count": open_step_count,
         "handoff_current": handoff_current,
+        # True only when this Task went quiet elsewhere (drives inactive /
+        # mostly_done); a factual sub-line signal, never a completion claim.
+        "went_quiet": went_quiet,
         **step_counts,
     }
 
@@ -844,6 +894,7 @@ __all__ = [
     "latest_check_events",
     "latest_task_checks",
     "task_newest_event_at",
+    "task_went_quiet_elsewhere",
     "reduce_task_outcome",
     "EVIDENCE_GRADE_RANK",
     "GRADE_NONE",

--- a/src/agentacct/task_outcome.py
+++ b/src/agentacct/task_outcome.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from typing import Any, Mapping
 
 from .finding_disposition import finding_target_digest
@@ -24,20 +25,24 @@ _HANDED_OFF_STATUS = "handed_off"
 # reading silence as abandonment. Absence of activity is not evidence a Task was
 # abandoned — the user may have been asleep, away, or out for the day. The only
 # honest signal that a frozen Task was LEFT BEHIND (not merely paused) is that the
-# user DEMONSTRABLY kept working ELSEWHERE in the store afterward: the store's
-# latest activity postdates this Task's newest event by more than this buffer. 24h
-# comfortably clears an overnight gap and a normal day away, so being absent never
-# looks like moving on; only later activity somewhere else does. This is compared
-# against a DETERMINISTIC store timestamp, never the wall clock, so the state
-# cannot flip between two reads at a time boundary. It only ever downgrades "in
-# progress" to an equally honest partial state; it never infers completion.
+# user DEMONSTRABLY moved on to a genuinely NEW SESSION elsewhere and then kept
+# working long enough afterward that this Task can no longer be read as a normal
+# pause. The buffer is counted FROM THAT NEW SESSION'S START (not from this Task's
+# last event, and never from the wall clock): the store's latest activity must
+# postdate the first brand-new session's start by more than this buffer. 48h
+# comfortably clears an overnight gap, a normal day away, and a weekend, so merely
+# being absent never looks like moving on; only a newer session plus sustained
+# later activity does. Because both the newer-session start and the store's latest
+# activity are DETERMINISTIC stored timestamps, the state cannot flip between two
+# reads at a time boundary. It only ever downgrades "in progress" to an equally
+# honest partial state; it never infers completion.
 #
 # This is the SINGLE knob for "the store went quiet on this Task": it governs BOTH
 # ``mostly_done`` (open steps + at least one completed step) AND ``inactive`` (open
 # steps + NOTHING finished). Both split on the exact same predicate
 # (``task_went_quiet_elsewhere``), so the two states share one boundary and can
-# never disagree about the middle zone. Owner's 24–48h range is this one line.
-_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS = 24 * 60 * 60
+# never disagree about the middle zone.
+_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS = 48 * 60 * 60
 
 # --- Per-step evidence grade (M2) --------------------------------------------
 # ONE vocabulary, shared by the per-step grade and the task-level headline,
@@ -438,10 +443,110 @@ def task_newest_event_at(task: Mapping[str, Any]) -> float:
     return max(candidates, default=0.0)
 
 
+def _finite_positive(value: Any) -> bool:
+    """A usable timestamp: a real, finite, strictly-positive number.
+
+    Guards every arithmetic input so NaN / inf / missing / non-positive values can
+    only ever resolve the went-quiet predicate toward NOT firing.
+    """
+
+    number = _number(value)
+    return math.isfinite(number) and number > 0.0
+
+
+def _task_session_ids(task: Mapping[str, Any]) -> set[str]:
+    """The ``client_session_id`` values belonging to THIS Task's own events.
+
+    Read from the work steps and check/evidence events (the reducer's own event
+    surface). A session in the store-wide start index that appears here is this
+    Task's own session and can never count as the "newer session elsewhere".
+    """
+
+    ids: set[str] = set()
+    for item in _items(task):
+        session_id = _text(item.get("client_session_id"))
+        if session_id:
+            ids.add(session_id)
+    for event in _all_check_events(task):
+        session_id = _text(event.get("client_session_id"))
+        if session_id:
+            ids.add(session_id)
+    return ids
+
+
+def task_session_starts(task: Mapping[str, Any]) -> dict[str, float]:
+    """Earliest recorded event timestamp per ``client_session_id`` in this Task.
+
+    A session's START is the MINIMUM over its work steps (``started_at`` then
+    ``updated_at``) and its check / evidence events (``created_at`` then
+    ``occurred_at`` then ``time``). Session objects' ``last_activity_at`` is a
+    LATEST, never a start, so it is deliberately NOT consulted here. The caller
+    (``receipt.session_start_index``) merges these per-Task maps across the whole
+    store, taking the MIN per session id, to get each session's true first
+    timestamp. Non-finite / non-positive timestamps are dropped.
+    """
+
+    starts: dict[str, float] = {}
+
+    def _consider(session_id: Any, timestamp: Any) -> None:
+        sid = _text(session_id)
+        if not sid or not _finite_positive(timestamp):
+            return
+        value = _number(timestamp)
+        if sid not in starts or value < starts[sid]:
+            starts[sid] = value
+
+    for item in _items(task):
+        _consider(
+            item.get("client_session_id"),
+            item.get("started_at") or item.get("updated_at"),
+        )
+    for event in _all_check_events(task):
+        _consider(
+            event.get("client_session_id"),
+            event.get("created_at") or event.get("occurred_at") or event.get("time"),
+        )
+    return starts
+
+
+def newer_session_start_after(
+    task: Mapping[str, Any],
+    session_starts: Mapping[str, float] | None,
+    *,
+    newest: float | None = None,
+) -> float | None:
+    """The first brand-new session that began AFTER this Task went quiet.
+
+    The MINIMUM session-start, across the whole store, among sessions that do NOT
+    belong to this Task and whose start is STRICTLY AFTER this Task's newest event.
+    ``None`` when no such session exists (or the inputs are missing / skewed),
+    which resolves the went-quiet predicate toward NOT firing.
+    """
+
+    if not session_starts:
+        return None
+    if newest is None:
+        newest = task_newest_event_at(task)
+    if not _finite_positive(newest):
+        return None
+    own = _task_session_ids(task)
+    candidates = [
+        _number(start)
+        for session_id, start in session_starts.items()
+        if _text(session_id) not in own
+        and _finite_positive(start)
+        and _number(start) > newest
+    ]
+    return min(candidates) if candidates else None
+
+
 def task_went_quiet_elsewhere(
-    task: Mapping[str, Any], latest_store_activity_at: float | None
+    task: Mapping[str, Any],
+    latest_store_activity_at: float | None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> bool:
-    """Did the store DEMONSTRABLY keep working elsewhere long after this Task froze?
+    """Did the user DEMONSTRABLY move on to a NEW SESSION and keep working long
+    after this Task froze?
 
     The ONE deterministic predicate behind both the ``mostly_done`` split (open
     steps + a completed step) and the ``inactive`` split (open steps + nothing
@@ -449,29 +554,49 @@ def task_went_quiet_elsewhere(
     two states can never drift onto different boundaries and open an inconsistent
     middle zone.
 
-    True only when the store's own latest activity postdates this Task's newest
-    event by more than ``_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS``. It is compared
-    against a DETERMINISTIC store timestamp (``latest_store_activity_at``), never
-    the wall clock, so the answer cannot flip between two reads at a time
-    boundary. Every edge case resolves toward NOT firing, so silence / skew can
-    only ever KEEP a Task active, never falsely retire it:
+    True only when there is a genuinely NEWER SESSION — one not belonging to this
+    Task whose start is strictly after this Task's newest event — AND the store's
+    own latest activity postdates THAT new session's start by at least
+    ``_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS``. Both the newer-session start and
+    ``latest_store_activity_at`` are DETERMINISTIC stored timestamps, never the
+    wall clock, so the answer cannot flip between two reads at a time boundary.
+    Every edge case resolves toward NOT firing, so silence / skew can only ever
+    KEEP a Task active, never falsely retire it:
 
-      * ``latest_store_activity_at is None`` (single-Task read / not plumbed) -> False.
-      * this Task's newest event is missing or zero -> False.
-      * this Task IS the store's latest activity (equal to the global max) -> the
-        strict ``>`` is False, so a live/frontier Task never trips its own rule.
+      * ``latest_store_activity_at is None`` / non-finite -> False.
+      * ``session_starts is None`` (single-Task read / not plumbed) -> False.
+      * this Task's newest event is missing / zero / non-finite -> False.
+      * no qualifying newer session (none outside this Task started strictly after
+        this Task's newest event) -> False.
+      * a newer session exists but the store's latest activity is < 48h past that
+        session's start -> False.
+      * future-dated / skewed timestamps -> the finite/strict-``>`` guards resolve
+        to False. In particular, when this Task IS the store's latest activity, no
+        session's start can be strictly after this Task's newest event, so a
+        live/frontier Task never trips its own rule.
     """
 
-    if latest_store_activity_at is None:
+    if latest_store_activity_at is None or not math.isfinite(latest_store_activity_at):
         return False
     newest = task_newest_event_at(task)
-    if newest <= 0.0:
+    if not _finite_positive(newest):
         return False
-    return latest_store_activity_at > newest + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+    newer_session_start = newer_session_start_after(
+        task, session_starts, newest=newest
+    )
+    if newer_session_start is None:
+        return False
+    return (
+        latest_store_activity_at
+        >= newer_session_start + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+    )
 
 
 def reduce_task_outcome(
-    task: Mapping[str, Any], *, latest_store_activity_at: float | None = None
+    task: Mapping[str, Any],
+    *,
+    latest_store_activity_at: float | None = None,
+    session_starts: Mapping[str, float] | None = None,
 ) -> dict[str, Any]:
     """Reduce work status and checks into one honest current Task outcome.
 
@@ -482,11 +607,17 @@ def reduce_task_outcome(
     ``latest_store_activity_at`` (seconds) is the DECISION 3a cross-session
     signal: the newest activity timestamp anywhere in the store (all
     sessions/tasks, including usage-only activity), computed once by the caller
-    that already holds every Task and passed in. It is compared ONLY against this
-    Task's own newest event — never the wall clock — so the outcome is
-    deterministic and stable across reads. When it is omitted (or the store has
-    no later activity anywhere), a frozen open Task stays ``in_progress``:
-    absence of activity is never read as abandonment. See
+    that already holds every Task and passed in. ``session_starts`` maps every
+    ``client_session_id`` in the store to its earliest event timestamp (see
+    ``task_session_starts`` / ``receipt.session_start_index``), likewise computed
+    once by the caller. Together they drive ``task_went_quiet_elsewhere``: a Task
+    is downgraded only when a genuinely NEWER SESSION began after this Task froze
+    AND the store kept working for at least
+    ``_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS`` past that new session's start. Both
+    inputs are compared against stored timestamps — never the wall clock — so the
+    outcome is deterministic and stable across reads. When either is omitted (or
+    there is no qualifying newer session), a frozen open Task stays
+    ``in_progress``: absence of activity is never read as abandonment. See
     ``_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS``.
 
     NOTE (DECISION 3c): the product strip has a fourth "outcome" stage that this
@@ -715,7 +846,14 @@ def reduce_task_outcome(
     # "quiet since <task_newest_event_at>" sub-line without re-deriving it. It is
     # only meaningful on the open-step branch (mostly_done / inactive); every
     # other terminal/non-open key leaves it at the honest default of False.
+    # ``quiet_since`` (this Task's newest event — when it went quiet) and
+    # ``newer_session_started_at`` (the first newer session's start) are factual
+    # timestamps for the Receipt detail line, set ONLY when the Task went quiet
+    # (i.e. inactive / mostly_done); they stay None on every other key. Neither is
+    # ever a completion claim.
     went_quiet = False
+    quiet_since: float | None = None
+    newer_session_started_at: float | None = None
     if statuses and any(status == _RESOLVED_STATUS for status in statuses) and all(
         status in _SUCCESS_STATUSES or status == _RESOLVED_STATUS
         for status in statuses
@@ -761,7 +899,21 @@ def reduce_task_outcome(
         # old — we never infer abandonment from absence. Fully deterministic from
         # stored data (no wall clock), so the state cannot flip between reads.
         has_completed_step = any(status in _SUCCESS_STATUSES for status in statuses)
-        went_quiet = task_went_quiet_elsewhere(task, latest_store_activity_at)
+        went_quiet = task_went_quiet_elsewhere(
+            task, latest_store_activity_at, session_starts
+        )
+        if went_quiet:
+            # Factual timestamps for the Receipt detail line (#3), populated only
+            # when the went-quiet predicate actually fired — so they land exactly
+            # on ``inactive`` / ``mostly_done`` and nowhere else. ``quiet_since``
+            # is this Task's newest event (when it fell silent);
+            # ``newer_session_started_at`` is the newer session's start the
+            # predicate keyed off. Never a completion claim.
+            newest_at = task_newest_event_at(task)
+            quiet_since = newest_at or None
+            newer_session_started_at = newer_session_start_after(
+                task, session_starts, newest=newest_at
+            )
         if went_quiet and has_completed_step:
             key = "mostly_done"
         elif went_quiet:
@@ -882,6 +1034,12 @@ def reduce_task_outcome(
         # True only when this Task went quiet elsewhere (drives inactive /
         # mostly_done); a factual sub-line signal, never a completion claim.
         "went_quiet": went_quiet,
+        # Factual timestamps for the Receipt detail line, present (non-None) ONLY
+        # on inactive / mostly_done. ``quiet_since`` = this Task's newest event
+        # (when it went quiet); ``newer_session_started_at`` = the newer session's
+        # start the predicate keyed off. Facts, never a completion claim.
+        "quiet_since": quiet_since,
+        "newer_session_started_at": newer_session_started_at,
         **step_counts,
     }
 
@@ -894,6 +1052,8 @@ __all__ = [
     "latest_check_events",
     "latest_task_checks",
     "task_newest_event_at",
+    "task_session_starts",
+    "newer_session_start_after",
     "task_went_quiet_elsewhere",
     "reduce_task_outcome",
     "EVIDENCE_GRADE_RANK",

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1381,7 +1381,11 @@ class ReceiptsScreen(Screen):
         app = self.app
         try:
             from .api import build_store_task_projection, _task_title
-            from .receipt import build_receipt_summary, latest_store_activity
+            from .receipt import (
+                build_receipt_summary,
+                latest_store_activity,
+                session_start_index,
+            )
 
             projection = build_store_task_projection(app.store_dir)
             tasks = [
@@ -1390,6 +1394,7 @@ class ReceiptsScreen(Screen):
                 if isinstance(task, dict) and str(task.get("public_task_id") or "")
             ]
             latest = latest_store_activity(tasks)
+            starts = session_start_index(tasks)
             tasks.sort(key=lambda task: float(task.get("last_activity_at") or 0.0), reverse=True)
             rows = [
                 (
@@ -1399,6 +1404,7 @@ class ReceiptsScreen(Screen):
                         public_task_id=str(task.get("public_task_id")),
                         title=_task_title(task),
                         latest_store_activity_at=latest,
+                        session_starts=starts,
                     ),
                 )
                 for task in tasks[:_RECEIPTS_LIMIT]
@@ -1488,13 +1494,18 @@ class ReceiptDetailScreen(Screen):
         with VerticalScroll(id="detail-scroll"):
             try:
                 from .api import _task_title
-                from .receipt import build_receipt, latest_store_activity
+                from .receipt import (
+                    build_receipt,
+                    latest_store_activity,
+                    session_start_index,
+                )
 
                 receipt = build_receipt(
                     self._task_record,
                     public_task_id=str(self._task_record.get("public_task_id")),
                     title=_task_title(self._task_record),
                     latest_store_activity_at=latest_store_activity([self._task_record]),
+                    session_starts=session_start_index([self._task_record]),
                 )
                 markup = _render_receipt_markup(receipt)
             except Exception as exc:  # noqa: BLE001 - surface, never crash the screen.

--- a/src/agentacct/tui.py
+++ b/src/agentacct/tui.py
@@ -1176,6 +1176,9 @@ def _receipt_decision_color(key: str) -> str:
         "reported": "yellow",
         "mostly_done": "yellow",
         "in_progress": "yellow",
+        # A quiet, non-alarming, non-green tint: inactive is an inferred downgrade
+        # of "In progress", never a completion — so it must not read green.
+        "inactive": "blue",
         "handed_off": "blue",
         "resolved": "blue",
         "finding_superseded": "blue",

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -16,6 +16,7 @@ from agentacct.receipt import (
     build_receipt,
     plan_share_headline,
 )
+from agentacct.task_outcome import _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
 
 
 def _check(
@@ -179,6 +180,37 @@ def test_ended_open_is_inferred_and_never_claims_completion() -> None:
     assert "inferred" in decision["statement"].lower()
     assert "complet" not in decision["statement"].lower() or "not a recorded completion" in decision["statement"].lower()
     assert receipt["dimensions"]["outcome"]["provenance"] == ["inferred"]
+
+
+def test_inactive_is_inferred_and_never_claims_completion() -> None:
+    # A Task with open steps, nothing finished, that the store moved on past by
+    # more than the threshold surfaces as the ``inactive`` decision word:
+    # asserted_by=inferred (weakest provenance), a statement that never claims
+    # completion, an inferred-source outcome provenance, a terminal-outcome gap,
+    # and — crucially — it is NOT queued for attention.
+    task = _task(
+        [
+            {"work_id": "a", "latest_status": "started", "updated_at": 100.0},
+            {"work_id": "b", "latest_status": "checkpoint", "updated_at": 100.0},
+        ]
+    )
+    quiet_now = 100.0 + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
+    receipt = build_receipt(
+        task, public_task_id="task_x", title="t", latest_store_activity_at=quiet_now
+    )
+    decision = receipt["axes"]["decision_status"]
+    assert decision["key"] == "inactive"
+    assert decision["label"] == "Inactive"
+    assert decision["asserted_by"] == "inferred"
+    assert "inferred" in decision["statement"].lower()
+    assert "not a completion" in decision["statement"].lower()
+    # The outcome dimension carries the inferred source and still owes a terminal
+    # outcome (a gap), never a settled result.
+    outcome_dim = receipt["dimensions"]["outcome"]
+    assert outcome_dim["provenance"] == ["inferred"]
+    assert any("No terminal outcome" in gap for gap in outcome_dim["gaps"])
+    # Inactive is a calm downgrade, not an attention item.
+    assert build_attention_reason(task, latest_store_activity_at=quiet_now) is None
 
 
 def test_resumed_task_receipt_shows_no_handoff_marker() -> None:

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -179,7 +179,12 @@ def test_ended_open_is_inferred_and_never_claims_completion() -> None:
     assert decision["asserted_by"] == "inferred"
     assert "inferred" in decision["statement"].lower()
     assert "complet" not in decision["statement"].lower() or "not a recorded completion" in decision["statement"].lower()
-    assert receipt["dimensions"]["outcome"]["provenance"] == ["inferred"]
+    outcome_dim = receipt["dimensions"]["outcome"]
+    assert outcome_dim["provenance"] == ["inferred"]
+    # The quiet detail-line timestamps are only for inactive / mostly_done; on any
+    # other key (here ended_open) they are present-but-None, never a stray fact.
+    assert outcome_dim["quiet_since"] is None
+    assert outcome_dim["newer_session_started_at"] is None
 
 
 def test_inactive_is_inferred_and_never_claims_completion() -> None:
@@ -194,9 +199,17 @@ def test_inactive_is_inferred_and_never_claims_completion() -> None:
             {"work_id": "b", "latest_status": "checkpoint", "updated_at": 100.0},
         ]
     )
-    quiet_now = 100.0 + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
+    # The 48h + newer-session rule: a distinct session began at 160.0 (after this
+    # Task's newest event at 100.0) and the store kept working past the buffer.
+    newer_session_start = 160.0
+    session_starts = {"elsewhere": newer_session_start}
+    quiet_now = newer_session_start + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
     receipt = build_receipt(
-        task, public_task_id="task_x", title="t", latest_store_activity_at=quiet_now
+        task,
+        public_task_id="task_x",
+        title="t",
+        latest_store_activity_at=quiet_now,
+        session_starts=session_starts,
     )
     decision = receipt["axes"]["decision_status"]
     assert decision["key"] == "inactive"
@@ -209,8 +222,18 @@ def test_inactive_is_inferred_and_never_claims_completion() -> None:
     outcome_dim = receipt["dimensions"]["outcome"]
     assert outcome_dim["provenance"] == ["inferred"]
     assert any("No terminal outcome" in gap for gap in outcome_dim["gaps"])
+    # The factual detail-line timestamps ride the outcome dimension on inactive:
+    # quiet_since = when this Task fell silent; newer_session_started_at = the
+    # newer session's start. Facts for the app to render, never a completion claim.
+    assert outcome_dim["quiet_since"] == 100.0
+    assert outcome_dim["newer_session_started_at"] == newer_session_start
     # Inactive is a calm downgrade, not an attention item.
-    assert build_attention_reason(task, latest_store_activity_at=quiet_now) is None
+    assert (
+        build_attention_reason(
+            task, latest_store_activity_at=quiet_now, session_starts=session_starts
+        )
+        is None
+    )
 
 
 def test_resumed_task_receipt_shows_no_handoff_marker() -> None:

--- a/tests/test_receipt_tui.py
+++ b/tests/test_receipt_tui.py
@@ -82,6 +82,16 @@ def _seed(store: Path) -> None:
     )
 
 
+def test_receipt_decision_color_inactive_is_calm_and_never_green() -> None:
+    # inactive is an inferred downgrade of "In progress", never a completion — it
+    # must read as a calm, non-alarming tint, never green.
+    from agentacct.tui import _receipt_decision_color
+
+    color = _receipt_decision_color("inactive")
+    assert color != "green"
+    assert color == "blue"
+
+
 def test_render_receipt_markup_contains_axes_and_dimensions() -> None:
     task = {
         "task_id": "task_x",

--- a/tests/test_task_intelligence.py
+++ b/tests/test_task_intelligence.py
@@ -62,12 +62,18 @@ def test_inactive_outcome_axis_is_not_collapsed_and_carries_its_statement() -> N
             {"work_id": "w2", "latest_status": "checkpoint", "updated_at": 100.0},
         ],
     }
-    quiet_now = 100.0 + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
+    # The new rule needs a genuinely NEWER session (not this Task's own) plus the
+    # store running >= 48h past its start. This Task's newest event is 100.0; a
+    # distinct session began at 160.0 and the store kept working long past it.
+    newer_session_start = 160.0
+    session_starts = {"elsewhere": newer_session_start}
+    quiet_now = newer_session_start + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
     result = build_task_intelligence(
         task,
         public_task_id="task_" + "1" * 32,
         title="Inactive",
         latest_store_activity_at=quiet_now,
+        session_starts=session_starts,
     )
     assert result["states"]["outcome"]["key"] == "inactive"
     statement = result["decision_brief"]["outcome_statement"].lower()

--- a/tests/test_task_intelligence.py
+++ b/tests/test_task_intelligence.py
@@ -44,6 +44,40 @@ def _task() -> dict[str, object]:
     }
 
 
+def test_inactive_outcome_axis_is_not_collapsed_and_carries_its_statement() -> None:
+    # inactive is in the outcome allowlist (not silently collapsed to 'unknown')
+    # and the decision brief carries the inferred 'went quiet' statement.
+    from agentacct.task_outcome import _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+
+    task = {
+        "primary_root": {"client": "claude-code", "client_session_id": "root"},
+        "root_keys": [{"client": "claude-code", "client_session_id": "root"}],
+        "sessions": [
+            {"client": "claude-code", "client_session_id": "root", "last_activity_at": 100.0}
+        ],
+        "usage": {"rows": 0},
+        "models": [],
+        "work_items": [
+            {"work_id": "w1", "latest_status": "started", "updated_at": 100.0},
+            {"work_id": "w2", "latest_status": "checkpoint", "updated_at": 100.0},
+        ],
+    }
+    quiet_now = 100.0 + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
+    result = build_task_intelligence(
+        task,
+        public_task_id="task_" + "1" * 32,
+        title="Inactive",
+        latest_store_activity_at=quiet_now,
+    )
+    assert result["states"]["outcome"]["key"] == "inactive"
+    statement = result["decision_brief"]["outcome_statement"].lower()
+    assert "inferred" in statement
+    assert "went quiet" in statement
+    # Open steps mean execution still reads running; only the outcome axis carries
+    # 'inactive' (the two axes stay decoupled).
+    assert result["states"]["execution"]["key"] == "running"
+
+
 def test_decision_brief_keeps_finding_separate_from_control_failure() -> None:
     result = build_task_intelligence(_task(), public_task_id="task_" + "1" * 32, title="Feature")
 

--- a/tests/test_task_outcome.py
+++ b/tests/test_task_outcome.py
@@ -277,6 +277,37 @@ def _multi_task(items: list[dict[str, Any]]) -> dict[str, Any]:
     return {"work_items": items, "task_evidence_events": [], "sessions": [], "usage": {"rows": 0}}
 
 
+# The 48h + newer-session rule needs BOTH a genuinely newer session (one not
+# belonging to this Task, started strictly after it went quiet) AND the store's
+# latest activity to postdate that new session's start by the buffer. These
+# helpers build exactly that trigger so the went-quiet fixtures stay honest.
+_ELSEWHERE_SID = "elsewhere-session"
+
+
+def _newer_session_start(
+    task: dict[str, Any], *, after: float = 60.0, sid: str = _ELSEWHERE_SID
+) -> dict[str, float]:
+    """A distinct, genuinely-newer session that began ``after`` seconds past this
+    Task's newest event — the first-new-session trigger the 48h rule requires."""
+
+    return {sid: task_newest_event_at(task) + after}
+
+
+def _quiet_kwargs(
+    task: dict[str, Any], *, after: float = 60.0, sid: str = _ELSEWHERE_SID
+) -> dict[str, Any]:
+    """Reducer kwargs that put ``task`` past the went-quiet-elsewhere threshold: a
+    genuinely newer session started just after it went quiet, and the store's
+    latest activity is at least the 48h buffer past THAT new session's start."""
+
+    starts = _newer_session_start(task, after=after, sid=sid)
+    newer = min(starts.values())
+    return {
+        "latest_store_activity_at": newer + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0,
+        "session_starts": starts,
+    }
+
+
 def test_handed_off_step_is_a_clean_terminal_not_in_progress_or_verified() -> None:
     # DECISION 1: a handed_off latest status is terminal. Before the fix
     # reduce_task_outcome had no handed_off branch, so an all-handed_off Task
@@ -307,11 +338,9 @@ def test_completed_task_left_behind_by_later_elsewhere_activity_is_mostly_done()
             _step("checkpoint", updated_at=_NOW),
         ]
     )
-    later_elsewhere = (
-        task_newest_event_at(task) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
-    )
+    quiet = _quiet_kwargs(task)
 
-    outcome = reduce_task_outcome(task, latest_store_activity_at=later_elsewhere)
+    outcome = reduce_task_outcome(task, **quiet)
     assert outcome["key"] == "mostly_done"
     assert outcome["open_step_count"] == 1
     # The open step stays open in the data; the Task is never called finished.
@@ -321,7 +350,7 @@ def test_completed_task_left_behind_by_later_elsewhere_activity_is_mostly_done()
         task,
         public_task_id="task_left_behind",
         title="Left behind",
-        latest_store_activity_at=later_elsewhere,
+        **quiet,
     )
     assert detail["states"]["outcome"]["key"] == "mostly_done"
     assert "not a claim the Task is finished" in detail["decision_brief"]["outcome_statement"]
@@ -347,18 +376,25 @@ def test_old_task_with_no_later_activity_anywhere_stays_in_progress() -> None:
 
 
 def test_elsewhere_activity_within_buffer_stays_in_progress() -> None:
-    # The buffer must be respected: later activity elsewhere only a couple of
-    # hours after this Task froze is a normal pause, not "left behind".
+    # The buffer must be respected: a genuinely newer session began, but the store
+    # kept working only a couple of hours past THAT new session's start — a normal
+    # pause, not "left behind".
     task = _multi_task(
         [
             _step("completed", updated_at=_NOW),
             _step("checkpoint", updated_at=_NOW),
         ]
     )
-    only_two_hours_later = task_newest_event_at(task) + 2 * 60 * 60
-    assert only_two_hours_later < task_newest_event_at(task) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+    starts = _newer_session_start(task, after=60.0)
+    newer = min(starts.values())
+    only_two_hours_later = newer + 2 * 60 * 60
+    assert only_two_hours_later < newer + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
     assert (
-        reduce_task_outcome(task, latest_store_activity_at=only_two_hours_later)["key"]
+        reduce_task_outcome(
+            task,
+            latest_store_activity_at=only_two_hours_later,
+            session_starts=starts,
+        )["key"]
         == "in_progress"
     )
 
@@ -375,16 +411,20 @@ def test_all_terminal_steps_do_not_read_in_progress_even_with_handoff() -> None:
 
 def test_genuinely_live_task_reads_in_progress() -> None:
     # Guard against over-correction (DECISION 3a): a genuinely live Task (recent,
-    # with no >24h-later activity elsewhere) stays "in progress". Here the store
-    # is actively in use but the latest activity is well within the buffer.
+    # with no newer session that then ran on past the buffer) stays "in progress".
+    # Here a newer session exists but the store's latest activity is only 30 min
+    # past its start — well within the buffer.
     task = _multi_task(
         [
             _step("completed", updated_at=_NOW),
             _step("checkpoint", updated_at=_NOW),
         ]
     )
-    live_store = task_newest_event_at(task) + 30 * 60  # 30 min later, still live
-    outcome = reduce_task_outcome(task, latest_store_activity_at=live_store)
+    starts = _newer_session_start(task, after=60.0)
+    live_store = min(starts.values()) + 30 * 60  # 30 min past the new session
+    outcome = reduce_task_outcome(
+        task, latest_store_activity_at=live_store, session_starts=starts
+    )
     assert outcome["key"] == "in_progress"
 
 
@@ -396,11 +436,8 @@ def test_open_steps_without_any_completed_step_read_inactive_when_quiet() -> Non
     task = _multi_task(
         [_step("started", updated_at=_NOW), _step("checkpoint", updated_at=_NOW)]
     )
-    far_later_elsewhere = (
-        task_newest_event_at(task) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
-    )
 
-    outcome = reduce_task_outcome(task, latest_store_activity_at=far_later_elsewhere)
+    outcome = reduce_task_outcome(task, **_quiet_kwargs(task))
     assert outcome["key"] == "inactive"
     assert outcome["key"] not in {"mostly_done", "verified", "reported"}
     assert outcome["went_quiet"] is True
@@ -443,14 +480,11 @@ def test_no_task_is_labeled_finished_or_verified_without_evidence() -> None:
     left_behind = _multi_task(
         [_step("completed", updated_at=_NOW), _step("started", updated_at=_NOW)]
     )
-    later_elsewhere = (
-        task_newest_event_at(left_behind) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
-    )
     completed_no_check = _multi_task([_step("completed"), _step("completed")])
 
     assert reduce_task_outcome(handed_off)["key"] not in {"verified"}
     left_behind_outcome = reduce_task_outcome(
-        left_behind, latest_store_activity_at=later_elsewhere
+        left_behind, **_quiet_kwargs(left_behind)
     )
     assert left_behind_outcome["key"] == "mostly_done"  # the left-behind partial
     assert left_behind_outcome["key"] not in {"verified", "reported_done"}
@@ -751,7 +785,7 @@ def test_inactive_fires_for_open_nothing_finished_and_quiet_elsewhere() -> None:
     # (a) The core case: open steps, nothing recorded finished, and the store
     # demonstrably kept working elsewhere past the threshold -> inactive.
     task = _open_only_task()
-    outcome = reduce_task_outcome(task, latest_store_activity_at=_quiet_after(task))
+    outcome = reduce_task_outcome(task, **_quiet_kwargs(task))
     assert outcome["key"] == "inactive"
     # Never a completion/verification claim.
     assert outcome["key"] not in {"verified", "reported", "mostly_done", "resolved"}
@@ -764,29 +798,37 @@ def test_completed_step_plus_quiet_is_mostly_done_not_inactive() -> None:
     task = _multi_task(
         [_step("completed", updated_at=_NOW), _step("checkpoint", updated_at=_NOW)]
     )
-    outcome = reduce_task_outcome(task, latest_store_activity_at=_quiet_after(task))
+    outcome = reduce_task_outcome(task, **_quiet_kwargs(task))
     assert outcome["key"] == "mostly_done"
     assert outcome["went_quiet"] is True
 
 
 def test_open_only_within_threshold_stays_in_progress() -> None:
-    # (c) Later activity elsewhere but UNDER the threshold is a normal pause, not
-    # abandonment — stays in_progress.
+    # (c) A newer session began, but the store kept working only 2h past its start
+    # — UNDER the 48h buffer — so it is a normal pause, not abandonment.
     task = _open_only_task()
-    within = task_newest_event_at(task) + 2 * 60 * 60
-    assert within < task_newest_event_at(task) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
-    outcome = reduce_task_outcome(task, latest_store_activity_at=within)
+    starts = _newer_session_start(task, after=60.0)
+    newer = min(starts.values())
+    within = newer + 2 * 60 * 60
+    assert within < newer + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+    outcome = reduce_task_outcome(
+        task, latest_store_activity_at=within, session_starts=starts
+    )
     assert outcome["key"] == "in_progress"
     assert outcome["went_quiet"] is False
 
 
 def test_open_only_that_is_store_latest_never_reads_inactive() -> None:
-    # (d) When this Task IS the store's latest activity (nothing later happened
-    # anywhere), the strict '>' is False, so it can never retire itself — an
-    # abandoned crash with nothing after it honestly stays in_progress.
+    # (d) When this Task IS the store's latest activity (no session began strictly
+    # after it), there is no newer session, so it can never retire itself — an
+    # abandoned crash with nothing after it honestly stays in_progress. A session
+    # that starts at the SAME instant (a tie, not strictly after) does not count.
     task = _open_only_task()
     latest = task_newest_event_at(task)
-    outcome = reduce_task_outcome(task, latest_store_activity_at=latest)
+    starts = {"elsewhere-session": latest}  # tie, not strictly newer
+    outcome = reduce_task_outcome(
+        task, latest_store_activity_at=latest, session_starts=starts
+    )
     assert outcome["key"] == "in_progress"
     assert outcome["went_quiet"] is False
 
@@ -799,28 +841,58 @@ def test_open_only_with_no_store_signal_stays_in_progress() -> None:
     assert reduce_task_outcome(task)["went_quiet"] is False
 
 
+def test_open_only_with_no_session_index_stays_in_progress() -> None:
+    # (e') A store 'now' far past the Task, but NO session-start index supplied:
+    # the new rule cannot prove a newer session began, so it never fires. Silence
+    # (a weekend, an idle stretch) with no new session must keep the Task active.
+    task = _open_only_task()
+    far_now = task_newest_event_at(task) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
+    outcome = reduce_task_outcome(task, latest_store_activity_at=far_now)
+    assert outcome["key"] == "in_progress"
+    assert outcome["went_quiet"] is False
+    # Even with an index that holds ONLY this Task's own (older) session, there is
+    # no genuinely newer session -> still in_progress.
+    own_only = {"elsewhere-session": task_newest_event_at(task) - 10.0}
+    assert (
+        reduce_task_outcome(
+            task, latest_store_activity_at=far_now, session_starts=own_only
+        )["key"]
+        == "in_progress"
+    )
+
+
 def test_open_only_with_zero_task_timestamps_stays_in_progress() -> None:
     # (f) Missing / zero task timestamps guard the arithmetic off — a Task whose
     # newest event is 0.0 can never be judged left behind, even under a huge
-    # store 'now'.
+    # store 'now' AND a genuinely newer session.
     task = _multi_task(
         [_step("started", updated_at=0.0), _step("checkpoint", updated_at=0.0)]
     )
     assert task_newest_event_at(task) == 0.0
     huge_now = _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS * 100
-    assert reduce_task_outcome(task, latest_store_activity_at=huge_now)["key"] == "in_progress"
+    starts = {"elsewhere-session": 10.0}
+    assert (
+        reduce_task_outcome(
+            task, latest_store_activity_at=huge_now, session_starts=starts
+        )["key"]
+        == "in_progress"
+    )
 
 
 def test_future_dated_task_event_skew_never_retires_the_task() -> None:
-    # (g) Clock skew: a Task event dated FAR in the future means it equals/exceeds
-    # any store 'now', so the strict '>' is False — skew can only KEEP a Task
-    # active, never falsely retire it.
+    # (g) Clock skew: a Task event dated FAR in the future means no session can
+    # start strictly after it, so there is no newer session — skew can only KEEP a
+    # Task active, never falsely retire it.
     future = _NOW + 10 * _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
     task = _multi_task(
         [_step("started", updated_at=future), _step("checkpoint", updated_at=future)]
     )
-    # A store 'now' that predates the skewed task event.
-    outcome = reduce_task_outcome(task, latest_store_activity_at=_NOW)
+    # A newer-looking session at _NOW is still BEFORE the skewed task event, and a
+    # store 'now' that predates the skewed task event.
+    starts = {"elsewhere-session": _NOW}
+    outcome = reduce_task_outcome(
+        task, latest_store_activity_at=_NOW, session_starts=starts
+    )
     assert outcome["key"] == "in_progress"
     assert outcome["went_quiet"] is False
 
@@ -857,17 +929,135 @@ def test_inactive_is_deterministic_across_identical_reads() -> None:
     # (k) Two reads with the SAME store timestamps give the SAME key — the whole
     # point of comparing against a stored store 'now', never the wall clock.
     task = _open_only_task()
-    now = _quiet_after(task)
-    first = reduce_task_outcome(task, latest_store_activity_at=now)
-    second = reduce_task_outcome(task, latest_store_activity_at=now)
+    quiet = _quiet_kwargs(task)
+    first = reduce_task_outcome(task, **quiet)
+    second = reduce_task_outcome(task, **quiet)
     assert first["key"] == second["key"] == "inactive"
 
 
 def test_task_went_quiet_elsewhere_predicate_edge_cases() -> None:
-    # The shared predicate directly: guards resolve toward NOT firing.
+    # The shared predicate directly, on the new (task, latest, session_starts)
+    # signature: every guard resolves toward NOT firing.
     task = _open_only_task()
-    assert task_went_quiet_elsewhere(task, _quiet_after(task)) is True
-    assert task_went_quiet_elsewhere(task, None) is False
-    assert task_went_quiet_elsewhere(task, task_newest_event_at(task)) is False
+    quiet = _quiet_kwargs(task)
+    starts = quiet["session_starts"]
+    latest = quiet["latest_store_activity_at"]
+    newer = min(starts.values())
+
+    # Fires: a genuinely newer distinct session AND the store ran >= 48h past it.
+    assert task_went_quiet_elsewhere(task, latest, starts) is True
+
+    # No session index at all -> False (single-Task read / not plumbed).
+    assert task_went_quiet_elsewhere(task, latest) is False
+    assert task_went_quiet_elsewhere(task, latest, None) is False
+    assert task_went_quiet_elsewhere(task, latest, {}) is False
+
+    # No store 'now' -> False.
+    assert task_went_quiet_elsewhere(task, None, starts) is False
+
+    # A newer session exists, but the store's latest is only 1s past it (< 48h).
+    just_after = newer + 1.0
+    assert task_went_quiet_elsewhere(task, just_after, starts) is False
+
+    # Exactly 48h past the newer session's start -> the boundary is inclusive.
+    at_boundary = newer + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+    assert task_went_quiet_elsewhere(task, at_boundary, starts) is True
+
+    # No qualifying newer session (only a same-instant tie / an older session).
+    tie = {"elsewhere-session": task_newest_event_at(task)}
+    assert task_went_quiet_elsewhere(task, latest, tie) is False
+    older = {"elsewhere-session": task_newest_event_at(task) - 100.0}
+    assert task_went_quiet_elsewhere(task, latest, older) is False
+
+    # This Task's newest event is zero -> False even under a huge 'now'.
     zero = _multi_task([_step("started", updated_at=0.0)])
-    assert task_went_quiet_elsewhere(zero, _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS * 100) is False
+    assert (
+        task_went_quiet_elsewhere(
+            zero,
+            _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS * 100,
+            {"elsewhere-session": 10.0},
+        )
+        is False
+    )
+
+    # A newer session that BELONGS to this Task (same client_session_id) never
+    # counts as "elsewhere".
+    own = _multi_task(
+        [_sitem("started", _NOW, sid="mine"), _sitem("checkpoint", _NOW, sid="mine")]
+    )
+    own_later = {"mine": task_newest_event_at(own) + 60.0}
+    own_latest = min(own_later.values()) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
+    assert task_went_quiet_elsewhere(own, own_latest, own_later) is False
+
+
+def test_reducer_48h_boundary_for_inactive() -> None:
+    # The reducer honours the exact 48h boundary, measured FROM the newer session's
+    # start: 47h59m past it stays in_progress, exactly 48h flips to inactive.
+    task = _open_only_task()
+    starts = _newer_session_start(task, after=60.0)
+    newer = min(starts.values())
+    just_under = newer + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS - 60.0
+    assert (
+        reduce_task_outcome(
+            task, latest_store_activity_at=just_under, session_starts=starts
+        )["key"]
+        == "in_progress"
+    )
+    at_boundary = newer + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+    assert (
+        reduce_task_outcome(
+            task, latest_store_activity_at=at_boundary, session_starts=starts
+        )["key"]
+        == "inactive"
+    )
+
+
+def test_reducer_same_task_later_session_never_reads_inactive() -> None:
+    # A LATER session that is THIS Task's own (same client_session_id) is not a
+    # "newer session elsewhere" — the Task simply continued, so it stays active.
+    task = _multi_task(
+        [_sitem("started", _NOW, sid="mine"), _sitem("checkpoint", _NOW, sid="mine")]
+    )
+    later = {"mine": task_newest_event_at(task) + 60.0}
+    latest = min(later.values()) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
+    outcome = reduce_task_outcome(
+        task, latest_store_activity_at=latest, session_starts=later
+    )
+    assert outcome["key"] == "in_progress"
+    assert outcome["went_quiet"] is False
+
+
+def test_quiet_timestamps_present_on_inactive_and_mostly_done() -> None:
+    # The two factual detail-line timestamps ride the outcome dict ONLY on the
+    # went-quiet keys. quiet_since = this Task's newest event; newer_session_started_at
+    # = the first newer session's start the predicate keyed off. Never a
+    # completion claim, just facts.
+    inactive_task = _open_only_task()
+    quiet = _quiet_kwargs(inactive_task)
+    inactive = reduce_task_outcome(inactive_task, **quiet)
+    assert inactive["key"] == "inactive"
+    assert inactive["quiet_since"] == task_newest_event_at(inactive_task)
+    assert inactive["newer_session_started_at"] == min(quiet["session_starts"].values())
+
+    mostly_task = _multi_task(
+        [_step("completed", updated_at=_NOW), _step("checkpoint", updated_at=_NOW)]
+    )
+    mquiet = _quiet_kwargs(mostly_task)
+    mostly = reduce_task_outcome(mostly_task, **mquiet)
+    assert mostly["key"] == "mostly_done"
+    assert mostly["quiet_since"] == task_newest_event_at(mostly_task)
+    assert mostly["newer_session_started_at"] == min(mquiet["session_starts"].values())
+
+
+def test_quiet_timestamps_absent_or_none_on_other_keys() -> None:
+    # in_progress and terminal keys carry the fields as None (never a stray
+    # timestamp that a surface could misread as a quiet/abandoned signal).
+    live = reduce_task_outcome(_open_only_task())
+    assert live["key"] == "in_progress"
+    assert live["quiet_since"] is None
+    assert live["newer_session_started_at"] is None
+
+    reported = reduce_task_outcome(_multi_task([_step("completed"), _step("completed")]))
+    assert reported["key"] == "reported"
+    assert reported["quiet_since"] is None
+    assert reported["newer_session_started_at"] is None

--- a/tests/test_task_outcome.py
+++ b/tests/test_task_outcome.py
@@ -13,6 +13,7 @@ from agentacct.task_outcome import (
     reduce_task_outcome,
     step_verification_counts,
     task_newest_event_at,
+    task_went_quiet_elsewhere,
 )
 
 
@@ -387,10 +388,11 @@ def test_genuinely_live_task_reads_in_progress() -> None:
     assert outcome["key"] == "in_progress"
 
 
-def test_open_steps_without_any_completed_step_stay_in_progress() -> None:
-    # Conservative: "mostly done" requires at least one completed step. A Task
-    # with only open steps and nothing finished is never "mostly done" — even
-    # when the user kept working far elsewhere long afterward.
+def test_open_steps_without_any_completed_step_read_inactive_when_quiet() -> None:
+    # inactive: only open steps, NOTHING finished, and the store demonstrably kept
+    # working far elsewhere long afterward. This is never "mostly done" (that needs
+    # a completed step); it is the honest inferred "went quiet" downgrade of a
+    # possibly-misleading "In progress" — never a completion claim.
     task = _multi_task(
         [_step("started", updated_at=_NOW), _step("checkpoint", updated_at=_NOW)]
     )
@@ -398,10 +400,11 @@ def test_open_steps_without_any_completed_step_stay_in_progress() -> None:
         task_newest_event_at(task) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
     )
 
-    assert (
-        reduce_task_outcome(task, latest_store_activity_at=far_later_elsewhere)["key"]
-        == "in_progress"
-    )
+    outcome = reduce_task_outcome(task, latest_store_activity_at=far_later_elsewhere)
+    assert outcome["key"] == "inactive"
+    assert outcome["key"] not in {"mostly_done", "verified", "reported"}
+    assert outcome["went_quiet"] is True
+    assert outcome["open_step_count"] == 2
 
 
 def test_partial_verification_counts_are_exposed_and_correct() -> None:
@@ -728,3 +731,143 @@ def test_non_blocked_outcomes_carry_no_blocker_detail() -> None:
         outcome = reduce_task_outcome(_task(status=status))
         assert outcome["key"] != "blocked"
         assert outcome["blocker"] is None
+
+
+# --- inactive: open + nothing finished + the store moved on ELSEWHERE ----------
+
+
+def _open_only_task() -> dict[str, Any]:
+    # Open steps, NOTHING finished — the population the inactive split governs.
+    return _multi_task(
+        [_step("started", updated_at=_NOW), _step("checkpoint", updated_at=_NOW)]
+    )
+
+
+def _quiet_after(task: dict[str, Any]) -> float:
+    return task_newest_event_at(task) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS + 60.0
+
+
+def test_inactive_fires_for_open_nothing_finished_and_quiet_elsewhere() -> None:
+    # (a) The core case: open steps, nothing recorded finished, and the store
+    # demonstrably kept working elsewhere past the threshold -> inactive.
+    task = _open_only_task()
+    outcome = reduce_task_outcome(task, latest_store_activity_at=_quiet_after(task))
+    assert outcome["key"] == "inactive"
+    # Never a completion/verification claim.
+    assert outcome["key"] not in {"verified", "reported", "mostly_done", "resolved"}
+    assert outcome["went_quiet"] is True
+
+
+def test_completed_step_plus_quiet_is_mostly_done_not_inactive() -> None:
+    # (b) With at least one completed step, the SAME quiet signal reads
+    # mostly_done, not inactive — the split is only on has_completed_step.
+    task = _multi_task(
+        [_step("completed", updated_at=_NOW), _step("checkpoint", updated_at=_NOW)]
+    )
+    outcome = reduce_task_outcome(task, latest_store_activity_at=_quiet_after(task))
+    assert outcome["key"] == "mostly_done"
+    assert outcome["went_quiet"] is True
+
+
+def test_open_only_within_threshold_stays_in_progress() -> None:
+    # (c) Later activity elsewhere but UNDER the threshold is a normal pause, not
+    # abandonment — stays in_progress.
+    task = _open_only_task()
+    within = task_newest_event_at(task) + 2 * 60 * 60
+    assert within < task_newest_event_at(task) + _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+    outcome = reduce_task_outcome(task, latest_store_activity_at=within)
+    assert outcome["key"] == "in_progress"
+    assert outcome["went_quiet"] is False
+
+
+def test_open_only_that_is_store_latest_never_reads_inactive() -> None:
+    # (d) When this Task IS the store's latest activity (nothing later happened
+    # anywhere), the strict '>' is False, so it can never retire itself — an
+    # abandoned crash with nothing after it honestly stays in_progress.
+    task = _open_only_task()
+    latest = task_newest_event_at(task)
+    outcome = reduce_task_outcome(task, latest_store_activity_at=latest)
+    assert outcome["key"] == "in_progress"
+    assert outcome["went_quiet"] is False
+
+
+def test_open_only_with_no_store_signal_stays_in_progress() -> None:
+    # (e) latest_store_activity_at omitted (single-Task read / not plumbed): the
+    # inference has no store 'now' to compare against and never fires.
+    task = _open_only_task()
+    assert reduce_task_outcome(task)["key"] == "in_progress"
+    assert reduce_task_outcome(task)["went_quiet"] is False
+
+
+def test_open_only_with_zero_task_timestamps_stays_in_progress() -> None:
+    # (f) Missing / zero task timestamps guard the arithmetic off — a Task whose
+    # newest event is 0.0 can never be judged left behind, even under a huge
+    # store 'now'.
+    task = _multi_task(
+        [_step("started", updated_at=0.0), _step("checkpoint", updated_at=0.0)]
+    )
+    assert task_newest_event_at(task) == 0.0
+    huge_now = _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS * 100
+    assert reduce_task_outcome(task, latest_store_activity_at=huge_now)["key"] == "in_progress"
+
+
+def test_future_dated_task_event_skew_never_retires_the_task() -> None:
+    # (g) Clock skew: a Task event dated FAR in the future means it equals/exceeds
+    # any store 'now', so the strict '>' is False — skew can only KEEP a Task
+    # active, never falsely retire it.
+    future = _NOW + 10 * _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS
+    task = _multi_task(
+        [_step("started", updated_at=future), _step("checkpoint", updated_at=future)]
+    )
+    # A store 'now' that predates the skewed task event.
+    outcome = reduce_task_outcome(task, latest_store_activity_at=_NOW)
+    assert outcome["key"] == "in_progress"
+    assert outcome["went_quiet"] is False
+
+
+def test_blocked_and_finding_win_over_would_be_inactive() -> None:
+    # (h) blocked / finding early-return before the open-step branch: a blocked or
+    # failing open Task can never be relabeled inactive — blocked stays blocked.
+    blocked = _multi_task([_step("blocked", updated_at=_NOW), _step("started", updated_at=_NOW)])
+    assert reduce_task_outcome(blocked, latest_store_activity_at=_quiet_after(blocked))["key"] == "blocked"
+
+    finding = _open_only_task()
+    finding["task_evidence_events"] = [_check("failed", created_at=_NOW, event_id="f")]
+    assert reduce_task_outcome(finding, latest_store_activity_at=_quiet_after(finding))["key"] == "finding"
+
+
+def test_ended_open_wins_over_would_be_inactive() -> None:
+    # (i) ended_open is a stronger, more specific stop signal evaluated before the
+    # open-step branch — a session that demonstrably ended stays ended_open even
+    # when the store also moved on elsewhere.
+    task = _multi_task([_sitem("started", _NOW, ended=_NOW + 5)])
+    assert reduce_task_outcome(task, latest_store_activity_at=_quiet_after(task))["key"] == "ended_open"
+
+
+def test_handed_off_frontier_wins_over_would_be_inactive() -> None:
+    # (j) A clean handoff frontier (the agent's own word) outranks the inferred
+    # inactive downgrade.
+    task = _multi_task(
+        [_step("started", updated_at=_NOW), _step("handed_off", updated_at=_NOW + 100)]
+    )
+    assert reduce_task_outcome(task, latest_store_activity_at=_quiet_after(task))["key"] == "handed_off"
+
+
+def test_inactive_is_deterministic_across_identical_reads() -> None:
+    # (k) Two reads with the SAME store timestamps give the SAME key — the whole
+    # point of comparing against a stored store 'now', never the wall clock.
+    task = _open_only_task()
+    now = _quiet_after(task)
+    first = reduce_task_outcome(task, latest_store_activity_at=now)
+    second = reduce_task_outcome(task, latest_store_activity_at=now)
+    assert first["key"] == second["key"] == "inactive"
+
+
+def test_task_went_quiet_elsewhere_predicate_edge_cases() -> None:
+    # The shared predicate directly: guards resolve toward NOT firing.
+    task = _open_only_task()
+    assert task_went_quiet_elsewhere(task, _quiet_after(task)) is True
+    assert task_went_quiet_elsewhere(task, None) is False
+    assert task_went_quiet_elsewhere(task, task_newest_event_at(task)) is False
+    zero = _multi_task([_step("started", updated_at=0.0)])
+    assert task_went_quiet_elsewhere(zero, _LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS * 100) is False


### PR DESCRIPTION
Adds an evidence-bounded **`Inactive`** decision state so a task shown as *in progress* stops silently misleading once it has clearly gone quiet — **without ever fabricating a "completed"**. Addresses the "status shows in-progress but it's actually done / I moved to a new session" problem.

### Behavior (honesty-critical)
- **Rule:** open steps + **nothing** recorded as finished + the store demonstrably kept working elsewhere for longer than the left-behind threshold → `inactive`. (Open steps + a *completed* step under the same condition → the existing `mostly_done`.)
- **Daemon-computed** via one predicate `task_went_quiet_elsewhere()` (`src/agentacct/task_outcome.py`), compared against a **deterministic stored activity timestamp, never the wall clock** — so the state can't flip between two reads, and every edge (no store signal / missing / zero / future-dated timestamp / the task *is* the store's latest) resolves toward **not firing**. Silence or clock skew can only keep a task *active*, never falsely retire it.
- Provenance **`inferred`** (weakest, same as `ended_open`); **never green** (neutral tint); counts as a **non-terminal gap** ("no terminal outcome recorded"); **excluded from the review/attention queue** (no false alarm, no false done). The app is a pure renderer of the daemon's word.

### Verification
- **Python full suite: 2677 passed** (exit 0, 3.11 venv).
- **Swift: 220 tests passed**, 6 visual entry points skipped as normal; new `InactiveDecisionStateTests.swift` included; `swift build` clean.
- **Adversarial honesty review (workflow verify agent + manual): 0 honesty findings** — no path asserts/implies completion it can't prove.
- **Visual snapshots unaffected:** existing fixtures carry explicit pre-computed decision keys and none use `inactive`, so baselines don't change. (This machine isn't the pinned renderer, so canonical pixel comparison is skipped here — same as CI.)

### For reviewer decision (non-blocking)
1. **Threshold = 24h**, reusing the existing `_LEFT_BEHIND_AFTER_ELSEWHERE_SECONDS` knob shared with `mostly_done`. 24–48h was floated; bumping to 48h also shifts `mostly_done`'s boundary (shared constant). Keep 24h, or split into an independent constant?
2. **IA:** `inactive` is grouped under the **"Stopped"** Work bucket (with handed-off / ended-open), though the daemon treats it as **non-terminal**. Each row still shows its own "Inactive" word. Keep here, or its own group?
3. Forward-looking `went_quiet` field on the outcome dict is emitted + unit-tested but has no render consumer yet (intended for a future "quiet since <time>" sub-line); it is `None` rather than `False` on terminal branches. Keep as scaffold, wire up, or drop?

### Follow-up (not here)
- A visual fixture exercising the `inactive` state, recorded on the pinned renderer.
