### PR TITLE
chore(release): 0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.6] — 2026-09-03
+
+A keyboard-native `agentacct tui` rebuilt to mirror the macOS app — now with a
+receipt → sessions & steps drill-down — an honest "Inactive" task state that
+never overstates completion, and a receipt-first README refresh.
+
+### Added
+
+- The TUI gains a `?` help overlay, a `/` filter and status tabs on Work, a
+  receipt → sessions & steps drill-down (the checks timeline behind a verdict,
+  with a currently-failing check kept visible under Needs attention), an Evidence
+  Sources pane, and a `T` light/dark theme toggle. (#185)
+- An honest **Inactive** task state: a task shown "in progress" is downgraded to
+  an evidence-bounded Inactive — never a completion claim — only when it has open
+  steps, nothing recorded as finished, and a genuinely newer session kept the
+  store working elsewhere for 48h past that session's start. Computed from stored
+  timestamps, never the wall clock, so silence or clock skew can only keep a task
+  active, never falsely retire it; provenance is `inferred` (weakest, never
+  green) and it stays out of the review queue. The Work Receipt detail shows a
+  factual "Quiet since X · a newer session started Y" sub-line. (#184)
+
 ### Changed
 
 - `agentacct tui` is rebuilt to mirror the macOS app's design language: a
@@ -18,17 +39,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and the cost grammar (`$` / `≈$` / `~$` / `unpriced`) is preserved. The data
   layer, screen set, and honest vocabulary are unchanged — this is a
   presentation-layer rewrite over the same local event log the CLI and app read,
-  so the surfaces cannot disagree.
-
-### Added
-
-- The TUI gains a `?` help overlay, a `/` filter and status tabs on Work, an
-  Evidence Sources pane, and a `T` light/dark theme toggle.
+  so the surfaces cannot disagree. (#185)
+- Refresh both READMEs for the shipped UI: lead with the Work Receipt in its wide
+  two-column layout, add a sessions & steps shot, regenerate the dashboard, work,
+  and usage panes, fold the Sources pane into prose, and correct the step
+  lifecycle vocabulary (`completed`). (#183)
 
 ### Fixed
 
 - Pin `textual` to `>=8,<9` so a future Textual major release cannot break the
-  installed TUI.
+  installed TUI. (#185)
 
 ## [0.10.5] — 2026-09-02
 
@@ -945,7 +965,8 @@ across all of them. Ships alongside the first signed, notarized macOS app.
   `agentacct-claude`, and `agentacct-codex` console scripts. Local-first,
   observe-only, no telemetry, no provider API keys. Python ≥ 3.11 on macOS / Linux.
 
-[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.10.5...HEAD
+[Unreleased]: https://github.com/mikehasa/agentacct/compare/v0.10.6...HEAD
+[0.10.6]: https://github.com/mikehasa/agentacct/releases/tag/v0.10.6
 [0.10.5]: https://github.com/mikehasa/agentacct/releases/tag/v0.10.5
 [0.10.4]: https://github.com/mikehasa/agentacct/releases/tag/v0.10.4
 [0.10.3]: https://github.com/mikehasa/agentacct/releases/tag/v0.10.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentacct"
-version = "0.10.5"
+version = "0.10.6"
 description = "Local-first Agent Work Intelligence for coding agents: usage truth, recorded work, and honest joins"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release 0.10.6.

## Scope (`v0.10.5..main`)
- feat(tui): rebuild the terminal UI to mirror the macOS app (#185)
- feat: honest inactive/stale task-status state (#184)
- docs: refresh README for the 0.10.5 UI (#183)

## Version bump
- `pyproject.toml` → `0.10.6`
- `CHANGELOG.md` → new `[0.10.6]` section + link refs
- `apps/agentacct/Scripts/build-app.sh` derives `APP_VERSION` from `pyproject.toml` (auto → 0.10.6); no manual edit needed.

## DMG: REBUILD (payload changed since v0.10.5)
Preflight `git diff v0.10.5..HEAD --stat -- src/agentacct apps/agentacct packaging` shows substantial changes under `src/agentacct/**` (tui.py, cli.py, receipt.py, task_outcome.py, api.py, task_intelligence.py) and `apps/agentacct/**` (Dashboard/Receipts/Work/Theme/SnapshotRunner/V1Model Swift) → **rebuild** a fresh signed+notarized+stapled DMG (it embeds the frozen Python CLI, so a Python change alters what the DMG runs).
